### PR TITLE
fix: sync Swift model registry with Python (Gemma 4)

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
@@ -15,11 +15,10 @@ private let modelOptions: [(id: String, name: String)] = [
     ("qwen3-4b", "Qwen3 4B (2.5 GB)"),
     ("phi4-mini", "Phi-4 Mini 3.8B (2.5 GB)"),
     ("deepseek-r1-0528-8b", "DeepSeek R1 0528 8B (5.0 GB)"),
-    ("gemma3-4b", "Gemma 3 4B (2.5 GB)"),
     ("smollm3-3b", "SmolLM3 3B (1.9 GB)"),
     ("gpt-oss-20b", "GPT-OSS 20B (11.6 GB)"),
     ("qwen3-30b-a3b", "Qwen3 30B-A3B Instruct (17.3 GB)"),
-    ("llama3.1-8b", "Llama 3.1 8B Instruct (4.9 GB)"),
+    ("gemma4-26b-a4b", "Gemma 4 26B-A4B (17.0 GB)"),
 ]
 
 struct WatchedFolderInfo: Identifiable {

--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -101,11 +101,10 @@ final class AppSettings: @unchecked Sendable {
             "qwen3-4b": "Qwen3-4B-Q4_K_M.gguf",
             "phi4-mini": "microsoft_Phi-4-mini-instruct-Q4_K_M.gguf",
             "deepseek-r1-0528-8b": "DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-            "gemma3-4b": "google_gemma-3-4b-it-Q4_K_M.gguf",
             "smollm3-3b": "HuggingFaceTB_SmolLM3-3B-Q4_K_M.gguf",
             "gpt-oss-20b": "gpt-oss-20b-Q4_K_M.gguf",
             "qwen3-30b-a3b": "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
-            "llama3.1-8b": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+            "gemma4-26b-a4b": "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
         ]
         guard let filename = filenames[modelId] else { return "" }
         return modelsDir.appendingPathComponent(filename).path
@@ -119,11 +118,10 @@ final class AppSettings: @unchecked Sendable {
             "qwen3-4b": 32768,
             "phi4-mini": 128000,
             "deepseek-r1-0528-8b": 32768,
-            "gemma3-4b": 128000,
             "smollm3-3b": 65536,
             "gpt-oss-20b": 128000,
             "qwen3-30b-a3b": 262144,
-            "llama3.1-8b": 128000,
+            "gemma4-26b-a4b": 128000,
         ]
         return contextWindows[modelId] ?? 32768
     }

--- a/macos/HarborClerkServer/HarborClerkServerTests/AppSettingsTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/AppSettingsTests.swift
@@ -95,11 +95,10 @@ final class AppSettingsTests: XCTestCase {
             "qwen3-4b": "Qwen3-4B-Q4_K_M.gguf",
             "phi4-mini": "microsoft_Phi-4-mini-instruct-Q4_K_M.gguf",
             "deepseek-r1-0528-8b": "DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-            "gemma3-4b": "google_gemma-3-4b-it-Q4_K_M.gguf",
             "smollm3-3b": "HuggingFaceTB_SmolLM3-3B-Q4_K_M.gguf",
             "gpt-oss-20b": "gpt-oss-20b-Q4_K_M.gguf",
             "qwen3-30b-a3b": "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
-            "llama3.1-8b": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+            "gemma4-26b-a4b": "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
         ]
         for (modelId, filename) in expected {
             settings.llmModelId = modelId


### PR DESCRIPTION
## Summary
- Add Gemma 4 26B-A4B to Swift model maps (Settings.swift, PreferencesWindow.swift)
- Remove Gemma 3 4B and Llama 3.1 8B (already dropped from Python registry)
- Update AppSettingsTests to match

The Python models.py was updated in a previous PR but the mirrored Swift files were missed, so the built apps did not include Gemma 4 in the model picker.

## Test plan
- [ ] make apps builds successfully
- [ ] Model picker in Preferences shows Gemma 4 26B-A4B, no Gemma 3 or Llama 3.1
- [ ] AppSettingsTests pass