### PR TITLE
Add native SwiftUI login with Keychain integration

### DIFF
--- a/macos/HarborClerk/HarborClerk.xcodeproj/project.pbxproj
+++ b/macos/HarborClerk/HarborClerk.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		A200000001 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000001; };
 		A200000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000002; };
 		A200000003 /* BackendDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000003; };
+		A200000005 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000005; };
+		A200000006 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000006; };
+		A200000007 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000007; };
 		A200000004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B200000004; };
 		AT20000001 /* BackendDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT20000001; };
 /* End PBXBuildFile section */
@@ -28,6 +31,9 @@
 		B200000001 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		B200000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		B200000003 /* BackendDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendDetector.swift; sourceTree = "<group>"; };
+		B200000005 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
+		B200000006 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		B200000007 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		B200000004 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C200000001 /* HarborClerk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HarborClerk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D200000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -69,6 +75,9 @@
 				B200000001 /* App.swift */,
 				B200000002 /* ContentView.swift */,
 				B200000003 /* BackendDetector.swift */,
+				B200000005 /* KeychainManager.swift */,
+				B200000006 /* AuthManager.swift */,
+				B200000007 /* LoginView.swift */,
 				B200000004 /* Assets.xcassets */,
 				D200000001 /* Info.plist */,
 				D200000002 /* HarborClerk.entitlements */,
@@ -186,6 +195,9 @@
 				A200000001 /* App.swift in Sources */,
 				A200000002 /* ContentView.swift in Sources */,
 				A200000003 /* BackendDetector.swift in Sources */,
+				A200000005 /* KeychainManager.swift in Sources */,
+				A200000006 /* AuthManager.swift in Sources */,
+				A200000007 /* LoginView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerk/HarborClerk/AuthManager.swift
+++ b/macos/HarborClerk/HarborClerk/AuthManager.swift
@@ -1,0 +1,151 @@
+import Foundation
+import WebKit
+
+enum AuthState: Equatable {
+    case waitingForServer
+    case checkingAuth
+    case loginRequired(errorMessage: String?)
+    case loggingIn
+    case authenticated
+    /// First-time setup — load the web UI directly so the user can create the admin account.
+    case needsSetup
+}
+
+/// Owns the authentication state machine: Keychain auto-login, API calls, cookie injection.
+@MainActor
+final class AuthManager: ObservableObject {
+    @Published var state: AuthState = .waitingForServer
+
+    let baseURL: URL
+
+    init(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+
+    // MARK: - Server became available
+
+    func onServerBecameAvailable() async {
+        state = .checkingAuth
+
+        // 1. Check if first-time setup is needed
+        if await needsSetup() {
+            state = .needsSetup
+            return
+        }
+
+        // 2. Try auto-login from Keychain
+        if let creds = KeychainManager.load() {
+            do {
+                try await performLogin(email: creds.email, password: creds.password)
+                return // state is now .authenticated
+            } catch {
+                // Saved credentials are stale — clear and show login
+                KeychainManager.delete()
+            }
+        }
+
+        state = .loginRequired(errorMessage: nil)
+    }
+
+    // MARK: - Manual login
+
+    func login(email: String, password: String, rememberMe: Bool) async {
+        state = .loggingIn
+        do {
+            try await performLogin(email: email, password: password)
+            if rememberMe {
+                KeychainManager.save(email: email, password: password)
+            }
+        } catch let error as LoginError {
+            state = .loginRequired(errorMessage: error.message)
+        } catch {
+            state = .loginRequired(errorMessage: "Connection failed. Is the server running?")
+        }
+    }
+
+    // MARK: - Logout (called when web UI navigates to /login)
+
+    func handleWebLogout() {
+        // Clear WKWebView cookies
+        let dataStore = WKWebsiteDataStore.default()
+        dataStore.httpCookieStore.getAllCookies { cookies in
+            for cookie in cookies where cookie.name == "refresh_token" {
+                dataStore.httpCookieStore.delete(cookie)
+            }
+        }
+        state = .loginRequired(errorMessage: nil)
+    }
+
+    // MARK: - After setup completes (web navigated to /login)
+
+    func handleSetupComplete() {
+        state = .loginRequired(errorMessage: nil)
+    }
+
+    // MARK: - Private
+
+    private func needsSetup() async -> Bool {
+        let url = baseURL.appendingPathComponent("api/system/setup-status")
+        guard let (data, response) = try? await URLSession.shared.data(from: url),
+              (response as? HTTPURLResponse)?.statusCode == 200,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let needs = json["needs_setup"] as? Bool
+        else {
+            return false
+        }
+        return needs
+    }
+
+    private func performLogin(email: String, password: String) async throws {
+        let url = baseURL.appendingPathComponent("api/auth/login")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = ["email": email, "password": password]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LoginError(message: "Unexpected response")
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw LoginError(message: "Invalid email or password")
+        }
+        if httpResponse.statusCode == 403 {
+            throw LoginError(message: "Account disabled")
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw LoginError(message: "Login failed (HTTP \(httpResponse.statusCode))")
+        }
+
+        // Transfer the refresh_token cookie from URLSession's shared cookie storage
+        // into WKWebView's cookie store so the React SPA can authenticate.
+        await injectCookiesIntoWebView()
+        state = .authenticated
+    }
+
+    private func injectCookiesIntoWebView() async {
+        guard let cookies = HTTPCookieStorage.shared.cookies(for: baseURL) else { return }
+
+        let webCookieStore = WKWebsiteDataStore.default().httpCookieStore
+        for cookie in cookies {
+            // If the server hasn't been updated yet and sends Secure on http://localhost,
+            // create a non-Secure copy so the cookie actually sticks in WKWebView.
+            var props = cookie.properties ?? [:]
+            if baseURL.scheme == "http" {
+                props.removeValue(forKey: .secure)
+            }
+            if let fixedCookie = HTTPCookie(properties: props) {
+                await webCookieStore.setCookie(fixedCookie)
+            } else {
+                await webCookieStore.setCookie(cookie)
+            }
+        }
+    }
+}
+
+private struct LoginError: Error {
+    let message: String
+}

--- a/macos/HarborClerk/HarborClerk/ContentView.swift
+++ b/macos/HarborClerk/HarborClerk/ContentView.swift
@@ -3,38 +3,50 @@ import WebKit
 
 struct ContentView: View {
     @StateObject private var detector = BackendDetector()
+    @StateObject private var authManager: AuthManager
+
+    init() {
+        let port = BackendDetector.readPort()
+        let url = URL(string: "http://localhost:\(port)")!
+        _authManager = StateObject(wrappedValue: AuthManager(baseURL: url))
+    }
 
     var body: some View {
         Group {
-            if detector.isAvailable {
-                WebView(url: detector.baseURL)
+            switch authManager.state {
+            case .waitingForServer:
+                WaitingView(launchServer: launchServer)
+
+            case .checkingAuth:
+                ProgressView("Signing in...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            case .loginRequired(let errorMessage):
+                LoginView(errorMessage: errorMessage)
+                    .environmentObject(authManager)
+
+            case .loggingIn:
+                ProgressView("Signing in...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            case .needsSetup:
+                WebView(url: authManager.baseURL, authManager: authManager)
                     .ignoresSafeArea()
-            } else {
-                VStack(spacing: 20) {
-                    Image(systemName: "server.rack")
-                        .font(.system(size: 48))
-                        .foregroundColor(.secondary)
 
-                    Text("Waiting for Harbor Clerk Server...")
-                        .font(.title2)
-
-                    Text("Please start Harbor Clerk Server to continue.")
-                        .foregroundColor(.secondary)
-
-                    Button("Launch Harbor Clerk Server") {
-                        launchServer()
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-
-                    ProgressView()
-                        .controlSize(.small)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .authenticated:
+                WebView(url: authManager.baseURL, authManager: authManager)
+                    .ignoresSafeArea()
             }
         }
         .onAppear { detector.startPolling() }
         .onDisappear { detector.stopPolling() }
+        .onChange(of: detector.isAvailable) { _, available in
+            if available {
+                Task { await authManager.onServerBecameAvailable() }
+            } else {
+                authManager.state = .waitingForServer
+            }
+        }
     }
 
     private func launchServer() {
@@ -45,44 +57,72 @@ struct ContentView: View {
     }
 }
 
+// MARK: - Waiting View
+
+private struct WaitingView: View {
+    let launchServer: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "server.rack")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+
+            Text("Waiting for Harbor Clerk Server...")
+                .font(.title2)
+
+            Text("Please start Harbor Clerk Server to continue.")
+                .foregroundColor(.secondary)
+
+            Button("Launch Harbor Clerk Server") {
+                launchServer()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+
+            ProgressView()
+                .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - WebView
+
 /// NSViewRepresentable wrapper for WKWebView.
 struct WebView: NSViewRepresentable {
     let url: URL
+    let authManager: AuthManager
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(authManager: authManager)
     }
 
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
-        // Use the default (persistent) data store so credentials and
-        // AutoFill state are preserved across launches.
         config.websiteDataStore = .default()
-        // Allow text interaction so the system credential provider
-        // (Keychain, 1Password, etc.) can detect and fill form fields.
         config.preferences.isTextInteractionEnabled = true
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.uiDelegate = context.coordinator
+        webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
 
-        // Store reference for navigation commands
         context.coordinator.webView = webView
-
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        if webView.url != url {
-            webView.load(URLRequest(url: url))
-        }
+        // Only reload if the base URL changed (not on every SwiftUI update)
     }
 
-    class Coordinator: NSObject, WKUIDelegate {
+    class Coordinator: NSObject, WKUIDelegate, WKNavigationDelegate {
         weak var webView: WKWebView?
         private var observers: [NSObjectProtocol] = []
+        private let authManager: AuthManager
 
-        override init() {
+        init(authManager: AuthManager) {
+            self.authManager = authManager
             super.init()
 
             observers.append(
@@ -108,7 +148,6 @@ struct WebView: NSViewRepresentable {
         }
 
         // Respond to new-window requests (e.g. target="_blank" links)
-        // by loading them in the same web view.
         func webView(
             _ webView: WKWebView,
             createWebViewWith configuration: WKWebViewConfiguration,
@@ -119,6 +158,27 @@ struct WebView: NSViewRepresentable {
                 webView.load(navigationAction.request)
             }
             return nil
+        }
+
+        // Intercept navigation to /login — means the web UI logged out (or setup finished)
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if let navURL = navigationAction.request.url,
+               navURL.path == "/login" || navURL.path == "/login/" {
+                decisionHandler(.cancel)
+                Task { @MainActor in
+                    if case .needsSetup = authManager.state {
+                        authManager.handleSetupComplete()
+                    } else {
+                        authManager.handleWebLogout()
+                    }
+                }
+                return
+            }
+            decisionHandler(.allow)
         }
     }
 }

--- a/macos/HarborClerk/HarborClerk/KeychainManager.swift
+++ b/macos/HarborClerk/HarborClerk/KeychainManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Security
+
+struct KeychainCredentials {
+    let email: String
+    let password: String
+}
+
+/// Thin wrapper around the macOS Keychain for saving and loading login credentials.
+enum KeychainManager {
+    private static let service = "com.harborclerk.HarborClerk"
+
+    static func save(email: String, password: String) {
+        // Delete any existing entry first
+        delete()
+
+        let passwordData = password.data(using: .utf8)!
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: email,
+            kSecValueData as String: passwordData,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+        ]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func load() -> KeychainCredentials? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let dict = item as? [String: Any],
+              let email = dict[kSecAttrAccount as String] as? String,
+              let data = dict[kSecValueData as String] as? Data,
+              let password = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        return KeychainCredentials(email: email, password: password)
+    }
+
+    static func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/macos/HarborClerk/HarborClerk/LoginView.swift
+++ b/macos/HarborClerk/HarborClerk/LoginView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject private var authManager: AuthManager
+
+    let errorMessage: String?
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var rememberMe = true
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case email, password
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 24) {
+                // App icon + title
+                VStack(spacing: 12) {
+                    Image(nsImage: NSApp.applicationIconImage)
+                        .resizable()
+                        .frame(width: 80, height: 80)
+
+                    Text("Harbor Clerk")
+                        .font(.title)
+                        .fontWeight(.semibold)
+                }
+
+                // Error message
+                if let msg = errorMessage {
+                    Text(msg)
+                        .foregroundColor(.red)
+                        .font(.callout)
+                        .multilineTextAlignment(.center)
+                }
+
+                // Form fields
+                VStack(spacing: 12) {
+                    TextField("Email", text: $email)
+                        .textFieldStyle(.roundedBorder)
+                        .textContentType(.username)
+                        .focused($focusedField, equals: .email)
+                        .onSubmit { focusedField = .password }
+
+                    SecureField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                        .textContentType(.password)
+                        .focused($focusedField, equals: .password)
+                        .onSubmit { submit() }
+
+                    Toggle("Remember me", isOn: $rememberMe)
+                        .toggleStyle(.checkbox)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                // Sign in button
+                Button(action: submit) {
+                    Text("Sign In")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(email.isEmpty || password.isEmpty)
+            }
+            .frame(width: 300)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            // Pre-fill email from Keychain if available
+            if let creds = KeychainManager.load() {
+                email = creds.email
+            }
+            focusedField = email.isEmpty ? .email : .password
+        }
+    }
+
+    private func submit() {
+        guard !email.isEmpty, !password.isEmpty else { return }
+        Task {
+            await authManager.login(email: email, password: password, rememberMe: rememberMe)
+        }
+    }
+}

--- a/src/harbor_clerk/api/routes/auth.py
+++ b/src/harbor_clerk/api/routes/auth.py
@@ -24,9 +24,18 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["auth"])
 
 
+def _is_secure_request(request: Request) -> bool:
+    """Check if the request came over HTTPS (directly or via reverse proxy)."""
+    proto = request.headers.get("x-forwarded-proto", "")
+    if proto:
+        return proto == "https"
+    return request.url.scheme == "https"
+
+
 @router.post("/auth/login", response_model=LoginResponse)
 async def login(
     body: LoginRequest,
+    request: Request,
     response: Response,
     session: AsyncSession = Depends(get_session),
 ):
@@ -65,7 +74,7 @@ async def login(
         key="refresh_token",
         value=refresh_token,
         httponly=True,
-        secure=True,
+        secure=_is_secure_request(request),
         samesite="strict",
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/api/auth",
@@ -126,7 +135,7 @@ async def refresh(
         key="refresh_token",
         value=new_refresh,
         httponly=True,
-        secure=True,
+        secure=_is_secure_request(request),
         samesite="strict",
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/api/auth",

--- a/src/harbor_clerk/api/routes/setup.py
+++ b/src/harbor_clerk/api/routes/setup.py
@@ -3,11 +3,12 @@
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from harbor_clerk.api.routes.auth import _is_secure_request
 from harbor_clerk.api.schemas.auth import LoginResponse, UserInfo
 from harbor_clerk.auth import create_access_token, create_refresh_token, hash_password
 from harbor_clerk.config import get_settings
@@ -28,6 +29,7 @@ class SetupRequest(BaseModel):
 @router.post("/setup", response_model=LoginResponse, status_code=status.HTTP_201_CREATED)
 async def setup(
     body: SetupRequest,
+    request: Request,
     response: Response,
     session: AsyncSession = Depends(get_session),
 ):
@@ -75,7 +77,7 @@ async def setup(
         key="refresh_token",
         value=refresh_token,
         httponly=True,
-        secure=True,
+        secure=_is_secure_request(request),
         samesite="strict",
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/api/auth",


### PR DESCRIPTION
## Summary

- **Native login screen**: SwiftUI login form replaces the web login, enabling macOS Keychain / password manager autofill (which Apple blocks in WKWebView on localhost)
- **Keychain persistence**: "Remember me" saves credentials; subsequent launches auto-login silently
- **Secure cookie fix**: `secure=True` on refresh cookies was silently breaking session persistence on `http://localhost` — now conditional on request scheme

## New files

| File | Purpose |
|------|---------|
| `KeychainManager.swift` | Security framework wrapper (save/load/delete) |
| `AuthManager.swift` | Auth state machine, API calls, WKWebView cookie injection |
| `LoginView.swift` | Native SwiftUI login form |

## State machine

```
App Launch → Backend polling
  → Server available → Check setup-status
    → needs_setup → Load WebView (setup page)
    → Keychain creds? → Auto-login API call
      → Success → Inject cookie → Load WebView (authenticated)
      → Failure → Clear Keychain → Show native LoginView
    → No creds → Show native LoginView
  → Server unavailable → "Waiting for server" UI
Web logout (navigates to /login) → Intercepted → Show native LoginView
```

## Test plan

- [ ] `make apps` builds clean
- [ ] `uv run pytest tests/ -x -q` — 92 passed
- [ ] First launch: native login form appears
- [ ] Wrong credentials → error shown
- [ ] Correct credentials + Remember me → WebView loads authenticated
- [ ] Keychain Access.app shows entry under `com.harborclerk.HarborClerk`
- [ ] Quit + relaunch → auto-login from Keychain
- [ ] Logout in web UI → native login reappears
- [ ] First-time setup (empty DB) → WebView loads setup page
- [ ] Light and dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)