### PR TITLE
fix: Docker runtime stages pick up OpenSSL security patch

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -37,7 +37,7 @@ RUN uv pip install pip --python /app/.venv/bin/python \
 # ── Runtime ──
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tesseract-ocr tesseract-ocr-eng tesseract-ocr-fra \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/embedder.Dockerfile
+++ b/docker/embedder.Dockerfile
@@ -22,6 +22,8 @@ RUN /app/.venv/bin/python -c \
 # ── Runtime ──
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /root/.cache /root/.cache
 

--- a/macos/HarborClerk/HarborClerk/ContentView.swift
+++ b/macos/HarborClerk/HarborClerk/ContentView.swift
@@ -219,6 +219,28 @@ struct WebView: NSViewRepresentable {
             }
             return nil
         }
+
+        // Handle <input type="file"> clicks — WKWebView requires an explicit
+        // delegate method to present the native file picker, otherwise the
+        // click silently does nothing.
+        func webView(
+            _ webView: WKWebView,
+            runOpenPanelWith parameters: WKOpenPanelParameters,
+            initiatedByFrame frame: WKFrameInfo,
+            completionHandler: @escaping ([URL]?) -> Void
+        ) {
+            let panel = NSOpenPanel()
+            panel.allowsMultipleSelection = parameters.allowsMultipleSelection
+            panel.canChooseDirectories = parameters.allowsDirectories
+            panel.canChooseFiles = true
+            panel.begin { response in
+                if response == .OK {
+                    completionHandler(panel.urls)
+                } else {
+                    completionHandler(nil)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `apt-get upgrade -y` to runtime stages in both `app.Dockerfile` and `embedder.Dockerfile`
- Fixes CVE-2026-28390 (HIGH) — OpenSSL NULL pointer dereference in CMS, flagged by Trivy container-scan
- The `python:3.12-slim` base image (Debian trixie) ships `libssl3t64 3.5.5-1~deb13u1`; the fix is in `3.5.5-1~deb13u2`

## Test plan
- [ ] Trivy container-scan passes in CI (no HIGH/CRITICAL findings)
- [ ] App and embedder images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)