### PR TITLE
fix: queue tray backfills active jobs on page reload

### DIFF
--- a/frontend/src/hooks/useQueueTray.ts
+++ b/frontend/src/hooks/useQueueTray.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth'
 import { useJobEvents, type JobEvent } from './useJobEvents'
 
 export type TrayState = 'collapsed' | 'toasting' | 'expanded'
@@ -80,6 +81,7 @@ function computeItemStatus(stages: Map<string, StageState>): 'running' | 'queued
 }
 
 export function useQueueTray() {
+  const { token } = useAuth()
   const [trayState, setTrayState] = useState<TrayState>('collapsed')
   const [activeItems, setActiveItems] = useState<Map<string, DocumentQueueItem>>(new Map())
   const [completed, setCompleted] = useState<CompletedItem[]>([])
@@ -249,6 +251,31 @@ export function useQueueTray() {
   )
 
   useJobEvents(onEvent)
+
+  // Backfill: fetch all active jobs on mount so the queue tray shows
+  // current state immediately instead of waiting for new SSE events.
+  useEffect(() => {
+    if (!token) return
+    let cancelled = false
+    async function backfill() {
+      try {
+        const res = await fetch('/api/jobs/active', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok || cancelled) return
+        const events: JobEvent[] = await res.json()
+        for (const event of events) {
+          if (!cancelled) onEvent(event)
+        }
+      } catch {
+        // non-fatal — SSE will catch up
+      }
+    }
+    backfill()
+    return () => {
+      cancelled = true
+    }
+  }, [token, onEvent])
 
   // Cleanup timers on unmount
   useEffect(() => {

--- a/src/harbor_clerk/api/routes/jobs.py
+++ b/src/harbor_clerk/api/routes/jobs.py
@@ -7,10 +7,16 @@ from collections.abc import AsyncGenerator
 import asyncpg
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.api.deps import Principal, require_read_access
 from harbor_clerk.config import get_settings
+from harbor_clerk.db import get_session
 from harbor_clerk.events import CHANNEL
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.document_version import DocumentVersion
+from harbor_clerk.models.ingestion_job import IngestionJob
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["jobs"])
@@ -59,3 +65,54 @@ async def job_stream(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.get("/jobs/active")
+async def active_jobs(
+    principal: Principal = Depends(require_read_access),
+    session: AsyncSession = Depends(get_session),
+):
+    """Return all non-terminal ingestion jobs for queue tray backfill on page load.
+
+    Returns the same shape as SSE JobEvent so the frontend can feed these
+    directly into the same onEvent handler.
+    """
+    rows = (
+        await session.execute(
+            select(
+                IngestionJob.version_id,
+                IngestionJob.stage,
+                IngestionJob.status,
+                IngestionJob.progress_current,
+                IngestionJob.progress_total,
+                IngestionJob.error,
+                DocumentVersion.doc_id,
+                Document.canonical_filename,
+            )
+            .join(DocumentVersion, IngestionJob.version_id == DocumentVersion.version_id)
+            .join(Document, DocumentVersion.doc_id == Document.doc_id)
+            .where(IngestionJob.status.in_(["queued", "running"]))
+            .order_by(IngestionJob.created_at)
+        )
+    ).all()
+
+    events = []
+    for r in rows:
+        event: dict = {
+            "version_id": str(r.version_id),
+            "stage": r.stage.value if hasattr(r.stage, "value") else str(r.stage),
+            "status": r.status.value if hasattr(r.status, "value") else str(r.status),
+        }
+        if r.progress_current:
+            event["progress"] = r.progress_current
+        if r.progress_total:
+            event["total"] = r.progress_total
+        if r.error:
+            event["error"] = r.error
+        if r.canonical_filename:
+            event["filename"] = r.canonical_filename
+        if r.doc_id:
+            event["doc_id"] = str(r.doc_id)
+        events.append(event)
+
+    return events


### PR DESCRIPTION
## Summary
- Queue tray was built purely from SSE events received after page load — on reload, all in-progress jobs disappeared
- Added `GET /api/jobs/active` endpoint that returns all queued/running ingestion jobs (same shape as SSE `JobEvent`)
- `useQueueTray` calls it on mount to populate the queue immediately, before SSE takes over

## Root cause
`useQueueTray` subscribed to `/api/jobs/stream` (SSE) but never fetched initial state. On reload, the Map started empty and only grew as new events arrived — so if 200 docs were processing, the user saw 0 until each doc happened to emit its next event.

## Test plan
- [ ] Start processing multiple documents, reload page — queue tray shows all active jobs immediately
- [ ] New jobs appearing via SSE still work normally after backfill
- [ ] Empty queue (no active jobs) — no errors, tray stays hidden

Generated with [Claude Code](https://claude.com/claude-code)