### PR TITLE
fix: expiry checkbox on API key creation

### DIFF
--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -370,13 +370,27 @@ function ScopeFormFields({
   return (
     <div className="space-y-4">
       <div>
-        <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Expires (optional)</label>
-        <input
-          type="date"
-          value={state.expiresAt}
-          onChange={(e) => setState((s) => ({ ...s, expiresAt: e.target.value }))}
-          className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
-        />
+        <label className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={state.expiresAt !== ''}
+            onChange={(e) =>
+              setState((s) => ({
+                ...s,
+                expiresAt: e.target.checked ? new Date(Date.now() + 90 * 86400000).toISOString().slice(0, 10) : '',
+              }))
+            }
+          />
+          Set expiry date
+        </label>
+        {state.expiresAt !== '' && (
+          <input
+            type="date"
+            value={state.expiresAt}
+            onChange={(e) => setState((s) => ({ ...s, expiresAt: e.target.value }))}
+            className="mt-1.5 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+          />
+        )}
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- Bare date input was ambiguous — empty looked like "today" not "no expiry"
- Added "Set expiry date" checkbox that controls whether expiry is enabled
- Checking it defaults to 90 days out; unchecking clears the date
- Date picker only visible when checkbox is checked

## Test plan
- [ ] Create key without checking expiry → `expires_at` is null
- [ ] Check expiry → date picker appears with 90-day default
- [ ] Uncheck → date picker disappears, expiry cleared
- [ ] Edit existing key with expiry → checkbox is checked, date shows

Generated with [Claude Code](https://claude.com/claude-code)