### PR TITLE
feat: scoped API keys

### DIFF
--- a/alembic/versions/0013_scoped_api_keys.py
+++ b/alembic/versions/0013_scoped_api_keys.py
@@ -1,0 +1,39 @@
+"""Add scoping fields to api_keys.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "api_keys",
+        sa.Column("permission_tier", sa.Text(), nullable=False, server_default="full"),
+    )
+    op.add_column(
+        "api_keys",
+        sa.Column("tool_overrides", postgresql.JSONB(), nullable=False, server_default="{}"),
+    )
+    op.add_column("api_keys", sa.Column("scope_topic_ids", postgresql.JSONB(), nullable=True))
+    op.add_column("api_keys", sa.Column("scope_folder_ids", postgresql.JSONB(), nullable=True))
+    op.add_column("api_keys", sa.Column("max_snippet_chars", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "max_snippet_chars")
+    op.drop_column("api_keys", "scope_folder_ids")
+    op.drop_column("api_keys", "scope_topic_ids")
+    op.drop_column("api_keys", "tool_overrides")
+    op.drop_column("api_keys", "permission_tier")
+    op.drop_column("api_keys", "expires_at")

--- a/docs/superpowers/plans/2026-04-09-scoped-api-keys.md
+++ b/docs/superpowers/plans/2026-04-09-scoped-api-keys.md
@@ -580,7 +580,7 @@ Expected: `ImportError: cannot import name 'apply_key_scope'`
 
 - [ ] **Step 3: Implement apply_key_scope**
 
-Add to `src/harbor_clerk/api/scope.py`:
+Add to `src/harbor_clerk/api/scope.py`. Note: `Principal` is imported lazily under `TYPE_CHECKING` to avoid a circular dep with `deps.py` (which imports `KeyScope` from this module). The model imports are top-level — they don't import deps.py.
 
 ```python
 import uuid
@@ -588,6 +588,9 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, select
 from sqlalchemy.sql import Select
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
 
 if TYPE_CHECKING:
     from harbor_clerk.api.deps import Principal
@@ -607,10 +610,6 @@ def apply_key_scope(query: Select, principal: "Principal") -> Select:
     scope = principal.key_scope
     if scope.is_unrestricted:
         return query
-
-    # Lazy imports to avoid circular dependencies
-    from harbor_clerk.models.document import Document
-    from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
 
     conditions = []
     if scope.scope_topic_ids is not None:
@@ -640,7 +639,92 @@ def apply_key_scope(query: Select, principal: "Principal") -> Select:
 uv run pytest tests/test_scoped_api_keys.py -v
 ```
 
-- [ ] **Step 5: Lint and commit**
+- [ ] **Step 5: Add integration tests with real DB data**
+
+The unit tests above check query string generation. Add integration tests that exercise the actual filtering against the test DB. These run in CI via the pgvector service container.
+
+Append to `tests/test_scoped_api_keys.py`:
+
+```python
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.api_key import ApiKey
+from harbor_clerk.auth import generate_api_key, hash_api_key
+
+
+@pytest_asyncio.fixture
+async def two_topic_docs(db_session: AsyncSession):
+    """Create 2 documents in topic 1 and 1 document in topic 2."""
+    docs = [
+        Document(title="Doc A1", canonical_filename="a1.txt", topic_id=1, status="active"),
+        Document(title="Doc A2", canonical_filename="a2.txt", topic_id=1, status="active"),
+        Document(title="Doc B1", canonical_filename="b1.txt", topic_id=2, status="active"),
+    ]
+    for d in docs:
+        db_session.add(d)
+    await db_session.commit()
+    yield docs
+    for d in docs:
+        await db_session.delete(d)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_scope_filters_by_topic_in_db(db_session, two_topic_docs):
+    """Real DB: key scoped to topic 1 sees only those documents."""
+    scope = KeyScope(
+        scope_topic_ids=[1], scope_folder_ids=None,
+        permission_tier="full", tool_overrides={}, max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = apply_key_scope(sa_select(Document), p)
+    result = await db_session.execute(query)
+    docs = result.scalars().all()
+    assert len(docs) == 2
+    assert all(d.topic_id == 1 for d in docs)
+
+
+@pytest.mark.asyncio
+async def test_unrestricted_key_sees_all_in_db(db_session, two_topic_docs):
+    """Real DB: unrestricted key sees all documents."""
+    scope = KeyScope(
+        scope_topic_ids=None, scope_folder_ids=None,
+        permission_tier="full", tool_overrides={}, max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = apply_key_scope(sa_select(Document), p)
+    result = await db_session.execute(query)
+    docs = result.scalars().all()
+    assert len(docs) == 3
+
+
+@pytest.mark.asyncio
+async def test_empty_topic_list_blocks_all_in_db(db_session, two_topic_docs):
+    """Real DB: scope_topic_ids=[] blocks everything (no topics match)."""
+    scope = KeyScope(
+        scope_topic_ids=[], scope_folder_ids=None,
+        permission_tier="full", tool_overrides={}, max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = apply_key_scope(sa_select(Document), p)
+    result = await db_session.execute(query)
+    docs = result.scalars().all()
+    assert len(docs) == 0
+```
+
+Note: this assumes a `db_session` fixture exists in conftest.py. If not, follow the pattern in existing test_*.py files (e.g. test_watch_pipeline.py for a simpler version, or test_watch_api.py if API integration tests already exist).
+
+- [ ] **Step 6: Run integration tests**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py -v
+```
+
+Expected: all unit AND integration tests pass.
+
+- [ ] **Step 7: Lint and commit**
 
 ```bash
 uv run ruff check src/harbor_clerk/api/scope.py tests/test_scoped_api_keys.py
@@ -719,12 +803,14 @@ git commit -m "feat(scoped-keys): apply_key_scope to docs list, get, and search"
 **Files:**
 - Modify: `src/harbor_clerk/mcp_server.py`
 
-This is the largest single task — there are 13 MCP tools that read documents/chunks. We need to apply scope to each. The pattern depends on what the tool fetches:
+This is the largest single task — there are 14 MCP tools that read documents/chunks/jobs. We need to apply scope to each. The pattern depends on what the tool fetches:
 
-- **Document-based tools** (kb_get_document, kb_list_recent, kb_find_related, kb_corpus_overview, kb_document_outline, kb_entity_overview): pass `principal` to internal helpers and use `apply_key_scope`.
-- **Search tools** (kb_search, kb_batch_search): same as Task 6 search filtering — compute visible doc_ids and filter.
-- **Chunk-based tools** (kb_read_passages, kb_expand_context): fetch chunks first, then filter to chunks whose `doc_id` is in the visible set. **This is the chunk-level enforcement from spec finding #6.**
-- **Entity tools** (kb_entity_search, kb_entity_cooccurrence): join via chunk → document → scope.
+- **Document-based tools** (kb_get_document, kb_list_recent, kb_find_related, kb_document_outline): pass `principal` to internal helpers and use `apply_key_scope`.
+- **Aggregate stats** (kb_corpus_overview): see Step 3 below — counts/languages/types must reflect the scoped subset, not the full corpus.
+- **Search tools** (kb_search, kb_batch_search): compute visible doc_ids and filter results.
+- **Chunk-based tools** (kb_read_passages, kb_expand_context): fetch chunks first, then filter to chunks whose `doc_id` is in the visible set. **This is the chunk-level enforcement.**
+- **Entity tools** (kb_entity_search, kb_entity_overview, kb_entity_cooccurrence): join via chunk → document → scope.
+- **Job status** (kb_ingest_status): join `IngestionJob → DocumentVersion → Document` to filter to versions whose document is in the visible set. Otherwise scoped agents can discover document existence via ingestion status.
 
 - [ ] **Step 1: Add a helper at the top of mcp_server.py (after _get_principal)**
 
@@ -747,14 +833,27 @@ For each `@mcp.tool()` function in `mcp_server.py`:
 2. Compute `visible_ids = await _visible_doc_ids(session, principal)`
 3. If `visible_ids is not None`, add `Document.doc_id.in_(visible_ids)` to the query, OR filter the result rows in Python.
 
-The 13 tools to update (find them with `grep -n '@mcp.tool()' src/harbor_clerk/mcp_server.py`):
+The 14 tools to update (find them with `grep -n '@mcp.tool()' src/harbor_clerk/mcp_server.py`):
 - kb_search, kb_batch_search
 - kb_read_passages, kb_expand_context
 - kb_get_document, kb_list_recent
 - kb_corpus_overview, kb_document_outline
-- kb_find_related, kb_entity_search
-- kb_entity_overview, kb_entity_cooccurrence
-- kb_read_document, kb_ingest_status
+- kb_find_related, kb_read_document
+- kb_entity_search, kb_entity_overview, kb_entity_cooccurrence
+- kb_ingest_status
+
+For `kb_ingest_status`, the join path is `IngestionJob.version_id → DocumentVersion.doc_id → Document.doc_id`. Filter the query so only jobs for documents in `visible_ids` are returned.
+
+- [ ] **Step 2a: Special case — kb_corpus_overview aggregate stats**
+
+`kb_corpus_overview` returns counts (document_count, total_chunks, total_pages), language histogram, mime_type histogram, date_range, and a list of CorpusDocumentSummary. ALL of these must reflect the scoped subset.
+
+Concretely: in the `corpus_overview` MCP tool, compute `visible_ids = await _visible_doc_ids(session, principal)` once. Then:
+- For every aggregate query (document_count, language histogram, mime_type histogram, date_range, total_chunks, total_pages), add `WHERE Document.doc_id.in_(visible_ids)` (or join Chunk → Document and filter there for chunk/page counts).
+- For the document list, add the same filter.
+- If `visible_ids is None`, no filter — full corpus stats.
+
+This is non-trivial because the existing function likely builds 5+ separate queries. Each one needs the filter. Walk through them carefully.
 
 For `kb_read_passages` and `kb_expand_context` specifically (chunk-based), filter chunks AFTER fetching:
 
@@ -899,29 +998,44 @@ Then subclass FastMCP. Replace `mcp = FastMCP(...)` with:
 
 ```python
 class ScopedFastMCP(FastMCP):
-    """FastMCP subclass that filters tool listing and calls by API key scope."""
+    """FastMCP subclass that filters tool listing and calls by API key scope.
+
+    Security: list_tools is a UX layer; the real enforcement is call_tool +
+    the apply_key_scope filters in each tool body. So even if list_tools is
+    bypassed (e.g. via the lowlevel server's tool cache), tool calls are
+    still rejected.
+    """
 
     async def list_tools(self):
         all_tools = await super().list_tools()
         try:
             principal = _get_principal()
         except PermissionError:
-            return all_tools  # not yet authenticated — return everything
-        allowed_names = set(_filter_tools_for_principal([t.name for t in all_tools], principal))
-        return [t for t in all_tools if t.name in allowed_names]
+            # No principal context (e.g. internal tool-cache refresh).
+            # Return [] rather than all_tools so we don't pollute caches with
+            # full visibility. Real per-call enforcement happens in call_tool.
+            return []
+        if principal.type != "api_key" or principal.key_scope is None:
+            return all_tools
+        allowed = principal.key_scope.effective_tools
+        return [t for t in all_tools if t.name in allowed]
 
     async def call_tool(self, name, arguments):
         try:
             principal = _get_principal()
         except PermissionError:
+            # No principal — let the underlying handler decide
+            # (this should not happen on a real call path; auth middleware sets it)
             return await super().call_tool(name, arguments)
         if principal.type == "api_key" and principal.key_scope is not None:
             if name not in principal.key_scope.effective_tools:
-                # Tool not in this key's set — return MCP "unknown tool" error
-                from mcp.shared.exceptions import McpError
-                from mcp.types import ErrorData
+                # Tool not in this key's set. McpError gets converted to an
+                # isError tool result by the lowlevel handler, which is fine —
+                # the agent just sees a clean error and the tool is effectively
+                # invisible.
+                from mcp.server.fastmcp.exceptions import ToolError
 
-                raise McpError(ErrorData(code=-32601, message=f"Unknown tool: {name}"))
+                raise ToolError(f"Unknown tool: {name}")
         return await super().call_tool(name, arguments)
 
 

--- a/docs/superpowers/plans/2026-04-09-scoped-api-keys.md
+++ b/docs/superpowers/plans/2026-04-09-scoped-api-keys.md
@@ -1,0 +1,1299 @@
+# Scoped API Keys Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-API-key access controls (document scoping by topic/folder, MCP tool tier with overrides, expiry dates, snippet size limits) so admins can give external agentic harnesses controlled, narrow access to a subset of the corpus.
+
+**Architecture:** Extend the `api_keys` table with 6 new columns. Carry scope data on the `Principal` dataclass (loaded once at auth time, no per-call DB hits). New `apply_key_scope()` helper modifies SQLAlchemy queries to filter documents. MCP tool gating via `list_tools` / `call_tool` overrides on a FastMCP subclass — silently omit tools the key isn't allowed to use.
+
+**Tech Stack:** Python (FastAPI, SQLAlchemy 2.0 async, Pydantic v2, Alembic), FastMCP, React/TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-04-07-scoped-api-keys-design.md`
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|---|---|
+| `alembic/versions/0013_scoped_api_keys.py` | Migration: 6 new columns on `api_keys` |
+| `src/harbor_clerk/api/scope.py` | `apply_key_scope()` helper, tier→tools mapping, KeyScope dataclass |
+| `tests/test_scoped_api_keys.py` | Auth, scope filtering, expiry, JSON parsing tests |
+| `tests/test_mcp_tool_filtering.py` | FastMCP tool filtering tests |
+
+### Modified Files
+
+| File | Changes |
+|---|---|
+| `src/harbor_clerk/models/api_key.py` | Add 6 columns |
+| `src/harbor_clerk/api/deps.py` | Extend `Principal` with `key_scope`, populate at auth, expiry check |
+| `src/harbor_clerk/api/schemas/api_keys.py` | New request/response models for create + patch + scope-preview |
+| `src/harbor_clerk/api/routes/api_keys.py` | Extend POST, add PATCH, add scope-preview, enrich GET response |
+| `src/harbor_clerk/mcp_server.py` | FastMCP subclass with filtered list_tools/call_tool, expiry check in `_resolve_principal` |
+| `src/harbor_clerk/api/routes/documents.py` | Apply scope to GET /docs and GET /docs/{id} |
+| `src/harbor_clerk/api/routes/search.py` | Apply scope to search results |
+| `src/harbor_clerk/llm/research.py` (chunk reads) | Chunk-level scope filter for kb_read_passages |
+| `frontend/src/pages/ApiKeysPage.tsx` | Expanded create form, edit panel, scope preview |
+
+---
+
+## Permission Tiers (Reference)
+
+Computed by `compute_effective_tools(tier, overrides)` in `scope.py`:
+
+| Tier | Base Tools |
+|---|---|
+| `search` | kb_search, kb_batch_search, kb_corpus_overview, kb_list_recent |
+| `read` | search + kb_read_passages, kb_expand_context, kb_document_outline, kb_get_document |
+| `full` | read + kb_read_document, kb_find_related, kb_entity_search, kb_entity_overview, kb_entity_cooccurrence, kb_ingest_status |
+
+**Admin-only** (excluded from all tiers): `kb_system_health`, `kb_reprocess`
+
+`tool_overrides` is a dict of `{tool_name: bool}` — `true` adds, `false` removes. Admin-only tools are always excluded.
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `alembic/versions/0013_scoped_api_keys.py`
+
+- [ ] **Step 1: Write the migration**
+
+```python
+"""Add scoping fields to api_keys.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "api_keys",
+        sa.Column("permission_tier", sa.Text(), nullable=False, server_default="full"),
+    )
+    op.add_column(
+        "api_keys",
+        sa.Column("tool_overrides", postgresql.JSONB(), nullable=False, server_default="{}"),
+    )
+    op.add_column("api_keys", sa.Column("scope_topic_ids", postgresql.JSONB(), nullable=True))
+    op.add_column("api_keys", sa.Column("scope_folder_ids", postgresql.JSONB(), nullable=True))
+    op.add_column("api_keys", sa.Column("max_snippet_chars", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "max_snippet_chars")
+    op.drop_column("api_keys", "scope_folder_ids")
+    op.drop_column("api_keys", "scope_topic_ids")
+    op.drop_column("api_keys", "tool_overrides")
+    op.drop_column("api_keys", "permission_tier")
+    op.drop_column("api_keys", "expires_at")
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/scoped-api-keys
+uv run ruff check alembic/versions/0013_scoped_api_keys.py
+```
+
+Expected: All checks passed!
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add alembic/versions/0013_scoped_api_keys.py
+git commit -m "feat(scoped-keys): migration adding 6 scope columns to api_keys"
+```
+
+---
+
+## Task 2: Update ApiKey Model
+
+**Files:**
+- Modify: `src/harbor_clerk/models/api_key.py`
+
+- [ ] **Step 1: Read the current model**
+
+```bash
+cat src/harbor_clerk/models/api_key.py
+```
+
+- [ ] **Step 2: Add the new fields**
+
+Add these fields after `last_used_at`. Update imports as needed:
+
+```python
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Integer, Text
+from sqlalchemy.dialects.postgresql import JSONB
+
+# ... existing imports
+
+class ApiKey(Base):
+    # ... existing columns ...
+    
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    permission_tier: Mapped[str] = mapped_column(Text, nullable=False, server_default="full")
+    tool_overrides: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    scope_topic_ids: Mapped[list[int] | None] = mapped_column(JSONB, nullable=True)
+    scope_folder_ids: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    max_snippet_chars: Mapped[int | None] = mapped_column(Integer, nullable=True)
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+uv run ruff check src/harbor_clerk/models/api_key.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/harbor_clerk/models/api_key.py
+git commit -m "feat(scoped-keys): ApiKey model fields for scope/tier/expiry"
+```
+
+---
+
+## Task 3: KeyScope dataclass and tier mapping
+
+**Files:**
+- Create: `src/harbor_clerk/api/scope.py`
+- Test: `tests/test_scoped_api_keys.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_scoped_api_keys.py`:
+
+```python
+"""Tests for scoped API keys."""
+from harbor_clerk.api.scope import (
+    KeyScope,
+    compute_effective_tools,
+    SEARCH_TIER_TOOLS,
+    READ_TIER_TOOLS,
+    FULL_TIER_TOOLS,
+    ADMIN_ONLY_TOOLS,
+)
+
+
+def test_search_tier_has_search_tools():
+    tools = compute_effective_tools("search", {})
+    assert "kb_search" in tools
+    assert "kb_batch_search" in tools
+    assert "kb_corpus_overview" in tools
+    assert "kb_list_recent" in tools
+    # No read tools
+    assert "kb_read_passages" not in tools
+    # No admin tools
+    assert "kb_system_health" not in tools
+    assert "kb_reprocess" not in tools
+
+
+def test_read_tier_extends_search():
+    tools = compute_effective_tools("read", {})
+    assert "kb_search" in tools  # search tier inherited
+    assert "kb_read_passages" in tools
+    assert "kb_expand_context" in tools
+    assert "kb_document_outline" in tools
+    assert "kb_get_document" in tools
+    # Not in this tier
+    assert "kb_find_related" not in tools
+    assert "kb_entity_search" not in tools
+
+
+def test_full_tier_has_most_tools():
+    tools = compute_effective_tools("full", {})
+    assert "kb_read_document" in tools
+    assert "kb_entity_search" in tools
+    assert "kb_find_related" in tools
+    # Admin tools never included
+    assert "kb_system_health" not in tools
+    assert "kb_reprocess" not in tools
+
+
+def test_overrides_can_remove_tool():
+    tools = compute_effective_tools("full", {"kb_read_document": False})
+    assert "kb_read_document" not in tools
+    assert "kb_search" in tools  # other tools unchanged
+
+
+def test_overrides_can_add_tool():
+    tools = compute_effective_tools("search", {"kb_read_passages": True})
+    assert "kb_read_passages" in tools
+
+
+def test_overrides_cannot_grant_admin_tools():
+    tools = compute_effective_tools("full", {"kb_system_health": True})
+    assert "kb_system_health" not in tools
+    tools = compute_effective_tools("full", {"kb_reprocess": True})
+    assert "kb_reprocess" not in tools
+
+
+def test_unknown_tier_treated_as_full():
+    # Defensive — unknown tier shouldn't crash
+    tools = compute_effective_tools("nonsense", {})
+    assert "kb_search" in tools
+
+
+def test_keyscope_default_no_restrictions():
+    scope = KeyScope(
+        scope_topic_ids=None,
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    assert scope.is_unrestricted is True
+
+
+def test_keyscope_with_topic_filter_is_restricted():
+    scope = KeyScope(
+        scope_topic_ids=[1, 2],
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    assert scope.is_unrestricted is False
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'harbor_clerk.api.scope'`
+
+- [ ] **Step 3: Create the module**
+
+Create `src/harbor_clerk/api/scope.py`:
+
+```python
+"""Per-API-key scope computation: tiers, tool sets, and query filters."""
+
+from dataclasses import dataclass
+
+# Tier -> base tool set
+SEARCH_TIER_TOOLS: frozenset[str] = frozenset(
+    {"kb_search", "kb_batch_search", "kb_corpus_overview", "kb_list_recent"}
+)
+READ_TIER_TOOLS: frozenset[str] = SEARCH_TIER_TOOLS | frozenset(
+    {"kb_read_passages", "kb_expand_context", "kb_document_outline", "kb_get_document"}
+)
+FULL_TIER_TOOLS: frozenset[str] = READ_TIER_TOOLS | frozenset(
+    {
+        "kb_read_document",
+        "kb_find_related",
+        "kb_entity_search",
+        "kb_entity_overview",
+        "kb_entity_cooccurrence",
+        "kb_ingest_status",
+    }
+)
+
+# Admin-only tools — never available to API keys regardless of tier or overrides
+ADMIN_ONLY_TOOLS: frozenset[str] = frozenset({"kb_system_health", "kb_reprocess"})
+
+_TIERS: dict[str, frozenset[str]] = {
+    "search": SEARCH_TIER_TOOLS,
+    "read": READ_TIER_TOOLS,
+    "full": FULL_TIER_TOOLS,
+}
+
+
+def compute_effective_tools(tier: str, overrides: dict[str, bool]) -> frozenset[str]:
+    """Compute the set of tools available to an API key.
+
+    Starts with the tier's base set, applies overrides (true=add, false=remove),
+    then strips admin-only tools.
+    """
+    base = _TIERS.get(tier, FULL_TIER_TOOLS)  # default to full for unknown tier
+    effective = set(base)
+    for tool_name, enabled in (overrides or {}).items():
+        if enabled:
+            effective.add(tool_name)
+        else:
+            effective.discard(tool_name)
+    return frozenset(effective - ADMIN_ONLY_TOOLS)
+
+
+@dataclass
+class KeyScope:
+    """Snapshot of an API key's scope, attached to Principal at auth time.
+
+    Avoids per-tool-call DB lookups for scope info.
+    """
+
+    scope_topic_ids: list[int] | None
+    scope_folder_ids: list[str] | None
+    permission_tier: str
+    tool_overrides: dict[str, bool]
+    max_snippet_chars: int | None
+
+    @property
+    def is_unrestricted(self) -> bool:
+        """True if no document-level scope filter applies."""
+        return self.scope_topic_ids is None and self.scope_folder_ids is None
+
+    @property
+    def effective_tools(self) -> frozenset[str]:
+        """The set of tool names this key may call."""
+        return compute_effective_tools(self.permission_tier, self.tool_overrides)
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py -v
+```
+
+Expected: 9 passed
+
+- [ ] **Step 5: Lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/scope.py tests/test_scoped_api_keys.py
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/api/scope.py tests/test_scoped_api_keys.py
+git commit -m "feat(scoped-keys): KeyScope dataclass + tier→tool computation"
+```
+
+---
+
+## Task 4: Extend Principal with key_scope, populate at auth, expiry check
+
+**Files:**
+- Modify: `src/harbor_clerk/api/deps.py`
+- Modify: `src/harbor_clerk/mcp_server.py` (`_resolve_principal`)
+- Test: `tests/test_scoped_api_keys.py`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `tests/test_scoped_api_keys.py`:
+
+```python
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import KeyScope
+
+
+def test_principal_default_no_key_scope():
+    p = Principal(type="user", id=uuid.uuid4(), role="admin")
+    assert p.key_scope is None
+
+
+def test_principal_with_key_scope():
+    scope = KeyScope(
+        scope_topic_ids=[1],
+        scope_folder_ids=None,
+        permission_tier="search",
+        tool_overrides={},
+        max_snippet_chars=500,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    assert p.key_scope.scope_topic_ids == [1]
+    assert p.key_scope.permission_tier == "search"
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py::test_principal_default_no_key_scope -v
+```
+
+Expected: `TypeError` because Principal doesn't accept `key_scope`
+
+- [ ] **Step 3: Update Principal dataclass**
+
+In `src/harbor_clerk/api/deps.py`, replace the Principal class:
+
+```python
+from harbor_clerk.api.scope import KeyScope
+
+
+@dataclass
+class Principal:
+    """Authenticated caller identity."""
+
+    type: str  # "user" or "api_key"
+    id: uuid.UUID  # user_id or key_id
+    role: str  # "admin" or "user"
+    key_scope: KeyScope | None = None  # populated for api_key principals only
+```
+
+- [ ] **Step 4: Update `get_current_principal` to populate key_scope and check expiry**
+
+In `src/harbor_clerk/api/deps.py`, find the API key branch (around line 70-82) and replace:
+
+```python
+    # API key lookup
+    key_hash = hash_api_key(token)
+    result = await session.execute(select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.is_active.is_(True)))
+    api_key = result.scalar_one_or_none()
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )
+    # Expiry check
+    if api_key.expires_at is not None and api_key.expires_at < datetime.now(UTC):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="API key expired",
+        )
+    # Update last_used_at
+    await session.execute(update(ApiKey).where(ApiKey.key_id == api_key.key_id).values(last_used_at=datetime.now(UTC)))
+    await session.commit()
+    scope = KeyScope(
+        scope_topic_ids=api_key.scope_topic_ids,
+        scope_folder_ids=api_key.scope_folder_ids,
+        permission_tier=api_key.permission_tier,
+        tool_overrides=api_key.tool_overrides or {},
+        max_snippet_chars=api_key.max_snippet_chars,
+    )
+    return Principal(type="api_key", id=api_key.key_id, role="user", key_scope=scope)
+```
+
+- [ ] **Step 5: Update `_resolve_principal` in mcp_server.py the same way**
+
+Find the API key branch in `_resolve_principal` (around line 84-98) and apply the same changes — load scope into KeyScope, check expiry, populate `key_scope` on Principal.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/deps.py src/harbor_clerk/mcp_server.py tests/test_scoped_api_keys.py
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/harbor_clerk/api/deps.py src/harbor_clerk/mcp_server.py tests/test_scoped_api_keys.py
+git commit -m "feat(scoped-keys): Principal carries KeyScope, expiry enforced at auth"
+```
+
+---
+
+## Task 5: apply_key_scope() query filter
+
+**Files:**
+- Modify: `src/harbor_clerk/api/scope.py`
+- Test: `tests/test_scoped_api_keys.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/test_scoped_api_keys.py`:
+
+```python
+from sqlalchemy import select as sa_select
+from harbor_clerk.api.scope import apply_key_scope
+from harbor_clerk.models.document import Document
+
+
+def test_apply_scope_user_principal_unchanged():
+    user = Principal(type="user", id=uuid.uuid4(), role="admin")
+    query = sa_select(Document)
+    result = apply_key_scope(query, user)
+    # Should return the same query unmodified
+    assert str(result) == str(query)
+
+
+def test_apply_scope_unrestricted_key_unchanged():
+    scope = KeyScope(
+        scope_topic_ids=None, scope_folder_ids=None,
+        permission_tier="full", tool_overrides={}, max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    assert str(result) == str(query)
+
+
+def test_apply_scope_topic_filter_adds_where():
+    scope = KeyScope(
+        scope_topic_ids=[1, 2], scope_folder_ids=None,
+        permission_tier="full", tool_overrides={}, max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    # Compiled SQL should contain a topic_id IN clause
+    sql = str(result.compile(compile_kwargs={"literal_binds": True}))
+    assert "topic_id" in sql.lower()
+    assert "in (1, 2)" in sql.lower() or "in ('1', '2')" in sql.lower()
+
+
+def test_apply_scope_folder_filter_subquery():
+    scope = KeyScope(
+        scope_topic_ids=None,
+        scope_folder_ids=["00000000-0000-0000-0000-000000000001"],
+        permission_tier="full", tool_overrides={}, max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    sql = str(result.compile(compile_kwargs={"literal_binds": True}))
+    assert "watched_files" in sql.lower()
+    assert "doc_id" in sql.lower()
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py -v
+```
+
+Expected: `ImportError: cannot import name 'apply_key_scope'`
+
+- [ ] **Step 3: Implement apply_key_scope**
+
+Add to `src/harbor_clerk/api/scope.py`:
+
+```python
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import or_, select
+from sqlalchemy.sql import Select
+
+if TYPE_CHECKING:
+    from harbor_clerk.api.deps import Principal
+
+
+def apply_key_scope(query: Select, principal: "Principal") -> Select:
+    """Filter a Document query by the API key's scope.
+
+    No-op for human users (type='user') and unrestricted API keys.
+    For scoped keys, adds a WHERE clause filtering documents to those
+    matching the topic OR folder scope.
+
+    Pure query builder — no DB access (scope is on Principal from auth time).
+    """
+    if principal.type != "api_key" or principal.key_scope is None:
+        return query
+    scope = principal.key_scope
+    if scope.is_unrestricted:
+        return query
+
+    # Lazy imports to avoid circular dependencies
+    from harbor_clerk.models.document import Document
+    from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
+
+    conditions = []
+    if scope.scope_topic_ids is not None:
+        conditions.append(Document.topic_id.in_(scope.scope_topic_ids))
+    if scope.scope_folder_ids is not None:
+        try:
+            folder_uuids = [uuid.UUID(fid) for fid in scope.scope_folder_ids]
+        except (ValueError, AttributeError):
+            folder_uuids = []
+        if folder_uuids:
+            watched_doc_ids = select(WatchedFile.doc_id).where(
+                WatchedFile.folder_id.in_(folder_uuids),
+                WatchedFile.status == WatchedFileStatus.active,
+            )
+            conditions.append(Document.doc_id.in_(watched_doc_ids))
+
+    if not conditions:
+        # Both axes empty — explicitly nothing visible
+        return query.where(Document.doc_id == uuid.UUID(int=0))
+
+    return query.where(or_(*conditions))
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+```bash
+uv run pytest tests/test_scoped_api_keys.py -v
+```
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check src/harbor_clerk/api/scope.py tests/test_scoped_api_keys.py
+git add src/harbor_clerk/api/scope.py tests/test_scoped_api_keys.py
+git commit -m "feat(scoped-keys): apply_key_scope query filter (topic OR folder)"
+```
+
+---
+
+## Task 6: Apply scope to REST endpoints
+
+**Files:**
+- Modify: `src/harbor_clerk/api/routes/documents.py`
+- Modify: `src/harbor_clerk/api/routes/search.py`
+
+- [ ] **Step 1: Add scope to GET /api/docs**
+
+In `src/harbor_clerk/api/routes/documents.py`, find the documents list endpoint (the function that calls `select(Document)` and returns `PaginatedDocuments`). After building the base query but before executing, apply scope:
+
+```python
+from harbor_clerk.api.scope import apply_key_scope
+
+# Inside list_documents (or whatever it's called):
+query = apply_key_scope(query, principal)
+```
+
+The query needs to be modified BEFORE the count subquery and BEFORE pagination. Apply to both the count query and the items query — total should also reflect scoped count.
+
+- [ ] **Step 2: Add scope to GET /api/docs/{doc_id}**
+
+For the single-document fetch, change the query from `Document.doc_id == doc_id` to also pass through `apply_key_scope`. Easiest pattern:
+
+```python
+query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
+query = apply_key_scope(query, principal)
+result = await session.execute(query)
+doc = result.scalar_one_or_none()
+if doc is None:
+    raise HTTPException(404, "Document not found")
+```
+
+This makes scoped-out docs return 404 — invisible to the agent.
+
+- [ ] **Step 3: Apply to search endpoints**
+
+In `src/harbor_clerk/api/routes/search.py`, find the search query construction. The search joins chunks → documents. Apply `apply_key_scope` to a Document subquery and use it as a filter on the chunks query.
+
+If search builds raw SQL, the simplest fix is to compute visible doc_ids first:
+
+```python
+from harbor_clerk.api.scope import apply_key_scope
+
+if principal.type == "api_key" and principal.key_scope and not principal.key_scope.is_unrestricted:
+    visible_q = apply_key_scope(select(Document.doc_id), principal)
+    visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+    # Filter search results to only visible_ids
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/routes/documents.py src/harbor_clerk/api/routes/search.py
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/harbor_clerk/api/routes/documents.py src/harbor_clerk/api/routes/search.py
+git commit -m "feat(scoped-keys): apply_key_scope to docs list, get, and search"
+```
+
+---
+
+## Task 7: Apply scope to MCP tools
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py`
+
+This is the largest single task — there are 13 MCP tools that read documents/chunks. We need to apply scope to each. The pattern depends on what the tool fetches:
+
+- **Document-based tools** (kb_get_document, kb_list_recent, kb_find_related, kb_corpus_overview, kb_document_outline, kb_entity_overview): pass `principal` to internal helpers and use `apply_key_scope`.
+- **Search tools** (kb_search, kb_batch_search): same as Task 6 search filtering — compute visible doc_ids and filter.
+- **Chunk-based tools** (kb_read_passages, kb_expand_context): fetch chunks first, then filter to chunks whose `doc_id` is in the visible set. **This is the chunk-level enforcement from spec finding #6.**
+- **Entity tools** (kb_entity_search, kb_entity_cooccurrence): join via chunk → document → scope.
+
+- [ ] **Step 1: Add a helper at the top of mcp_server.py (after _get_principal)**
+
+```python
+async def _visible_doc_ids(session: AsyncSession, principal: Principal) -> set[uuid.UUID] | None:
+    """Get the set of doc_ids visible to this principal, or None if unrestricted."""
+    if principal.type != "api_key" or principal.key_scope is None or principal.key_scope.is_unrestricted:
+        return None
+    from harbor_clerk.api.scope import apply_key_scope
+    from harbor_clerk.models.document import Document
+    query = apply_key_scope(select(Document.doc_id), principal)
+    result = await session.execute(query)
+    return {row[0] for row in result.all()}
+```
+
+- [ ] **Step 2: Wire scope into each MCP tool**
+
+For each `@mcp.tool()` function in `mcp_server.py`:
+1. Call `principal = _get_principal()` (already done)
+2. Compute `visible_ids = await _visible_doc_ids(session, principal)`
+3. If `visible_ids is not None`, add `Document.doc_id.in_(visible_ids)` to the query, OR filter the result rows in Python.
+
+The 13 tools to update (find them with `grep -n '@mcp.tool()' src/harbor_clerk/mcp_server.py`):
+- kb_search, kb_batch_search
+- kb_read_passages, kb_expand_context
+- kb_get_document, kb_list_recent
+- kb_corpus_overview, kb_document_outline
+- kb_find_related, kb_entity_search
+- kb_entity_overview, kb_entity_cooccurrence
+- kb_read_document, kb_ingest_status
+
+For `kb_read_passages` and `kb_expand_context` specifically (chunk-based), filter chunks AFTER fetching:
+
+```python
+# Inside kb_read_passages, after loading chunks:
+visible_ids = await _visible_doc_ids(session, principal)
+if visible_ids is not None:
+    chunks = [c for c in chunks if c.doc_id in visible_ids]
+```
+
+For `kb_corpus_overview`, also recompute counts (languages, mime_types, etc.) using the scoped doc set.
+
+- [ ] **Step 3: Apply max_snippet_chars truncation in passage tools**
+
+In `kb_read_passages` and `kb_expand_context`, after filtering, truncate passage text:
+
+```python
+if principal.key_scope and principal.key_scope.max_snippet_chars is not None:
+    limit = principal.key_scope.max_snippet_chars
+    for passage in passages:
+        passage.text = passage.text[:limit]
+```
+
+(Adapt the field name to whatever the actual schema uses.)
+
+- [ ] **Step 4: Lint and run existing MCP tests if any**
+
+```bash
+uv run ruff check src/harbor_clerk/mcp_server.py
+uv run pytest tests/ -k mcp -v 2>&1 | tail -20
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_server.py
+git commit -m "feat(scoped-keys): apply scope to all 13 read MCP tools"
+```
+
+---
+
+## Task 8: MCP tool gating (silent omission)
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Test: `tests/test_mcp_tool_filtering.py`
+
+We need to override `FastMCP.list_tools` and `FastMCP.call_tool` so that the tool list and call dispatch respect the current principal's `effective_tools`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_mcp_tool_filtering.py`:
+
+```python
+"""Tests for MCP tool filtering by API key scope."""
+import uuid
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import KeyScope
+
+
+def make_scoped_key(tier="search", overrides=None):
+    return Principal(
+        type="api_key",
+        id=uuid.uuid4(),
+        role="user",
+        key_scope=KeyScope(
+            scope_topic_ids=None,
+            scope_folder_ids=None,
+            permission_tier=tier,
+            tool_overrides=overrides or {},
+            max_snippet_chars=None,
+        ),
+    )
+
+
+def test_human_user_sees_all_tools():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+    from harbor_clerk.api.deps import Principal as P
+
+    user = P(type="user", id=uuid.uuid4(), role="admin")
+    all_tool_names = ["kb_search", "kb_read_passages", "kb_system_health", "kb_reprocess"]
+    filtered = _filter_tools_for_principal(all_tool_names, user)
+    assert set(filtered) == set(all_tool_names)
+
+
+def test_search_tier_filters_to_search_tools():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    p = make_scoped_key("search")
+    all_tool_names = ["kb_search", "kb_read_passages", "kb_system_health"]
+    filtered = _filter_tools_for_principal(all_tool_names, p)
+    assert "kb_search" in filtered
+    assert "kb_read_passages" not in filtered
+    assert "kb_system_health" not in filtered
+
+
+def test_overrides_remove_tool():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    p = make_scoped_key("full", overrides={"kb_read_document": False})
+    filtered = _filter_tools_for_principal(["kb_read_document", "kb_search"], p)
+    assert "kb_read_document" not in filtered
+    assert "kb_search" in filtered
+
+
+def test_admin_only_tools_never_for_api_key_even_with_override():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    p = make_scoped_key("full", overrides={"kb_system_health": True, "kb_reprocess": True})
+    filtered = _filter_tools_for_principal(["kb_system_health", "kb_reprocess", "kb_search"], p)
+    assert "kb_system_health" not in filtered
+    assert "kb_reprocess" not in filtered
+    assert "kb_search" in filtered
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```bash
+uv run pytest tests/test_mcp_tool_filtering.py -v
+```
+
+Expected: `ImportError: cannot import name '_filter_tools_for_principal'`
+
+- [ ] **Step 3: Add the helper and override list_tools/call_tool**
+
+In `src/harbor_clerk/mcp_server.py`, add this helper near the top (after imports, before `mcp = FastMCP(...)`):
+
+```python
+def _filter_tools_for_principal(tool_names: list[str] | set[str], principal: Principal | None) -> list[str]:
+    """Return only the tool names this principal is allowed to use."""
+    if principal is None:
+        return []
+    if principal.type != "api_key" or principal.key_scope is None:
+        # Human users see everything (admin checks happen inside individual tools)
+        return list(tool_names)
+    allowed = principal.key_scope.effective_tools
+    return [t for t in tool_names if t in allowed]
+```
+
+Then subclass FastMCP. Replace `mcp = FastMCP(...)` with:
+
+```python
+class ScopedFastMCP(FastMCP):
+    """FastMCP subclass that filters tool listing and calls by API key scope."""
+
+    async def list_tools(self):
+        all_tools = await super().list_tools()
+        try:
+            principal = _get_principal()
+        except PermissionError:
+            return all_tools  # not yet authenticated — return everything
+        allowed_names = set(_filter_tools_for_principal([t.name for t in all_tools], principal))
+        return [t for t in all_tools if t.name in allowed_names]
+
+    async def call_tool(self, name, arguments):
+        try:
+            principal = _get_principal()
+        except PermissionError:
+            return await super().call_tool(name, arguments)
+        if principal.type == "api_key" and principal.key_scope is not None:
+            if name not in principal.key_scope.effective_tools:
+                # Tool not in this key's set — return MCP "unknown tool" error
+                from mcp.shared.exceptions import McpError
+                from mcp.types import ErrorData
+
+                raise McpError(ErrorData(code=-32601, message=f"Unknown tool: {name}"))
+        return await super().call_tool(name, arguments)
+
+
+mcp = ScopedFastMCP(
+    "Harbor Clerk",
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+```bash
+uv run pytest tests/test_mcp_tool_filtering.py -v
+```
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check src/harbor_clerk/mcp_server.py tests/test_mcp_tool_filtering.py
+git add src/harbor_clerk/mcp_server.py tests/test_mcp_tool_filtering.py
+git commit -m "feat(scoped-keys): MCP tool filtering via ScopedFastMCP subclass"
+```
+
+---
+
+## Task 9: API endpoints — extend POST, add PATCH, scope-preview, enrich GET
+
+**Files:**
+- Modify: `src/harbor_clerk/api/schemas/api_keys.py`
+- Modify: `src/harbor_clerk/api/routes/api_keys.py`
+
+- [ ] **Step 1: Extend the schemas**
+
+In `src/harbor_clerk/api/schemas/api_keys.py`:
+
+```python
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class CreateApiKeyRequest(BaseModel):
+    name: str
+    expires_at: datetime | None = None
+    permission_tier: Literal["search", "read", "full"] = "full"
+    tool_overrides: dict[str, bool] | None = None
+    scope_topic_ids: list[int] | None = None
+    scope_folder_ids: list[str] | None = None
+    max_snippet_chars: int | None = None
+
+
+class PatchApiKeyRequest(BaseModel):
+    name: str | None = None
+    expires_at: datetime | None = None
+    permission_tier: Literal["search", "read", "full"] | None = None
+    tool_overrides: dict[str, bool] | None = None
+    scope_topic_ids: list[int] | None = None
+    scope_folder_ids: list[str] | None = None
+    max_snippet_chars: int | None = None
+
+
+class ApiKeyOut(BaseModel):
+    key_id: str
+    name: str
+    is_active: bool
+    created_at: datetime
+    last_used_at: datetime | None
+    expires_at: datetime | None
+    permission_tier: str
+    tool_overrides: dict[str, bool]
+    scope_topic_ids: list[int] | None
+    scope_folder_ids: list[str] | None
+    max_snippet_chars: int | None
+    scope_summary: str  # human-readable: "Full access", "3 topics", etc.
+
+
+class ScopePreviewResponse(BaseModel):
+    accessible_documents: int
+    total_documents: int
+
+
+class ApiKeyCreatedResponse(BaseModel):
+    key_id: str
+    name: str
+    raw_key: str
+    mcp_path: str
+    created_at: datetime
+```
+
+- [ ] **Step 2: Add scope_summary helper and update routes**
+
+In `src/harbor_clerk/api/routes/api_keys.py`:
+
+```python
+def _scope_summary(api_key: ApiKey) -> str:
+    parts = []
+    if api_key.permission_tier != "full":
+        parts.append(api_key.permission_tier.capitalize())
+    if api_key.scope_topic_ids:
+        parts.append(f"{len(api_key.scope_topic_ids)} topic{'s' if len(api_key.scope_topic_ids) != 1 else ''}")
+    if api_key.scope_folder_ids:
+        parts.append(f"{len(api_key.scope_folder_ids)} folder{'s' if len(api_key.scope_folder_ids) != 1 else ''}")
+    if api_key.expires_at:
+        parts.append(f"expires {api_key.expires_at.date().isoformat()}")
+    return ", ".join(parts) if parts else "Full access"
+
+
+def _api_key_to_out(api_key: ApiKey) -> ApiKeyOut:
+    return ApiKeyOut(
+        key_id=str(api_key.key_id),
+        name=api_key.name,
+        is_active=api_key.is_active,
+        created_at=api_key.created_at,
+        last_used_at=api_key.last_used_at,
+        expires_at=api_key.expires_at,
+        permission_tier=api_key.permission_tier,
+        tool_overrides=api_key.tool_overrides or {},
+        scope_topic_ids=api_key.scope_topic_ids,
+        scope_folder_ids=api_key.scope_folder_ids,
+        max_snippet_chars=api_key.max_snippet_chars,
+        scope_summary=_scope_summary(api_key),
+    )
+```
+
+Then update the `POST /api-keys` endpoint to accept the new fields:
+
+```python
+@router.post("/api-keys", response_model=ApiKeyCreatedResponse, status_code=status.HTTP_201_CREATED)
+async def create_api_key(
+    body: CreateApiKeyRequest,
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    raw_key = generate_api_key()
+    api_key = ApiKey(
+        name=body.name,
+        key_hash=hash_api_key(raw_key),
+        expires_at=body.expires_at,
+        permission_tier=body.permission_tier,
+        tool_overrides=body.tool_overrides or {},
+        scope_topic_ids=body.scope_topic_ids,
+        scope_folder_ids=body.scope_folder_ids,
+        max_snippet_chars=body.max_snippet_chars,
+    )
+    session.add(api_key)
+    await session.commit()
+    await session.refresh(api_key)
+    await log_audit(
+        session,
+        user_id=admin.id,
+        action="create_api_key",
+        target_type="api_key",
+        target_id=api_key.key_id,
+    )
+    await session.commit()
+    return ApiKeyCreatedResponse(
+        key_id=str(api_key.key_id),
+        name=api_key.name,
+        raw_key=raw_key,
+        mcp_path=f"/t/{raw_key}",
+        created_at=api_key.created_at,
+    )
+```
+
+Add the PATCH endpoint:
+
+```python
+@router.patch("/api-keys/{key_id}", response_model=ApiKeyOut)
+async def patch_api_key(
+    key_id: uuid.UUID,
+    body: PatchApiKeyRequest,
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    api_key = await session.get(ApiKey, key_id)
+    if api_key is None:
+        raise HTTPException(404, "API key not found")
+    # Use model_fields_set to distinguish "field absent" from "field=null"
+    patch = body.model_dump(exclude_unset=True)
+    for field, value in patch.items():
+        setattr(api_key, field, value)
+    await log_audit(
+        session,
+        user_id=admin.id,
+        action="patch_api_key",
+        target_type="api_key",
+        target_id=key_id,
+        detail={"fields": list(patch.keys())},
+    )
+    await session.commit()
+    await session.refresh(api_key)
+    return _api_key_to_out(api_key)
+```
+
+Add the scope-preview endpoint:
+
+```python
+@router.get("/api-keys/{key_id}/scope-preview", response_model=ScopePreviewResponse)
+async def scope_preview(
+    key_id: uuid.UUID,
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    from harbor_clerk.api.scope import KeyScope, apply_key_scope
+    from harbor_clerk.models.document import Document
+    from sqlalchemy import func
+
+    api_key = await session.get(ApiKey, key_id)
+    if api_key is None:
+        raise HTTPException(404, "API key not found")
+
+    total = (await session.execute(select(func.count(Document.doc_id)).where(Document.status == "active"))).scalar_one()
+
+    # Build a synthetic principal with this key's scope to reuse apply_key_scope
+    scope = KeyScope(
+        scope_topic_ids=api_key.scope_topic_ids,
+        scope_folder_ids=api_key.scope_folder_ids,
+        permission_tier=api_key.permission_tier,
+        tool_overrides=api_key.tool_overrides or {},
+        max_snippet_chars=api_key.max_snippet_chars,
+    )
+    fake_principal = Principal(type="api_key", id=key_id, role="user", key_scope=scope)
+    visible_query = apply_key_scope(
+        select(func.count(Document.doc_id)).where(Document.status == "active"),
+        fake_principal,
+    )
+    visible = (await session.execute(visible_query)).scalar_one()
+
+    return ScopePreviewResponse(accessible_documents=visible, total_documents=total)
+```
+
+Update GET /api-keys to use `_api_key_to_out`:
+
+```python
+@router.get("/api-keys", response_model=list[ApiKeyOut])
+async def list_api_keys(
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(ApiKey).order_by(ApiKey.created_at.desc()))
+    return [_api_key_to_out(k) for k in result.scalars().all()]
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/schemas/api_keys.py src/harbor_clerk/api/routes/api_keys.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/harbor_clerk/api/schemas/api_keys.py src/harbor_clerk/api/routes/api_keys.py
+git commit -m "feat(scoped-keys): API endpoints for create/patch/list/scope-preview"
+```
+
+---
+
+## Task 10: Frontend — API Keys page
+
+**Files:**
+- Modify: `frontend/src/pages/ApiKeysPage.tsx`
+
+- [ ] **Step 1: Read the current page**
+
+```bash
+cat frontend/src/pages/ApiKeysPage.tsx | head -100
+```
+
+Note the existing component structure (interfaces, state, render).
+
+- [ ] **Step 2: Extend the form and table**
+
+This is a UI task — make the changes incrementally. The minimum needed:
+
+1. **TypeScript interface** — add the new fields to the `ApiKey` interface used in the list:
+```typescript
+interface ApiKey {
+  key_id: string
+  name: string
+  is_active: boolean
+  created_at: string
+  last_used_at: string | null
+  expires_at: string | null
+  permission_tier: 'search' | 'read' | 'full'
+  tool_overrides: Record<string, boolean>
+  scope_topic_ids: number[] | null
+  scope_folder_ids: string[] | null
+  max_snippet_chars: number | null
+  scope_summary: string
+}
+```
+
+2. **Create form** — add fields below the Name input:
+   - Expires (date picker, optional)
+   - Permission tier (radio: Search/Read/Full)
+   - `<details>` element with summary "Tool overrides" → grid of tool checkboxes
+   - `<details>` element with summary "Document scope" → topic multi-select + folder multi-select
+   - Max snippet chars (number input)
+
+3. **List table** — add columns:
+   - Scope (display `scope_summary`)
+   - Expires (display `expires_at` formatted, or "Never")
+
+4. **Edit panel** — clicking a key opens a modal with the same form fields, populated from current values, calls PATCH on save
+
+5. **Scope preview** — after setting scopes, debounced fetch of `/api-keys/{key_id}/scope-preview` showing "X of Y documents accessible"
+
+This task is about UI polish — exact code is left to the implementer. Match the existing styling patterns in the file (dark mode classes, button styles).
+
+- [ ] **Step 3: Lint and typecheck**
+
+```bash
+cd frontend && npx eslint src/pages/ApiKeysPage.tsx && npx tsc --noEmit
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/scoped-api-keys
+git add frontend/src/pages/ApiKeysPage.tsx
+git commit -m "feat(scoped-keys): API Keys page UI with scope/tier/expiry controls"
+```
+
+---
+
+## Task 11: Run all tests and final verification
+
+- [ ] **Step 1: Run all Python tests**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/scoped-api-keys
+uv run pytest tests/ -v 2>&1 | tail -20
+```
+
+Expected: all tests pass, including the new scope tests.
+
+- [ ] **Step 2: Lint**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+```
+
+- [ ] **Step 3: Frontend lint and typecheck**
+
+```bash
+cd frontend && npx eslint src/ && npx tsc --noEmit
+```
+
+- [ ] **Step 4: Run the migration locally to verify**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/scoped-api-keys
+# Use the macOS app's PostgreSQL (port 5433, user lka, db lka)
+DATABASE_URL="postgresql+asyncpg://lka@localhost:5433/lka" uv run alembic upgrade head 2>&1 | tail -5
+```
+
+Expected: migration 0013 applied successfully.
+
+- [ ] **Step 5: Manual smoke test**
+
+1. Create a scoped API key via `POST /api/api-keys` with curl using a JWT
+2. Use that key to GET /api/docs — verify it only sees scoped documents
+3. Use it on the MCP endpoint — verify only allowed tools appear in `tools/list`
+4. Try calling a disallowed tool — verify it returns "unknown tool"
+5. Set `expires_at` to a past date via PATCH — verify auth fails with 401
+
+- [ ] **Step 6: Push the branch and open a PR**
+
+```bash
+git push -u origin feat/scoped-api-keys
+gh pr create --title "feat: scoped API keys" --body "Implements per-key access controls per spec docs/superpowers/specs/2026-04-07-scoped-api-keys-design.md"
+```

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -1,5 +1,7 @@
-import { FormEvent, useEffect, useState } from 'react'
-import { del, get, post } from '../api'
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { del, get, patch, post } from '../api'
+
+type PermissionTier = 'search' | 'read' | 'full'
 
 interface ApiKeyInfo {
   key_id: string
@@ -7,6 +9,13 @@ interface ApiKeyInfo {
   is_active: boolean
   created_at: string
   last_used_at?: string
+  expires_at: string | null
+  permission_tier: PermissionTier
+  tool_overrides: Record<string, boolean>
+  scope_topic_ids: number[] | null
+  scope_folder_ids: string[] | null
+  max_snippet_chars: number | null
+  scope_summary: string
 }
 
 interface ApiKeyCreated {
@@ -17,12 +26,131 @@ interface ApiKeyCreated {
   created_at: string
 }
 
+interface TopicCluster {
+  cluster_id: number
+  name: string
+}
+
+interface WatchedFolderInfo {
+  folder_id: string
+  path: string
+}
+
+interface ScopePreview {
+  accessible_documents: number
+  total_documents: number
+}
+
+// Mirrors src/harbor_clerk/api/scope.py — keep in sync
+const SEARCH_TIER_TOOLS = ['kb_search', 'kb_batch_search', 'kb_corpus_overview', 'kb_list_recent'] as const
+const READ_TIER_TOOLS = [
+  ...SEARCH_TIER_TOOLS,
+  'kb_read_passages',
+  'kb_expand_context',
+  'kb_document_outline',
+  'kb_get_document',
+] as const
+const FULL_TIER_TOOLS = [
+  ...READ_TIER_TOOLS,
+  'kb_read_document',
+  'kb_find_related',
+  'kb_entity_search',
+  'kb_entity_overview',
+  'kb_entity_cooccurrence',
+  'kb_ingest_status',
+] as const
+
+const ALL_TOOLS: readonly string[] = FULL_TIER_TOOLS
+
+function tierBaseTools(tier: PermissionTier): ReadonlySet<string> {
+  if (tier === 'search') return new Set(SEARCH_TIER_TOOLS)
+  if (tier === 'read') return new Set(READ_TIER_TOOLS)
+  return new Set(FULL_TIER_TOOLS)
+}
+
+function toolEnabled(tool: string, tier: PermissionTier, overrides: Record<string, boolean>): boolean {
+  if (tool in overrides) return overrides[tool]
+  return tierBaseTools(tier).has(tool)
+}
+
+function toggleToolOverride(
+  tool: string,
+  nextChecked: boolean,
+  tier: PermissionTier,
+  overrides: Record<string, boolean>,
+): Record<string, boolean> {
+  const inTier = tierBaseTools(tier).has(tool)
+  const next = { ...overrides }
+  if (nextChecked === inTier) {
+    delete next[tool]
+  } else {
+    next[tool] = nextChecked
+  }
+  return next
+}
+
+interface ScopeFormState {
+  expiresAt: string // yyyy-mm-dd or ''
+  tier: PermissionTier
+  toolOverrides: Record<string, boolean>
+  topicIds: number[] | null
+  folderIds: string[] | null
+  maxSnippetChars: string // raw input string
+}
+
+function emptyScopeState(): ScopeFormState {
+  return {
+    expiresAt: '',
+    tier: 'full',
+    toolOverrides: {},
+    topicIds: null,
+    folderIds: null,
+    maxSnippetChars: '',
+  }
+}
+
+function scopeStateFromKey(k: ApiKeyInfo): ScopeFormState {
+  return {
+    expiresAt: k.expires_at ? k.expires_at.slice(0, 10) : '',
+    tier: k.permission_tier,
+    toolOverrides: { ...k.tool_overrides },
+    topicIds: k.scope_topic_ids,
+    folderIds: k.scope_folder_ids,
+    maxSnippetChars: k.max_snippet_chars != null ? String(k.max_snippet_chars) : '',
+  }
+}
+
+interface ScopePayload {
+  expires_at: string | null
+  permission_tier: PermissionTier
+  tool_overrides: Record<string, boolean>
+  scope_topic_ids: number[] | null
+  scope_folder_ids: string[] | null
+  max_snippet_chars: number | null
+}
+
+function scopeStateToPayload(s: ScopeFormState): ScopePayload {
+  const maxSnippet = s.maxSnippetChars.trim() ? Number(s.maxSnippetChars) : null
+  return {
+    expires_at: s.expiresAt ? new Date(s.expiresAt + 'T23:59:59').toISOString() : null,
+    permission_tier: s.tier,
+    tool_overrides: s.toolOverrides,
+    scope_topic_ids: s.topicIds,
+    scope_folder_ids: s.folderIds,
+    max_snippet_chars: maxSnippet != null && Number.isFinite(maxSnippet) && maxSnippet > 0 ? maxSnippet : null,
+  }
+}
+
 export default function ApiKeysPage() {
   const [keys, setKeys] = useState<ApiKeyInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [showCreate, setShowCreate] = useState(false)
   const [newKey, setNewKey] = useState<ApiKeyCreated | null>(null)
+  const [editingKey, setEditingKey] = useState<ApiKeyInfo | null>(null)
+
+  const [topics, setTopics] = useState<TopicCluster[]>([])
+  const [folders, setFolders] = useState<WatchedFolderInfo[]>([])
 
   async function loadKeys() {
     try {
@@ -35,8 +163,22 @@ export default function ApiKeysPage() {
     }
   }
 
+  async function loadScopeOptions() {
+    try {
+      const [t, f] = await Promise.all([
+        get<{ clusters: TopicCluster[] }>('/api/stats/topics').catch(() => ({ clusters: [] })),
+        get<WatchedFolderInfo[]>('/api/watch/folders').catch(() => [] as WatchedFolderInfo[]),
+      ])
+      setTopics(t.clusters || [])
+      setFolders(Array.isArray(f) ? f : [])
+    } catch {
+      // non-fatal
+    }
+  }
+
   useEffect(() => {
     loadKeys()
+    loadScopeOptions()
   }, [])
 
   async function handleRevoke(keyId: string) {
@@ -100,6 +242,8 @@ export default function ApiKeysPage() {
 
       {showCreate && !newKey && (
         <CreateKeyForm
+          topics={topics}
+          folders={folders}
           onCreated={(key) => {
             setNewKey(key)
             loadKeys()
@@ -117,6 +261,12 @@ export default function ApiKeysPage() {
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
                 Status
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+                Scope
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+                Expires
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
                 Created
@@ -144,6 +294,10 @@ export default function ApiKeysPage() {
                     {k.is_active ? 'active' : 'revoked'}
                   </span>
                 </td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{k.scope_summary}</td>
+                <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                  {k.expires_at ? new Date(k.expires_at).toLocaleDateString() : 'Never'}
+                </td>
                 <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                   {new Date(k.created_at).toLocaleDateString()}
                 </td>
@@ -152,19 +306,27 @@ export default function ApiKeysPage() {
                 </td>
                 <td className="px-4 py-3 text-right">
                   {k.is_active && (
-                    <button
-                      onClick={() => handleRevoke(k.key_id)}
-                      className="text-sm text-red-600 dark:text-red-400 hover:underline"
-                    >
-                      Revoke
-                    </button>
+                    <div className="flex justify-end gap-3">
+                      <button
+                        onClick={() => setEditingKey(k)}
+                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleRevoke(k.key_id)}
+                        className="text-sm text-red-600 dark:text-red-400 hover:underline"
+                      >
+                        Revoke
+                      </button>
+                    </div>
                   )}
                 </td>
               </tr>
             ))}
             {keys.length === 0 && (
               <tr>
-                <td colSpan={5} className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                <td colSpan={7} className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
                   No API keys yet.
                 </td>
               </tr>
@@ -172,25 +334,210 @@ export default function ApiKeysPage() {
           </tbody>
         </table>
       </div>
+
+      {editingKey && (
+        <EditKeyModal
+          apiKey={editingKey}
+          topics={topics}
+          folders={folders}
+          onClose={() => setEditingKey(null)}
+          onSaved={() => {
+            setEditingKey(null)
+            loadKeys()
+          }}
+          onError={setError}
+        />
+      )}
     </div>
   )
 }
 
+// ---------------------------------------------------------------------------
+// Shared scope form fields
+// ---------------------------------------------------------------------------
+
+function ScopeFormFields({
+  state,
+  setState,
+  topics,
+  folders,
+}: {
+  state: ScopeFormState
+  setState: (updater: (prev: ScopeFormState) => ScopeFormState) => void
+  topics: TopicCluster[]
+  folders: WatchedFolderInfo[]
+}) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Expires (optional)</label>
+        <input
+          type="date"
+          value={state.expiresAt}
+          onChange={(e) => setState((s) => ({ ...s, expiresAt: e.target.value }))}
+          className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Permission tier</label>
+        <div className="flex gap-4 text-sm">
+          {(['search', 'read', 'full'] as const).map((t) => (
+            <label key={t} className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="tier"
+                value={t}
+                checked={state.tier === t}
+                onChange={() => setState((s) => ({ ...s, tier: t }))}
+              />
+              <span className="capitalize">{t}</span>
+            </label>
+          ))}
+        </div>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Search: search only · Read: search + passage read · Full: all read-only tools
+        </p>
+      </div>
+
+      <details className="rounded-lg bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) p-3">
+        <summary className="cursor-pointer text-xs font-medium text-gray-700 dark:text-gray-300">
+          Tool overrides ({Object.keys(state.toolOverrides).length} custom)
+        </summary>
+        <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5">
+          {ALL_TOOLS.map((tool) => {
+            const checked = toolEnabled(tool, state.tier, state.toolOverrides)
+            const overridden = tool in state.toolOverrides
+            return (
+              <label key={tool} className="flex items-center gap-1.5 text-xs">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(e) =>
+                    setState((s) => ({
+                      ...s,
+                      toolOverrides: toggleToolOverride(tool, e.target.checked, s.tier, s.toolOverrides),
+                    }))
+                  }
+                />
+                <code className={overridden ? 'font-semibold text-(--color-accent)' : ''}>{tool}</code>
+              </label>
+            )
+          })}
+        </div>
+      </details>
+
+      <details className="rounded-lg bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) p-3">
+        <summary className="cursor-pointer text-xs font-medium text-gray-700 dark:text-gray-300">
+          Document scope (empty = no restriction)
+        </summary>
+        <div className="mt-3 space-y-3">
+          <div>
+            <p className="mb-1 text-xs font-medium text-gray-600 dark:text-gray-400">Topics</p>
+            {topics.length === 0 ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400">No topics available.</p>
+            ) : (
+              <div className="max-h-40 overflow-y-auto rounded-sm bg-white dark:bg-[#1e1e1f] p-2 ring-1 ring-(--color-border)">
+                {topics.map((t) => {
+                  const selected = state.topicIds?.includes(t.cluster_id) ?? false
+                  return (
+                    <label key={t.cluster_id} className="flex items-center gap-1.5 text-xs py-0.5">
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={(e) =>
+                          setState((s) => {
+                            const current = s.topicIds ?? []
+                            const next = e.target.checked
+                              ? [...current, t.cluster_id]
+                              : current.filter((id) => id !== t.cluster_id)
+                            return { ...s, topicIds: next.length > 0 ? next : null }
+                          })
+                        }
+                      />
+                      <span>{t.name}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <p className="mb-1 text-xs font-medium text-gray-600 dark:text-gray-400">Watched folders</p>
+            {folders.length === 0 ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400">No watched folders configured.</p>
+            ) : (
+              <div className="max-h-40 overflow-y-auto rounded-sm bg-white dark:bg-[#1e1e1f] p-2 ring-1 ring-(--color-border)">
+                {folders.map((f) => {
+                  const selected = state.folderIds?.includes(f.folder_id) ?? false
+                  return (
+                    <label key={f.folder_id} className="flex items-center gap-1.5 text-xs py-0.5">
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={(e) =>
+                          setState((s) => {
+                            const current = s.folderIds ?? []
+                            const next = e.target.checked
+                              ? [...current, f.folder_id]
+                              : current.filter((id) => id !== f.folder_id)
+                            return { ...s, folderIds: next.length > 0 ? next : null }
+                          })
+                        }
+                      />
+                      <span className="font-mono">{f.path}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </details>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
+          Max snippet chars (optional)
+        </label>
+        <input
+          type="number"
+          min="1"
+          value={state.maxSnippetChars}
+          onChange={(e) => setState((s) => ({ ...s, maxSnippetChars: e.target.value }))}
+          placeholder="No limit"
+          className="w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+        />
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Create form
+// ---------------------------------------------------------------------------
+
 function CreateKeyForm({
   onCreated,
   onError,
+  topics,
+  folders,
 }: {
   onCreated: (key: ApiKeyCreated) => void
   onError: (msg: string) => void
+  topics: TopicCluster[]
+  folders: WatchedFolderInfo[]
 }) {
   const [name, setName] = useState('')
+  const [scope, setScope] = useState<ScopeFormState>(emptyScopeState())
   const [submitting, setSubmitting] = useState(false)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setSubmitting(true)
     try {
-      const key = await post<ApiKeyCreated>('/api/api-keys', { name })
+      const payload = { name, ...scopeStateToPayload(scope) }
+      const key = await post<ApiKeyCreated>('/api/api-keys', payload)
       onCreated(key)
     } catch (e) {
       onError(e instanceof Error ? e.message : 'Create failed')
@@ -202,9 +549,9 @@ function CreateKeyForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="mb-4 flex items-end space-x-3 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4"
+      className="mb-4 space-y-4 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4"
     >
-      <div className="flex-1">
+      <div>
         <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Key Name</label>
         <input
           type="text"
@@ -215,13 +562,141 @@ function CreateKeyForm({
           className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
         />
       </div>
-      <button
-        type="submit"
-        disabled={submitting}
-        className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
-      >
-        Create
-      </button>
+
+      <ScopeFormFields state={scope} setState={setScope} topics={topics} folders={folders} />
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+        >
+          Create
+        </button>
+      </div>
     </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Edit modal
+// ---------------------------------------------------------------------------
+
+function EditKeyModal({
+  apiKey,
+  topics,
+  folders,
+  onClose,
+  onSaved,
+  onError,
+}: {
+  apiKey: ApiKeyInfo
+  topics: TopicCluster[]
+  folders: WatchedFolderInfo[]
+  onClose: () => void
+  onSaved: () => void
+  onError: (msg: string) => void
+}) {
+  const [scope, setScope] = useState<ScopeFormState>(scopeStateFromKey(apiKey))
+  const [submitting, setSubmitting] = useState(false)
+  const [preview, setPreview] = useState<ScopePreview | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const debounceRef = useRef<number | null>(null)
+
+  // Track the payload as a JSON string for effect dep stability
+  const payloadKey = useMemo(() => JSON.stringify(scopeStateToPayload(scope)), [scope])
+
+  // Debounced scope preview: PATCH the key, then fetch preview.
+  // Rather than mutating on every keystroke, we use a dry-run approach:
+  // the backend scope-preview endpoint reads the current stored scope,
+  // so we need to save-then-preview. For UX, we only preview on debounce and
+  // revert silently by reading back the returned key (caller's loadKeys on save).
+  // To avoid persisting unintended state, preview here is informational only
+  // and computed client-side against the currently-saved key; accurate preview
+  // happens after Save. We fetch on mount so users see the current state.
+  useEffect(() => {
+    let cancelled = false
+    async function fetchPreview() {
+      setPreviewLoading(true)
+      try {
+        const data = await get<ScopePreview>(`/api/api-keys/${apiKey.key_id}/scope-preview`)
+        if (!cancelled) setPreview(data)
+      } catch {
+        if (!cancelled) setPreview(null)
+      } finally {
+        if (!cancelled) setPreviewLoading(false)
+      }
+    }
+    if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    debounceRef.current = window.setTimeout(fetchPreview, 500)
+    return () => {
+      cancelled = true
+      if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    }
+  }, [apiKey.key_id, payloadKey])
+
+  async function handleSave() {
+    setSubmitting(true)
+    try {
+      await patch(`/api/api-keys/${apiKey.key_id}`, scopeStateToPayload(scope))
+      onSaved()
+    } catch (e) {
+      onError(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-5">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-bold">Edit Key: {apiKey.name}</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <ScopeFormFields state={scope} setState={setScope} topics={topics} folders={folders} />
+
+        <div className="mt-4 rounded-lg bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) p-3 text-xs">
+          {previewLoading && <span className="text-gray-500 dark:text-gray-400">Loading scope preview…</span>}
+          {!previewLoading && preview && (
+            <span className="text-gray-700 dark:text-gray-300">
+              <strong>{preview.accessible_documents}</strong> of <strong>{preview.total_documents}</strong> documents
+              accessible (reflects currently-saved scope; save to recompute)
+            </span>
+          )}
+          {!previewLoading && !preview && (
+            <span className="text-gray-500 dark:text-gray-400">Scope preview unavailable.</span>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded-lg bg-gray-200 dark:bg-gray-700 px-4 py-1.5 text-sm font-medium text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={submitting}
+            className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/harbor_clerk/api/deps.py
+++ b/src/harbor_clerk/api/deps.py
@@ -9,6 +9,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from harbor_clerk.api.scope import KeyScope
 from harbor_clerk.auth import API_KEY_PREFIXES, decode_token, hash_api_key
 from harbor_clerk.db import get_session
 from harbor_clerk.models import ApiKey
@@ -21,6 +22,7 @@ class Principal:
     type: str  # "user" or "api_key"
     id: uuid.UUID  # user_id or key_id
     role: str  # "admin" or "user"
+    key_scope: KeyScope | None = None  # populated for api_key principals only
 
 
 def _extract_bearer_token(request: Request) -> str | None:
@@ -76,10 +78,23 @@ async def get_current_principal(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",
         )
+    # Expiry check
+    if api_key.expires_at is not None and api_key.expires_at < datetime.now(UTC):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="API key expired",
+        )
     # Update last_used_at
     await session.execute(update(ApiKey).where(ApiKey.key_id == api_key.key_id).values(last_used_at=datetime.now(UTC)))
     await session.commit()
-    return Principal(type="api_key", id=api_key.key_id, role="user")
+    scope = KeyScope(
+        scope_topic_ids=api_key.scope_topic_ids,
+        scope_folder_ids=api_key.scope_folder_ids,
+        permission_tier=api_key.permission_tier,
+        tool_overrides=api_key.tool_overrides or {},
+        max_snippet_chars=api_key.max_snippet_chars,
+    )
+    return Principal(type="api_key", id=api_key.key_id, role="user", key_scope=scope)
 
 
 async def require_user(

--- a/src/harbor_clerk/api/routes/api_keys.py
+++ b/src/harbor_clerk/api/routes/api_keys.py
@@ -4,41 +4,68 @@ import logging
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.api.deps import Principal, require_admin
 from harbor_clerk.api.schemas.api_keys import (
     ApiKeyCreatedResponse,
-    ApiKeyInfo,
+    ApiKeyOut,
     CreateApiKeyRequest,
+    PatchApiKeyRequest,
+    ScopePreviewResponse,
 )
+from harbor_clerk.api.scope import KeyScope, apply_key_scope
 from harbor_clerk.audit import log_audit
 from harbor_clerk.auth import generate_api_key, hash_api_key
 from harbor_clerk.db import get_session
 from harbor_clerk.models import ApiKey
+from harbor_clerk.models.document import Document
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["api-keys"])
 
 
-@router.get("/api-keys", response_model=list[ApiKeyInfo])
+def _scope_summary(api_key: ApiKey) -> str:
+    parts = []
+    if api_key.permission_tier != "full":
+        parts.append(api_key.permission_tier.capitalize() + " only")
+    if api_key.scope_topic_ids is not None:
+        n = len(api_key.scope_topic_ids)
+        parts.append(f"{n} topic{'s' if n != 1 else ''}")
+    if api_key.scope_folder_ids is not None:
+        n = len(api_key.scope_folder_ids)
+        parts.append(f"{n} folder{'s' if n != 1 else ''}")
+    if api_key.expires_at:
+        parts.append(f"expires {api_key.expires_at.date().isoformat()}")
+    return ", ".join(parts) if parts else "Full access"
+
+
+def _api_key_to_out(api_key: ApiKey) -> ApiKeyOut:
+    return ApiKeyOut(
+        key_id=str(api_key.key_id),
+        name=api_key.name,
+        is_active=api_key.is_active,
+        created_at=api_key.created_at,
+        last_used_at=api_key.last_used_at,
+        expires_at=api_key.expires_at,
+        permission_tier=api_key.permission_tier,
+        tool_overrides=api_key.tool_overrides or {},
+        scope_topic_ids=api_key.scope_topic_ids,
+        scope_folder_ids=api_key.scope_folder_ids,
+        max_snippet_chars=api_key.max_snippet_chars,
+        scope_summary=_scope_summary(api_key),
+    )
+
+
+@router.get("/api-keys", response_model=list[ApiKeyOut])
 async def list_api_keys(
     admin: Principal = Depends(require_admin),
     session: AsyncSession = Depends(get_session),
 ):
-    result = await session.execute(select(ApiKey).order_by(ApiKey.created_at))
+    result = await session.execute(select(ApiKey).order_by(ApiKey.created_at.desc()))
     keys = result.scalars().all()
-    return [
-        ApiKeyInfo(
-            key_id=str(k.key_id),
-            name=k.name,
-            is_active=k.is_active,
-            created_at=k.created_at,
-            last_used_at=k.last_used_at,
-        )
-        for k in keys
-    ]
+    return [_api_key_to_out(k) for k in keys]
 
 
 @router.post("/api-keys", response_model=ApiKeyCreatedResponse, status_code=status.HTTP_201_CREATED)
@@ -48,28 +75,92 @@ async def create_api_key(
     session: AsyncSession = Depends(get_session),
 ):
     raw_key = generate_api_key()
-    key_obj = ApiKey(
+    api_key = ApiKey(
         name=body.name,
         key_hash=hash_api_key(raw_key),
-        is_active=True,
+        expires_at=body.expires_at,
+        permission_tier=body.permission_tier,
+        tool_overrides=body.tool_overrides or {},
+        scope_topic_ids=body.scope_topic_ids,
+        scope_folder_ids=body.scope_folder_ids,
+        max_snippet_chars=body.max_snippet_chars,
     )
-    session.add(key_obj)
+    session.add(api_key)
+    await session.commit()
+    await session.refresh(api_key)
     await log_audit(
         session,
         user_id=admin.id,
         action="create_api_key",
         target_type="api_key",
-        target_id=key_obj.key_id,
+        target_id=api_key.key_id,
     )
     await session.commit()
-    await session.refresh(key_obj)
-
     return ApiKeyCreatedResponse(
-        key_id=str(key_obj.key_id),
-        name=key_obj.name,
+        key_id=str(api_key.key_id),
+        name=api_key.name,
         raw_key=raw_key,
         mcp_path=f"/t/{raw_key}",
-        created_at=key_obj.created_at,
+        created_at=api_key.created_at,
+    )
+
+
+@router.patch("/api-keys/{key_id}", response_model=ApiKeyOut)
+async def patch_api_key(
+    key_id: uuid.UUID,
+    body: PatchApiKeyRequest,
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    api_key = await session.get(ApiKey, key_id)
+    if api_key is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+    # exclude_unset so null vs absent is distinguishable
+    patch = body.model_dump(exclude_unset=True)
+    for field, value in patch.items():
+        setattr(api_key, field, value)
+    await log_audit(
+        session,
+        user_id=admin.id,
+        action="patch_api_key",
+        target_type="api_key",
+        target_id=key_id,
+        detail={"fields": list(patch.keys())},
+    )
+    await session.commit()
+    await session.refresh(api_key)
+    return _api_key_to_out(api_key)
+
+
+@router.get("/api-keys/{key_id}/scope-preview", response_model=ScopePreviewResponse)
+async def scope_preview(
+    key_id: uuid.UUID,
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    api_key = await session.get(ApiKey, key_id)
+    if api_key is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+
+    total = (await session.execute(select(func.count(Document.doc_id)).where(Document.status == "active"))).scalar_one()
+
+    scope = KeyScope(
+        scope_topic_ids=api_key.scope_topic_ids,
+        scope_folder_ids=api_key.scope_folder_ids,
+        permission_tier=api_key.permission_tier,
+        tool_overrides=api_key.tool_overrides or {},
+        max_snippet_chars=api_key.max_snippet_chars,
+    )
+    fake_principal = Principal(type="api_key", id=key_id, role="user", key_scope=scope)
+    visible_query = apply_key_scope(
+        select(func.count(Document.doc_id)).where(Document.status == "active"),
+        fake_principal,
+    )
+    visible = (await session.execute(visible_query)).scalar_one()
+
+    return ScopePreviewResponse(
+        accessible_documents=visible,
+        total_documents=total,
     )
 
 

--- a/src/harbor_clerk/api/routes/api_keys.py
+++ b/src/harbor_clerk/api/routes/api_keys.py
@@ -117,6 +117,14 @@ async def patch_api_key(
         raise HTTPException(status_code=404, detail="API key not found")
     # exclude_unset so null vs absent is distinguishable
     patch = body.model_dump(exclude_unset=True)
+    # Non-nullable DB columns can't be set to None via PATCH
+    _non_nullable = {"name", "permission_tier", "tool_overrides"}
+    for field in _non_nullable:
+        if field in patch and patch[field] is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Field '{field}' cannot be null",
+            )
     for field, value in patch.items():
         setattr(api_key, field, value)
     await log_audit(

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -207,63 +207,69 @@ async def corpus_overview(
     session: AsyncSession = Depends(get_session),
 ):
     """Corpus-level statistics: counts, language distribution, mime types, date range, and document list."""
-    doc_count = (
-        await session.execute(select(func.count()).select_from(Document).where(Document.status == "active"))
-    ).scalar() or 0
-
-    chunk_count = (
-        await session.execute(
-            select(func.count())
-            .select_from(Chunk)
-            .join(Document, Document.latest_version_id == Chunk.version_id)
-            .where(Document.status == "active")
+    # Per-API-key scope: limit aggregates to visible doc_ids for scoped keys.
+    visible_ids: set[uuid.UUID] | None = None
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            principal,
         )
-    ).scalar() or 0
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
 
-    total_pages = (
-        await session.execute(
-            select(func.count())
-            .select_from(DocumentPage)
-            .join(Document, Document.latest_version_id == DocumentPage.version_id)
-            .where(Document.status == "active")
-        )
-    ).scalar() or 0
+    doc_count_q = select(func.count()).select_from(Document).where(Document.status == "active")
+    if visible_ids is not None:
+        doc_count_q = doc_count_q.where(Document.doc_id.in_(visible_ids))
+    doc_count = (await session.execute(doc_count_q)).scalar() or 0
 
-    lang_rows = (
-        await session.execute(
-            select(Chunk.language, func.count())
-            .join(Document, Document.latest_version_id == Chunk.version_id)
-            .where(Document.status == "active")
-            .group_by(Chunk.language)
-            .order_by(func.count().desc())
-        )
-    ).all()
+    chunk_count_q = (
+        select(func.count())
+        .select_from(Chunk)
+        .join(Document, Document.latest_version_id == Chunk.version_id)
+        .where(Document.status == "active")
+    )
+    if visible_ids is not None:
+        chunk_count_q = chunk_count_q.where(Document.doc_id.in_(visible_ids))
+    chunk_count = (await session.execute(chunk_count_q)).scalar() or 0
+
+    total_pages_q = (
+        select(func.count())
+        .select_from(DocumentPage)
+        .join(Document, Document.latest_version_id == DocumentPage.version_id)
+        .where(Document.status == "active")
+    )
+    if visible_ids is not None:
+        total_pages_q = total_pages_q.where(Document.doc_id.in_(visible_ids))
+    total_pages = (await session.execute(total_pages_q)).scalar() or 0
+
+    lang_q = (
+        select(Chunk.language, func.count())
+        .join(Document, Document.latest_version_id == Chunk.version_id)
+        .where(Document.status == "active")
+    )
+    if visible_ids is not None:
+        lang_q = lang_q.where(Document.doc_id.in_(visible_ids))
+    lang_rows = (await session.execute(lang_q.group_by(Chunk.language).order_by(func.count().desc()))).all()
     languages = {row[0]: row[1] for row in lang_rows if row[0]}
 
-    mime_rows = (
-        await session.execute(
-            select(DocumentVersion.mime_type, func.count())
-            .join(Document, Document.latest_version_id == DocumentVersion.version_id)
-            .where(Document.status == "active")
-            .group_by(DocumentVersion.mime_type)
-            .order_by(func.count().desc())
-        )
-    ).all()
+    mime_q = (
+        select(DocumentVersion.mime_type, func.count())
+        .join(Document, Document.latest_version_id == DocumentVersion.version_id)
+        .where(Document.status == "active")
+    )
+    if visible_ids is not None:
+        mime_q = mime_q.where(Document.doc_id.in_(visible_ids))
+    mime_rows = (await session.execute(mime_q.group_by(DocumentVersion.mime_type).order_by(func.count().desc()))).all()
     mime_types = {row[0]: row[1] for row in mime_rows if row[0]}
 
-    date_row = (
-        await session.execute(
-            select(func.min(Document.updated_at), func.max(Document.updated_at)).where(Document.status == "active")
-        )
-    ).one()
+    date_q = select(func.min(Document.updated_at), func.max(Document.updated_at)).where(Document.status == "active")
+    if visible_ids is not None:
+        date_q = date_q.where(Document.doc_id.in_(visible_ids))
+    date_row = (await session.execute(date_q)).one()
 
-    result = await session.execute(
-        select(Document)
-        .options(selectinload(Document.versions))
-        .where(Document.status == "active")
-        .order_by(Document.updated_at.desc())
-        .limit(200)
-    )
+    docs_q = select(Document).options(selectinload(Document.versions)).where(Document.status == "active")
+    if visible_ids is not None:
+        docs_q = docs_q.where(Document.doc_id.in_(visible_ids))
+    result = await session.execute(docs_q.order_by(Document.updated_at.desc()).limit(200))
     docs = result.scalars().all()
 
     items = []
@@ -321,7 +327,7 @@ async def entity_autocomplete(
     if entity_type:
         filters.append(Entity.entity_type == entity_type)
 
-    result = await session.execute(
+    query = (
         select(
             Entity.entity_text,
             Entity.entity_type,
@@ -329,7 +335,11 @@ async def entity_autocomplete(
         )
         .join(Document, Document.doc_id == Entity.doc_id)
         .where(*filters)
-        .group_by(Entity.entity_text, Entity.entity_type)
+    )
+    # Per-API-key scope: filter to visible docs only (no-op for users / unrestricted keys).
+    query = apply_key_scope(query, principal)
+    result = await session.execute(
+        query.group_by(Entity.entity_text, Entity.entity_type)
         .order_by(func.count(func.distinct(Entity.doc_id)).desc())
         .limit(limit)
     )
@@ -345,16 +355,18 @@ async def top_entities(
     session: AsyncSession = Depends(get_session),
 ):
     """Top entities of a given type across active documents."""
-    result = await session.execute(
+    query = (
         select(
             Entity.entity_text,
             func.count(func.distinct(Entity.doc_id)).label("doc_count"),
         )
         .join(Document, Document.doc_id == Entity.doc_id)
         .where(Document.status == "active", Entity.entity_type == entity_type)
-        .group_by(Entity.entity_text)
-        .order_by(func.count(func.distinct(Entity.doc_id)).desc())
-        .limit(limit)
+    )
+    # Per-API-key scope: filter to visible docs only (no-op for users / unrestricted keys).
+    query = apply_key_scope(query, principal)
+    result = await session.execute(
+        query.group_by(Entity.entity_text).order_by(func.count(func.distinct(Entity.doc_id)).desc()).limit(limit)
     )
     return [{"entity_text": r[0], "doc_count": r[1]} for r in result.all()]
 
@@ -365,47 +377,60 @@ async def document_filters(
     session: AsyncSession = Depends(get_session),
 ):
     """Return available filter values for the documents list."""
-    # MIME types
-    mime_rows = (
-        await session.execute(
-            select(DocumentVersion.mime_type, func.count())
-            .join(Document, Document.latest_version_id == DocumentVersion.version_id)
-            .where(Document.status == "active", DocumentVersion.mime_type.isnot(None))
-            .group_by(DocumentVersion.mime_type)
-            .order_by(func.count().desc())
+    # Per-API-key scope: limit facet counts to visible docs for scoped keys.
+    visible_ids: set[uuid.UUID] | None = None
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            principal,
         )
-    ).all()
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+
+    # MIME types
+    mime_q = (
+        select(DocumentVersion.mime_type, func.count())
+        .join(Document, Document.latest_version_id == DocumentVersion.version_id)
+        .where(Document.status == "active", DocumentVersion.mime_type.isnot(None))
+    )
+    if visible_ids is not None:
+        mime_q = mime_q.where(Document.doc_id.in_(visible_ids))
+    mime_rows = (await session.execute(mime_q.group_by(DocumentVersion.mime_type).order_by(func.count().desc()))).all()
 
     # Doc types
+    doc_type_q = (
+        select(DocumentVersion.doc_type, func.count())
+        .join(Document, Document.latest_version_id == DocumentVersion.version_id)
+        .where(Document.status == "active", DocumentVersion.doc_type.isnot(None))
+    )
+    if visible_ids is not None:
+        doc_type_q = doc_type_q.where(Document.doc_id.in_(visible_ids))
     doc_type_rows = (
-        await session.execute(
-            select(DocumentVersion.doc_type, func.count())
-            .join(Document, Document.latest_version_id == DocumentVersion.version_id)
-            .where(Document.status == "active", DocumentVersion.doc_type.isnot(None))
-            .group_by(DocumentVersion.doc_type)
-            .order_by(func.count().desc())
-        )
+        await session.execute(doc_type_q.group_by(DocumentVersion.doc_type).order_by(func.count().desc()))
     ).all()
 
     # Languages
+    lang_q = (
+        select(Chunk.language, func.count(func.distinct(Chunk.doc_id)))
+        .join(Document, Document.doc_id == Chunk.doc_id)
+        .where(Document.status == "active", Chunk.language.isnot(None))
+    )
+    if visible_ids is not None:
+        lang_q = lang_q.where(Document.doc_id.in_(visible_ids))
     lang_rows = (
-        await session.execute(
-            select(Chunk.language, func.count(func.distinct(Chunk.doc_id)))
-            .join(Document, Document.doc_id == Chunk.doc_id)
-            .where(Document.status == "active", Chunk.language.isnot(None))
-            .group_by(Chunk.language)
-            .order_by(func.count(func.distinct(Chunk.doc_id)).desc())
-        )
+        await session.execute(lang_q.group_by(Chunk.language).order_by(func.count(func.distinct(Chunk.doc_id)).desc()))
     ).all()
 
     # Entity types
+    ent_type_q = (
+        select(Entity.entity_type, func.count(func.distinct(Entity.doc_id)))
+        .join(Document, Document.doc_id == Entity.doc_id)
+        .where(Document.status == "active")
+    )
+    if visible_ids is not None:
+        ent_type_q = ent_type_q.where(Document.doc_id.in_(visible_ids))
     ent_type_rows = (
         await session.execute(
-            select(Entity.entity_type, func.count(func.distinct(Entity.doc_id)))
-            .join(Document, Document.doc_id == Entity.doc_id)
-            .where(Document.status == "active")
-            .group_by(Entity.entity_type)
-            .order_by(func.count(func.distinct(Entity.doc_id)).desc())
+            ent_type_q.group_by(Entity.entity_type).order_by(func.count(func.distinct(Entity.doc_id)).desc())
         )
     ).all()
 
@@ -503,11 +528,9 @@ async def get_document_content(
     session: AsyncSession = Depends(get_session),
 ):
     # Get document + latest version
-    result = await session.execute(
-        select(Document)
-        .where(Document.doc_id == doc_id, Document.status == "active")
-        .options(selectinload(Document.versions))
-    )
+    doc_query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
+    doc_query = apply_key_scope(doc_query, principal)
+    result = await session.execute(doc_query.options(selectinload(Document.versions)))
     doc = result.scalar_one_or_none()
     if doc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
@@ -585,11 +608,9 @@ async def get_document_outline(
     session: AsyncSession = Depends(get_session),
 ):
     """Get document heading outline/structure with page and chunk counts."""
-    result = await session.execute(
-        select(Document)
-        .where(Document.doc_id == doc_id, Document.status == "active")
-        .options(selectinload(Document.versions))
-    )
+    doc_query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
+    doc_query = apply_key_scope(doc_query, principal)
+    result = await session.execute(doc_query.options(selectinload(Document.versions)))
     doc = result.scalar_one_or_none()
     if doc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
@@ -636,11 +657,9 @@ async def get_document_entities(
     session: AsyncSession = Depends(get_session),
 ):
     """Get deduplicated entities with mention counts for a document's latest version."""
-    result = await session.execute(
-        select(Document)
-        .where(Document.doc_id == doc_id, Document.status == "active")
-        .options(selectinload(Document.versions))
-    )
+    doc_query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
+    doc_query = apply_key_scope(doc_query, principal)
+    result = await session.execute(doc_query.options(selectinload(Document.versions)))
     doc = result.scalar_one_or_none()
     if doc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
@@ -702,9 +721,9 @@ async def find_related_documents(
     session: AsyncSession = Depends(get_session),
 ):
     """Find documents most similar to the given document by embedding cosine similarity."""
-    doc = (
-        await session.execute(select(Document).where(Document.doc_id == doc_id, Document.status == "active"))
-    ).scalar_one_or_none()
+    doc_query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
+    doc_query = apply_key_scope(doc_query, principal)
+    doc = (await session.execute(doc_query)).scalar_one_or_none()
     if doc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
 
@@ -734,22 +753,20 @@ async def find_related_documents(
     n = len(rows)
     avg = [v / n for v in avg]
 
-    # Find nearest docs
+    # Find nearest docs — scope-filter the candidate set so scoped keys
+    # only see related docs within their allowed topics/folders.
     distance = Chunk.embedding.cosine_distance(avg)
-    nearest = (
-        await session.execute(
-            select(Chunk.doc_id, func.min(distance).label("min_distance"))
-            .join(Document, Document.latest_version_id == Chunk.version_id)
-            .where(
-                Document.status == "active",
-                Chunk.embedding.isnot(None),
-                Chunk.doc_id != doc_id,
-            )
-            .group_by(Chunk.doc_id)
-            .order_by(func.min(distance))
-            .limit(k)
+    nearest_q = (
+        select(Chunk.doc_id, func.min(distance).label("min_distance"))
+        .join(Document, Document.latest_version_id == Chunk.version_id)
+        .where(
+            Document.status == "active",
+            Chunk.embedding.isnot(None),
+            Chunk.doc_id != doc_id,
         )
-    ).all()
+    )
+    nearest_q = apply_key_scope(nearest_q, principal)
+    nearest = (await session.execute(nearest_q.group_by(Chunk.doc_id).order_by(func.min(distance)).limit(k))).all()
 
     if not nearest:
         return RelatedDocumentsResponse(doc_id=str(doc_id), related=[])
@@ -792,11 +809,9 @@ async def download_document(
     session: AsyncSession = Depends(get_session),
 ):
     """Download the original file for the latest version of a document."""
-    result = await session.execute(
-        select(Document)
-        .where(Document.doc_id == doc_id, Document.status == "active")
-        .options(selectinload(Document.versions))
-    )
+    query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
+    query = apply_key_scope(query, principal)
+    result = await session.execute(query.options(selectinload(Document.versions)))
     doc = result.scalar_one_or_none()
     if doc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -27,6 +27,7 @@ from harbor_clerk.api.schemas.documents import (
     RelatedDocumentsResponse,
     VersionInfo,
 )
+from harbor_clerk.api.scope import apply_key_scope
 from harbor_clerk.audit import log_audit
 from harbor_clerk.db import get_session
 from harbor_clerk.models import (
@@ -109,6 +110,9 @@ async def list_documents(
             entity_filters.append(Entity.entity_type == entity_type)
         entity_subq = select(Entity.doc_id).where(*entity_filters).group_by(Entity.doc_id).subquery()
         base = base.where(Document.doc_id.in_(select(entity_subq.c.doc_id)))
+
+    # Per-API-key scope filter (no-op for users / unrestricted keys)
+    base = apply_key_scope(base, principal)
 
     total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar() or 0
 
@@ -419,9 +423,11 @@ async def get_document(
     principal: Principal = Depends(require_read_access),
     session: AsyncSession = Depends(get_session),
 ):
-    result = await session.execute(
-        select(Document).where(Document.doc_id == doc_id).options(selectinload(Document.versions))
-    )
+    doc_query = apply_key_scope(
+        select(Document).where(Document.doc_id == doc_id),
+        principal,
+    ).options(selectinload(Document.versions))
+    result = await session.execute(doc_query)
     doc = result.scalar_one_or_none()
     if doc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -160,8 +160,19 @@ async def read_passages(
                 detail=f"Invalid chunk_id: {cid}",
             )
 
+    # Per-API-key scope: compute the set of visible doc_ids for scoped keys.
+    visible_ids: set[uuid.UUID] | None = None
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(select(Document.doc_id), principal)
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+
     result = await session.execute(select(Chunk).where(Chunk.chunk_id.in_(chunk_uuids)))
     chunks = {c.chunk_id: c for c in result.scalars().all()}
+
+    # Drop chunks whose parent doc is outside this key's scope — scoped-out
+    # docs must be invisible (same as a 404 on per-doc endpoints).
+    if visible_ids is not None:
+        chunks = {cid: c for cid, c in chunks.items() if c.doc_id in visible_ids}
 
     # Load doc titles
     doc_ids = {c.doc_id for c in chunks.values()}

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -19,6 +19,7 @@ from harbor_clerk.api.schemas.search import (
     SearchRequest,
     SearchResponse,
 )
+from harbor_clerk.api.scope import apply_key_scope
 from harbor_clerk.db import get_session
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.search import hybrid_search
@@ -53,6 +54,40 @@ async def search(
     doc_id = uuid.UUID(body.doc_id) if body.doc_id else None
     version_id = uuid.UUID(body.version_id) if body.version_id else None
     doc_ids = [uuid.UUID(d) for d in body.doc_ids] if body.doc_ids else None
+
+    # Per-API-key scope: intersect with visible doc_ids for scoped keys.
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(select(Document.doc_id), principal)
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+        if not visible_ids:
+            return SearchResponse(
+                hits=[],
+                total_candidates=0,
+                has_more=False,
+                possible_conflict=False,
+                conflict_sources=[],
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in visible_ids]
+            if not doc_ids:
+                return SearchResponse(
+                    hits=[],
+                    total_candidates=0,
+                    has_more=False,
+                    possible_conflict=False,
+                    conflict_sources=[],
+                )
+        else:
+            doc_ids = list(visible_ids)
+        # Also enforce single-doc filter against visible set
+        if doc_id is not None and doc_id not in visible_ids:
+            return SearchResponse(
+                hits=[],
+                total_candidates=0,
+                has_more=False,
+                possible_conflict=False,
+                conflict_sources=[],
+            )
 
     result = await hybrid_search(
         session,

--- a/src/harbor_clerk/api/schemas/api_keys.py
+++ b/src/harbor_clerk/api/schemas/api_keys.py
@@ -1,12 +1,49 @@
-"""API key management schemas."""
+"""API key schemas."""
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
 
 class CreateApiKeyRequest(BaseModel):
     name: str
+    expires_at: datetime | None = None
+    permission_tier: Literal["search", "read", "full"] = "full"
+    tool_overrides: dict[str, bool] | None = None
+    scope_topic_ids: list[int] | None = None
+    scope_folder_ids: list[str] | None = None
+    max_snippet_chars: int | None = None
+
+
+class PatchApiKeyRequest(BaseModel):
+    name: str | None = None
+    expires_at: datetime | None = None
+    permission_tier: Literal["search", "read", "full"] | None = None
+    tool_overrides: dict[str, bool] | None = None
+    scope_topic_ids: list[int] | None = None
+    scope_folder_ids: list[str] | None = None
+    max_snippet_chars: int | None = None
+
+
+class ApiKeyOut(BaseModel):
+    key_id: str
+    name: str
+    is_active: bool
+    created_at: datetime
+    last_used_at: datetime | None
+    expires_at: datetime | None
+    permission_tier: str
+    tool_overrides: dict[str, bool]
+    scope_topic_ids: list[int] | None
+    scope_folder_ids: list[str] | None
+    max_snippet_chars: int | None
+    scope_summary: str
+
+
+class ScopePreviewResponse(BaseModel):
+    accessible_documents: int
+    total_documents: int
 
 
 class ApiKeyCreatedResponse(BaseModel):
@@ -15,11 +52,3 @@ class ApiKeyCreatedResponse(BaseModel):
     raw_key: str  # shown once on creation
     mcp_path: str  # URL path for authless MCP clients: /t/<key>
     created_at: datetime
-
-
-class ApiKeyInfo(BaseModel):
-    key_id: str
-    name: str
-    is_active: bool
-    created_at: datetime
-    last_used_at: datetime | None = None

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -1,0 +1,68 @@
+"""Per-API-key scope computation: tiers, tool sets, and query filters."""
+
+from dataclasses import dataclass
+
+# Tier -> base tool set
+SEARCH_TIER_TOOLS: frozenset[str] = frozenset({"kb_search", "kb_batch_search", "kb_corpus_overview", "kb_list_recent"})
+READ_TIER_TOOLS: frozenset[str] = SEARCH_TIER_TOOLS | frozenset(
+    {"kb_read_passages", "kb_expand_context", "kb_document_outline", "kb_get_document"}
+)
+FULL_TIER_TOOLS: frozenset[str] = READ_TIER_TOOLS | frozenset(
+    {
+        "kb_read_document",
+        "kb_find_related",
+        "kb_entity_search",
+        "kb_entity_overview",
+        "kb_entity_cooccurrence",
+        "kb_ingest_status",
+    }
+)
+
+# Admin-only tools — never available to API keys regardless of tier or overrides
+ADMIN_ONLY_TOOLS: frozenset[str] = frozenset({"kb_system_health", "kb_reprocess"})
+
+_TIERS: dict[str, frozenset[str]] = {
+    "search": SEARCH_TIER_TOOLS,
+    "read": READ_TIER_TOOLS,
+    "full": FULL_TIER_TOOLS,
+}
+
+
+def compute_effective_tools(tier: str, overrides: dict[str, bool]) -> frozenset[str]:
+    """Compute the set of tools available to an API key.
+
+    Starts with the tier's base set, applies overrides (true=add, false=remove),
+    then strips admin-only tools.
+    """
+    base = _TIERS.get(tier, FULL_TIER_TOOLS)  # default to full for unknown tier
+    effective = set(base)
+    for tool_name, enabled in (overrides or {}).items():
+        if enabled:
+            effective.add(tool_name)
+        else:
+            effective.discard(tool_name)
+    return frozenset(effective - ADMIN_ONLY_TOOLS)
+
+
+@dataclass
+class KeyScope:
+    """Snapshot of an API key's scope, attached to Principal at auth time.
+
+    Avoids per-tool-call DB lookups for scope info.
+    """
+
+    scope_topic_ids: list[int] | None
+    scope_folder_ids: list[str] | None
+    permission_tier: str
+    tool_overrides: dict[str, bool]
+    max_snippet_chars: int | None
+
+    @property
+    def is_unrestricted(self) -> bool:
+        """True if no document-level scope filter applies."""
+        return self.scope_topic_ids is None and self.scope_folder_ids is None
+
+    @property
+    def effective_tools(self) -> frozenset[str]:
+        """The set of tool names this key may call."""
+        return compute_effective_tools(self.permission_tier, self.tool_overrides)

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -1,6 +1,17 @@
 """Per-API-key scope computation: tiers, tool sets, and query filters."""
 
+import uuid
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy import or_, select
+from sqlalchemy.sql import Select
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
+
+if TYPE_CHECKING:
+    from harbor_clerk.api.deps import Principal
 
 # Tier -> base tool set
 SEARCH_TIER_TOOLS: frozenset[str] = frozenset({"kb_search", "kb_batch_search", "kb_corpus_overview", "kb_list_recent"})
@@ -66,3 +77,40 @@ class KeyScope:
     def effective_tools(self) -> frozenset[str]:
         """The set of tool names this key may call."""
         return compute_effective_tools(self.permission_tier, self.tool_overrides)
+
+
+def apply_key_scope(query: Select, principal: "Principal") -> Select:
+    """Filter a Document query by the API key's scope.
+
+    No-op for human users (type='user') and unrestricted API keys.
+    For scoped keys, adds a WHERE clause filtering documents to those
+    matching the topic OR folder scope.
+
+    Pure query builder — no DB access (scope is on Principal from auth time).
+    """
+    if principal.type != "api_key" or principal.key_scope is None:
+        return query
+    scope = principal.key_scope
+    if scope.is_unrestricted:
+        return query
+
+    conditions = []
+    if scope.scope_topic_ids is not None:
+        conditions.append(Document.topic_id.in_(scope.scope_topic_ids))
+    if scope.scope_folder_ids is not None:
+        try:
+            folder_uuids = [uuid.UUID(fid) for fid in scope.scope_folder_ids]
+        except (ValueError, AttributeError):
+            folder_uuids = []
+        if folder_uuids:
+            watched_doc_ids = select(WatchedFile.doc_id).where(
+                WatchedFile.folder_id.in_(folder_uuids),
+                WatchedFile.status == WatchedFileStatus.active,
+            )
+            conditions.append(Document.doc_id.in_(watched_doc_ids))
+
+    if not conditions:
+        # Both axes empty — explicitly nothing visible
+        return query.where(Document.doc_id == uuid.UUID(int=0))
+
+    return query.where(or_(*conditions))

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -240,12 +240,13 @@ async def _visible_doc_ids(session: AsyncSession, principal: Principal) -> set[u
 
     Returns None for human users and unrestricted API keys (no filter needed).
     Returns the explicit set for scoped keys — callers use this to filter results.
+    Only active (non-removed) documents are included.
     """
     if principal.type != "api_key" or principal.key_scope is None or principal.key_scope.is_unrestricted:
         return None
     from harbor_clerk.api.scope import apply_key_scope
 
-    query = apply_key_scope(select(Document.doc_id), principal)
+    query = apply_key_scope(select(Document.doc_id).where(Document.status == "active"), principal)
     result = await session.execute(query)
     return {row[0] for row in result.all()}
 
@@ -301,6 +302,11 @@ mcp = ScopedFastMCP(
     # DNS rebinding protection is unnecessary — we run behind Caddy with
     # our own Bearer-token auth middleware wrapping the MCP ASGI app.
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    # Stateless mode: each request spawns a fresh run_server task, so contextvars
+    # (including _mcp_principal) are captured per-request instead of at session
+    # establishment. Required for scoped API keys — otherwise all tool calls in a
+    # session would use the first request's principal snapshot.
+    stateless_http=True,
 )
 
 

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -224,6 +224,21 @@ def _require_admin() -> Principal:
     return p
 
 
+async def _visible_doc_ids(session: AsyncSession, principal: Principal) -> set[uuid.UUID] | None:
+    """Get the set of doc_ids visible to this principal, or None if unrestricted.
+
+    Returns None for human users and unrestricted API keys (no filter needed).
+    Returns the explicit set for scoped keys — callers use this to filter results.
+    """
+    if principal.type != "api_key" or principal.key_scope is None or principal.key_scope.is_unrestricted:
+        return None
+    from harbor_clerk.api.scope import apply_key_scope
+
+    query = apply_key_scope(select(Document.doc_id), principal)
+    result = await session.execute(query)
+    return {row[0] for row in result.all()}
+
+
 # ---------------------------------------------------------------------------
 # FastMCP server
 # ---------------------------------------------------------------------------
@@ -391,7 +406,7 @@ async def kb_search(
     Pagination: use offset to page through results. Check has_more
     in the response to know if more results exist beyond your window.
     """
-    _get_principal()
+    principal = _get_principal()
     settings = get_settings()
 
     # Mutual exclusion check
@@ -431,6 +446,20 @@ async def kb_search(
         detail = "full"
 
     async with async_session_factory() as session:
+        # Per-API-key scope: intersect with visible doc_ids for scoped keys.
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None:
+            if not visible_ids:
+                return json.dumps({"hits": [], "total_candidates": 0, "has_more": False}, indent=2)
+            if did is not None and did not in visible_ids:
+                return json.dumps({"hits": [], "total_candidates": 0, "has_more": False}, indent=2)
+            if parsed_doc_ids is not None:
+                parsed_doc_ids = [d for d in parsed_doc_ids if d in visible_ids]
+                if not parsed_doc_ids:
+                    return json.dumps({"hits": [], "total_candidates": 0, "has_more": False}, indent=2)
+            elif did is None:
+                parsed_doc_ids = list(visible_ids)
+
         result = await hybrid_search(
             session,
             query,
@@ -530,7 +559,7 @@ async def kb_batch_search(
 
     See kb_search for filter and detail level documentation.
     """
-    _get_principal()
+    principal = _get_principal()
     settings = get_settings()
 
     # Validate query count
@@ -581,7 +610,24 @@ async def kb_batch_search(
 
     results = []
     async with async_session_factory() as session:
+        # Per-API-key scope: intersect with visible doc_ids for scoped keys.
+        visible_ids = await _visible_doc_ids(session, principal)
+        scope_blocks_all = False
+        if visible_ids is not None:
+            if not visible_ids or (did is not None and did not in visible_ids):
+                scope_blocks_all = True
+            elif parsed_doc_ids is not None:
+                parsed_doc_ids = [d for d in parsed_doc_ids if d in visible_ids]
+                if not parsed_doc_ids:
+                    scope_blocks_all = True
+            elif did is None:
+                parsed_doc_ids = list(visible_ids)
+
         for query in queries:
+            if scope_blocks_all:
+                resp: dict = {"hits": [], "total_candidates": 0, "has_more": False, "query": query}
+                results.append(resp)
+                continue
             result = await hybrid_search(
                 session,
                 query,
@@ -639,17 +685,27 @@ async def kb_read_passages(
     following chunks — useful for understanding a passage in context
     without a separate kb_expand_context call.
     """
-    _get_principal()
+    principal = _get_principal()
     uuids = [uuid.UUID(cid) for cid in chunk_ids]
 
     async with async_session_factory() as session:
         result = await session.execute(select(Chunk).where(Chunk.chunk_id.in_(uuids)))
         chunks = {c.chunk_id: c for c in result.scalars().all()}
 
+        # Per-API-key scope: drop chunks from documents the key can't see.
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None:
+            chunks = {cid: c for cid, c in chunks.items() if c.doc_id in visible_ids}
+
         # Doc titles
         doc_ids = {c.doc_id for c in chunks.values()}
         docs_result = await session.execute(select(Document).where(Document.doc_id.in_(list(doc_ids))))
         docs = {d.doc_id: d for d in docs_result.scalars().all()}
+
+        # Snippet truncation limit from key scope, if any
+        snippet_limit: int | None = None
+        if principal.key_scope and principal.key_scope.max_snippet_chars is not None:
+            snippet_limit = principal.key_scope.max_snippet_chars
 
         passages = []
         for cid in uuids:
@@ -657,10 +713,13 @@ async def kb_read_passages(
             if chunk is None:
                 continue
             doc = docs.get(chunk.doc_id)
+            text = chunk.chunk_text
+            if snippet_limit is not None:
+                text = text[:snippet_limit]
             p: dict = {
                 "chunk_id": str(cid),
                 "doc_title": doc.title if doc else None,
-                "text": chunk.chunk_text,
+                "text": text,
                 "language": chunk.language,
             }
             if chunk.page_start is not None:
@@ -679,6 +738,8 @@ async def kb_read_passages(
                 )
                 prev_text = prev.scalar_one_or_none()
                 if prev_text:
+                    if snippet_limit is not None:
+                        prev_text = prev_text[:snippet_limit]
                     p["context_before"] = prev_text
 
                 nxt = await session.execute(
@@ -689,6 +750,8 @@ async def kb_read_passages(
                 )
                 nxt_text = nxt.scalar_one_or_none()
                 if nxt_text:
+                    if snippet_limit is not None:
+                        nxt_text = nxt_text[:snippet_limit]
                     p["context_after"] = nxt_text
 
             passages.append(p)
@@ -704,13 +767,18 @@ async def kb_expand_context(chunk_id: str, n: int = 2) -> str:
     Use after kb_search or kb_read_passages when you need more surrounding
     text. The target chunk is marked with "is_target": true.
     """
-    _get_principal()
+    principal = _get_principal()
     n = max(1, min(n, 10))
     target_id = uuid.UUID(chunk_id)
 
     async with async_session_factory() as session:
         target = (await session.execute(select(Chunk).where(Chunk.chunk_id == target_id))).scalar_one_or_none()
         if target is None:
+            return json.dumps({"error": "Chunk not found"})
+
+        # Per-API-key scope: block access if the target doc isn't visible.
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and target.doc_id not in visible_ids:
             return json.dumps({"error": "Chunk not found"})
 
         result = await session.execute(
@@ -725,12 +793,20 @@ async def kb_expand_context(chunk_id: str, n: int = 2) -> str:
 
         doc = (await session.execute(select(Document).where(Document.doc_id == target.doc_id))).scalar_one_or_none()
 
+        # Snippet truncation limit from key scope, if any
+        snippet_limit: int | None = None
+        if principal.key_scope and principal.key_scope.max_snippet_chars is not None:
+            snippet_limit = principal.key_scope.max_snippet_chars
+
         chunks = []
         for c in neighbours:
+            text = c.chunk_text
+            if snippet_limit is not None:
+                text = text[:snippet_limit]
             entry: dict = {
                 "chunk_id": str(c.chunk_id),
                 "chunk_num": c.chunk_num,
-                "text": c.chunk_text,
+                "text": text,
                 "language": c.language,
             }
             if c.page_start is not None:
@@ -760,10 +836,14 @@ async def kb_get_document(doc_id: str) -> str:
     Use this to inspect a specific document after finding it via search
     or kb_list_recent.
     """
-    _get_principal()
+    principal = _get_principal()
     did = uuid.UUID(doc_id)
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and did not in visible_ids:
+            return json.dumps({"error": "Document not found"})
+
         result = await session.execute(
             select(Document).options(selectinload(Document.versions)).where(Document.doc_id == did)
         )
@@ -812,21 +892,29 @@ async def kb_list_recent(limit: int = 20) -> str:
     for each document. Use this to see what's new or recently changed,
     or as a paginated document browser (max 100 per call).
     """
-    _get_principal()
+    principal = _get_principal()
 
     async with async_session_factory() as session:
-        total_result = await session.execute(
-            select(func.count()).select_from(Document).where(Document.status == "active")
-        )
-        total_count = total_result.scalar() or 0
+        visible_ids = await _visible_doc_ids(session, principal)
 
-        result = await session.execute(
+        count_q = select(func.count()).select_from(Document).where(Document.status == "active")
+        list_q = (
             select(Document)
             .options(selectinload(Document.versions))
             .where(Document.status == "active")
             .order_by(Document.updated_at.desc())
             .limit(min(limit, 100))
         )
+        if visible_ids is not None:
+            if not visible_ids:
+                return json.dumps({"total_count": 0, "truncated": False, "documents": []}, indent=2)
+            count_q = count_q.where(Document.doc_id.in_(visible_ids))
+            list_q = list_q.where(Document.doc_id.in_(visible_ids))
+
+        total_result = await session.execute(count_q)
+        total_count = total_result.scalar() or 0
+
+        result = await session.execute(list_q)
         docs = result.scalars().all()
 
     items = []
@@ -875,38 +963,65 @@ async def kb_corpus_overview(limit: int = 50) -> str:
             documents; decrease for faster responses with large corpora.
             The response includes a 'truncated' flag and total
             'document_count' so you know if more exist."""
-    _get_principal()
+    principal = _get_principal()
 
     limit = max(1, min(limit, 500))
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and not visible_ids:
+            return json.dumps(
+                {
+                    "document_count": 0,
+                    "total_chunks": 0,
+                    "total_pages": 0,
+                    "languages": {},
+                    "mime_types": {},
+                    "date_range": {"oldest": None, "newest": None},
+                    "documents": [],
+                    "truncated": False,
+                },
+                indent=2,
+            )
+
+        def _scoped(q):
+            if visible_ids is not None:
+                return q.where(Document.doc_id.in_(visible_ids))
+            return q
+
         doc_count_result = await session.execute(
-            select(func.count()).select_from(Document).where(Document.status == "active")
+            _scoped(select(func.count()).select_from(Document).where(Document.status == "active"))
         )
         doc_count = doc_count_result.scalar() or 0
 
         chunk_count_result = await session.execute(
-            select(func.count())
-            .select_from(Chunk)
-            .join(Document, Document.latest_version_id == Chunk.version_id)
-            .where(Document.status == "active")
+            _scoped(
+                select(func.count())
+                .select_from(Chunk)
+                .join(Document, Document.latest_version_id == Chunk.version_id)
+                .where(Document.status == "active")
+            )
         )
         chunk_count = chunk_count_result.scalar() or 0
 
         page_count_result = await session.execute(
-            select(func.count())
-            .select_from(DocumentPage)
-            .join(Document, Document.latest_version_id == DocumentPage.version_id)
-            .where(Document.status == "active")
+            _scoped(
+                select(func.count())
+                .select_from(DocumentPage)
+                .join(Document, Document.latest_version_id == DocumentPage.version_id)
+                .where(Document.status == "active")
+            )
         )
         total_pages = page_count_result.scalar() or 0
 
         # Language distribution from chunks (scoped to active docs' latest versions)
         lang_rows = (
             await session.execute(
-                select(Chunk.language, func.count())
-                .join(Document, Document.latest_version_id == Chunk.version_id)
-                .where(Document.status == "active")
+                _scoped(
+                    select(Chunk.language, func.count())
+                    .join(Document, Document.latest_version_id == Chunk.version_id)
+                    .where(Document.status == "active")
+                )
                 .group_by(Chunk.language)
                 .order_by(func.count().desc())
             )
@@ -916,9 +1031,11 @@ async def kb_corpus_overview(limit: int = 50) -> str:
         # Mime type breakdown from latest versions of active docs
         mime_rows = (
             await session.execute(
-                select(DocumentVersion.mime_type, func.count())
-                .join(Document, Document.latest_version_id == DocumentVersion.version_id)
-                .where(Document.status == "active")
+                _scoped(
+                    select(DocumentVersion.mime_type, func.count())
+                    .join(Document, Document.latest_version_id == DocumentVersion.version_id)
+                    .where(Document.status == "active")
+                )
                 .group_by(DocumentVersion.mime_type)
                 .order_by(func.count().desc())
             )
@@ -927,19 +1044,24 @@ async def kb_corpus_overview(limit: int = 50) -> str:
 
         # Date range
         date_result = await session.execute(
-            select(func.min(Document.updated_at), func.max(Document.updated_at)).where(Document.status == "active")
+            _scoped(
+                select(func.min(Document.updated_at), func.max(Document.updated_at)).where(Document.status == "active")
+            )
         )
         date_row = date_result.one()
         oldest = date_row[0].isoformat() if date_row[0] else None
         newest = date_row[1].isoformat() if date_row[1] else None
 
-        result = await session.execute(
+        list_q = (
             select(Document)
             .options(selectinload(Document.versions))
             .where(Document.status == "active")
             .order_by(Document.updated_at.desc())
             .limit(limit)
         )
+        if visible_ids is not None:
+            list_q = list_q.where(Document.doc_id.in_(visible_ids))
+        result = await session.execute(list_q)
         docs = result.scalars().all()
 
     items = []
@@ -986,10 +1108,14 @@ async def kb_ingest_status(doc_id: str) -> str:
     timestamps, and any error messages. Use this to check if a document
     is still being processed or to diagnose ingestion failures.
     """
-    _get_principal()
+    principal = _get_principal()
     did = uuid.UUID(doc_id)
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and did not in visible_ids:
+            return json.dumps({"error": "Document not found"})
+
         result = await session.execute(select(Document).where(Document.doc_id == did))
         doc = result.scalar_one_or_none()
         if doc is None:
@@ -1081,10 +1207,14 @@ async def kb_document_outline(doc_id: str) -> str:
     for the latest version of the document. Useful for understanding document structure
     before reading specific sections.
     """
-    _get_principal()
+    principal = _get_principal()
     did = uuid.UUID(doc_id)
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and did not in visible_ids:
+            return json.dumps({"error": "Document not found"})
+
         result = await session.execute(
             select(Document)
             .options(selectinload(Document.versions))
@@ -1145,7 +1275,7 @@ async def kb_find_related(doc_id: str, k: int = 5) -> str:
         doc_id: The document to find related documents for.
         k: Number of related documents to return (1-20, default 5).
     """
-    _get_principal()
+    principal = _get_principal()
     k = max(1, min(k, 20))
 
     try:
@@ -1154,6 +1284,10 @@ async def kb_find_related(doc_id: str, k: int = 5) -> str:
         return json.dumps({"error": f"Invalid doc_id: {doc_id}"})
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and target_id not in visible_ids:
+            return json.dumps({"error": "Document not found"})
+
         # Verify document exists and get latest version
         doc = (
             await session.execute(select(Document).where(Document.doc_id == target_id, Document.status == "active"))
@@ -1189,23 +1323,21 @@ async def kb_find_related(doc_id: str, k: int = 5) -> str:
 
         # Find nearest chunks from OTHER active documents' latest versions
         distance = Chunk.embedding.cosine_distance(avg)
-        nearest = (
-            await session.execute(
-                select(
-                    Chunk.doc_id,
-                    func.min(distance).label("min_distance"),
-                )
-                .join(Document, Document.latest_version_id == Chunk.version_id)
-                .where(
-                    Document.status == "active",
-                    Chunk.embedding.isnot(None),
-                    Chunk.doc_id != target_id,
-                )
-                .group_by(Chunk.doc_id)
-                .order_by(func.min(distance))
-                .limit(k)
+        nearest_q = (
+            select(
+                Chunk.doc_id,
+                func.min(distance).label("min_distance"),
             )
-        ).all()
+            .join(Document, Document.latest_version_id == Chunk.version_id)
+            .where(
+                Document.status == "active",
+                Chunk.embedding.isnot(None),
+                Chunk.doc_id != target_id,
+            )
+        )
+        if visible_ids is not None:
+            nearest_q = nearest_q.where(Chunk.doc_id.in_(visible_ids))
+        nearest = (await session.execute(nearest_q.group_by(Chunk.doc_id).order_by(func.min(distance)).limit(k))).all()
 
         if not nearest:
             return json.dumps({"doc_id": doc_id, "related": []})
@@ -1264,7 +1396,7 @@ async def kb_entity_search(
         limit: Max results (1-100, default 20).
         offset: Pagination offset.
     """
-    _get_principal()
+    principal = _get_principal()
     limit = max(1, min(limit, 100))
     offset = max(0, offset)
 
@@ -1272,6 +1404,10 @@ async def kb_entity_search(
     escaped_query = re.sub(r"([%_\\])", r"\\\1", query)
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and not visible_ids:
+            return json.dumps({"entities": [], "total": 0, "has_more": False})
+
         # Base filter: active docs, latest version
         base_filter = [
             Entity.entity_text.ilike(f"%{escaped_query}%"),
@@ -1282,6 +1418,8 @@ async def kb_entity_search(
 
         if doc_id:
             did = uuid.UUID(doc_id)
+            if visible_ids is not None and did not in visible_ids:
+                return json.dumps({"error": "Document not found"})
             # Scope to latest version of the document
             doc = (
                 await session.execute(select(Document).where(Document.doc_id == did, Document.status == "active"))
@@ -1302,6 +1440,8 @@ async def kb_entity_search(
                     )
                 )
             )
+            if visible_ids is not None:
+                base_filter.append(Entity.doc_id.in_(visible_ids))
 
         if deduplicate:
             count_q = (
@@ -1373,26 +1513,31 @@ async def kb_entity_overview(doc_id: str | None = None) -> str:
     Args:
         doc_id: Optional — scope to a single document's latest version.
     """
-    _get_principal()
+    principal = _get_principal()
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        empty_resp = {
+            "total_entities": 0,
+            "unique_entities": 0,
+            "type_distribution": {},
+            "top_entities": [],
+        }
+        if visible_ids is not None and not visible_ids:
+            return json.dumps(empty_resp)
+
         # Build version filter
         if doc_id:
             did = uuid.UUID(doc_id)
+            if visible_ids is not None and did not in visible_ids:
+                return json.dumps({"error": "Document not found"})
             doc = (
                 await session.execute(select(Document).where(Document.doc_id == did, Document.status == "active"))
             ).scalar_one_or_none()
             if doc is None:
                 return json.dumps({"error": "Document not found"})
             if not doc.latest_version_id:
-                return json.dumps(
-                    {
-                        "total_entities": 0,
-                        "unique_entities": 0,
-                        "type_distribution": {},
-                        "top_entities": [],
-                    }
-                )
+                return json.dumps(empty_resp)
             version_filter = [Entity.version_id == doc.latest_version_id]
         else:
             version_filter = [
@@ -1403,6 +1548,8 @@ async def kb_entity_overview(doc_id: str | None = None) -> str:
                     )
                 )
             ]
+            if visible_ids is not None:
+                version_filter.append(Entity.doc_id.in_(visible_ids))
 
         # Total entities
         total = (await session.execute(select(func.count()).select_from(Entity).where(*version_filter))).scalar() or 0
@@ -1480,7 +1627,7 @@ async def kb_entity_cooccurrence(
         limit: Max results (1-100, default 20).
         offset: Pagination offset.
     """
-    _get_principal()
+    principal = _get_principal()
 
     if scope not in ("chunk", "document"):
         return json.dumps({"error": f"Invalid scope '{scope}'. Must be 'chunk' or 'document'."})
@@ -1494,18 +1641,23 @@ async def kb_entity_cooccurrence(
     e2 = aliased(Entity, name="e2")
 
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        empty_resp = {"entity_text": entity_text, "scope": scope, "cooccurrences": [], "total": 0, "has_more": False}
+        if visible_ids is not None and not visible_ids:
+            return json.dumps(empty_resp)
+
         # Version filter: active docs' latest versions
         if doc_id:
             did = uuid.UUID(doc_id)
+            if visible_ids is not None and did not in visible_ids:
+                return json.dumps({"error": "Document not found"})
             doc = (
                 await session.execute(select(Document).where(Document.doc_id == did, Document.status == "active"))
             ).scalar_one_or_none()
             if doc is None:
                 return json.dumps({"error": "Document not found"})
             if not doc.latest_version_id:
-                return json.dumps(
-                    {"entity_text": entity_text, "scope": scope, "cooccurrences": [], "total": 0, "has_more": False}
-                )
+                return json.dumps(empty_resp)
             version_filter_e1 = [e1.version_id == doc.latest_version_id]
             version_filter_e2 = [e2.version_id == doc.latest_version_id]
         else:
@@ -1515,6 +1667,9 @@ async def kb_entity_cooccurrence(
             )
             version_filter_e1 = [e1.version_id.in_(active_versions)]
             version_filter_e2 = [e2.version_id.in_(active_versions)]
+            if visible_ids is not None:
+                version_filter_e1.append(e1.doc_id.in_(visible_ids))
+                version_filter_e2.append(e2.doc_id.in_(visible_ids))
 
         # Source entity filter
         source_filter = [e1.entity_text.ilike(f"%{escaped_text}%"), *version_filter_e1]
@@ -1600,14 +1755,22 @@ async def kb_read_document(
     Use page_start/page_end to limit the range. max_chars caps total output
     (default 50 000, max 100 000).
     """
-    _get_principal()
+    principal = _get_principal()
     try:
         did = uuid.UUID(doc_id)
     except ValueError:
         return json.dumps({"error": f"Invalid doc_id: {doc_id}"})
     max_chars = max(1, min(max_chars, 100_000))
 
+    # Per-key snippet cap (applied on top of max_chars)
+    if principal.key_scope and principal.key_scope.max_snippet_chars is not None:
+        max_chars = min(max_chars, principal.key_scope.max_snippet_chars)
+
     async with async_session_factory() as session:
+        visible_ids = await _visible_doc_ids(session, principal)
+        if visible_ids is not None and did not in visible_ids:
+            return json.dumps({"error": "Document not found"})
+
         result = await session.execute(
             select(Document)
             .options(selectinload(Document.versions))

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -217,6 +217,17 @@ def _get_principal() -> Principal:
     return p
 
 
+def _filter_tools_for_principal(tool_names, principal):
+    """Return only the tool names this principal is allowed to use."""
+    if principal is None:
+        return []
+    if principal.type != "api_key" or principal.key_scope is None:
+        # Human users see everything (admin checks happen inside individual tools)
+        return list(tool_names)
+    allowed = principal.key_scope.effective_tools
+    return [t for t in tool_names if t in allowed]
+
+
 def _require_admin() -> Principal:
     p = _get_principal()
     if p.role != "admin":
@@ -245,7 +256,47 @@ async def _visible_doc_ids(session: AsyncSession, principal: Principal) -> set[u
 from mcp.server.fastmcp import FastMCP  # noqa: E402
 from mcp.server.transport_security import TransportSecuritySettings  # noqa: E402
 
-mcp = FastMCP(
+
+class ScopedFastMCP(FastMCP):
+    """FastMCP subclass that filters tool listing and calls by API key scope.
+
+    Security: list_tools is a UX layer; the real enforcement is call_tool +
+    the apply_key_scope filters in each tool body. So even if list_tools is
+    bypassed (e.g. via the lowlevel server's tool cache), tool calls are
+    still rejected.
+    """
+
+    async def list_tools(self):
+        all_tools = await super().list_tools()
+        try:
+            principal = _get_principal()
+        except PermissionError:
+            # No principal context (e.g. internal tool-cache refresh).
+            # Return [] rather than all_tools so we don't pollute caches with
+            # full visibility. Real per-call enforcement happens in call_tool.
+            return []
+        if principal.type != "api_key" or principal.key_scope is None:
+            return all_tools
+        allowed = principal.key_scope.effective_tools
+        return [t for t in all_tools if t.name in allowed]
+
+    async def call_tool(self, name, arguments):
+        try:
+            principal = _get_principal()
+        except PermissionError:
+            return await super().call_tool(name, arguments)
+        if (
+            principal.type == "api_key"
+            and principal.key_scope is not None
+            and name not in principal.key_scope.effective_tools
+        ):
+            from mcp.server.fastmcp.exceptions import ToolError
+
+            raise ToolError(f"Unknown tool: {name}")
+        return await super().call_tool(name, arguments)
+
+
+mcp = ScopedFastMCP(
     "Harbor Clerk",
     # DNS rebinding protection is unnecessary — we run behind Caddy with
     # our own Bearer-token auth middleware wrapping the MCP ASGI app.

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -91,11 +91,23 @@ async def _resolve_principal(token: str) -> Principal | None:
         api_key = result.scalar_one_or_none()
         if api_key is None:
             return None
+        # Expiry check
+        if api_key.expires_at is not None and api_key.expires_at < datetime.now(UTC):
+            return None
         await session.execute(
             update(ApiKey).where(ApiKey.key_id == api_key.key_id).values(last_used_at=datetime.now(UTC))
         )
         await session.commit()
-        return Principal(type="api_key", id=api_key.key_id, role="user")
+        from harbor_clerk.api.scope import KeyScope
+
+        scope = KeyScope(
+            scope_topic_ids=api_key.scope_topic_ids,
+            scope_folder_ids=api_key.scope_folder_ids,
+            permission_tier=api_key.permission_tier,
+            tool_overrides=api_key.tool_overrides or {},
+            max_snippet_chars=api_key.max_snippet_chars,
+        )
+        return Principal(type="api_key", id=api_key.key_id, role="user", key_scope=scope)
 
 
 class MCPAuthMiddleware:

--- a/src/harbor_clerk/models/api_key.py
+++ b/src/harbor_clerk/models/api_key.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from typing import Any
 
-from sqlalchemy import Boolean, DateTime, Text, text
+from sqlalchemy import Boolean, DateTime, Integer, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from harbor_clerk.models.base import Base, created_at, uuid_pk
@@ -22,3 +24,11 @@ class ApiKey(Base):
         DateTime(timezone=True),
         nullable=True,
     )
+
+    # Scoping (added in migration 0013)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    permission_tier: Mapped[str] = mapped_column(Text, nullable=False, server_default="full")
+    tool_overrides: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    scope_topic_ids: Mapped[list[int] | None] = mapped_column(JSONB, nullable=True)
+    scope_folder_ids: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    max_snippet_chars: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/tests/test_mcp_tool_filtering.py
+++ b/tests/test_mcp_tool_filtering.py
@@ -1,0 +1,66 @@
+"""Tests for MCP tool filtering by API key scope."""
+
+import uuid
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import KeyScope
+
+
+def make_scoped_key(tier="search", overrides=None):
+    return Principal(
+        type="api_key",
+        id=uuid.uuid4(),
+        role="user",
+        key_scope=KeyScope(
+            scope_topic_ids=None,
+            scope_folder_ids=None,
+            permission_tier=tier,
+            tool_overrides=overrides or {},
+            max_snippet_chars=None,
+        ),
+    )
+
+
+def test_human_user_sees_all_tools():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    user = Principal(type="user", id=uuid.uuid4(), role="admin")
+    all_tool_names = ["kb_search", "kb_read_passages", "kb_system_health", "kb_reprocess"]
+    filtered = _filter_tools_for_principal(all_tool_names, user)
+    assert set(filtered) == set(all_tool_names)
+
+
+def test_search_tier_filters_to_search_tools():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    p = make_scoped_key("search")
+    all_tool_names = ["kb_search", "kb_read_passages", "kb_system_health"]
+    filtered = _filter_tools_for_principal(all_tool_names, p)
+    assert "kb_search" in filtered
+    assert "kb_read_passages" not in filtered
+    assert "kb_system_health" not in filtered
+
+
+def test_overrides_remove_tool():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    p = make_scoped_key("full", overrides={"kb_read_document": False})
+    filtered = _filter_tools_for_principal(["kb_read_document", "kb_search"], p)
+    assert "kb_read_document" not in filtered
+    assert "kb_search" in filtered
+
+
+def test_admin_only_tools_never_for_api_key_even_with_override():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    p = make_scoped_key("full", overrides={"kb_system_health": True, "kb_reprocess": True})
+    filtered = _filter_tools_for_principal(["kb_system_health", "kb_reprocess", "kb_search"], p)
+    assert "kb_system_health" not in filtered
+    assert "kb_reprocess" not in filtered
+    assert "kb_search" in filtered
+
+
+def test_none_principal_returns_empty():
+    from harbor_clerk.mcp_server import _filter_tools_for_principal
+
+    assert _filter_tools_for_principal(["kb_search"], None) == []

--- a/tests/test_mcp_tool_filtering.py
+++ b/tests/test_mcp_tool_filtering.py
@@ -64,3 +64,75 @@ def test_none_principal_returns_empty():
     from harbor_clerk.mcp_server import _filter_tools_for_principal
 
     assert _filter_tools_for_principal(["kb_search"], None) == []
+
+
+# --- ScopedFastMCP dispatch layer ---
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_scoped_fastmcp_list_tools_filters_by_scope():
+    """list_tools override returns only tools in the effective set."""
+    from harbor_clerk.mcp_server import _mcp_principal, mcp
+
+    p = make_scoped_key("search")
+    token = _mcp_principal.set(p)
+    try:
+        tools = await mcp.list_tools()
+        tool_names = {t.name for t in tools}
+        # search-tier tools present
+        assert "kb_search" in tool_names
+        assert "kb_batch_search" in tool_names
+        # read-tier tools absent
+        assert "kb_read_passages" not in tool_names
+        # admin tools absent
+        assert "kb_system_health" not in tool_names
+    finally:
+        _mcp_principal.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_scoped_fastmcp_list_tools_no_principal_returns_empty():
+    """No principal context → empty list (not full access)."""
+    from harbor_clerk.mcp_server import mcp
+
+    # Don't set _mcp_principal
+    tools = await mcp.list_tools()
+    # Should return empty — no principal means no access
+    assert tools == []
+
+
+@pytest.mark.asyncio
+async def test_scoped_fastmcp_call_tool_rejects_disallowed():
+    """call_tool raises ToolError when a scoped key invokes a disallowed tool."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    from harbor_clerk.mcp_server import _mcp_principal, mcp
+
+    p = make_scoped_key("search")  # no read tools allowed
+    token = _mcp_principal.set(p)
+    try:
+        with pytest.raises(ToolError, match="Unknown tool"):
+            await mcp.call_tool("kb_read_document", {"doc_id": "some-id"})
+    finally:
+        _mcp_principal.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_scoped_fastmcp_human_user_sees_all():
+    """Human users see all tools in list_tools, including admin tools."""
+    from harbor_clerk.mcp_server import _mcp_principal, mcp
+
+    user = Principal(type="user", id=uuid.uuid4(), role="admin")
+    token = _mcp_principal.set(user)
+    try:
+        tools = await mcp.list_tools()
+        tool_names = {t.name for t in tools}
+        # All 16 tools should be present for humans
+        assert "kb_search" in tool_names
+        assert "kb_read_passages" in tool_names
+        assert "kb_system_health" in tool_names
+        assert "kb_reprocess" in tool_names
+    finally:
+        _mcp_principal.reset(token)

--- a/tests/test_scoped_api_keys.py
+++ b/tests/test_scoped_api_keys.py
@@ -101,3 +101,29 @@ def test_tier_constants_are_frozen_sets():
     assert isinstance(SEARCH_TIER_TOOLS, frozenset)
     assert isinstance(READ_TIER_TOOLS, frozenset)
     assert isinstance(FULL_TIER_TOOLS, frozenset)
+
+
+# --- Principal integration ---
+
+import uuid  # noqa: E402
+
+from harbor_clerk.api.deps import Principal  # noqa: E402
+
+
+def test_principal_default_no_key_scope():
+    p = Principal(type="user", id=uuid.uuid4(), role="admin")
+    assert p.key_scope is None
+
+
+def test_principal_with_key_scope():
+    scope = KeyScope(
+        scope_topic_ids=[1],
+        scope_folder_ids=None,
+        permission_tier="search",
+        tool_overrides={},
+        max_snippet_chars=500,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    assert p.key_scope is not None
+    assert p.key_scope.scope_topic_ids == [1]
+    assert p.key_scope.permission_tier == "search"

--- a/tests/test_scoped_api_keys.py
+++ b/tests/test_scoped_api_keys.py
@@ -1,0 +1,103 @@
+"""Tests for scoped API keys."""
+
+from harbor_clerk.api.scope import (
+    ADMIN_ONLY_TOOLS,
+    FULL_TIER_TOOLS,
+    READ_TIER_TOOLS,
+    SEARCH_TIER_TOOLS,
+    KeyScope,
+    compute_effective_tools,
+)
+
+
+def test_search_tier_has_search_tools():
+    tools = compute_effective_tools("search", {})
+    assert "kb_search" in tools
+    assert "kb_batch_search" in tools
+    assert "kb_corpus_overview" in tools
+    assert "kb_list_recent" in tools
+    # No read tools
+    assert "kb_read_passages" not in tools
+    # No admin tools
+    assert "kb_system_health" not in tools
+    assert "kb_reprocess" not in tools
+
+
+def test_read_tier_extends_search():
+    tools = compute_effective_tools("read", {})
+    assert "kb_search" in tools  # search tier inherited
+    assert "kb_read_passages" in tools
+    assert "kb_expand_context" in tools
+    assert "kb_document_outline" in tools
+    assert "kb_get_document" in tools
+    # Not in this tier
+    assert "kb_find_related" not in tools
+    assert "kb_entity_search" not in tools
+
+
+def test_full_tier_has_most_tools():
+    tools = compute_effective_tools("full", {})
+    assert "kb_read_document" in tools
+    assert "kb_entity_search" in tools
+    assert "kb_find_related" in tools
+    assert "kb_ingest_status" in tools
+    # Admin tools never included
+    assert "kb_system_health" not in tools
+    assert "kb_reprocess" not in tools
+
+
+def test_overrides_can_remove_tool():
+    tools = compute_effective_tools("full", {"kb_read_document": False})
+    assert "kb_read_document" not in tools
+    assert "kb_search" in tools  # other tools unchanged
+
+
+def test_overrides_can_add_tool():
+    tools = compute_effective_tools("search", {"kb_read_passages": True})
+    assert "kb_read_passages" in tools
+
+
+def test_overrides_cannot_grant_admin_tools():
+    tools = compute_effective_tools("full", {"kb_system_health": True})
+    assert "kb_system_health" not in tools
+    tools = compute_effective_tools("full", {"kb_reprocess": True})
+    assert "kb_reprocess" not in tools
+
+
+def test_unknown_tier_treated_as_full():
+    # Defensive — unknown tier shouldn't crash
+    tools = compute_effective_tools("nonsense", {})
+    assert "kb_search" in tools
+
+
+def test_keyscope_default_no_restrictions():
+    scope = KeyScope(
+        scope_topic_ids=None,
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    assert scope.is_unrestricted is True
+
+
+def test_keyscope_with_topic_filter_is_restricted():
+    scope = KeyScope(
+        scope_topic_ids=[1, 2],
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    assert scope.is_unrestricted is False
+
+
+def test_admin_only_tools_constant():
+    assert "kb_system_health" in ADMIN_ONLY_TOOLS
+    assert "kb_reprocess" in ADMIN_ONLY_TOOLS
+
+
+def test_tier_constants_are_frozen_sets():
+    assert isinstance(SEARCH_TIER_TOOLS, frozenset)
+    assert isinstance(READ_TIER_TOOLS, frozenset)
+    assert isinstance(FULL_TIER_TOOLS, frozenset)

--- a/tests/test_scoped_api_keys.py
+++ b/tests/test_scoped_api_keys.py
@@ -127,3 +127,204 @@ def test_principal_with_key_scope():
     assert p.key_scope is not None
     assert p.key_scope.scope_topic_ids == [1]
     assert p.key_scope.permission_tier == "search"
+
+
+# --- apply_key_scope query builder ---
+
+from sqlalchemy import select as sa_select  # noqa: E402
+
+from harbor_clerk.api.scope import apply_key_scope  # noqa: E402
+from harbor_clerk.models.document import Document  # noqa: E402
+
+
+def test_apply_scope_user_principal_unchanged():
+    user = Principal(type="user", id=uuid.uuid4(), role="admin")
+    query = sa_select(Document)
+    result = apply_key_scope(query, user)
+    # Should return the same query unmodified
+    assert str(result) == str(query)
+
+
+def test_apply_scope_unrestricted_key_unchanged():
+    scope = KeyScope(
+        scope_topic_ids=None,
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    assert str(result) == str(query)
+
+
+def test_apply_scope_topic_filter_adds_where():
+    scope = KeyScope(
+        scope_topic_ids=[1, 2],
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    sql = str(result.compile(compile_kwargs={"literal_binds": True}))
+    assert "topic_id" in sql.lower()
+    assert "in (1, 2)" in sql.lower()
+
+
+def test_apply_scope_folder_filter_subquery():
+    scope = KeyScope(
+        scope_topic_ids=None,
+        scope_folder_ids=["00000000-0000-0000-0000-000000000001"],
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    sql = str(result.compile(compile_kwargs={"literal_binds": True}))
+    assert "watched_files" in sql.lower()
+    assert "doc_id" in sql.lower()
+
+
+def test_apply_scope_topic_or_folder_or_logic():
+    scope = KeyScope(
+        scope_topic_ids=[5],
+        scope_folder_ids=["00000000-0000-0000-0000-000000000001"],
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    sql = str(result.compile(compile_kwargs={"literal_binds": True})).lower()
+    # Both filters present, joined by OR
+    assert "topic_id" in sql
+    assert "watched_files" in sql
+    assert " or " in sql
+
+
+def test_apply_scope_empty_topics_blocks_all():
+    scope = KeyScope(
+        scope_topic_ids=[],  # explicit empty list
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = sa_select(Document)
+    result = apply_key_scope(query, p)
+    sql = str(result.compile(compile_kwargs={"literal_binds": True})).lower()
+    # Empty IN clause: topic_id IN () — postgres treats this as false
+    # Either an empty IN or a no-rows constraint
+    assert "topic_id" in sql or "00000000-0000-0000-0000-000000000000" in sql
+
+
+# --- Integration tests with real DB ---
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def two_topic_docs(db_session: AsyncSession):
+    """Create 2 corpus_topics + 3 documents (2 in topic A, 1 in topic B)."""
+    from datetime import UTC, datetime
+
+    from harbor_clerk.models.corpus_topic import CorpusTopic
+
+    now = datetime.now(UTC)
+    topic_a = CorpusTopic(
+        topic_id=9001,
+        label="ScopeTest Topic A",
+        keywords=["test"],
+        doc_count=2,
+        representative_doc_ids=[],
+        updated_at=now,
+    )
+    topic_b = CorpusTopic(
+        topic_id=9002,
+        label="ScopeTest Topic B",
+        keywords=["test"],
+        doc_count=1,
+        representative_doc_ids=[],
+        updated_at=now,
+    )
+    db_session.add_all([topic_a, topic_b])
+    await db_session.commit()
+
+    docs = [
+        Document(title="ScopeTest A1", canonical_filename="a1.txt", topic_id=9001, status="active"),
+        Document(title="ScopeTest A2", canonical_filename="a2.txt", topic_id=9001, status="active"),
+        Document(title="ScopeTest B1", canonical_filename="b1.txt", topic_id=9002, status="active"),
+    ]
+    for d in docs:
+        db_session.add(d)
+    await db_session.commit()
+    yield docs
+    for d in docs:
+        await db_session.delete(d)
+    await db_session.delete(topic_a)
+    await db_session.delete(topic_b)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_scope_filters_by_topic_in_db(db_session, two_topic_docs):
+    """Real DB: key scoped to topic 9001 sees only those documents."""
+    scope = KeyScope(
+        scope_topic_ids=[9001],
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = apply_key_scope(sa_select(Document).where(Document.topic_id.in_([9001, 9002])), p)
+    result = await db_session.execute(query)
+    docs = result.scalars().all()
+    assert len(docs) == 2
+    assert all(d.topic_id == 9001 for d in docs)
+
+
+@pytest.mark.asyncio
+async def test_unrestricted_key_sees_all_in_db(db_session, two_topic_docs):
+    """Real DB: unrestricted key sees all our test documents."""
+    scope = KeyScope(
+        scope_topic_ids=None,
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = apply_key_scope(sa_select(Document).where(Document.topic_id.in_([9001, 9002])), p)
+    result = await db_session.execute(query)
+    docs = result.scalars().all()
+    titles = {d.title for d in docs}
+    assert {"ScopeTest A1", "ScopeTest A2", "ScopeTest B1"}.issubset(titles)
+
+
+@pytest.mark.asyncio
+async def test_empty_topic_list_blocks_all_in_db(db_session, two_topic_docs):
+    """Real DB: scope_topic_ids=[] blocks everything (no topics match)."""
+    scope = KeyScope(
+        scope_topic_ids=[],
+        scope_folder_ids=None,
+        permission_tier="full",
+        tool_overrides={},
+        max_snippet_chars=None,
+    )
+    p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
+    query = apply_key_scope(sa_select(Document).where(Document.topic_id.in_([9001, 9002])), p)
+    result = await db_session.execute(query)
+    docs = result.scalars().all()
+    our_titles = {d.title for d in docs} & {"ScopeTest A1", "ScopeTest A2", "ScopeTest B1"}
+    assert our_titles == set()


### PR DESCRIPTION
Implements per-API-key access controls for giving external agentic harnesses (OpenClaw, Claude, ChatGPT, etc.) controlled read access to a subset of the corpus.

## Features

- **Document scoping** by topic and/or watched folder (OR logic). Scoped-out documents are completely invisible — API keys with topic scope can't discover documents outside their scope.
- **Permission tiers** (search / read / full) with per-tool overrides. Admin-only tools (`kb_system_health`, `kb_reprocess`) are always excluded from API keys.
- **Expiry dates** — optional per-key expiration, auth rejects expired keys.
- **Snippet size limits** — per-key max_chars for `kb_read_passages`, `kb_expand_context`, `kb_read_document`.
- **Silent tool omission** — MCP `tools/list` filters to only the keys effective tool set; calls to disallowed tools return `ToolError("Unknown tool")`.

## What's included

- Migration 0013 adding 6 columns to `api_keys`
- `KeyScope` dataclass carried on `Principal` (no per-call DB lookups)
- `apply_key_scope()` query builder helper
- REST endpoints: extended POST, new PATCH, new scope-preview, enriched GET list
- All 14 read-side MCP tools respect scope (docs, chunks, entities, corpus stats, job status)
- `ScopedFastMCP` subclass filters `list_tools` and `call_tool`
- Frontend: expanded create form (tier, overrides, scope), edit modal, scope preview
- **24 new tests** covering tier computation, query filtering, integration with real DB

## Spec
`docs/superpowers/specs/2026-04-07-scoped-api-keys-design.md`

## Plan
`docs/superpowers/plans/2026-04-09-scoped-api-keys.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)