### PR TITLE
feat: per-API-key rate limiting (RPM + RPH)

### DIFF
--- a/alembic/versions/0015_rate_limits.py
+++ b/alembic/versions/0015_rate_limits.py
@@ -1,0 +1,24 @@
+"""Add rate_limit_rpm and rate_limit_rph to api_keys.
+
+Revision ID: 0015
+Revises: 0014
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("rate_limit_rpm", sa.Integer(), nullable=True))
+    op.add_column("api_keys", sa.Column("rate_limit_rph", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "rate_limit_rph")
+    op.drop_column("api_keys", "rate_limit_rpm")

--- a/docs/superpowers/plans/2026-04-10-rate-limits.md
+++ b/docs/superpowers/plans/2026-04-10-rate-limits.md
@@ -1,0 +1,826 @@
+# Per-API-Key Rate Limits Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-minute and per-hour rate limiting for API key requests, with system-wide defaults, in-memory enforcement, and audit dashboard integration.
+
+**Architecture:** Two new columns on `api_keys` (migration 0015). `KeyScope` extended to carry rate limit values at auth time. New `RateLimiter` singleton with sliding window + per-key asyncio.Lock + crash recovery from `api_request_log`. Enforcement in `ScopedFastMCP.call_tool()` and `ApiKeyRequestLogMiddleware`. System defaults via Settings + sync_native_config pattern.
+
+**Tech Stack:** PostgreSQL, SQLAlchemy 2.0 async, Alembic, FastAPI, asyncio, React 19, Tailwind CSS 4
+
+**Spec:** `docs/superpowers/specs/2026-04-10-rate-limits-design.md`
+
+---
+
+### Task 1: Migration + Model
+
+**Files:**
+- Create: `alembic/versions/0015_rate_limits.py`
+- Modify: `src/harbor_clerk/models/api_key.py`
+
+- [ ] **Step 1: Add columns to ApiKey model**
+
+In `src/harbor_clerk/models/api_key.py`, add after `max_snippet_chars`:
+
+```python
+rate_limit_rpm: Mapped[int | None] = mapped_column(Integer, nullable=True)
+rate_limit_rph: Mapped[int | None] = mapped_column(Integer, nullable=True)
+```
+
+- [ ] **Step 2: Write migration 0015**
+
+Create `alembic/versions/0015_rate_limits.py`:
+
+```python
+"""Add rate_limit_rpm and rate_limit_rph to api_keys.
+
+Revision ID: 0015
+Revises: 0014
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("rate_limit_rpm", sa.Integer(), nullable=True))
+    op.add_column("api_keys", sa.Column("rate_limit_rph", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "rate_limit_rph")
+    op.drop_column("api_keys", "rate_limit_rpm")
+```
+
+- [ ] **Step 3: Run migration and verify**
+
+```bash
+cd /Users/alex/mcp-gateway
+alembic upgrade head
+uv run ruff check src/harbor_clerk/models/api_key.py alembic/versions/0015_rate_limits.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/harbor_clerk/models/api_key.py alembic/versions/0015_rate_limits.py
+git commit -m "feat: add rate_limit_rpm/rph columns to api_keys (migration 0015)"
+```
+
+---
+
+### Task 2: KeyScope + Principal Extension
+
+**Files:**
+- Modify: `src/harbor_clerk/api/scope.py`
+- Modify: `src/harbor_clerk/mcp_server.py` (lines ~103-110, _resolve_principal)
+- Modify: `src/harbor_clerk/api/deps.py` (lines ~90-96, get_current_principal)
+- Test: `tests/test_scoped_api_keys.py` (extend)
+
+- [ ] **Step 1: Add rate limit fields to KeyScope**
+
+In `src/harbor_clerk/api/scope.py`, add two fields to the `KeyScope` dataclass:
+
+```python
+rate_limit_rpm: int | None
+rate_limit_rph: int | None
+```
+
+- [ ] **Step 2: Populate in _resolve_principal (MCP path)**
+
+In `src/harbor_clerk/mcp_server.py`, in `_resolve_principal()`, where `KeyScope` is constructed (around line 103-110), add the two new fields:
+
+```python
+scope = KeyScope(
+    scope_topic_ids=api_key.scope_topic_ids,
+    scope_folder_ids=api_key.scope_folder_ids,
+    permission_tier=api_key.permission_tier,
+    tool_overrides=api_key.tool_overrides or {},
+    max_snippet_chars=api_key.max_snippet_chars,
+    rate_limit_rpm=api_key.rate_limit_rpm,
+    rate_limit_rph=api_key.rate_limit_rph,
+)
+```
+
+- [ ] **Step 3: Populate in get_current_principal (REST path)**
+
+In `src/harbor_clerk/api/deps.py`, same change where `KeyScope` is constructed (around line 90-96):
+
+```python
+scope = KeyScope(
+    scope_topic_ids=api_key.scope_topic_ids,
+    scope_folder_ids=api_key.scope_folder_ids,
+    permission_tier=api_key.permission_tier,
+    tool_overrides=api_key.tool_overrides or {},
+    max_snippet_chars=api_key.max_snippet_chars,
+    rate_limit_rpm=api_key.rate_limit_rpm,
+    rate_limit_rph=api_key.rate_limit_rph,
+)
+```
+
+- [ ] **Step 4: Fix existing tests**
+
+Any existing test that constructs `KeyScope` directly (e.g., in `tests/test_scoped_api_keys.py`, `tests/test_mcp_tool_filtering.py`) will fail because of the two new required fields. Add `rate_limit_rpm=None, rate_limit_rph=None` to all existing `KeyScope(...)` calls.
+
+Also update `src/harbor_clerk/api/routes/api_keys.py` where `KeyScope` is constructed in `scope_preview` and `scope_preview_adhoc` endpoints.
+
+- [ ] **Step 5: Run tests and lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/scope.py src/harbor_clerk/api/deps.py src/harbor_clerk/mcp_server.py
+uv run pytest tests/test_scoped_api_keys.py tests/test_mcp_tool_filtering.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/api/scope.py src/harbor_clerk/api/deps.py src/harbor_clerk/mcp_server.py src/harbor_clerk/api/routes/api_keys.py tests/
+git commit -m "feat: extend KeyScope with rate_limit_rpm/rph fields"
+```
+
+---
+
+### Task 3: RateLimiter Class
+
+**Files:**
+- Create: `src/harbor_clerk/api/rate_limiter.py`
+- Create: `tests/test_rate_limiter.py`
+
+- [ ] **Step 1: Write the RateLimiter**
+
+Create `src/harbor_clerk/api/rate_limiter.py`:
+
+```python
+"""In-memory sliding window rate limiter with crash recovery."""
+
+import asyncio
+import logging
+import time
+import uuid
+from collections import deque
+
+logger = logging.getLogger(__name__)
+
+
+class RateLimiter:
+    """Per-key sliding window rate limiter.
+
+    Maintains a deque of request timestamps per key. check() counts
+    entries in the last 60s/3600s and compares against limits.
+
+    Thread-safe via per-key asyncio.Lock (prevents double-seeding
+    and ensures check-and-record is atomic).
+    """
+
+    def __init__(self):
+        self._windows: dict[uuid.UUID, deque[float]] = {}
+        self._locks: dict[uuid.UUID, asyncio.Lock] = {}
+        self._seeded: set[uuid.UUID] = set()
+
+    def _get_lock(self, key_id: uuid.UUID) -> asyncio.Lock:
+        if key_id not in self._locks:
+            self._locks[key_id] = asyncio.Lock()
+        return self._locks[key_id]
+
+    def _get_window(self, key_id: uuid.UUID) -> deque[float]:
+        if key_id not in self._windows:
+            self._windows[key_id] = deque()
+        return self._windows[key_id]
+
+    async def _seed_if_needed(self, key_id: uuid.UUID) -> None:
+        """Seed the window from api_request_log on first access after startup."""
+        if key_id in self._seeded:
+            return
+        try:
+            from harbor_clerk.db import async_session_factory
+            from harbor_clerk.models.api_request_log import ApiRequestLog
+            from sqlalchemy import select
+
+            async with async_session_factory() as session:
+                cutoff = time.time() - 3600
+                from datetime import UTC, datetime, timedelta
+
+                rows = (
+                    await session.execute(
+                        select(ApiRequestLog.created_at)
+                        .where(
+                            ApiRequestLog.api_key_id == key_id,
+                            ApiRequestLog.created_at >= datetime.now(UTC) - timedelta(hours=1),
+                            ApiRequestLog.status.in_(["ok", "error"]),
+                        )
+                        .order_by(ApiRequestLog.created_at)
+                    )
+                ).scalars().all()
+
+                window = self._get_window(key_id)
+                for ts in rows:
+                    window.append(ts.timestamp())
+        except Exception:
+            logger.debug("Failed to seed rate limiter for key %s", key_id, exc_info=True)
+        self._seeded.add(key_id)
+
+    def _prune(self, window: deque[float], now: float) -> None:
+        """Remove entries older than 1 hour."""
+        cutoff = now - 3600
+        while window and window[0] < cutoff:
+            window.popleft()
+
+    async def check(
+        self,
+        key_id: uuid.UUID,
+        rpm_limit: int,
+        rph_limit: int,
+    ) -> tuple[bool, int]:
+        """Check rate limit and record the request if allowed.
+
+        Returns (allowed, retry_after_seconds).
+        If allowed is True, the request timestamp is recorded.
+        If allowed is False, retry_after_seconds indicates when to retry.
+        """
+        if rpm_limit == 0 and rph_limit == 0:
+            return True, 0  # both unlimited
+
+        lock = self._get_lock(key_id)
+        async with lock:
+            await self._seed_if_needed(key_id)
+            window = self._get_window(key_id)
+            now = time.time()
+            self._prune(window, now)
+
+            # Check per-minute limit
+            if rpm_limit > 0:
+                minute_cutoff = now - 60
+                minute_count = sum(1 for t in window if t >= minute_cutoff)
+                if minute_count >= rpm_limit:
+                    oldest_in_window = next(t for t in window if t >= minute_cutoff)
+                    retry_after = int(oldest_in_window + 60 - now) + 1
+                    return False, max(retry_after, 1)
+
+            # Check per-hour limit
+            if rph_limit > 0:
+                hour_count = len(window)  # already pruned to 1h
+                if hour_count >= rph_limit:
+                    retry_after = int(window[0] + 3600 - now) + 1
+                    return False, max(retry_after, 1)
+
+            # Allowed — record timestamp
+            window.append(now)
+            return True, 0
+
+
+# Module-level singleton
+rate_limiter = RateLimiter()
+```
+
+- [ ] **Step 2: Write tests**
+
+Create `tests/test_rate_limiter.py`:
+
+```python
+"""Tests for the in-memory sliding window rate limiter."""
+
+import asyncio
+import time
+import uuid
+
+import pytest
+
+from harbor_clerk.api.rate_limiter import RateLimiter
+
+
+@pytest.mark.anyio
+async def test_allows_under_limit():
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)  # skip DB seed
+
+    allowed, retry = await limiter.check(key, rpm_limit=10, rph_limit=100)
+    assert allowed is True
+    assert retry == 0
+
+
+@pytest.mark.anyio
+async def test_blocks_over_rpm():
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)
+
+    for _ in range(5):
+        allowed, _ = await limiter.check(key, rpm_limit=5, rph_limit=1000)
+        assert allowed is True
+
+    allowed, retry = await limiter.check(key, rpm_limit=5, rph_limit=1000)
+    assert allowed is False
+    assert retry >= 1
+
+
+@pytest.mark.anyio
+async def test_blocks_over_rph():
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)
+
+    for _ in range(3):
+        allowed, _ = await limiter.check(key, rpm_limit=100, rph_limit=3)
+        assert allowed is True
+
+    allowed, retry = await limiter.check(key, rpm_limit=100, rph_limit=3)
+    assert allowed is False
+    assert retry >= 1
+
+
+@pytest.mark.anyio
+async def test_unlimited_always_allows():
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)
+
+    for _ in range(100):
+        allowed, _ = await limiter.check(key, rpm_limit=0, rph_limit=0)
+        assert allowed is True
+
+
+@pytest.mark.anyio
+async def test_independent_keys():
+    limiter = RateLimiter()
+    key_a = uuid.uuid4()
+    key_b = uuid.uuid4()
+    limiter._seeded.update({key_a, key_b})
+
+    for _ in range(5):
+        await limiter.check(key_a, rpm_limit=5, rph_limit=1000)
+
+    # key_a is at limit
+    allowed_a, _ = await limiter.check(key_a, rpm_limit=5, rph_limit=1000)
+    assert allowed_a is False
+
+    # key_b is still fine
+    allowed_b, _ = await limiter.check(key_b, rpm_limit=5, rph_limit=1000)
+    assert allowed_b is True
+
+
+@pytest.mark.anyio
+async def test_prune_old_entries():
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)
+
+    # Manually insert old timestamps
+    window = limiter._get_window(key)
+    old_time = time.time() - 3700  # older than 1 hour
+    for _ in range(10):
+        window.append(old_time)
+
+    # Should be pruned and allow new requests
+    allowed, _ = await limiter.check(key, rpm_limit=5, rph_limit=5)
+    assert allowed is True
+    assert len(window) == 1  # only the new one
+
+
+@pytest.mark.anyio
+async def test_concurrent_checks_atomic():
+    """Two concurrent checks shouldn't both succeed when only one slot remains."""
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)
+
+    # Fill to limit - 1
+    for _ in range(4):
+        await limiter.check(key, rpm_limit=5, rph_limit=1000)
+
+    # Two concurrent checks for the last slot
+    results = await asyncio.gather(
+        limiter.check(key, rpm_limit=5, rph_limit=1000),
+        limiter.check(key, rpm_limit=5, rph_limit=1000),
+    )
+    allowed_count = sum(1 for allowed, _ in results if allowed)
+    assert allowed_count == 1  # exactly one should succeed
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+uv run ruff check src/harbor_clerk/api/rate_limiter.py tests/test_rate_limiter.py
+uv run pytest tests/test_rate_limiter.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/harbor_clerk/api/rate_limiter.py tests/test_rate_limiter.py
+git commit -m "feat: in-memory sliding window rate limiter with crash recovery"
+```
+
+---
+
+### Task 4: MCP Enforcement
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py`
+
+- [ ] **Step 1: Add rate limit check in call_tool**
+
+In `ScopedFastMCP.call_tool()`, after the `if principal.type != "api_key"` early return and before the denial check, add:
+
+```python
+# --- Rate limit check ---
+if principal.key_scope is not None:
+    from harbor_clerk.api.rate_limiter import rate_limiter
+    from harbor_clerk.config import get_settings
+
+    rl_settings = get_settings()
+    rpm = (
+        principal.key_scope.rate_limit_rpm
+        if principal.key_scope.rate_limit_rpm is not None
+        else rl_settings.default_rate_limit_rpm
+    )
+    rph = (
+        principal.key_scope.rate_limit_rph
+        if principal.key_scope.rate_limit_rph is not None
+        else rl_settings.default_rate_limit_rph
+    )
+    allowed, retry_after = await rate_limiter.check(principal.id, rpm, rph)
+    if not allowed:
+        logger.warning(
+            "Rate limit exceeded for key %s: %d rpm / %d rph (retry_after=%ds)",
+            principal.id, rpm, rph, retry_after,
+        )
+        try:
+            async with async_session_factory() as log_session:
+                await log_api_request(
+                    log_session,
+                    api_key_id=principal.id,
+                    request_type="mcp_tool",
+                    endpoint=name,
+                    parameters=dict(arguments) if arguments else None,
+                    status="rate_limited",
+                    status_detail=f"retry_after={retry_after}s",
+                    duration_ms=0,
+                )
+                await log_session.commit()
+        except Exception:
+            logger.debug("Failed to log rate-limited MCP call", exc_info=True)
+
+        from mcp.server.fastmcp.exceptions import ToolError
+        raise ToolError(f"Rate limit exceeded. Try again in {retry_after} seconds.")
+```
+
+- [ ] **Step 2: Add default settings to config.py**
+
+In `src/harbor_clerk/config.py`, add to the Settings class:
+
+```python
+# Rate limiting
+default_rate_limit_rpm: int = Field(default=60)
+default_rate_limit_rph: int = Field(default=2000)
+```
+
+- [ ] **Step 3: Run tests and lint**
+
+```bash
+uv run ruff check src/harbor_clerk/mcp_server.py src/harbor_clerk/config.py
+uv run pytest tests/test_mcp_tool_filtering.py tests/test_scoped_api_keys.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_server.py src/harbor_clerk/config.py
+git commit -m "feat: rate limit enforcement in MCP call_tool"
+```
+
+---
+
+### Task 5: REST Middleware Enforcement
+
+**Files:**
+- Modify: `src/harbor_clerk/api/middleware.py`
+
+- [ ] **Step 1: Expand ApiKey query and add rate limit check**
+
+In `ApiKeyRequestLogMiddleware.__call__()`, expand the existing `select(ApiKey.key_id)` to also fetch rate limit columns. Then add a rate limit check before forwarding to the inner app.
+
+The current flow is: detect API key → forward to app → log after response. Change to: detect API key → check rate limit → if limited, return 429 + log → else forward to app → log after response.
+
+The key change: the rate limit check must happen BEFORE `await self.app(scope, receive, send_wrapper)`, not after. Restructure the middleware to query ApiKey fields first, check rate limit, then either reject or proceed.
+
+```python
+# After token extraction and before forwarding:
+key_hash = hash_api_key(token)
+async with async_session_factory() as check_session:
+    row = (
+        await check_session.execute(
+            select(ApiKey.key_id, ApiKey.rate_limit_rpm, ApiKey.rate_limit_rph)
+            .where(ApiKey.key_hash == key_hash)
+        )
+    ).one_or_none()
+    if row is None:
+        await self.app(scope, receive, send)
+        return
+
+    key_id, key_rpm, key_rph = row
+
+# Resolve effective limits
+settings = get_settings()
+rpm = key_rpm if key_rpm is not None else settings.default_rate_limit_rpm
+rph = key_rph if key_rph is not None else settings.default_rate_limit_rph
+
+allowed, retry_after = await rate_limiter.check(key_id, rpm, rph)
+if not allowed:
+    # Return 429 directly
+    logger.warning("Rate limit exceeded for key %s on REST %s %s", key_id, method, path)
+    # ... send 429 response with Retry-After header ...
+    # ... log to api_request_log with status="rate_limited" ...
+    return
+
+# Proceed with request
+await self.app(scope, receive, send_wrapper)
+# ... log success/error as before ...
+```
+
+The implementer should read the full middleware and restructure it. The rate limit check goes between the key lookup and the `self.app()` call. The 429 response uses the same ASGI send pattern as `MCPTokenPathAuth._send_401()`.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/middleware.py
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/harbor_clerk/api/middleware.py
+git commit -m "feat: rate limit enforcement in REST middleware"
+```
+
+---
+
+### Task 6: API Schemas + Endpoints
+
+**Files:**
+- Modify: `src/harbor_clerk/api/schemas/api_keys.py`
+- Modify: `src/harbor_clerk/api/routes/api_keys.py`
+
+- [ ] **Step 1: Add rate limit fields to schemas**
+
+In `src/harbor_clerk/api/schemas/api_keys.py`:
+
+Add to `CreateApiKeyRequest`:
+```python
+rate_limit_rpm: int | None = None
+rate_limit_rph: int | None = None
+```
+
+Add to `PatchApiKeyRequest`:
+```python
+rate_limit_rpm: int | None = None
+rate_limit_rph: int | None = None
+```
+
+Add to `ApiKeyOut`:
+```python
+rate_limit_rpm: int | None
+rate_limit_rph: int | None
+```
+
+- [ ] **Step 2: Update route handlers**
+
+In `src/harbor_clerk/api/routes/api_keys.py`:
+
+- `create_api_key`: pass `rate_limit_rpm` and `rate_limit_rph` to the ApiKey constructor
+- `_api_key_to_out`: include the two new fields
+- `_scope_summary`: append rate limit info when set (e.g., "60 rpm", "2000 rph")
+- Validation in PATCH: reject `rate_limit_rpm < 1` unless exactly 0 or None
+
+- [ ] **Step 3: Add `rate_limited` to usage summary**
+
+In `get_key_usage`, add `rate_limited` FILTER counts alongside the existing error/denial buckets:
+
+```python
+for label, hours in error_buckets.items():
+    cutoff = now - timedelta(hours=hours)
+    # ... existing err and den columns ...
+    columns.append(
+        func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "rate_limited").label(f"rl_{label}")
+    )
+
+# In the response:
+rate_limited = {label: getattr(row, f"rl_{label}") for label in error_buckets}
+```
+
+Also update the timeline endpoint to include `rate_limited` in the `by_day` pivot.
+
+- [ ] **Step 4: Run tests and lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/routes/api_keys.py src/harbor_clerk/api/schemas/api_keys.py
+uv run pytest tests/test_api_request_log.py tests/test_api_request_log_endpoints.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/harbor_clerk/api/routes/api_keys.py src/harbor_clerk/api/schemas/api_keys.py
+git commit -m "feat: rate limit fields in API key schemas + usage summary"
+```
+
+---
+
+### Task 7: System Default Settings
+
+**Files:**
+- Modify: `src/harbor_clerk/api/routes/system.py`
+
+- [ ] **Step 1: Add GET/PUT endpoints for rate limit defaults**
+
+Follow the existing `retrieval-settings` pattern in `system.py`:
+
+```python
+@router.get("/system/rate-limit-settings")
+async def get_rate_limit_settings(admin: Principal = Depends(require_admin)):
+    s = get_settings()
+    return {
+        "default_rate_limit_rpm": s.default_rate_limit_rpm,
+        "default_rate_limit_rph": s.default_rate_limit_rph,
+    }
+
+@router.put("/system/rate-limit-settings")
+async def update_rate_limit_settings(
+    body: RateLimitSettingsUpdate,
+    admin: Principal = Depends(require_admin),
+):
+    s = get_settings()
+    if body.default_rate_limit_rpm is not None:
+        s.default_rate_limit_rpm = body.default_rate_limit_rpm
+        sync_native_config("default_rate_limit_rpm", body.default_rate_limit_rpm)
+    if body.default_rate_limit_rph is not None:
+        s.default_rate_limit_rph = body.default_rate_limit_rph
+        sync_native_config("default_rate_limit_rph", body.default_rate_limit_rph)
+    return {
+        "default_rate_limit_rpm": s.default_rate_limit_rpm,
+        "default_rate_limit_rph": s.default_rate_limit_rph,
+    }
+```
+
+Add a Pydantic model for the update body with `min=1` validation.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+uv run ruff check src/harbor_clerk/api/routes/system.py
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/harbor_clerk/api/routes/system.py
+git commit -m "feat: system default rate limit settings endpoints"
+```
+
+---
+
+### Task 8: Frontend — API Key Form Fields
+
+**Files:**
+- Modify: `frontend/src/pages/ApiKeysPage.tsx`
+
+- [ ] **Step 1: Add rate limit fields to ScopeFormFields**
+
+Add two field groups to `ScopeFormFields`, following the expiry checkbox pattern:
+
+Each has an "Unlimited" checkbox. When unchecked, a number input appears (min 1). When checked, stores `0`. When neither checked nor filled, stores null (use system default).
+
+The `ScopeFormState` interface gets:
+```typescript
+rateLimitRpm: string  // '' = system default, '0' = unlimited, else custom
+rateLimitRpmUnlimited: boolean
+rateLimitRph: string
+rateLimitRphUnlimited: boolean
+```
+
+`scopeStateToPayload` maps: unlimited checkbox → 0, empty string → null, number → the number.
+
+Helper text under each field: "System default: {N}/min" / "System default: {N}/hour" (fetch from a new settings endpoint or hardcode initially).
+
+- [ ] **Step 2: Lint and type-check**
+
+```bash
+cd /Users/alex/mcp-gateway/frontend
+npx eslint src/pages/ApiKeysPage.tsx
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/ApiKeysPage.tsx
+git commit -m "feat: rate limit fields with unlimited checkbox in API key form"
+```
+
+---
+
+### Task 9: Frontend — Dashboard Integration
+
+**Files:**
+- Modify: `frontend/src/pages/ApiKeyDashboardPage.tsx`
+
+- [ ] **Step 1: Add rate limited card and timeline color**
+
+In `ApiKeyDashboardPage.tsx`:
+
+1. Add `rate_limited` to the `UsageSummary` interface
+2. Add a new summary card: "Rate Limited" with dropdown (1h / 24h / 7d), orange-tinted when > 0
+3. Add a 4th stacked bar to the timeline chart: `rate_limited` in orange (`#f97316`)
+4. Add an orange badge for `status="rate_limited"` in the `statusBadge` function
+5. Add orange left border for rate-limited rows in the request log table
+
+- [ ] **Step 2: Lint and type-check**
+
+```bash
+cd /Users/alex/mcp-gateway/frontend
+npx eslint src/pages/ApiKeyDashboardPage.tsx
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/ApiKeyDashboardPage.tsx
+git commit -m "feat: rate limited card + timeline bar + badge in audit dashboard"
+```
+
+---
+
+### Task 10: Frontend — System Settings
+
+**Files:**
+- Modify: `frontend/src/pages/SystemSettingsPage.tsx` (or the appropriate settings page)
+
+- [ ] **Step 1: Add rate limit default inputs**
+
+Add a "Rate Limits" section to the System Settings page with:
+- Default requests/minute — number input, min 1
+- Default requests/hour — number input, min 1
+- Save button that PATCHes `/api/system/rate-limit-settings`
+
+Follow the existing pattern for whatever settings are already on this page.
+
+- [ ] **Step 2: Lint and type-check**
+
+```bash
+cd /Users/alex/mcp-gateway/frontend
+npx eslint src/pages/SystemSettingsPage.tsx
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/SystemSettingsPage.tsx
+git commit -m "feat: system default rate limit settings in admin UI"
+```
+
+---
+
+### Task 11: Final Verification
+
+- [ ] **Step 1: Update _EXPECTED_SCHEMA_VERSION**
+
+In `src/harbor_clerk/api/app.py`, update `_EXPECTED_SCHEMA_VERSION = "0015"`.
+
+- [ ] **Step 2: Full lint pass**
+
+```bash
+cd /Users/alex/mcp-gateway
+uv run ruff check src/harbor_clerk/
+uv run ruff format --check src/harbor_clerk/
+cd frontend && npx eslint src/ && npx tsc --noEmit
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+cd /Users/alex/mcp-gateway
+uv run pytest tests/ -v
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+1. Create an API key with rate_limit_rpm=5
+2. Make 5 MCP tool calls → all succeed
+3. 6th call → 429 / ToolError with retry_after
+4. Wait 60s, try again → succeeds
+5. Check audit dashboard → rate_limited events visible
+6. System Settings → change default RPM → new keys use it
+
+- [ ] **Step 5: Commit any final fixes**
+
+```bash
+git add -A
+git commit -m "fix: final adjustments for rate limiting"
+```

--- a/docs/superpowers/specs/2026-04-10-rate-limits-design.md
+++ b/docs/superpowers/specs/2026-04-10-rate-limits-design.md
@@ -1,0 +1,157 @@
+# Per-API-Key Rate Limits
+
+## Goal
+
+Protect against runaway AI agents that hammer the API in a loop. Circuit breaker, not billing system.
+
+## Design Principle
+
+Safe defaults out of the box. Every new key gets rate limits automatically. Admins override per-key when needed. Maximum introspection — rate-limited requests are logged and visible in the audit dashboard.
+
+## Data Model
+
+### System defaults
+
+Two new fields stored in the `model_settings` table (same pattern as LLM model config — DB-backed, runtime-editable, falls back to env var defaults):
+
+- `default_rate_limit_rpm` — requests per minute, default `60`
+- `default_rate_limit_rph` — requests per hour, default `2000`
+
+Cached in memory; refreshed on PATCH. Exposed in System Settings UI via `GET/PATCH /api/system/settings`. In the macOS app, also synced to `native_config_file` via the existing `sync_native_config()` pattern.
+
+### Per-key overrides (migration 0015)
+
+Two new nullable columns on `api_keys`:
+
+| Column | Type | Notes |
+|---|---|---|
+| `rate_limit_rpm` | integer, nullable | NULL = use system default. 0 = unlimited. >=1 = custom limit. |
+| `rate_limit_rph` | integer, nullable | Same semantics. |
+
+**Effective limit** for a key = per-key value if not NULL, else system default. `0` is the sentinel for "explicitly unlimited" — never exposed as a number in the UI; the frontend uses an "Unlimited" checkbox.
+
+### KeyScope extension
+
+Add `rate_limit_rpm: int | None` and `rate_limit_rph: int | None` to `KeyScope` dataclass. Populated in `_resolve_principal()` (MCP auth) and available on `principal.key_scope` at call time — no per-request DB lookups needed.
+
+## Enforcement
+
+### In-memory sliding window
+
+A `RateLimiter` singleton holds per-key sliding windows. Each window is a deque of request timestamps.
+
+```
+RateLimiter:
+  check(key_id, rpm_limit, rph_limit) -> (allowed: bool, retry_after_seconds: int)
+```
+
+`check()` counts entries in the last 60s and 3600s, compares against limits, prunes entries older than 1 hour. Returns `retry_after_seconds` = seconds until the oldest entry in the violated window expires.
+
+**Concurrency:** The `RateLimiter` is accessed from async coroutines on a single event loop (no threads). Deque operations are atomic in CPython, but the "check count + append" sequence is not. Use a per-key `asyncio.Lock` (stored in a `dict[UUID, asyncio.Lock]`, lazily created) to make check-and-record atomic. This also guards crash recovery seeding.
+
+### Crash recovery
+
+On the first request from a key after process startup, the limiter seeds the window from `api_request_log` — one query for the last hour of timestamps for that key. The per-key `asyncio.Lock` ensures only one coroutine seeds; concurrent requests for the same cold key wait on the lock rather than double-seeding. Cached thereafter. If `api_request_log` is unavailable, the window starts empty (fail-open).
+
+### Enforcement points
+
+Two enforcement points, each resolving effective limits from their available context:
+
+1. **MCP tool calls** — at the top of `ScopedFastMCP.call_tool()`, before the existing denial check. Reads limits from `principal.key_scope.rate_limit_rpm/rph` (populated at auth time from the `ApiKey` model). If rate-limited, raise `ToolError("Rate limit exceeded. Try again in {N} seconds.")`.
+
+2. **REST API requests** — in `ApiKeyRequestLogMiddleware`. The middleware already queries the `ApiKey` by token hash; expand the existing `select(ApiKey.key_id)` to also fetch `rate_limit_rpm` and `rate_limit_rph`. If rate-limited, short-circuit with HTTP 429 + `Retry-After: {N}` header + JSON body `{"detail": "Rate limit exceeded", "retry_after": N}`.
+
+### Effective limit resolution
+
+Both paths resolve effective limits the same way:
+
+```python
+rpm = key_rpm if key_rpm is not None else settings.default_rate_limit_rpm
+rph = key_rph if key_rph is not None else settings.default_rate_limit_rph
+# 0 means unlimited — skip that window
+```
+
+### Logging
+
+Rate-limited requests are logged to `api_request_log` with `status="rate_limited"` (new value alongside `ok`, `error`, `denied`). Log level: **WARN**.
+
+**Existing route updates required:** The usage summary endpoint's COUNT FILTER queries, the timeline pivot, and the dashboard all hard-code `ok`/`error`/`denied`. All three must add `rate_limited` as a fourth status — otherwise rate-limited events are silently dropped from aggregations.
+
+## Frontend
+
+### System Settings
+
+New "Rate Limits" section (under the existing Settings hub):
+
+- **Default requests/minute** — number input, min 1
+- **Default requests/hour** — number input, min 1
+
+### API Key edit modal
+
+Two new field groups in the scope form:
+
+- **Requests/minute** — "Unlimited" checkbox (checked = store 0). Unchecked + empty = NULL (use system default). Unchecked + value = custom limit (validated >=1). Helper text: "System default: {N}/min"
+- **Requests/hour** — same pattern.
+
+UI rejects values < 1 (frontend validation). Backend also validates: reject < 1 unless exactly 0 (unlimited).
+
+The `_scope_summary` includes rate limits when set: e.g., "Read only, 3 topics, 30 rpm, 1000 rph".
+
+### API Key create form
+
+Same fields as the edit modal. New keys default to NULL (system default applies).
+
+### Audit dashboard
+
+- `status="rate_limited"` rows get an orange badge in the request log table (distinct from amber "denied")
+- New **Rate limited** summary card with dropdown (1h / 24h / 7d), same pattern as Errors/Denials
+- Timeline chart: 4th stacked bar color for rate-limited (orange)
+
+## API Changes
+
+### PATCH /api/api-keys/{key_id}
+
+Accepts `rate_limit_rpm` and `rate_limit_rph` in the patch body (same partial-update semantics as existing fields). Validates: null (clear override), 0 (unlimited), or >=1.
+
+### POST /api/api-keys
+
+Accepts `rate_limit_rpm` and `rate_limit_rph` in the create body. Same validation.
+
+### GET /api/api-keys
+
+Response includes `rate_limit_rpm` and `rate_limit_rph` per key.
+
+### GET /api/api-keys/{key_id}/usage
+
+Add `rate_limited` to the error/denial bucket pattern:
+```json
+{
+  "rate_limited": {"1h": 0, "24h": 2, "7d": 5},
+  ...
+}
+```
+
+### GET/PATCH /api/system/settings
+
+Expose `default_rate_limit_rpm` and `default_rate_limit_rph`. Admin-only.
+
+## Files
+
+| File | Change |
+|---|---|
+| `alembic/versions/0015_rate_limits.py` | Add `rate_limit_rpm`, `rate_limit_rph` to `api_keys` |
+| `src/harbor_clerk/models/api_key.py` | Two new columns |
+| `src/harbor_clerk/models/model_settings.py` | Two new default fields (or new row) |
+| `src/harbor_clerk/api/scope.py` | Add `rate_limit_rpm`, `rate_limit_rph` to `KeyScope` |
+| `src/harbor_clerk/api/deps.py` | Populate rate limit fields on `KeyScope` in `get_current_principal()` |
+| `src/harbor_clerk/mcp_server.py` | Populate rate limit fields in `_resolve_principal()` |
+| `src/harbor_clerk/api/rate_limiter.py` | New: `RateLimiter` class with sliding window, per-key lock, crash recovery |
+| `src/harbor_clerk/mcp_server.py` | Rate limit check in `ScopedFastMCP.call_tool()` |
+| `src/harbor_clerk/api/middleware.py` | Expand ApiKey query + rate limit check |
+| `src/harbor_clerk/api/routes/api_keys.py` | Accept/return rate limit fields; add `rate_limited` to usage buckets |
+| `src/harbor_clerk/api/schemas/api_keys.py` | Add fields to request/response schemas |
+| `src/harbor_clerk/api/routes/system.py` | Expose default rate limit settings |
+| `frontend/src/pages/ApiKeysPage.tsx` | Rate limit fields with unlimited checkbox |
+| `frontend/src/pages/ApiKeyDashboardPage.tsx` | Rate limited card + timeline bar + orange badge |
+| `frontend/src/pages/SystemSettingsPage.tsx` | Default rate limit inputs |
+| `tests/test_rate_limiter.py` | Unit tests: sliding window, crash recovery, concurrency, effective limit resolution |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import ChatPage from './pages/ChatPage'
 import HomePage from './pages/HomePage'
 import ModelsPage from './pages/ModelsPage'
 import PreferencesPage from './pages/PreferencesPage'
+import RateLimitSettingsPage from './pages/RateLimitSettingsPage'
 import RetrievalSettingsPage from './pages/RetrievalSettingsPage'
 import StatsPage from './pages/StatsPage'
 import ExplorePage from './pages/ExplorePage'
@@ -61,6 +62,7 @@ export default function App() {
             <Route path="/admin/system/maintenance" element={<SystemMaintenancePage />} />
             <Route path="/admin/models" element={<ModelsPage />} />
             <Route path="/admin/retrieval" element={<RetrievalSettingsPage />} />
+            <Route path="/admin/rate-limits" element={<RateLimitSettingsPage />} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/pages/ApiKeyDashboardPage.tsx
+++ b/frontend/src/pages/ApiKeyDashboardPage.tsx
@@ -19,6 +19,7 @@ interface UsageSummary {
   requests: RangeMap<number>
   errors: RangeMap<number>
   denials: RangeMap<number>
+  rate_limited: RangeMap<number>
   last_used_at: string | null
   top_tools: RangeMap<Array<{ endpoint: string; count: number }>>
 }
@@ -28,6 +29,7 @@ interface TimelineBucket {
   ok: number
   error: number
   denied: number
+  rate_limited: number
 }
 
 interface RequestEntry {
@@ -72,7 +74,9 @@ function statusBadge(status: string) {
       ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
       : status === 'error'
         ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-        : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+        : status === 'rate_limited'
+          ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+          : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
   return <span className={`rounded-md px-2 py-0.5 text-[11px] font-medium ${cls}`}>{status}</span>
 }
 
@@ -92,6 +96,7 @@ export default function ApiKeyDashboardPage() {
   const [reqRange, setReqRange] = useState<string>('24h')
   const [errRange, setErrRange] = useState<string>('7d')
   const [denRange, setDenRange] = useState<string>('7d')
+  const [rlRange, setRlRange] = useState<string>('7d')
 
   // request log filters + pagination
   const [logPage, setLogPage] = useState(1)
@@ -267,7 +272,7 @@ export default function ApiKeyDashboardPage() {
       {usage && (
         <>
           {/* Summary cards */}
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
             {/* Requests card */}
             <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
               <div className="flex items-center justify-between">
@@ -335,6 +340,33 @@ export default function ApiKeyDashboardPage() {
               </p>
             </div>
 
+            {/* Rate Limited card */}
+            <div
+              className={`rounded-xl shadow-mac ring-1 ring-(--color-border) p-4 ${
+                (usage.rate_limited[rlRange] ?? 0) > 0
+                  ? 'bg-orange-50 dark:bg-orange-900/20'
+                  : 'bg-white dark:bg-[#2c2c2e]'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Rate Limited</span>
+                <select
+                  value={rlRange}
+                  onChange={(e) => setRlRange(e.target.value)}
+                  className="rounded border-0 bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs"
+                >
+                  {DENIAL_RANGES.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <p className="mt-2 text-2xl font-bold text-orange-600 dark:text-orange-400">
+                {usage.rate_limited[rlRange] ?? 0}
+              </p>
+            </div>
+
             {/* Last Used card */}
             <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
               <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Last Used</span>
@@ -358,6 +390,7 @@ export default function ApiKeyDashboardPage() {
                     <Bar dataKey="ok" stackId="a" fill="#3b82f6" name="OK" />
                     <Bar dataKey="error" stackId="a" fill="#ef4444" name="Error" />
                     <Bar dataKey="denied" stackId="a" fill="#f59e0b" name="Denied" />
+                    <Bar dataKey="rate_limited" stackId="a" fill="#f97316" name="Rate Limited" />
                   </BarChart>
                 </ResponsiveContainer>
               ) : (
@@ -428,6 +461,7 @@ export default function ApiKeyDashboardPage() {
                   <option value="ok">ok</option>
                   <option value="error">error</option>
                   <option value="denied">denied</option>
+                  <option value="rate_limited">rate limited</option>
                 </select>
                 <input
                   type="date"
@@ -487,7 +521,9 @@ export default function ApiKeyDashboardPage() {
                             ? 'border-l-2 border-red-400'
                             : r.status === 'denied'
                               ? 'border-l-2 border-amber-400'
-                              : ''
+                              : r.status === 'rate_limited'
+                                ? 'border-l-2 border-orange-400'
+                                : ''
                         const isExpanded = expandedRow === r.request_id
                         return (
                           <Fragment key={r.request_id}>

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -17,6 +17,8 @@ interface ApiKeyInfo {
   scope_folder_ids: string[] | null
   max_snippet_chars: number | null
   scope_summary: string
+  rate_limit_rpm: number | null
+  rate_limit_rph: number | null
 }
 
 interface ApiKeyCreated {
@@ -97,6 +99,10 @@ interface ScopeFormState {
   topicIds: number[] | null
   folderIds: string[] | null
   maxSnippetChars: string // raw input string
+  rateLimitRpmUnlimited: boolean
+  rateLimitRpm: string // '' = system default, number string = custom
+  rateLimitRphUnlimited: boolean
+  rateLimitRph: string
 }
 
 function emptyScopeState(): ScopeFormState {
@@ -107,6 +113,10 @@ function emptyScopeState(): ScopeFormState {
     topicIds: null,
     folderIds: null,
     maxSnippetChars: '',
+    rateLimitRpmUnlimited: false,
+    rateLimitRpm: '',
+    rateLimitRphUnlimited: false,
+    rateLimitRph: '',
   }
 }
 
@@ -118,6 +128,10 @@ function scopeStateFromKey(k: ApiKeyInfo): ScopeFormState {
     topicIds: k.scope_topic_ids,
     folderIds: k.scope_folder_ids,
     maxSnippetChars: k.max_snippet_chars != null ? String(k.max_snippet_chars) : '',
+    rateLimitRpmUnlimited: k.rate_limit_rpm === 0,
+    rateLimitRpm: k.rate_limit_rpm != null && k.rate_limit_rpm > 0 ? String(k.rate_limit_rpm) : '',
+    rateLimitRphUnlimited: k.rate_limit_rph === 0,
+    rateLimitRph: k.rate_limit_rph != null && k.rate_limit_rph > 0 ? String(k.rate_limit_rph) : '',
   }
 }
 
@@ -128,6 +142,8 @@ interface ScopePayload {
   scope_topic_ids: number[] | null
   scope_folder_ids: string[] | null
   max_snippet_chars: number | null
+  rate_limit_rpm: number | null
+  rate_limit_rph: number | null
 }
 
 function scopeStateToPayload(s: ScopeFormState): ScopePayload {
@@ -139,6 +155,8 @@ function scopeStateToPayload(s: ScopeFormState): ScopePayload {
     scope_topic_ids: s.topicIds,
     scope_folder_ids: s.folderIds,
     max_snippet_chars: maxSnippet != null && Number.isFinite(maxSnippet) && maxSnippet > 0 ? maxSnippet : null,
+    rate_limit_rpm: s.rateLimitRpmUnlimited ? 0 : s.rateLimitRpm.trim() ? Number(s.rateLimitRpm) : null,
+    rate_limit_rph: s.rateLimitRphUnlimited ? 0 : s.rateLimitRph.trim() ? Number(s.rateLimitRph) : null,
   }
 }
 
@@ -527,6 +545,60 @@ function ScopeFormFields({
           placeholder="No limit"
           className="w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
         />
+      </div>
+
+      <div>
+        <label className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={state.rateLimitRpmUnlimited}
+            onChange={(e) =>
+              setState((s) => ({
+                ...s,
+                rateLimitRpmUnlimited: e.target.checked,
+                rateLimitRpm: e.target.checked ? '' : s.rateLimitRpm,
+              }))
+            }
+          />
+          Unlimited requests/min
+        </label>
+        {!state.rateLimitRpmUnlimited && (
+          <input
+            type="number"
+            min="1"
+            value={state.rateLimitRpm}
+            onChange={(e) => setState((s) => ({ ...s, rateLimitRpm: e.target.value }))}
+            placeholder="System default"
+            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+          />
+        )}
+      </div>
+
+      <div>
+        <label className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={state.rateLimitRphUnlimited}
+            onChange={(e) =>
+              setState((s) => ({
+                ...s,
+                rateLimitRphUnlimited: e.target.checked,
+                rateLimitRph: e.target.checked ? '' : s.rateLimitRph,
+              }))
+            }
+          />
+          Unlimited requests/hour
+        </label>
+        {!state.rateLimitRphUnlimited && (
+          <input
+            type="number"
+            min="1"
+            value={state.rateLimitRph}
+            onChange={(e) => setState((s) => ({ ...s, rateLimitRph: e.target.value }))}
+            placeholder="System default"
+            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+          />
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/RateLimitSettingsPage.tsx
+++ b/frontend/src/pages/RateLimitSettingsPage.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { get, put } from '../api'
+
+interface RateLimitSettings {
+  default_rpm: number
+  default_rph: number
+}
+
+export default function RateLimitSettingsPage() {
+  const [saved, setSaved] = useState<RateLimitSettings | null>(null)
+  const [form, setForm] = useState<RateLimitSettings | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [success, setSuccess] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    get<RateLimitSettings>('/api/system/rate-limit-settings')
+      .then((data) => {
+        setSaved(data)
+        setForm(data)
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="text-sm text-(--color-text-secondary)">Loading...</div>
+  if (!form || !saved) return <div className="text-sm text-red-500">{error || 'Failed to load settings'}</div>
+
+  const dirty = JSON.stringify(form) !== JSON.stringify(saved)
+
+  function updateField(key: keyof RateLimitSettings, value: number) {
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev))
+    setSuccess('')
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    setError('')
+    setSuccess('')
+    try {
+      const data = await put<RateLimitSettings>('/api/system/rate-limit-settings', form)
+      setSaved(data)
+      setForm(data)
+      setSuccess('Settings saved')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleReset() {
+    setForm(saved)
+    setSuccess('')
+    setError('')
+  }
+
+  return (
+    <div className="animate-slide-in">
+      <h1 className="mb-4 text-xl font-bold">Rate Limits</h1>
+      <p className="mb-4 text-sm text-(--color-text-secondary)">
+        Default rate limits applied to API keys that don&apos;t specify their own limits.
+      </p>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="mb-4 rounded-lg bg-green-50 dark:bg-green-900/20 px-3 py-2 text-sm text-green-700 dark:text-green-400">
+          {success}
+        </div>
+      )}
+
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+        <div className="px-4 py-3 bg-(--color-bg-secondary)">
+          <h2 className="text-sm font-medium text-(--color-text-primary)">Default Limits</h2>
+        </div>
+        <div className="px-4 divide-y divide-(--color-border)">
+          <div className="flex items-center justify-between gap-4 py-3">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-(--color-text-primary)">Default requests/minute</div>
+              <div className="text-xs text-(--color-text-secondary) mt-0.5">
+                Applied when an API key has no per-key RPM override
+              </div>
+            </div>
+            <input
+              type="number"
+              min={1}
+              value={form.default_rpm}
+              onChange={(e) => updateField('default_rpm', Number(e.target.value))}
+              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+            />
+          </div>
+          <div className="flex items-center justify-between gap-4 py-3">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-(--color-text-primary)">Default requests/hour</div>
+              <div className="text-xs text-(--color-text-secondary) mt-0.5">
+                Applied when an API key has no per-key RPH override
+              </div>
+            </div>
+            <input
+              type="number"
+              min={1}
+              value={form.default_rph}
+              onChange={(e) => updateField('default_rph', Number(e.target.value))}
+              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 flex gap-3">
+        <button
+          onClick={handleSave}
+          disabled={!dirty || saving}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          onClick={handleReset}
+          disabled={!dirty}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-4 py-2 text-sm font-medium text-(--color-text-primary) hover:bg-(--color-bg-secondary) disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -5,6 +5,7 @@ const ITEMS = [
   { to: '/admin/keys', label: 'API Keys', description: 'Create and revoke API keys' },
   { to: '/admin/models', label: 'Models', description: 'Download and manage LLM models' },
   { to: '/admin/retrieval', label: 'Retrieval', description: 'Chat and MCP search behavior' },
+  { to: '/admin/rate-limits', label: 'Rate Limits', description: 'Default API key rate limits' },
   { to: '/admin/system/status', label: 'System Status', description: 'Health checks and statistics' },
   { to: '/admin/system/logs', label: 'Service Logs', description: 'View log files and tail commands' },
   { to: '/admin/system/maintenance', label: 'System Maintenance', description: 'Purge, reaper, and cleanup' },

--- a/src/harbor_clerk/api/app.py
+++ b/src/harbor_clerk/api/app.py
@@ -179,7 +179,7 @@ async def lifespan(app: FastAPI):
     logger.info("Starting Harbor Clerk API")
 
     # Verify database schema is up to date
-    _EXPECTED_SCHEMA_VERSION = "0014"
+    _EXPECTED_SCHEMA_VERSION = "0015"
     try:
         from harbor_clerk.db import async_session_factory
 

--- a/src/harbor_clerk/api/deps.py
+++ b/src/harbor_clerk/api/deps.py
@@ -93,6 +93,8 @@ async def get_current_principal(
         permission_tier=api_key.permission_tier,
         tool_overrides=api_key.tool_overrides or {},
         max_snippet_chars=api_key.max_snippet_chars,
+        rate_limit_rpm=api_key.rate_limit_rpm,
+        rate_limit_rph=api_key.rate_limit_rph,
     )
     return Principal(type="api_key", id=api_key.key_id, role="user", key_scope=scope)
 

--- a/src/harbor_clerk/api/middleware.py
+++ b/src/harbor_clerk/api/middleware.py
@@ -65,6 +65,95 @@ class ApiKeyRequestLogMiddleware:
             await self.app(scope, receive, send)
             return
 
+        method = scope.get("method", "GET")
+        endpoint = _normalize_path(method, path)
+
+        # Extract query params
+        qs = scope.get("query_string", b"").decode("latin-1")
+        parameters = dict(pair.split("=", 1) for pair in qs.split("&") if "=" in pair) if qs else None
+
+        # --- Resolve API key and check rate limit BEFORE forwarding ---
+        key_id = None
+        try:
+            from harbor_clerk.auth import hash_api_key
+            from harbor_clerk.db import async_session_factory
+            from harbor_clerk.models import ApiKey
+
+            key_hash = hash_api_key(token)
+            async with async_session_factory() as pre_session:
+                from sqlalchemy import select
+
+                row = (
+                    await pre_session.execute(
+                        select(ApiKey.key_id, ApiKey.rate_limit_rpm, ApiKey.rate_limit_rph).where(
+                            ApiKey.key_hash == key_hash
+                        )
+                    )
+                ).one_or_none()
+                if row is None:
+                    # Invalid key — let auth handler reject it
+                    await self.app(scope, receive, send)
+                    return
+
+                key_id = row.key_id
+                rl_rpm = row.rate_limit_rpm
+                rl_rph = row.rate_limit_rph
+
+            # Rate limit check
+            from harbor_clerk.api.rate_limiter import rate_limiter
+            from harbor_clerk.config import get_settings as _get_settings
+
+            _s = _get_settings()
+            rpm = rl_rpm if rl_rpm is not None else _s.default_rate_limit_rpm
+            rph = rl_rph if rl_rph is not None else _s.default_rate_limit_rph
+            allowed, retry_after = await rate_limiter.check(key_id, rpm, rph)
+            if not allowed:
+                logger.warning(
+                    "Rate limit exceeded for key %s on REST %s (retry_after=%ds)",
+                    key_id,
+                    endpoint,
+                    retry_after,
+                )
+                # Log the rate-limited request
+                try:
+                    from harbor_clerk.api.request_log import log_api_request
+
+                    async with async_session_factory() as log_session:
+                        await log_api_request(
+                            log_session,
+                            api_key_id=key_id,
+                            request_type="rest",
+                            endpoint=endpoint,
+                            parameters=parameters,
+                            status="rate_limited",
+                            status_detail=f"retry_after={retry_after}s",
+                            duration_ms=0,
+                        )
+                        await log_session.commit()
+                except Exception:
+                    logger.debug("Failed to log rate-limited REST request", exc_info=True)
+
+                # Send 429 response
+                import json as _json
+
+                body = _json.dumps({"detail": "Rate limit exceeded", "retry_after": retry_after}).encode()
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 429,
+                        "headers": [
+                            [b"content-type", b"application/json"],
+                            [b"content-length", str(len(body)).encode()],
+                            [b"retry-after", str(retry_after).encode()],
+                        ],
+                    }
+                )
+                await send({"type": "http.response.body", "body": body})
+                return
+        except Exception:
+            logger.debug("Failed to check rate limit for REST request", exc_info=True)
+
+        # --- Forward request to app ---
         start = time.monotonic()
         response_status = [200]
 
@@ -76,43 +165,27 @@ class ApiKeyRequestLogMiddleware:
         await self.app(scope, receive, send_wrapper)
 
         elapsed = int((time.monotonic() - start) * 1000)
-        method = scope.get("method", "GET")
-        endpoint = _normalize_path(method, path)
         status_code = response_status[0]
         req_status = "ok" if status_code < 400 else "error"
         status_detail = None if req_status == "ok" else f"HTTP {status_code}"
 
-        # Extract query params
-        qs = scope.get("query_string", b"").decode("latin-1")
-        parameters = dict(pair.split("=", 1) for pair in qs.split("&") if "=" in pair) if qs else None
+        # --- Log the request ---
+        if key_id is not None:
+            try:
+                from harbor_clerk.api.request_log import log_api_request
+                from harbor_clerk.db import async_session_factory
 
-        try:
-            from harbor_clerk.api.request_log import log_api_request
-            from harbor_clerk.auth import hash_api_key
-            from harbor_clerk.db import async_session_factory
-            from harbor_clerk.models import ApiKey
-
-            # Resolve the key_id from the token hash
-            key_hash = hash_api_key(token)
-            async with async_session_factory() as log_session:
-                from sqlalchemy import select
-
-                row = (
-                    await log_session.execute(select(ApiKey.key_id).where(ApiKey.key_hash == key_hash))
-                ).scalar_one_or_none()
-                if row is None:
-                    return  # invalid key, auth handler already rejected it
-
-                await log_api_request(
-                    log_session,
-                    api_key_id=row,
-                    request_type="rest",
-                    endpoint=endpoint,
-                    parameters=parameters,
-                    status=req_status,
-                    status_detail=status_detail,
-                    duration_ms=elapsed,
-                )
-                await log_session.commit()
-        except Exception:
-            logger.debug("Failed to log REST request", exc_info=True)
+                async with async_session_factory() as log_session:
+                    await log_api_request(
+                        log_session,
+                        api_key_id=key_id,
+                        request_type="rest",
+                        endpoint=endpoint,
+                        parameters=parameters,
+                        status=req_status,
+                        status_detail=status_detail,
+                        duration_ms=elapsed,
+                    )
+                    await log_session.commit()
+            except Exception:
+                logger.debug("Failed to log REST request", exc_info=True)

--- a/src/harbor_clerk/api/rate_limiter.py
+++ b/src/harbor_clerk/api/rate_limiter.py
@@ -1,0 +1,124 @@
+"""In-memory sliding window rate limiter with crash recovery."""
+
+import asyncio
+import logging
+import time
+import uuid
+from collections import deque
+
+logger = logging.getLogger(__name__)
+
+
+class RateLimiter:
+    """Per-key sliding window rate limiter.
+
+    Maintains a deque of request timestamps per key. check() counts
+    entries in the last 60s/3600s and compares against limits.
+
+    Thread-safe via per-key asyncio.Lock (prevents double-seeding
+    and ensures check-and-record is atomic).
+    """
+
+    def __init__(self):
+        self._windows: dict[uuid.UUID, deque[float]] = {}
+        self._locks: dict[uuid.UUID, asyncio.Lock] = {}
+        self._seeded: set[uuid.UUID] = set()
+
+    def _get_lock(self, key_id: uuid.UUID) -> asyncio.Lock:
+        if key_id not in self._locks:
+            self._locks[key_id] = asyncio.Lock()
+        return self._locks[key_id]
+
+    def _get_window(self, key_id: uuid.UUID) -> deque[float]:
+        if key_id not in self._windows:
+            self._windows[key_id] = deque()
+        return self._windows[key_id]
+
+    async def _seed_if_needed(self, key_id: uuid.UUID) -> None:
+        """Seed the window from api_request_log on first access after startup."""
+        if key_id in self._seeded:
+            return
+        try:
+            from datetime import UTC, datetime, timedelta
+
+            from sqlalchemy import select
+
+            from harbor_clerk.db import async_session_factory
+            from harbor_clerk.models.api_request_log import ApiRequestLog
+
+            async with async_session_factory() as session:
+                rows = (
+                    (
+                        await session.execute(
+                            select(ApiRequestLog.created_at)
+                            .where(
+                                ApiRequestLog.api_key_id == key_id,
+                                ApiRequestLog.created_at >= datetime.now(UTC) - timedelta(hours=1),
+                                ApiRequestLog.status.in_(["ok", "error"]),
+                            )
+                            .order_by(ApiRequestLog.created_at)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+
+                window = self._get_window(key_id)
+                for ts in rows:
+                    window.append(ts.timestamp())
+        except Exception:
+            logger.debug("Failed to seed rate limiter for key %s", key_id, exc_info=True)
+        self._seeded.add(key_id)
+
+    def _prune(self, window: deque[float], now: float) -> None:
+        """Remove entries older than 1 hour."""
+        cutoff = now - 3600
+        while window and window[0] < cutoff:
+            window.popleft()
+
+    async def check(
+        self,
+        key_id: uuid.UUID,
+        rpm_limit: int,
+        rph_limit: int,
+    ) -> tuple[bool, int]:
+        """Check rate limit and record the request if allowed.
+
+        Returns (allowed, retry_after_seconds).
+        If allowed is True, the request timestamp is recorded.
+        If allowed is False, retry_after_seconds indicates when to retry.
+        rpm_limit/rph_limit of 0 means unlimited for that window.
+        """
+        if rpm_limit == 0 and rph_limit == 0:
+            return True, 0
+
+        lock = self._get_lock(key_id)
+        async with lock:
+            await self._seed_if_needed(key_id)
+            window = self._get_window(key_id)
+            now = time.time()
+            self._prune(window, now)
+
+            # Check per-minute limit
+            if rpm_limit > 0:
+                minute_cutoff = now - 60
+                minute_count = sum(1 for t in window if t >= minute_cutoff)
+                if minute_count >= rpm_limit:
+                    oldest_in_minute = next(t for t in window if t >= minute_cutoff)
+                    retry_after = int(oldest_in_minute + 60 - now) + 1
+                    return False, max(retry_after, 1)
+
+            # Check per-hour limit
+            if rph_limit > 0:
+                hour_count = len(window)
+                if hour_count >= rph_limit:
+                    retry_after = int(window[0] + 3600 - now) + 1
+                    return False, max(retry_after, 1)
+
+            # Allowed — record timestamp
+            window.append(now)
+            return True, 0
+
+
+# Module-level singleton
+rate_limiter = RateLimiter()

--- a/src/harbor_clerk/api/routes/api_keys.py
+++ b/src/harbor_clerk/api/routes/api_keys.py
@@ -169,6 +169,8 @@ async def scope_preview(
         permission_tier=api_key.permission_tier,
         tool_overrides=api_key.tool_overrides or {},
         max_snippet_chars=api_key.max_snippet_chars,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     fake_principal = Principal(type="api_key", id=key_id, role="user", key_scope=scope)
     visible_query = apply_key_scope(
@@ -198,6 +200,8 @@ async def scope_preview_adhoc(
         permission_tier=body.permission_tier,
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     fake_principal = Principal(type="api_key", id=admin.id, role="user", key_scope=scope)
     visible_query = apply_key_scope(

--- a/src/harbor_clerk/api/routes/api_keys.py
+++ b/src/harbor_clerk/api/routes/api_keys.py
@@ -47,6 +47,10 @@ def _scope_summary(api_key: ApiKey) -> str:
         parts.append(f"{n} folder{'s' if n != 1 else ''}")
     if api_key.max_snippet_chars:
         parts.append(f"max {api_key.max_snippet_chars} chars")
+    if api_key.rate_limit_rpm is not None:
+        parts.append(f"{api_key.rate_limit_rpm} rpm" if api_key.rate_limit_rpm > 0 else "unlimited rpm")
+    if api_key.rate_limit_rph is not None:
+        parts.append(f"{api_key.rate_limit_rph} rph" if api_key.rate_limit_rph > 0 else "unlimited rph")
     if api_key.expires_at:
         parts.append(f"expires {api_key.expires_at.date().isoformat()}")
     return ", ".join(parts) if parts else "Full access"
@@ -65,6 +69,8 @@ def _api_key_to_out(api_key: ApiKey) -> ApiKeyOut:
         scope_topic_ids=api_key.scope_topic_ids,
         scope_folder_ids=api_key.scope_folder_ids,
         max_snippet_chars=api_key.max_snippet_chars,
+        rate_limit_rpm=api_key.rate_limit_rpm,
+        rate_limit_rph=api_key.rate_limit_rph,
         scope_summary=_scope_summary(api_key),
     )
 
@@ -95,6 +101,8 @@ async def create_api_key(
         scope_topic_ids=body.scope_topic_ids,
         scope_folder_ids=body.scope_folder_ids,
         max_snippet_chars=body.max_snippet_chars,
+        rate_limit_rpm=body.rate_limit_rpm,
+        rate_limit_rph=body.rate_limit_rph,
     )
     session.add(api_key)
     await session.commit()
@@ -136,6 +144,9 @@ async def patch_api_key(
                 status_code=422,
                 detail=f"Field '{field}' cannot be null",
             )
+    for field in ("rate_limit_rpm", "rate_limit_rph"):
+        if field in patch and patch[field] is not None and patch[field] < 0:
+            raise HTTPException(status_code=422, detail=f"'{field}' must be 0 (unlimited) or >= 1")
     for field, value in patch.items():
         setattr(api_key, field, value)
     await log_audit(
@@ -268,13 +279,17 @@ async def get_key_usage(
         cutoff = now - timedelta(hours=hours)
         columns.append(func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "error").label(f"err_{label}"))
         columns.append(func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "denied").label(f"den_{label}"))
-        labels.extend([f"err_{label}", f"den_{label}"])
+        columns.append(
+            func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "rate_limited").label(f"rl_{label}")
+        )
+        labels.extend([f"err_{label}", f"den_{label}", f"rl_{label}"])
 
     row = (await session.execute(select(*columns).where(ApiRequestLog.api_key_id == key_id))).one()
 
     requests = {label: getattr(row, f"req_{label}") for label in request_buckets}
     errors = {label: getattr(row, f"err_{label}") for label in error_buckets}
     denials = {label: getattr(row, f"den_{label}") for label in error_buckets}
+    rate_limited = {label: getattr(row, f"rl_{label}") for label in error_buckets}
 
     # Top tools: single query with FILTER per bucket, sort/limit in Python
     tool_columns = [ApiRequestLog.endpoint]
@@ -303,6 +318,7 @@ async def get_key_usage(
         "requests": requests,
         "errors": errors,
         "denials": denials,
+        "rate_limited": rate_limited,
         "last_used_at": row.last_used,
         "top_tools": top_tools,
     }
@@ -339,7 +355,7 @@ async def get_key_timeline(
     for day, stat, cnt in rows:
         d = str(day)
         if d not in by_day:
-            by_day[d] = {"ok": 0, "error": 0, "denied": 0}
+            by_day[d] = {"ok": 0, "error": 0, "denied": 0, "rate_limited": 0}
         if stat in by_day[d]:
             by_day[d][stat] = cnt
     return [{"date": d, **counts} for d, counts in sorted(by_day.items())]

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -553,6 +554,47 @@ def _retrieval_response(s) -> RetrievalSettingsResponse:
         research_search_paginated=s.research_search_paginated,
         research_search_k=s.research_search_k,
     )
+
+
+class RateLimitSettingsUpdate(BaseModel):
+    default_rate_limit_rpm: int | None = None
+    default_rate_limit_rph: int | None = None
+
+    @field_validator("default_rate_limit_rpm", "default_rate_limit_rph")
+    @classmethod
+    def validate_min(cls, v):
+        if v is not None and v < 1:
+            raise ValueError("must be >= 1")
+        return v
+
+
+@router.get("/system/rate-limit-settings")
+async def get_rate_limit_settings(
+    admin: Principal = Depends(require_admin),
+):
+    s = get_settings()
+    return {
+        "default_rate_limit_rpm": s.default_rate_limit_rpm,
+        "default_rate_limit_rph": s.default_rate_limit_rph,
+    }
+
+
+@router.put("/system/rate-limit-settings")
+async def update_rate_limit_settings(
+    body: RateLimitSettingsUpdate,
+    admin: Principal = Depends(require_admin),
+):
+    s = get_settings()
+    if body.default_rate_limit_rpm is not None:
+        s.default_rate_limit_rpm = body.default_rate_limit_rpm
+        sync_native_config("default_rate_limit_rpm", body.default_rate_limit_rpm)
+    if body.default_rate_limit_rph is not None:
+        s.default_rate_limit_rph = body.default_rate_limit_rph
+        sync_native_config("default_rate_limit_rph", body.default_rate_limit_rph)
+    return {
+        "default_rate_limit_rpm": s.default_rate_limit_rpm,
+        "default_rate_limit_rph": s.default_rate_limit_rph,
+    }
 
 
 @router.get("/system/logs")

--- a/src/harbor_clerk/api/schemas/api_keys.py
+++ b/src/harbor_clerk/api/schemas/api_keys.py
@@ -14,6 +14,8 @@ class CreateApiKeyRequest(BaseModel):
     scope_topic_ids: list[int] | None = None
     scope_folder_ids: list[str] | None = None
     max_snippet_chars: int | None = None
+    rate_limit_rpm: int | None = None
+    rate_limit_rph: int | None = None
 
 
 class PatchApiKeyRequest(BaseModel):
@@ -24,6 +26,8 @@ class PatchApiKeyRequest(BaseModel):
     scope_topic_ids: list[int] | None = None
     scope_folder_ids: list[str] | None = None
     max_snippet_chars: int | None = None
+    rate_limit_rpm: int | None = None
+    rate_limit_rph: int | None = None
 
 
 class ApiKeyOut(BaseModel):
@@ -38,6 +42,8 @@ class ApiKeyOut(BaseModel):
     scope_topic_ids: list[int] | None
     scope_folder_ids: list[str] | None
     max_snippet_chars: int | None
+    rate_limit_rpm: int | None
+    rate_limit_rph: int | None
     scope_summary: str
 
 
@@ -72,6 +78,7 @@ class UsageSummaryResponse(BaseModel):
     requests: dict[str, int]
     errors: dict[str, int]
     denials: dict[str, int]
+    rate_limited: dict[str, int]
     last_used_at: datetime | None
     top_tools: dict[str, list[ToolCount]]
 
@@ -81,6 +88,7 @@ class TimelineDay(BaseModel):
     ok: int
     error: int
     denied: int
+    rate_limited: int
 
 
 class RequestLogEntry(BaseModel):

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -67,6 +67,8 @@ class KeyScope:
     permission_tier: str
     tool_overrides: dict[str, bool]
     max_snippet_chars: int | None
+    rate_limit_rpm: int | None
+    rate_limit_rph: int | None
 
     @property
     def is_unrestricted(self) -> bool:

--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -89,6 +89,10 @@ class Settings(BaseSettings):
     # Summaries
     summary_max_chars: int = Field(default=500)
 
+    # Rate limiting defaults
+    default_rate_limit_rpm: int = Field(default=60)
+    default_rate_limit_rph: int = Field(default=2000)
+
     # OAuth 2.1
     public_url: str = Field(default="")
     oauth_refresh_token_days: int = Field(default=90)

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -106,6 +106,8 @@ async def _resolve_principal(token: str) -> Principal | None:
             permission_tier=api_key.permission_tier,
             tool_overrides=api_key.tool_overrides or {},
             max_snippet_chars=api_key.max_snippet_chars,
+            rate_limit_rpm=api_key.rate_limit_rpm,
+            rate_limit_rph=api_key.rate_limit_rph,
         )
         return Principal(type="api_key", id=api_key.key_id, role="user", key_scope=scope)
 

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -300,6 +300,50 @@ class ScopedFastMCP(FastMCP):
 
         from harbor_clerk.api.request_log import log_api_request
 
+        # --- Rate limit check ---
+        if principal.key_scope is not None:
+            from harbor_clerk.api.rate_limiter import rate_limiter
+            from harbor_clerk.config import get_settings as _get_settings
+
+            _s = _get_settings()
+            _rpm = (
+                principal.key_scope.rate_limit_rpm
+                if principal.key_scope.rate_limit_rpm is not None
+                else _s.default_rate_limit_rpm
+            )
+            _rph = (
+                principal.key_scope.rate_limit_rph
+                if principal.key_scope.rate_limit_rph is not None
+                else _s.default_rate_limit_rph
+            )
+            allowed, retry_after = await rate_limiter.check(principal.id, _rpm, _rph)
+            if not allowed:
+                logger.warning(
+                    "Rate limit exceeded for key %s on MCP tool %s (retry_after=%ds)",
+                    principal.id,
+                    name,
+                    retry_after,
+                )
+                try:
+                    async with async_session_factory() as log_session:
+                        await log_api_request(
+                            log_session,
+                            api_key_id=principal.id,
+                            request_type="mcp_tool",
+                            endpoint=name,
+                            parameters=dict(arguments) if arguments else None,
+                            status="rate_limited",
+                            status_detail=f"retry_after={retry_after}s",
+                            duration_ms=0,
+                        )
+                        await log_session.commit()
+                except Exception:
+                    logger.debug("Failed to log rate-limited MCP call", exc_info=True)
+
+                from mcp.server.fastmcp.exceptions import ToolError
+
+                raise ToolError(f"Rate limit exceeded. Try again in {retry_after} seconds.")
+
         # --- Denial check ---
         if principal.key_scope is not None and name not in principal.key_scope.effective_tools:
             try:

--- a/src/harbor_clerk/models/api_key.py
+++ b/src/harbor_clerk/models/api_key.py
@@ -32,3 +32,5 @@ class ApiKey(Base):
     scope_topic_ids: Mapped[list[int] | None] = mapped_column(JSONB, nullable=True)
     scope_folder_ids: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     max_snippet_chars: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rate_limit_rpm: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rate_limit_rph: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/tests/test_api_request_log.py
+++ b/tests/test_api_request_log.py
@@ -133,6 +133,8 @@ async def test_mcp_call_tool_denied_is_logged(_engine, db_session, admin_user):
             permission_tier="search",
             tool_overrides={},
             max_snippet_chars=None,
+            rate_limit_rpm=None,
+            rate_limit_rph=None,
         ),
     )
 

--- a/tests/test_mcp_tool_filtering.py
+++ b/tests/test_mcp_tool_filtering.py
@@ -17,6 +17,8 @@ def make_scoped_key(tier="search", overrides=None):
             permission_tier=tier,
             tool_overrides=overrides or {},
             max_snippet_chars=None,
+            rate_limit_rpm=None,
+            rate_limit_rph=None,
         ),
     )
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,118 @@
+"""Tests for in-memory sliding window rate limiter."""
+
+import asyncio
+import time
+import uuid
+
+import pytest
+
+from harbor_clerk.api.rate_limiter import RateLimiter
+
+
+def _make_limiter_with_key() -> tuple[RateLimiter, uuid.UUID]:
+    """Create a fresh limiter and pre-seeded key (skips DB seeding)."""
+    limiter = RateLimiter()
+    key = uuid.uuid4()
+    limiter._seeded.add(key)
+    return limiter, key
+
+
+@pytest.mark.asyncio
+async def test_allows_under_limit():
+    limiter, key = _make_limiter_with_key()
+    allowed, retry = await limiter.check(key, rpm_limit=10, rph_limit=100)
+    assert allowed is True
+    assert retry == 0
+
+
+@pytest.mark.asyncio
+async def test_blocks_over_rpm():
+    limiter, key = _make_limiter_with_key()
+    rpm = 5
+    for _ in range(rpm):
+        allowed, _ = await limiter.check(key, rpm_limit=rpm, rph_limit=0)
+        assert allowed is True
+
+    allowed, retry = await limiter.check(key, rpm_limit=rpm, rph_limit=0)
+    assert allowed is False
+    assert retry >= 1
+
+
+@pytest.mark.asyncio
+async def test_blocks_over_rph():
+    limiter, key = _make_limiter_with_key()
+    rph = 5
+    for _ in range(rph):
+        allowed, _ = await limiter.check(key, rpm_limit=0, rph_limit=rph)
+        assert allowed is True
+
+    allowed, retry = await limiter.check(key, rpm_limit=0, rph_limit=rph)
+    assert allowed is False
+    assert retry >= 1
+
+
+@pytest.mark.asyncio
+async def test_unlimited_always_allows():
+    limiter, key = _make_limiter_with_key()
+    for _ in range(100):
+        allowed, retry = await limiter.check(key, rpm_limit=0, rph_limit=0)
+        assert allowed is True
+        assert retry == 0
+
+
+@pytest.mark.asyncio
+async def test_independent_keys():
+    limiter = RateLimiter()
+    key_a = uuid.uuid4()
+    key_b = uuid.uuid4()
+    limiter._seeded.add(key_a)
+    limiter._seeded.add(key_b)
+
+    # Fill key_a to its limit
+    for _ in range(3):
+        allowed, _ = await limiter.check(key_a, rpm_limit=3, rph_limit=0)
+        assert allowed is True
+
+    # key_a blocked
+    allowed, _ = await limiter.check(key_a, rpm_limit=3, rph_limit=0)
+    assert allowed is False
+
+    # key_b still allowed
+    allowed, _ = await limiter.check(key_b, rpm_limit=3, rph_limit=0)
+    assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_prune_old_entries():
+    limiter, key = _make_limiter_with_key()
+    window = limiter._get_window(key)
+    now = time.time()
+
+    # Insert timestamps older than 1 hour
+    window.append(now - 7200)
+    window.append(now - 3700)
+    # Insert one recent timestamp
+    window.append(now - 30)
+
+    limiter._prune(window, now)
+    assert len(window) == 1
+    assert window[0] == pytest.approx(now - 30, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_checks_atomic():
+    limiter, key = _make_limiter_with_key()
+    rpm = 5
+
+    # Fill to limit - 1
+    for _ in range(rpm - 1):
+        allowed, _ = await limiter.check(key, rpm_limit=rpm, rph_limit=0)
+        assert allowed is True
+
+    # Fire two concurrent checks — exactly one should succeed
+    results = await asyncio.gather(
+        limiter.check(key, rpm_limit=rpm, rph_limit=0),
+        limiter.check(key, rpm_limit=rpm, rph_limit=0),
+    )
+    allowed_count = sum(1 for allowed, _ in results if allowed)
+    assert allowed_count == 1

--- a/tests/test_scoped_api_keys.py
+++ b/tests/test_scoped_api_keys.py
@@ -77,6 +77,8 @@ def test_keyscope_default_no_restrictions():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     assert scope.is_unrestricted is True
 
@@ -88,6 +90,8 @@ def test_keyscope_with_topic_filter_is_restricted():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     assert scope.is_unrestricted is False
 
@@ -122,6 +126,8 @@ def test_principal_with_key_scope():
         permission_tier="search",
         tool_overrides={},
         max_snippet_chars=500,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     assert p.key_scope is not None
@@ -152,6 +158,8 @@ def test_apply_scope_unrestricted_key_unchanged():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = sa_select(Document)
@@ -166,6 +174,8 @@ def test_apply_scope_topic_filter_adds_where():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = sa_select(Document)
@@ -182,6 +192,8 @@ def test_apply_scope_folder_filter_subquery():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = sa_select(Document)
@@ -198,6 +210,8 @@ def test_apply_scope_topic_or_folder_or_logic():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = sa_select(Document)
@@ -217,6 +231,8 @@ def test_apply_scope_empty_topics_is_unrestricted():
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     assert scope.is_unrestricted is True
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
@@ -285,6 +301,8 @@ async def test_scope_filters_by_topic_in_db(db_session, two_topic_docs):
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = apply_key_scope(sa_select(Document).where(Document.topic_id.in_([9001, 9002])), p)
@@ -303,6 +321,8 @@ async def test_unrestricted_key_sees_all_in_db(db_session, two_topic_docs):
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = apply_key_scope(sa_select(Document).where(Document.topic_id.in_([9001, 9002])), p)
@@ -321,6 +341,8 @@ async def test_empty_topic_list_is_unrestricted_in_db(db_session, two_topic_docs
         permission_tier="full",
         tool_overrides={},
         max_snippet_chars=None,
+        rate_limit_rpm=None,
+        rate_limit_rph=None,
     )
     p = Principal(type="api_key", id=uuid.uuid4(), role="user", key_scope=scope)
     query = apply_key_scope(sa_select(Document).where(Document.topic_id.in_([9001, 9002])), p)


### PR DESCRIPTION
## Summary

Per-minute and per-hour rate limiting for API key requests, with system-wide defaults and per-key overrides.

### Backend
- **Migration 0015:** `rate_limit_rpm` and `rate_limit_rph` nullable integer columns on `api_keys`
- **KeyScope extension:** rate limit values carried at auth time (no per-request DB lookups)
- **RateLimiter singleton:** in-memory sliding window with per-key asyncio.Lock, crash recovery from `api_request_log` on first access
- **MCP enforcement:** rate limit check in `ScopedFastMCP.call_tool()` before tool execution
- **REST enforcement:** rate limit check in `ApiKeyRequestLogMiddleware` before forwarding; returns HTTP 429 + Retry-After header
- **Logging:** rate-limited requests logged with `status="rate_limited"` at WARN level
- **System defaults:** `GET/PUT /api/system/rate-limit-settings` (60 rpm, 2000 rph defaults)
- **Usage summary:** `rate_limited` bucket added to usage/timeline endpoints
- **7 unit tests** for the RateLimiter (under-limit, RPM block, RPH block, unlimited, independent keys, pruning, concurrent atomicity)

### Frontend
- **API key form:** "Unlimited" checkbox + number input for RPM and RPH (same pattern as expiry checkbox)
- **Audit dashboard:** orange "Rate Limited" summary card, 4th stacked bar on timeline, orange badge + border in request log
- **System settings:** new Rate Limits page at `/admin/rate-limits` with default RPM/RPH inputs

### Semantics
- `NULL` = use system default
- `0` = explicitly unlimited (shown as "Unlimited" checkbox in UI)
- `>= 1` = custom limit
- Values < 0 rejected by backend (422)

## Test plan
- [ ] 38 tests pass (7 rate limiter + 22 scoped keys + 9 tool filtering)
- [ ] Lint clean (ruff + eslint + tsc)
- [ ] Create key with rpm=5, make 6 MCP calls -> 6th gets ToolError with retry_after
- [ ] REST request with API key at limit -> HTTP 429 + Retry-After header
- [ ] Audit dashboard shows rate_limited events in orange
- [ ] System Settings -> Rate Limits -> change defaults -> new keys use them

Generated with [Claude Code](https://claude.com/claude-code)