### PR TITLE
feat: add kb_entity_cooccurrence MCP tool

### DIFF
--- a/docs/plans/2026-02-26-mcp-enhancements-roadmap.md
+++ b/docs/plans/2026-02-26-mcp-enhancements-roadmap.md
@@ -58,7 +58,7 @@
 
 ## Status
 
-All 9 features shipped in v0.4.0.
+Features 1–9 shipped in v0.4.0. Features 10–12 are the next batch.
 
 | # | Feature | Status |
 |---|---------|--------|
@@ -71,6 +71,43 @@ All 9 features shipped in v0.4.0.
 | 7 | Cross-Document Similarity | **Done** |
 | 8 | Entity Extraction | **Done** |
 | 9 | Auto-Inject RAG | **Done** |
+| 10 | Entity Co-occurrence | Planned |
+| 11 | Full-Document Retrieval | Planned |
+| 12 | Batch Search | Planned |
+
+---
+
+## Feature List (next batch)
+
+### 10. Entity Co-occurrence Queries
+
+New `kb_entity_cooccurrence` tool: given an entity (text + optional type), find other entities that co-occur with it. Configurable scope — same chunk (tight proximity, strong signal) or same document (broader net).
+
+- **Impact: High.** "Which organizations are mentioned alongside John Smith?" is a daily question for law firms, researchers, policy analysts. This is the relationship-discovery layer on top of Feature 8.
+- **Effort: Low-Medium.** Query-layer feature only — self-join on existing `entities` table, no new ingestion stage, no schema migration, no CPU cost.
+- **Parameters:** `entity_text` (required), `entity_type` (optional filter on the target entity), `scope` (chunk | document, default chunk), `cooccur_type` (optional filter on co-occurring entity types), `doc_id` (optional scoping), `limit`, `offset`
+- **Returns:** Co-occurring entities with mention counts, scoped appropriately. Each result includes entity_text, entity_type, cooccurrence_count, and sample doc_ids/chunk_ids for citation.
+- **YAGNI risk: Low.** If you have entity extraction, co-occurrence is the natural next question.
+
+### 11. Full-Document Retrieval
+
+New `kb_read_document` tool: retrieve the full extracted text of a document, paginated by page range. For short documents (memos, policies, one-page letters), an LLM needs to read the whole thing without chaining chunk-by-chunk reads.
+
+- **Impact: Medium.** "Summarize this document" is a common request. Currently requires chaining `kb_expand_context` or guessing chunk IDs.
+- **Effort: Low.** Query all chunks for a version ordered by chunk_num, paginate by page range. All data already exists.
+- **Parameters:** `doc_id` (required), `page_start` (optional, default 1), `page_end` (optional, default last page)
+- **Returns:** doc_id, version_id, title, page_count, total_chars, pages requested, and concatenated text (with page break markers). Caps output to prevent returning a 500-page PDF in one call.
+- **YAGNI risk: Low-Medium.** Short documents are common in all target use cases.
+
+### 12. Batch Search
+
+New `kb_batch_search` tool: run multiple search queries in a single call, returning results grouped by query. Saves round-trips during comparative analysis ("do any of these case files mention X, Y, or Z?").
+
+- **Impact: Medium.** Reduces latency for cross-cutting analysis. Each round-trip is time the user waits.
+- **Effort: Low.** Loop over existing `hybrid_search`, return grouped results.
+- **Parameters:** `queries` (list of strings, max 5), plus shared filter params (doc_id, doc_ids, after, before, language, mime_type), `k` per query, `detail`
+- **Returns:** Array of result sets, one per query, same shape as `kb_search` response.
+- **YAGNI risk: Medium.** LLMs can call `kb_search` sequentially, but batching is a genuine convenience for multi-query patterns.
 
 ---
 
@@ -110,9 +147,20 @@ Possible approaches:
 
 No good automatic heuristic yet — context window size correlates loosely with tool-handling ability but isn't a reliable proxy. For now, the simplified schemas work and the full MCP tools remain available to external agents (Claude, etc.) that can handle the complexity.
 
-### Entity Co-occurrence Graph
+### DATE Entity Filtering Improvements
 
-Once Feature 8 (Entity Extraction) is in place, a natural extension is a `kb_entity_graph` tool that finds entities mentioned near a given entity (within N chunks). This enables relationship discovery — e.g., "which organizations are mentioned alongside John Smith?" Deferred because the core entity search + overview tools cover the primary use case; co-occurrence is a power-user feature that can be layered on top of the same `entities` table without schema changes.
+Improve `kb_entity_search` for date-type queries. Currently DATE entities are stored as raw text ("March 2020", "2019-01-15"), making them hard to filter or sort meaningfully. Low-effort improvements without a new pipeline stage:
+- Sort DATE entities chronologically when `entity_type=DATE` (best-effort parsing of common date formats)
+- Add a `sort` param to `kb_entity_search` (e.g., `sort=chronological` for dates, `sort=frequency` for others)
+- No date normalization or temporal range extraction — that's a separate, high-effort feature (see below)
+
+**Decision:** Low-effort query improvement. No new ingestion, no CPU cost. Useful but not urgent — DATE entities are already queryable via substring search.
+
+### Temporal Awareness (Date Range Extraction)
+
+Full chunk-level temporal awareness: extract and normalize date references during ingestion, store as queryable date ranges, enable "find chunks about events in 2020-2021" queries. Would require NLP date extraction (beyond spaCy's NER), normalization to ISO ranges, disambiguation (document date vs event date), new schema, new query interface.
+
+**Decision:** Deferred. High effort, high ambiguity (does "March 2020" mean authored then or describes an event then?), highly corpus-dependent. The existing DATE entity extraction from Feature 8 captures the raw strings; this would be a major extension. Revisit if user feedback shows strong demand.
 
 ### PostgreSQL 17 Upgrade (target: v0.5.0)
 

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import func, select, update
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 
 from harbor_clerk.api.deps import Principal
 from harbor_clerk.auth import API_KEY_PREFIXES, decode_token, hash_api_key
@@ -1125,6 +1125,132 @@ async def kb_entity_overview(doc_id: str | None = None) -> str:
             "unique_entities": unique,
             "type_distribution": type_distribution,
             "top_entities": top_entities,
+        },
+        indent=2,
+    )
+
+
+@mcp.tool()
+async def kb_entity_cooccurrence(
+    entity_text: str,
+    entity_type: str | None = None,
+    scope: str = "chunk",
+    cooccur_type: str | None = None,
+    doc_id: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> str:
+    """Find entities that co-occur with a given entity.
+
+    Discovers relationships by finding which other entities appear alongside
+    the specified entity in the same chunk or document.
+
+    Args:
+        entity_text: The entity text to find co-occurrences for (case-insensitive).
+        entity_type: Optional — filter the source entity by type (PERSON, ORG, etc.).
+        scope: "chunk" (same chunk) or "document" (same document version). Default "chunk".
+        cooccur_type: Optional — filter co-occurring entities by type.
+        doc_id: Optional — scope to a single document's latest version.
+        limit: Max results (1-100, default 20).
+        offset: Pagination offset.
+    """
+    _get_principal()
+
+    if scope not in ("chunk", "document"):
+        return json.dumps({"error": f"Invalid scope '{scope}'. Must be 'chunk' or 'document'."})
+
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+
+    escaped_text = re.sub(r"([%_\\])", r"\\\1", entity_text)
+
+    e1 = aliased(Entity, name="e1")
+    e2 = aliased(Entity, name="e2")
+
+    async with async_session_factory() as session:
+        # Version filter: active docs' latest versions
+        if doc_id:
+            did = uuid.UUID(doc_id)
+            doc = (
+                await session.execute(select(Document).where(Document.doc_id == did, Document.status == "active"))
+            ).scalar_one_or_none()
+            if doc is None:
+                return json.dumps({"error": "Document not found"})
+            if not doc.latest_version_id:
+                return json.dumps(
+                    {"entity_text": entity_text, "scope": scope, "cooccurrences": [], "total": 0, "has_more": False}
+                )
+            version_filter_e1 = [e1.version_id == doc.latest_version_id]
+            version_filter_e2 = [e2.version_id == doc.latest_version_id]
+        else:
+            active_versions = select(Document.latest_version_id).where(
+                Document.status == "active",
+                Document.latest_version_id.isnot(None),
+            )
+            version_filter_e1 = [e1.version_id.in_(active_versions)]
+            version_filter_e2 = [e2.version_id.in_(active_versions)]
+
+        # Source entity filter
+        source_filter = [e1.entity_text.ilike(f"%{escaped_text}%"), *version_filter_e1]
+        if entity_type:
+            source_filter.append(e1.entity_type == entity_type)
+
+        # Join condition based on scope
+        if scope == "chunk":
+            join_cond = e2.chunk_id == e1.chunk_id
+        else:
+            join_cond = e2.version_id == e1.version_id
+
+        # Co-occurring entity filters
+        cooccur_filter = [*version_filter_e2]
+        if cooccur_type:
+            cooccur_filter.append(e2.entity_type == cooccur_type)
+
+        # Exclude self-matches
+        self_exclude = ~(
+            (func.lower(e2.entity_text) == func.lower(e1.entity_text)) & (e2.entity_type == e1.entity_type)
+        )
+
+        # Build the query
+        base_q = (
+            select(
+                e2.entity_text,
+                e2.entity_type,
+                func.count().label("cooccurrence_count"),
+                func.array_agg(func.distinct(e2.chunk_id)).label("sample_chunk_ids"),
+                func.array_agg(func.distinct(e2.doc_id)).label("sample_doc_ids"),
+            )
+            .join(e1, join_cond)
+            .where(*source_filter, *cooccur_filter, self_exclude)
+            .group_by(e2.entity_text, e2.entity_type)
+        )
+
+        # Total count
+        total = (await session.execute(select(func.count()).select_from(base_q.subquery()))).scalar() or 0
+
+        # Paginated results
+        rows = (
+            await session.execute(base_q.order_by(func.count().desc(), e2.entity_text).offset(offset).limit(limit))
+        ).all()
+
+        cooccurrences = [
+            {
+                "entity_text": r.entity_text,
+                "entity_type": r.entity_type,
+                "cooccurrence_count": r.cooccurrence_count,
+                "sample_chunk_ids": [str(cid) for cid in r.sample_chunk_ids[:3]],
+                "sample_doc_ids": [str(did) for did in list(dict.fromkeys(r.sample_doc_ids))[:3]],
+            }
+            for r in rows
+        ]
+
+    return json.dumps(
+        {
+            "entity_text": entity_text,
+            "scope": scope,
+            "cooccurrences": cooccurrences,
+            "total": total,
+            "has_more": offset + limit < total,
         },
         indent=2,
     )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -13,6 +13,7 @@ from harbor_clerk.mcp_server import (
     _mcp_principal,
     kb_corpus_overview,
     kb_document_outline,
+    kb_entity_cooccurrence,
     kb_entity_overview,
     kb_entity_search,
     kb_expand_context,
@@ -916,3 +917,142 @@ async def test_entity_overview_empty(
     assert result["unique_entities"] == 0
     assert result["type_distribution"] == {}
     assert result["top_entities"] == []
+
+
+# ---------------------------------------------------------------------------
+# Entity co-occurrence tests
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_cooccurrence_chunk_scope(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Chunk scope: entities in same chunk as 'John Smith'."""
+    result = json.loads(await kb_entity_cooccurrence("John Smith", scope="chunk"))
+    assert result["scope"] == "chunk"
+    texts = {c["entity_text"] for c in result["cooccurrences"]}
+    assert "Acme Corp" in texts
+    assert "New York" in texts
+    assert "Paris" not in texts  # Paris is in a different chunk
+    for c in result["cooccurrences"]:
+        assert c["cooccurrence_count"] == 1
+
+
+async def test_entity_cooccurrence_document_scope(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Document scope: all entities in same version as 'Paris'."""
+    result = json.loads(await kb_entity_cooccurrence("Paris", scope="document"))
+    texts = {c["entity_text"] for c in result["cooccurrences"]}
+    assert "John Smith" in texts
+    assert "Acme Corp" in texts
+    assert "New York" in texts
+    # John Smith appears in 2 chunks in the same version
+    john = next(c for c in result["cooccurrences"] if c["entity_text"] == "John Smith")
+    assert john["cooccurrence_count"] == 2
+
+
+async def test_entity_cooccurrence_cooccur_type_filter(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Filter co-occurring entities by type."""
+    result = json.loads(await kb_entity_cooccurrence("John Smith", cooccur_type="ORG"))
+    assert all(c["entity_type"] == "ORG" for c in result["cooccurrences"])
+    texts = {c["entity_text"] for c in result["cooccurrences"]}
+    assert "Acme Corp" in texts
+    assert "New York" not in texts
+
+
+async def test_entity_cooccurrence_source_type_filter(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Filter source entity by type."""
+    result = json.loads(await kb_entity_cooccurrence("John", entity_type="PERSON", scope="chunk"))
+    texts = {c["entity_text"] for c in result["cooccurrences"]}
+    assert "Acme Corp" in texts
+    assert "New York" in texts
+
+
+async def test_entity_cooccurrence_no_results_chunk(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Paris is alone in its chunk — no co-occurrences at chunk scope."""
+    result = json.loads(await kb_entity_cooccurrence("Paris", scope="chunk"))
+    assert result["cooccurrences"] == []
+    assert result["total"] == 0
+
+
+async def test_entity_cooccurrence_invalid_scope(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Invalid scope returns error."""
+    result = json.loads(await kb_entity_cooccurrence("John", scope="paragraph"))
+    assert "error" in result
+
+
+async def test_entity_cooccurrence_doc_id_scoped(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Scope to a specific document."""
+    doc, _ = sample_doc
+    result = json.loads(await kb_entity_cooccurrence("John Smith", doc_id=str(doc.doc_id)))
+    texts = {c["entity_text"] for c in result["cooccurrences"]}
+    assert "Acme Corp" in texts
+    assert "New York" in texts
+
+
+async def test_entity_cooccurrence_entity_not_found(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    sample_doc,
+    sample_chunks,
+    sample_entities,
+):
+    """Nonexistent entity returns empty results."""
+    result = json.loads(await kb_entity_cooccurrence("Nonexistent Entity XYZ"))
+    assert result["cooccurrences"] == []
+    assert result["total"] == 0


### PR DESCRIPTION
## Summary
- Adds `kb_entity_cooccurrence` MCP tool for discovering entity relationships via co-occurrence
- Supports chunk scope (same chunk) and document scope (same version) with type filters, doc_id scoping, and pagination
- Self-joins `entities` table using `aliased()` — no new schema or indexes needed
- 8 test cases covering all parameter combinations and edge cases

## Test plan
- [x] `uv run pytest tests/test_mcp_tools.py -k entity_cooccurrence` — 8/8 pass
- [x] `uv run pytest tests/test_mcp_tools.py` — all 43 tests pass
- [x] `uv run ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)