### PR TITLE
fix: tesseract SIGKILL in app bundle + auto-reap orphaned jobs

### DIFF
--- a/macos/scripts/build-deps.sh
+++ b/macos/scripts/build-deps.sh
@@ -39,15 +39,25 @@ for dylib in $(otool -L "$TESSERACT_DIR/bin/tesseract" | grep '/opt/homebrew\|/u
     install_name_tool -change "$dylib" "@executable_path/../lib/$libname" "$TESSERACT_DIR/bin/tesseract" 2>/dev/null || true
 done
 
-# Recursively fix dylib dependencies
-for lib in "$TESSERACT_DIR/lib/"*.dylib; do
-    for dep in $(otool -L "$lib" | grep '/opt/homebrew\|/usr/local' | awk '{print $1}'); do
-        depname=$(basename "$dep")
-        if [ ! -f "$TESSERACT_DIR/lib/$depname" ]; then
-            cp "$dep" "$TESSERACT_DIR/lib/" 2>/dev/null || true
-        fi
-        install_name_tool -change "$dep" "@loader_path/$depname" "$lib" 2>/dev/null || true
+# Recursively fix dylib dependencies (iterate until no new libs found)
+changed=true
+while $changed; do
+    changed=false
+    for lib in "$TESSERACT_DIR/lib/"*.dylib; do
+        for dep in $(otool -L "$lib" | grep '/opt/homebrew\|/usr/local' | awk '{print $1}'); do
+            depname=$(basename "$dep")
+            if [ ! -f "$TESSERACT_DIR/lib/$depname" ]; then
+                cp "$dep" "$TESSERACT_DIR/lib/" 2>/dev/null || true
+                changed=true
+            fi
+            install_name_tool -change "$dep" "@loader_path/$depname" "$lib" 2>/dev/null || true
+        done
     done
+done
+
+# Ad-hoc sign all binaries (macOS kills unsigned executables inside app bundles)
+for f in "$TESSERACT_DIR/lib/"*.dylib "$TESSERACT_DIR/bin/tesseract"; do
+    codesign --force --sign - "$f" 2>/dev/null || true
 done
 
 echo "==> Tesseract installed to ${TESSERACT_DIR}"

--- a/src/harbor_clerk/api/app.py
+++ b/src/harbor_clerk/api/app.py
@@ -107,14 +107,39 @@ async def _session_reaper_loop() -> None:
                     rs.status = "interrupted"
                     rs.error = "Research task stalled — no progress for 5+ minutes"
 
+                # Re-queue orphaned ingestion jobs (running with stale heartbeat >90s)
+                from harbor_clerk.models import IngestionJob
+                from harbor_clerk.models.ingestion import JobStatus
+
+                heartbeat_cutoff = now - timedelta(seconds=90)
+                orphan_result = await db.execute(
+                    select(IngestionJob).where(
+                        IngestionJob.status == JobStatus.running,
+                        IngestionJob.heartbeat_at < heartbeat_cutoff,
+                    )
+                )
+                orphan_jobs = orphan_result.scalars().all()
+                for job in orphan_jobs:
+                    logger.warning(
+                        "Reaper: re-queuing orphan job version=%s stage=%s (heartbeat=%s)",
+                        job.version_id,
+                        job.stage.value,
+                        job.heartbeat_at,
+                    )
+                    job.status = JobStatus.queued
+                    job.started_at = None
+                    job.heartbeat_at = None
+                    job.error = None
+
                 await db.commit()
                 total = len(stale_sessions) + len(done_sessions)
-                if total > 0 or stale_research:
+                if total > 0 or stale_research or orphan_jobs:
                     logger.info(
-                        "Session reaper: cancelled %d stale, cleaned %d done, interrupted %d research",
+                        "Session reaper: cancelled %d stale, cleaned %d done, interrupted %d research, re-queued %d orphan jobs",
                         len(stale_sessions),
                         len(done_sessions),
                         len(stale_research),
+                        len(orphan_jobs),
                     )
 
                 # Clean up watched files removed >30 days ago


### PR DESCRIPTION
## Summary
- build-deps.sh: iterate dependency copy to convergence (was single-pass, missing transitive deps like libsharpyuv). Ad-hoc sign all bundled binaries — macOS kills unsigned executables inside app bundles.
- app.py: add orphaned ingestion job reaping to the background reaper loop. Jobs stuck as running with heartbeat >90s are automatically re-queued every 5 minutes.

## Root cause
Homebrew upgraded webp, adding libsharpyuv as a new transitive dep. The single-pass dep copy missed it. Then macOS killed the unsigned binary (SIGKILL/signal 9), causing all OCR jobs to fail.

## Test plan
- [ ] make apps builds successfully
- [ ] Bundled tesseract --version works
- [ ] Reprocess errored OCR documents
- [ ] Orphaned jobs auto-reap after 5 minutes