### PR TITLE
feat: inline tool result disclosure triangles

### DIFF
--- a/docs/superpowers/plans/2026-04-12-tool-result-disclosure.md
+++ b/docs/superpowers/plans/2026-04-12-tool-result-disclosure.md
@@ -1,0 +1,794 @@
+# Tool Result Disclosure Triangles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show full tool call results inline via disclosure triangles in both Ask and Research modes, with formatted views for common tools and a raw JSON toggle.
+
+**Architecture:** Backend adds `raw_result` to SSE events and API responses. A new shared `ToolResultDisplay` component renders formatted + raw views. Chat's `ToolCallCard` and Research's `ToolLogEntry` integrate it.
+
+**Tech Stack:** Python/FastAPI (SSE), React/TypeScript (frontend), Tailwind CSS
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/harbor_clerk/llm/chat.py:450` | Modify | Add `raw_result` to `tool_result` SSE event |
+| `src/harbor_clerk/llm/research.py:386` | Modify | Add `raw_result` to `tool_result` SSE event |
+| `src/harbor_clerk/api/routes/chat.py:42-69` | Modify | `_enrich_tool_calls` returns `raw_result` |
+| `src/harbor_clerk/api/routes/chat.py:129-135` | Modify | Pass raw content alongside summary |
+| `src/harbor_clerk/api/routes/research.py:134-141` | Modify | Pass raw content alongside summary |
+| `frontend/src/contexts/ChatContext.tsx:26-30` | Modify | Add `rawResult` to `ToolCallInfo` |
+| `frontend/src/contexts/ChatContext.tsx:168-186` | Modify | Populate `rawResult` from SSE |
+| `frontend/src/contexts/ResearchContext.tsx:4-9` | Modify | Add `rawResult` to `ToolCallEntry` |
+| `frontend/src/contexts/ResearchContext.tsx:103-115` | Modify | Populate `rawResult` from SSE |
+| `frontend/src/components/ToolResultDisplay.tsx` | Create | Shared formatted + raw result renderer |
+| `frontend/src/pages/ChatPage.tsx:801-883` | Modify | Add `ToolResultDisplay` to `ToolCallCard` body |
+| `frontend/src/pages/ResearchPage.tsx:834-868` | Modify | Convert `ToolLogEntry` to disclosure triangle |
+| `frontend/src/pages/ResearchPage.tsx:42-59` | Modify | `extractToolCalls` populates `rawResult` |
+
+---
+
+### Task 1: Backend — Add raw_result to SSE events
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/chat.py:450`
+- Modify: `src/harbor_clerk/llm/research.py:386`
+
+- [ ] **Step 1: Add raw_result to chat SSE tool_result event**
+
+In `src/harbor_clerk/llm/chat.py`, line 450, change:
+
+```python
+yield f"data: {json.dumps({'type': 'tool_result', 'name': fn_name, 'summary': summarize_tool_result(result_str)})}\n\n"
+```
+
+to:
+
+```python
+yield f"data: {json.dumps({'type': 'tool_result', 'name': fn_name, 'summary': summarize_tool_result(result_str), 'raw_result': result_str})}\n\n"
+```
+
+`result_str` is already available from line 448.
+
+- [ ] **Step 2: Add raw_result to research SSE tool_result event**
+
+In `src/harbor_clerk/llm/research.py`, line 386, change:
+
+```python
+yield f"data: {json.dumps({'type': 'tool_result', 'name': tc_name, 'summary': summary})}\n\n"
+```
+
+to:
+
+```python
+yield f"data: {json.dumps({'type': 'tool_result', 'name': tc_name, 'summary': summary, 'raw_result': observation})}\n\n"
+```
+
+`observation` is already available from line 383.
+
+- [ ] **Step 3: Verify manually**
+
+Start the app, open a chat, ask a question that triggers a search tool. Open browser DevTools Network tab, find the SSE stream, confirm `tool_result` events now include `raw_result` with full JSON.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/harbor_clerk/llm/chat.py src/harbor_clerk/llm/research.py
+git commit -m "feat: include raw_result in tool_result SSE events"
+```
+
+---
+
+### Task 2: Backend — Add raw_result to API reload responses
+
+**Files:**
+- Modify: `src/harbor_clerk/api/routes/chat.py:42-69, 129-135`
+- Modify: `src/harbor_clerk/api/routes/research.py:134-141`
+
+- [ ] **Step 1: Change tool_results_by_id to store both summary and raw content (chat)**
+
+In `src/harbor_clerk/api/routes/chat.py`, lines 129-135, change:
+
+```python
+tool_results_by_id: dict[str, str] = {}
+for m in all_msgs:
+    if m.role == "tool" and m.tool_call_id and m.content:
+        tool_results_by_id[m.tool_call_id] = summarize_tool_result(m.content)
+```
+
+to:
+
+```python
+tool_results_by_id: dict[str, tuple[str, str]] = {}
+for m in all_msgs:
+    if m.role == "tool" and m.tool_call_id and m.content:
+        tool_results_by_id[m.tool_call_id] = (summarize_tool_result(m.content), m.content)
+```
+
+- [ ] **Step 2: Update _enrich_tool_calls to accept and return raw_result**
+
+In `src/harbor_clerk/api/routes/chat.py`, change the `_enrich_tool_calls` function (lines 42-69):
+
+```python
+def _enrich_tool_calls(tool_calls: list[dict], results: dict[str, tuple[str, str] | str]) -> list[dict]:
+    """Add result summaries and raw results to tool calls.
+
+    results values are either (summary, raw_content) tuples or plain summary strings
+    for backwards compatibility.
+    """
+    enriched = []
+    for tc in tool_calls:
+        func = tc.get("function", {})
+        name = func.get("name", tc.get("name", ""))
+        raw_args = func.get("arguments", tc.get("arguments", {}))
+        if isinstance(raw_args, str):
+            try:
+                args = json.loads(raw_args)
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+        else:
+            args = raw_args
+        tc_id = tc.get("id", "")
+        result_val = results.get(tc_id)
+        if isinstance(result_val, tuple):
+            summary, raw_result = result_val
+        else:
+            summary = result_val
+            raw_result = None
+        enriched.append(
+            {
+                "name": name,
+                "arguments": args,
+                "result": summary,
+                "raw_result": raw_result,
+            }
+        )
+    return enriched
+```
+
+- [ ] **Step 3: Change tool_results_by_id in research detail endpoint**
+
+In `src/harbor_clerk/api/routes/research.py`, lines 138-141, change:
+
+```python
+tool_results_by_id: dict[str, str] = {}
+for m in all_msgs:
+    if m.role == "tool" and m.tool_call_id and m.content:
+        tool_results_by_id[m.tool_call_id] = _summarize_tool_result(m.content)
+```
+
+to:
+
+```python
+tool_results_by_id: dict[str, tuple[str, str]] = {}
+for m in all_msgs:
+    if m.role == "tool" and m.tool_call_id and m.content:
+        tool_results_by_id[m.tool_call_id] = (_summarize_tool_result(m.content), m.content)
+```
+
+- [ ] **Step 4: Verify manually**
+
+Reload a conversation that has tool calls. Check browser DevTools → Network → response for the conversation detail endpoint. Confirm tool_calls entries now include `raw_result` with full JSON content.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/harbor_clerk/api/routes/chat.py src/harbor_clerk/api/routes/research.py
+git commit -m "feat: include raw_result in tool call API responses"
+```
+
+---
+
+### Task 3: Frontend — Update types and SSE handlers
+
+**Files:**
+- Modify: `frontend/src/contexts/ChatContext.tsx:26-30, 168-186`
+- Modify: `frontend/src/contexts/ResearchContext.tsx:4-9, 103-115`
+- Modify: `frontend/src/pages/ResearchPage.tsx:42-59`
+
+- [ ] **Step 1: Add rawResult to ToolCallInfo (ChatContext)**
+
+In `frontend/src/contexts/ChatContext.tsx`, lines 26-30, change:
+
+```typescript
+export interface ToolCallInfo {
+  name: string
+  arguments: Record<string, unknown>
+  result?: string
+}
+```
+
+to:
+
+```typescript
+export interface ToolCallInfo {
+  name: string
+  arguments: Record<string, unknown>
+  result?: string
+  rawResult?: string
+}
+```
+
+- [ ] **Step 2: Populate rawResult in chat SSE handler**
+
+In `frontend/src/contexts/ChatContext.tsx`, in the `tool_result` case (around line 177), change:
+
+```typescript
+{ name: event.name, arguments: {}, result: event.summary },
+```
+
+to:
+
+```typescript
+{ name: event.name, arguments: {}, result: event.summary, rawResult: event.raw_result },
+```
+
+- [ ] **Step 3: Add rawResult to ToolCallEntry (ResearchContext)**
+
+In `frontend/src/contexts/ResearchContext.tsx`, lines 4-9, change:
+
+```typescript
+export interface ToolCallEntry {
+  name: string
+  arguments: Record<string, unknown>
+  summary?: string
+  round?: number
+}
+```
+
+to:
+
+```typescript
+export interface ToolCallEntry {
+  name: string
+  arguments: Record<string, unknown>
+  summary?: string
+  rawResult?: string
+  round?: number
+}
+```
+
+- [ ] **Step 4: Populate rawResult in research SSE handler**
+
+In `frontend/src/contexts/ResearchContext.tsx`, in the `tool_result` case (around line 109), change:
+
+```typescript
+toolCalls[i] = { ...toolCalls[i], summary: event.summary }
+```
+
+to:
+
+```typescript
+toolCalls[i] = { ...toolCalls[i], summary: event.summary, rawResult: event.raw_result }
+```
+
+- [ ] **Step 5: Add raw_result to ResearchMessage interface**
+
+In `frontend/src/pages/ResearchPage.tsx`, lines 20-28, change:
+
+```typescript
+interface ResearchMessage {
+  role: string
+  content?: string
+  tool_calls?: Array<{
+    name: string
+    arguments: Record<string, unknown>
+    result?: string
+  }>
+}
+```
+
+to:
+
+```typescript
+interface ResearchMessage {
+  role: string
+  content?: string
+  tool_calls?: Array<{
+    name: string
+    arguments: Record<string, unknown>
+    result?: string
+    raw_result?: string
+  }>
+}
+```
+
+- [ ] **Step 6: Map raw_result to rawResult in chat reload path**
+
+In `frontend/src/pages/ChatPage.tsx`, line 150, change:
+
+```typescript
+tool_calls: (m.tool_calls as ToolCallInfo[] | undefined) || undefined,
+```
+
+to:
+
+```typescript
+tool_calls: m.tool_calls
+  ? (m.tool_calls as Array<Record<string, unknown>>).map((tc) => ({
+      name: tc.name as string,
+      arguments: (tc.arguments as Record<string, unknown>) || {},
+      result: tc.result as string | undefined,
+      rawResult: tc.raw_result as string | undefined,
+    }))
+  : undefined,
+```
+
+- [ ] **Step 7: Populate rawResult in extractToolCalls (ResearchPage)**
+
+In `frontend/src/pages/ResearchPage.tsx`, in `extractToolCalls` (around line 50), change:
+
+```typescript
+entries.push({
+  name: tc.name,
+  arguments: tc.arguments,
+  summary: tc.result || undefined,
+  round,
+})
+```
+
+to:
+
+```typescript
+entries.push({
+  name: tc.name,
+  arguments: tc.arguments,
+  summary: tc.result || undefined,
+  rawResult: tc.raw_result || undefined,
+  round,
+})
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/contexts/ChatContext.tsx frontend/src/contexts/ResearchContext.tsx frontend/src/pages/ResearchPage.tsx frontend/src/pages/ChatPage.tsx
+git commit -m "feat: add rawResult to tool call types and SSE handlers"
+```
+
+---
+
+### Task 4: Frontend — Create ToolResultDisplay component
+
+**Files:**
+- Create: `frontend/src/components/ToolResultDisplay.tsx`
+
+- [ ] **Step 1: Create the component file**
+
+Create `frontend/src/components/ToolResultDisplay.tsx`:
+
+```tsx
+import { useState } from 'react'
+
+interface ToolResultDisplayProps {
+  rawResult: string
+  toolName: string
+}
+
+// ---------------------------------------------------------------------------
+// Tool-specific formatters
+// ---------------------------------------------------------------------------
+
+function SearchHitList({ data }: { data: Record<string, unknown> }) {
+  const hits = (data.hits || data.results || []) as Record<string, unknown>[]
+  if (!hits.length) return <p className="text-gray-400 italic">No results</p>
+  return (
+    <div className="space-y-1.5">
+      {hits.map((hit, i) => (
+        <div key={i} className="flex items-baseline gap-2">
+          <span className="shrink-0 text-gray-400 tabular-nums w-4 text-right">{i + 1}.</span>
+          <div className="min-w-0">
+            <span className="font-medium text-gray-600 dark:text-gray-300">
+              {(hit.doc_title as string) || 'Untitled'}
+            </span>
+            {hit.page != null && (
+              <span className="ml-1 text-gray-400">p.{String(hit.page)}</span>
+            )}
+            {hit.score != null && (
+              <span className="ml-1.5 text-gray-400/70">({Number(hit.score).toFixed(2)})</span>
+            )}
+            {hit.snippet && (
+              <p className="text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">
+                {String(hit.snippet).slice(0, 150)}
+              </p>
+            )}
+            {hit.text && !hit.snippet && (
+              <p className="text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">
+                {String(hit.text).slice(0, 150)}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PassageBlocks({ data }: { data: Record<string, unknown> }) {
+  const passages = (data.passages || data.chunks || []) as Record<string, unknown>[]
+  if (!passages.length) return <p className="text-gray-400 italic">No passages</p>
+  return (
+    <div className="space-y-2">
+      {passages.map((p, i) => (
+        <div key={i}>
+          <div className="text-gray-500 dark:text-gray-400 text-[10px] uppercase tracking-wide mb-0.5">
+            {(p.doc_title as string) || 'Untitled'}
+            {p.page != null && <span> — p.{String(p.page)}</span>}
+          </div>
+          <p className="text-gray-600 dark:text-gray-300 whitespace-pre-wrap">
+            {String(p.text || p.content || '')}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EntityList({ data }: { data: Record<string, unknown> }) {
+  const entities = (data.entities || []) as Record<string, unknown>[]
+  if (!entities.length) return <p className="text-gray-400 italic">No entities</p>
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {entities.map((e, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center gap-1 rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5"
+        >
+          <span className="font-medium text-gray-600 dark:text-gray-300">{String(e.name || e.text || '')}</span>
+          {e.type && (
+            <span className="text-[10px] text-gray-400 uppercase">{String(e.type)}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function GenericView({ data }: { data: unknown }) {
+  if (data === null || data === undefined) return null
+  if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
+    return <span className="text-gray-600 dark:text-gray-300">{String(data)}</span>
+  }
+  if (Array.isArray(data)) {
+    if (data.length === 0) return <span className="text-gray-400 italic">empty list</span>
+    return (
+      <ul className="list-disc pl-4 space-y-0.5">
+        {data.map((item, i) => (
+          <li key={i}><GenericView data={item} /></li>
+        ))}
+      </ul>
+    )
+  }
+  if (typeof data === 'object') {
+    const entries = Object.entries(data as Record<string, unknown>)
+    if (entries.length === 0) return <span className="text-gray-400 italic">empty</span>
+    return (
+      <dl className="space-y-1">
+        {entries.map(([key, val]) => (
+          <div key={key}>
+            <dt className="text-[10px] text-gray-400 uppercase tracking-wide">{key}</dt>
+            <dd className="ml-2"><GenericView data={val} /></dd>
+          </div>
+        ))}
+      </dl>
+    )
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Determine which formatter to use
+// ---------------------------------------------------------------------------
+
+const SEARCH_TOOLS = new Set([
+  'search_documents', 'kb_search', 'kb_batch_search',
+])
+const PASSAGE_TOOLS = new Set([
+  'read_passages', 'kb_read_passages', 'expand_context', 'kb_expand_context',
+  'read_document', 'kb_read_document',
+])
+const ENTITY_TOOLS = new Set([
+  'entity_search', 'kb_entity_search', 'entity_overview', 'kb_entity_overview',
+  'entity_cooccurrence', 'kb_entity_cooccurrence',
+])
+
+function FormattedResult({ data, toolName }: { data: Record<string, unknown>; toolName: string }) {
+  if (SEARCH_TOOLS.has(toolName)) return <SearchHitList data={data} />
+  if (PASSAGE_TOOLS.has(toolName)) return <PassageBlocks data={data} />
+  if (ENTITY_TOOLS.has(toolName)) return <EntityList data={data} />
+  return <GenericView data={data} />
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function ToolResultDisplay({ rawResult, toolName }: ToolResultDisplayProps) {
+  const [showRaw, setShowRaw] = useState(false)
+
+  let parsed: unknown = null
+  let parseOk = false
+  try {
+    parsed = JSON.parse(rawResult)
+    parseOk = true
+  } catch {
+    // not JSON — show as plain text
+  }
+
+  if (!parseOk) {
+    return (
+      <div className="text-[11px] text-gray-500 dark:text-gray-400 whitespace-pre-wrap max-h-64 overflow-auto">
+        {rawResult}
+      </div>
+    )
+  }
+
+  // Check for error responses
+  const obj = parsed as Record<string, unknown>
+  if (obj.error) {
+    return (
+      <div className="text-[11px] text-red-500 dark:text-red-400">
+        Error: {String(obj.error)}
+      </div>
+    )
+  }
+
+  return (
+    <div className="text-[11px]">
+      {showRaw ? (
+        <pre className="text-gray-400 dark:text-gray-500 whitespace-pre-wrap font-mono max-h-80 overflow-auto">
+          {JSON.stringify(parsed, null, 2)}
+        </pre>
+      ) : (
+        <FormattedResult data={obj} toolName={toolName} />
+      )}
+      <button
+        onClick={() => setShowRaw(!showRaw)}
+        className="mt-1.5 text-[10px] text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 underline"
+      >
+        {showRaw ? 'Show formatted' : 'Show raw'}
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Run lint**
+
+```bash
+cd frontend && npm run lint && npm run type-check
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ToolResultDisplay.tsx
+git commit -m "feat: add ToolResultDisplay component with formatted + raw views"
+```
+
+---
+
+### Task 5: Frontend — Integrate into ToolCallCard (Chat)
+
+**Files:**
+- Modify: `frontend/src/pages/ChatPage.tsx:801-883`
+
+- [ ] **Step 1: Add import**
+
+At the top of `ChatPage.tsx`, add:
+
+```typescript
+import ToolResultDisplay from '../components/ToolResultDisplay'
+```
+
+- [ ] **Step 2: Replace the expanded body in ToolCallCard**
+
+In the `ToolCallCard` component (around line 860), replace the expanded content block:
+
+```tsx
+{expanded && (
+  <div className="border-t border-gray-100 dark:border-gray-700/50 px-2.5 py-1.5 text-[11px] bg-gray-50/50 dark:bg-gray-800/30 space-y-1">
+    {tool.arguments && Object.keys(tool.arguments).length > 0 && (
+      <div className="font-mono text-gray-400 dark:text-gray-500">{JSON.stringify(tool.arguments, null, 2)}</div>
+    )}
+    {tool.result && <div className="text-gray-500 dark:text-gray-400">{tool.result}</div>}
+  </div>
+)}
+```
+
+with:
+
+```tsx
+{expanded && (
+  <div className="border-t border-gray-100 dark:border-gray-700/50 px-2.5 py-1.5 text-[11px] bg-gray-50/50 dark:bg-gray-800/30 space-y-2">
+    {tool.arguments && Object.keys(tool.arguments).length > 0 && (
+      <div>
+        <div className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Arguments</div>
+        <div className="font-mono text-gray-400 dark:text-gray-500">{JSON.stringify(tool.arguments, null, 2)}</div>
+      </div>
+    )}
+    {tool.rawResult ? (
+      <div>
+        <div className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Result</div>
+        <ToolResultDisplay rawResult={tool.rawResult} toolName={tool.name} />
+      </div>
+    ) : tool.result ? (
+      <div className="text-gray-500 dark:text-gray-400">{tool.result}</div>
+    ) : null}
+  </div>
+)}
+```
+
+This shows `ToolResultDisplay` when `rawResult` is available, falling back to the summary string for older data without raw results.
+
+- [ ] **Step 3: Run lint and type-check**
+
+```bash
+cd frontend && npm run lint && npm run type-check
+```
+
+- [ ] **Step 4: Verify manually**
+
+Open a chat conversation, ask a question. Expand a tool call card. Confirm:
+- Arguments section shown with label
+- Result section shows formatted view (search hits as a list with doc titles, scores, snippets)
+- "Show raw" toggle switches to JSON
+- "Show formatted" toggle switches back
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/ChatPage.tsx
+git commit -m "feat: show full tool results in chat ToolCallCard disclosure"
+```
+
+---
+
+### Task 6: Frontend — Convert ToolLogEntry to disclosure triangle (Research)
+
+**Files:**
+- Modify: `frontend/src/pages/ResearchPage.tsx:834-868`
+
+- [ ] **Step 1: Add import**
+
+At the top of `ResearchPage.tsx`, add:
+
+```typescript
+import ToolResultDisplay from '../components/ToolResultDisplay'
+```
+
+- [ ] **Step 2: Replace ToolLogEntry with disclosure triangle version**
+
+Replace the `ToolLogEntry` component (lines 834-868) with:
+
+```tsx
+function ToolLogEntry({ tool, isLast }: { tool: ToolCallEntry; isLast: boolean }) {
+  const isDone = !!tool.summary
+  const hasResult = !!tool.rawResult
+
+  const icon = !isDone && isLast ? (
+    <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+      />
+    </svg>
+  ) : (
+    <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+    </svg>
+  )
+
+  const iconColor = !isDone && isLast
+    ? 'text-blue-500 dark:text-blue-400 animate-pulse'
+    : 'text-emerald-500 dark:text-emerald-400'
+
+  const summaryContent = (
+    <div className="flex items-start gap-2 w-full">
+      <span className={`shrink-0 mt-0.5 ${iconColor}`}>{icon}</span>
+      <div className="min-w-0 flex-1">
+        <span className="text-[12px] font-medium text-gray-600 dark:text-gray-300">{tool.name}</span>
+        {tool.summary && (
+          <span className="ml-1.5 text-[11px] text-gray-400 dark:text-gray-500 truncate">{tool.summary}</span>
+        )}
+      </div>
+    </div>
+  )
+
+  if (!hasResult) {
+    return <div className="px-3 py-2">{summaryContent}</div>
+  }
+
+  return (
+    <details className="group">
+      <summary className="px-3 py-2 cursor-pointer list-none flex items-center [&::-webkit-details-marker]:hidden">
+        {summaryContent}
+        <svg
+          className="h-3 w-3 shrink-0 text-gray-300 dark:text-gray-600 transition-transform duration-150 group-open:rotate-90 ml-1"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </summary>
+      <div className="px-3 pb-2 pl-8">
+        <ToolResultDisplay rawResult={tool.rawResult!} toolName={tool.name} />
+      </div>
+    </details>
+  )
+}
+```
+
+- [ ] **Step 3: Run lint and type-check**
+
+```bash
+cd frontend && npm run lint && npm run type-check
+```
+
+- [ ] **Step 4: Verify manually**
+
+Run a Research task. During live streaming:
+- Tool calls without results yet show as flat rows (no triangle)
+- Once a result arrives, the row becomes a disclosure triangle
+- Expanding shows the formatted result
+- After completion, reload the page — disclosure triangles still work with data from the API
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/ResearchPage.tsx
+git commit -m "feat: show full tool results in research ToolLogEntry disclosure"
+```
+
+---
+
+### Task 7: Final verification and PR
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full lint + type-check**
+
+```bash
+cd frontend && npm run lint && npm run type-check
+```
+
+- [ ] **Step 2: Run Python lint**
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+- [ ] **Step 3: End-to-end verification — Chat**
+
+1. Open Harbor Clerk, start a new Ask conversation
+2. Ask a question that triggers search + read passages
+3. Verify tool call cards appear with disclosure triangles
+4. Expand a search result card — confirm formatted hit list with titles, scores, snippets
+5. Click "Show raw" — confirm JSON view with `max-height` scroll
+6. Reload the page — confirm disclosures still work with API data
+
+- [ ] **Step 4: End-to-end verification — Research**
+
+1. Start a new Research task
+2. Watch the activity log — tool calls appear as flat rows while in-flight
+3. Once results arrive, rows become expandable disclosure triangles
+4. Expand one — confirm formatted view
+5. After completion, reload the page — confirm disclosures still work
+
+- [ ] **Step 5: Push and create PR**
+
+```bash
+git push -u origin feat/tool-result-disclosure
+gh pr create --title "feat: inline tool result disclosure triangles" --body "## Summary
+- Add full tool results to SSE events and API responses (raw_result field)
+- New ToolResultDisplay component with tool-specific formatted views + raw JSON toggle
+- Chat ToolCallCard shows formatted results in disclosure body
+- Research ToolLogEntry converts to disclosure triangle when result is available
+
+Closes #TBD"
+```

--- a/docs/superpowers/specs/2026-04-12-tool-result-disclosure-design.md
+++ b/docs/superpowers/specs/2026-04-12-tool-result-disclosure-design.md
@@ -1,0 +1,111 @@
+# Tool Result Disclosure Triangles
+
+> **For agentic workers:** Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this spec.
+
+**Goal:** Make full tool call results visible inline via disclosure triangles in both Ask (chat) and Research modes, with formatted views for common tools and a raw JSON toggle.
+
+**Motivation:** Transparency for non-technical users and easier debugging when research quality regresses.
+
+---
+
+## Data Flow
+
+### SSE Streaming (live)
+
+The `tool_result` SSE event gains a `result` field containing the full tool output JSON string.
+
+**Chat (`chat.py`):** The `tool_result` event currently sends `{ type, name, summary }`. Add `result: <raw JSON string>` from the tool execution.
+
+**Research (`research.py`):** The `tool_result` event currently sends `{ type, name, summary }`. Add `result: <raw JSON string>` from the tool observation.
+
+### API Reload
+
+`_enrich_tool_calls()` in `api/routes/chat.py` already looks up `role='tool'` messages by `tool_call_id` to derive summaries. Include the full `content` from the tool-role message as `raw_result` in the response.
+
+The `ToolCallOut` schema (or equivalent) gains `raw_result: str | None`.
+
+### Frontend Types
+
+- `ToolCallInfo` in `ChatContext.tsx` gains `rawResult?: string`
+- `ToolCallEntry` in `ResearchContext.tsx` gains `rawResult?: string`
+
+Both contexts populate `rawResult` from the SSE `result` field (live) and API response (reload).
+
+---
+
+## Frontend Components
+
+### ToolResultDisplay (new)
+
+**File:** `frontend/src/components/ToolResultDisplay.tsx`
+
+**Props:** `rawResult: string`, `toolName: string`
+
+**Behavior:**
+1. Parses `rawResult` as JSON (falls back to plain text display on parse failure)
+2. Renders **formatted view** by default using tool-specific templates
+3. Provides a "Show raw" / "Show formatted" toggle at the bottom switching to pretty-printed `<pre>` JSON
+
+**Tool-specific templates:**
+
+| Tool name pattern | Template |
+|---|---|
+| `search_documents`, `kb_search`, `kb_batch_search` | Hit list: doc title, page, score, snippet (~100 chars) |
+| `read_passages`, `kb_read_passages` | Text blocks with doc title + page header |
+| `entity_search`, `kb_entity_search` | Tagged list: entity name, type, source doc |
+| Everything else | Generic recursive renderer: objects as labeled groups, arrays as bullet lists, scalars as values |
+
+Templates are intentionally lean — no hover states, no interactivity, just clean readable output. The generic fallback handles any tool output readably.
+
+### Chat Mode — ToolCallCard Changes
+
+The existing `ToolCallCard` component (ChatPage.tsx) has an expand/collapse accordion. In the expanded body, add `<ToolResultDisplay>` below the existing arguments display when `rawResult` is present. No structural change to the card.
+
+### Research Mode — ToolLogEntry Changes
+
+Convert `ToolLogEntry` (ResearchPage.tsx) from a flat row to a `<details>/<summary>` element:
+
+- **Summary row:** Same as current — icon (pulsing blue if active, green check if done) + tool name + inline summary text
+- **Disclosure body:** `<ToolResultDisplay>` with the full result
+- Entries without results yet (still in-flight) remain flat with no disclosure triangle
+- All triangles start **collapsed**
+
+---
+
+## Backend Changes
+
+### chat.py — SSE emission
+
+In the tool call execution loop, the `tool_result` SSE event currently sends:
+```python
+{"type": "tool_result", "name": name, "summary": summary}
+```
+
+Change to:
+```python
+{"type": "tool_result", "name": name, "summary": summary, "result": raw_result_string}
+```
+
+Where `raw_result_string` is the string returned by `execute_tool()`.
+
+### research.py — SSE emission
+
+In the step consumer loop, when emitting `tool_result` events, include the full observation string:
+```python
+{"type": "tool_result", "name": tc_name, "summary": summary, "result": observation}
+```
+
+Where `observation` is already available from `step.observation or step.output`.
+
+### api/routes/chat.py — _enrich_tool_calls
+
+Add `raw_result` to the enriched tool call dict, sourced from the matching `role='tool'` message's `content` field (already looked up for summary derivation).
+
+---
+
+## Scope Notes
+
+- **smolagents regression:** Separately investigate smolagents 1.22→1.24 changelog for research quality changes. Not part of this spec.
+- No lazy loading — full results included inline in SSE and API responses (typically 2-10KB per tool call).
+- No new API endpoints.
+- No database changes.

--- a/docs/superpowers/specs/2026-04-12-tool-result-disclosure-design.md
+++ b/docs/superpowers/specs/2026-04-12-tool-result-disclosure-design.md
@@ -12,17 +12,21 @@
 
 ### SSE Streaming (live)
 
-The `tool_result` SSE event gains a `result` field containing the full tool output JSON string.
+The `tool_result` SSE event gains a `raw_result` field containing the full tool output JSON string. The existing `summary` field is unchanged.
 
-**Chat (`chat.py`):** The `tool_result` event currently sends `{ type, name, summary }`. Add `result: <raw JSON string>` from the tool execution.
+**Chat (`chat.py`):** The `tool_result` event currently sends `{ type, name, summary }`. Add `raw_result: <raw JSON string>` from the tool execution.
 
-**Research (`research.py`):** The `tool_result` event currently sends `{ type, name, summary }`. Add `result: <raw JSON string>` from the tool observation.
+**Research (`research.py`):** The `tool_result` event currently sends `{ type, name, summary }`. Add `raw_result: <raw JSON string>` from the tool observation.
+
+**Important naming note:** The SSE field is `raw_result` (not `result`) to avoid confusion with the existing `summary` field. On the frontend, `ChatContext.tsx` stores the summary as `result` on `ToolCallInfo` — that field is unchanged. The new `raw_result` SSE field maps to `rawResult` on the frontend types.
 
 ### API Reload
 
 `_enrich_tool_calls()` in `api/routes/chat.py` already looks up `role='tool'` messages by `tool_call_id` to derive summaries. Include the full `content` from the tool-role message as `raw_result` in the response.
 
-The `ToolCallOut` schema (or equivalent) gains `raw_result: str | None`.
+The enriched dict returned by `_enrich_tool_calls` gains `raw_result: str | None`.
+
+**Research reload:** The research detail endpoint (`GET /api/research/{id}`) returns persisted messages. `ResearchPage.tsx`'s `extractToolCalls()` reconstructs `ToolCallEntry[]` from these. The research messages API response must also include the full tool result content (from `role='tool'` messages) so that `rawResult` is populated on reload, not just during live SSE streaming.
 
 ### Frontend Types
 
@@ -50,9 +54,9 @@ Both contexts populate `rawResult` from the SSE `result` field (live) and API re
 
 | Tool name pattern | Template |
 |---|---|
-| `search_documents`, `kb_search`, `kb_batch_search` | Hit list: doc title, page, score, snippet (~100 chars) |
-| `read_passages`, `kb_read_passages` | Text blocks with doc title + page header |
-| `entity_search`, `kb_entity_search` | Tagged list: entity name, type, source doc |
+| `search_documents`, `kb_search`, `kb_batch_search` | Hit list: doc title, page, score, snippet (~100 chars). Chat tools use `search_documents`, MCP tools use `kb_search` — match both. |
+| `read_passages`, `kb_read_passages` | Text blocks with doc title + page header. Chat: `read_passages`, MCP: `kb_read_passages`. |
+| `entity_search`, `kb_entity_search` | Tagged list: entity name, type, source doc. Chat: `entity_search`, MCP: `kb_entity_search`. |
 | Everything else | Generic recursive renderer: objects as labeled groups, arrays as bullet lists, scalars as values |
 
 Templates are intentionally lean — no hover states, no interactivity, just clean readable output. The generic fallback handles any tool output readably.
@@ -83,7 +87,7 @@ In the tool call execution loop, the `tool_result` SSE event currently sends:
 
 Change to:
 ```python
-{"type": "tool_result", "name": name, "summary": summary, "result": raw_result_string}
+{"type": "tool_result", "name": name, "summary": summary, "raw_result": raw_result_string}
 ```
 
 Where `raw_result_string` is the string returned by `execute_tool()`.
@@ -92,7 +96,7 @@ Where `raw_result_string` is the string returned by `execute_tool()`.
 
 In the step consumer loop, when emitting `tool_result` events, include the full observation string:
 ```python
-{"type": "tool_result", "name": tc_name, "summary": summary, "result": observation}
+{"type": "tool_result", "name": tc_name, "summary": summary, "raw_result": observation}
 ```
 
 Where `observation` is already available from `step.observation or step.output`.
@@ -106,6 +110,6 @@ Add `raw_result` to the enriched tool call dict, sourced from the matching `role
 ## Scope Notes
 
 - **smolagents regression:** Separately investigate smolagents 1.22→1.24 changelog for research quality changes. Not part of this spec.
-- No lazy loading — full results included inline in SSE and API responses (typically 2-10KB per tool call).
+- No lazy loading — full results included inline in SSE and API responses. Most tool results are 2-10KB; `kb_read_passages` / `kb_read_document` can be larger (up to ~50KB). The raw JSON `<pre>` view should have `max-height` with overflow scroll to handle large results gracefully.
 - No new API endpoints.
 - No database changes.

--- a/frontend/src/components/ToolResultDisplay.tsx
+++ b/frontend/src/components/ToolResultDisplay.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react'
+
+interface ToolResultDisplayProps {
+  rawResult: string
+  toolName: string
+}
+
+function SearchHitList({ data }: { data: Record<string, unknown> }) {
+  const hits = (data.hits || data.results || []) as Record<string, unknown>[]
+  if (!hits.length) return <p className="text-gray-400 italic">No results</p>
+  return (
+    <div className="space-y-1.5">
+      {hits.map((hit, i) => (
+        <div key={i} className="flex items-baseline gap-2">
+          <span className="shrink-0 text-gray-400 tabular-nums w-4 text-right">{i + 1}.</span>
+          <div className="min-w-0">
+            <span className="font-medium text-gray-600 dark:text-gray-300">
+              {(hit.doc_title as string) || 'Untitled'}
+            </span>
+            {hit.page != null && <span className="ml-1 text-gray-400">p.{String(hit.page)}</span>}
+            {hit.score != null && <span className="ml-1.5 text-gray-400/70">({Number(hit.score).toFixed(2)})</span>}
+            {!!hit.snippet && (
+              <p className="text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">
+                {String(hit.snippet).slice(0, 150)}
+              </p>
+            )}
+            {!!hit.text && !hit.snippet && (
+              <p className="text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">{String(hit.text).slice(0, 150)}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PassageBlocks({ data }: { data: Record<string, unknown> }) {
+  const passages = (data.passages || data.chunks || []) as Record<string, unknown>[]
+  if (!passages.length) return <p className="text-gray-400 italic">No passages</p>
+  return (
+    <div className="space-y-2">
+      {passages.map((p, i) => (
+        <div key={i}>
+          <div className="text-gray-500 dark:text-gray-400 text-[10px] uppercase tracking-wide mb-0.5">
+            {(p.doc_title as string) || 'Untitled'}
+            {p.page != null && <span> — p.{String(p.page)}</span>}
+          </div>
+          <p className="text-gray-600 dark:text-gray-300 whitespace-pre-wrap">{String(p.text || p.content || '')}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EntityList({ data }: { data: Record<string, unknown> }) {
+  const entities = (data.entities || []) as Record<string, unknown>[]
+  if (!entities.length) return <p className="text-gray-400 italic">No entities</p>
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {entities.map((e, i) => (
+        <span key={i} className="inline-flex items-center gap-1 rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5">
+          <span className="font-medium text-gray-600 dark:text-gray-300">{String(e.name || e.text || '')}</span>
+          {!!e.type && <span className="text-[10px] text-gray-400 uppercase">{String(e.type)}</span>}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function GenericView({ data }: { data: unknown }) {
+  if (data === null || data === undefined) return null
+  if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
+    return <span className="text-gray-600 dark:text-gray-300">{String(data)}</span>
+  }
+  if (Array.isArray(data)) {
+    if (data.length === 0) return <span className="text-gray-400 italic">empty list</span>
+    return (
+      <ul className="list-disc pl-4 space-y-0.5">
+        {data.map((item, i) => (
+          <li key={i}>
+            <GenericView data={item} />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+  if (typeof data === 'object') {
+    const entries = Object.entries(data as Record<string, unknown>)
+    if (entries.length === 0) return <span className="text-gray-400 italic">empty</span>
+    return (
+      <dl className="space-y-1">
+        {entries.map(([key, val]) => (
+          <div key={key}>
+            <dt className="text-[10px] text-gray-400 uppercase tracking-wide">{key}</dt>
+            <dd className="ml-2">
+              <GenericView data={val} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    )
+  }
+  return null
+}
+
+const SEARCH_TOOLS = new Set(['search_documents', 'kb_search', 'kb_batch_search'])
+const PASSAGE_TOOLS = new Set([
+  'read_passages',
+  'kb_read_passages',
+  'expand_context',
+  'kb_expand_context',
+  'read_document',
+  'kb_read_document',
+])
+const ENTITY_TOOLS = new Set([
+  'entity_search',
+  'kb_entity_search',
+  'entity_overview',
+  'kb_entity_overview',
+  'entity_cooccurrence',
+  'kb_entity_cooccurrence',
+])
+
+function FormattedResult({ data, toolName }: { data: Record<string, unknown>; toolName: string }) {
+  if (SEARCH_TOOLS.has(toolName)) return <SearchHitList data={data} />
+  if (PASSAGE_TOOLS.has(toolName)) return <PassageBlocks data={data} />
+  if (ENTITY_TOOLS.has(toolName)) return <EntityList data={data} />
+  return <GenericView data={data} />
+}
+
+export default function ToolResultDisplay({ rawResult, toolName }: ToolResultDisplayProps) {
+  const [showRaw, setShowRaw] = useState(false)
+
+  let parsed: unknown = null
+  let parseOk = false
+  try {
+    parsed = JSON.parse(rawResult)
+    parseOk = true
+  } catch {
+    // not JSON — show as plain text
+  }
+
+  if (!parseOk) {
+    return (
+      <div className="text-[11px] text-gray-500 dark:text-gray-400 whitespace-pre-wrap max-h-64 overflow-auto">
+        {rawResult}
+      </div>
+    )
+  }
+
+  const obj = parsed as Record<string, unknown>
+  if (obj.error) {
+    return <div className="text-[11px] text-red-500 dark:text-red-400">Error: {String(obj.error)}</div>
+  }
+
+  return (
+    <div className="text-[11px]">
+      {showRaw ? (
+        <pre className="text-gray-400 dark:text-gray-500 whitespace-pre-wrap font-mono max-h-80 overflow-auto">
+          {JSON.stringify(parsed, null, 2)}
+        </pre>
+      ) : (
+        <FormattedResult data={obj} toolName={toolName} />
+      )}
+      <button
+        onClick={() => setShowRaw(!showRaw)}
+        className="mt-1.5 text-[10px] text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 underline"
+      >
+        {showRaw ? 'Show formatted' : 'Show raw'}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -27,6 +27,7 @@ export interface ToolCallInfo {
   name: string
   arguments: Record<string, unknown>
   result?: string
+  rawResult?: string
 }
 
 interface ChatState {
@@ -174,7 +175,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
                         ...last,
                         tool_calls: [
                           ...(last.tool_calls || []),
-                          { name: event.name, arguments: {}, result: event.summary },
+                          { name: event.name, arguments: {}, result: event.summary, rawResult: event.raw_result },
                         ],
                       }
                     }

--- a/frontend/src/contexts/ResearchContext.tsx
+++ b/frontend/src/contexts/ResearchContext.tsx
@@ -5,6 +5,7 @@ export interface ToolCallEntry {
   name: string
   arguments: Record<string, unknown>
   summary?: string
+  rawResult?: string
   round?: number
 }
 
@@ -106,7 +107,7 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
                 const toolCalls = [...prev.toolCalls]
                 for (let i = toolCalls.length - 1; i >= 0; i--) {
                   if (toolCalls[i].name === event.name && !toolCalls[i].summary) {
-                    toolCalls[i] = { ...toolCalls[i], summary: event.summary }
+                    toolCalls[i] = { ...toolCalls[i], summary: event.summary, rawResult: event.raw_result }
                     break
                   }
                 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -147,7 +147,14 @@ export default function ChatPage() {
               message_id: m.message_id,
               role: m.role as ChatMessage['role'],
               content: m.content,
-              tool_calls: (m.tool_calls as ToolCallInfo[] | undefined) || undefined,
+              tool_calls: m.tool_calls
+                ? (m.tool_calls as Array<Record<string, unknown>>).map((tc) => ({
+                    name: tc.name as string,
+                    arguments: (tc.arguments as Record<string, unknown>) || {},
+                    result: tc.result as string | undefined,
+                    rawResult: tc.raw_result as string | undefined,
+                  }))
+                : undefined,
               rag_context: m.rag_context,
               model_id: m.model_id || undefined,
               context_pct: m.context_pct,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../auth'
 import { useChat, type ChatMessage, type RagContextChunk, type ToolCallInfo } from '../contexts/ChatContext'
 import { useResearch } from '../contexts/ResearchContext'
 import RagContextCard from '../components/RagContextCard'
+import ToolResultDisplay from '../components/ToolResultDisplay'
 import { formatRelativeDate } from '../utils/dates'
 
 interface ConversationSummary {
@@ -878,11 +879,23 @@ function ToolCallCard({ tool, active }: { tool: ToolCallInfo; active: boolean })
         </svg>
       </button>
       {expanded && (
-        <div className="border-t border-gray-100 dark:border-gray-700/50 px-2.5 py-1.5 text-[11px] bg-gray-50/50 dark:bg-gray-800/30 space-y-1">
+        <div className="border-t border-gray-100 dark:border-gray-700/50 px-2.5 py-1.5 text-[11px] bg-gray-50/50 dark:bg-gray-800/30 space-y-2">
           {tool.arguments && Object.keys(tool.arguments).length > 0 && (
-            <div className="font-mono text-gray-400 dark:text-gray-500">{JSON.stringify(tool.arguments, null, 2)}</div>
+            <div>
+              <div className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Arguments</div>
+              <div className="font-mono text-gray-400 dark:text-gray-500">
+                {JSON.stringify(tool.arguments, null, 2)}
+              </div>
+            </div>
           )}
-          {tool.result && <div className="text-gray-500 dark:text-gray-400">{tool.result}</div>}
+          {tool.rawResult ? (
+            <div>
+              <div className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Result</div>
+              <ToolResultDisplay rawResult={tool.rawResult} toolName={tool.name} />
+            </div>
+          ) : tool.result ? (
+            <div className="text-gray-500 dark:text-gray-400">{tool.result}</div>
+          ) : null}
         </div>
       )}
     </div>

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
+import ToolResultDisplay from '../components/ToolResultDisplay'
 import { del, get } from '../api'
 import { useChat } from '../contexts/ChatContext'
 import { useResearch, type ToolCallEntry } from '../contexts/ResearchContext'
@@ -835,30 +836,29 @@ export default function ResearchPage() {
 
 function ToolLogEntry({ tool, isLast }: { tool: ToolCallEntry; isLast: boolean }) {
   const isDone = !!tool.summary
+  const hasResult = !!tool.rawResult
 
-  return (
-    <div className="flex items-start gap-2 px-3 py-2">
-      <span
-        className={`shrink-0 mt-0.5 ${
-          !isDone && isLast
-            ? 'text-blue-500 dark:text-blue-400 animate-pulse'
-            : 'text-emerald-500 dark:text-emerald-400'
-        }`}
-      >
-        {!isDone && isLast ? (
-          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-            />
-          </svg>
-        ) : (
-          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-          </svg>
-        )}
-      </span>
+  const icon =
+    !isDone && isLast ? (
+      <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+        />
+      </svg>
+    ) : (
+      <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+      </svg>
+    )
+
+  const iconColor =
+    !isDone && isLast ? 'text-blue-500 dark:text-blue-400 animate-pulse' : 'text-emerald-500 dark:text-emerald-400'
+
+  const summaryContent = (
+    <div className="flex items-start gap-2 w-full">
+      <span className={`shrink-0 mt-0.5 ${iconColor}`}>{icon}</span>
       <div className="min-w-0 flex-1">
         <span className="text-[12px] font-medium text-gray-600 dark:text-gray-300">{tool.name}</span>
         {tool.summary && (
@@ -866,6 +866,30 @@ function ToolLogEntry({ tool, isLast }: { tool: ToolCallEntry; isLast: boolean }
         )}
       </div>
     </div>
+  )
+
+  if (!hasResult) {
+    return <div className="px-3 py-2">{summaryContent}</div>
+  }
+
+  return (
+    <details className="group">
+      <summary className="px-3 py-2 cursor-pointer list-none flex items-center [&::-webkit-details-marker]:hidden">
+        {summaryContent}
+        <svg
+          className="h-3 w-3 shrink-0 text-gray-300 dark:text-gray-600 transition-transform duration-150 group-open:rotate-90 ml-1"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </summary>
+      <div className="px-3 pb-2 pl-8">
+        <ToolResultDisplay rawResult={tool.rawResult!} toolName={tool.name} />
+      </div>
+    </details>
   )
 }
 

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -24,6 +24,7 @@ interface ResearchMessage {
     name: string
     arguments: Record<string, unknown>
     result?: string
+    raw_result?: string
   }>
 }
 
@@ -50,6 +51,7 @@ function extractToolCalls(messages: ResearchMessage[]): ToolCallEntry[] {
           name: tc.name,
           arguments: tc.arguments,
           summary: tc.result || undefined,
+          rawResult: tc.raw_result || undefined,
           round,
         })
       }

--- a/src/harbor_clerk/api/routes/chat.py
+++ b/src/harbor_clerk/api/routes/chat.py
@@ -39,17 +39,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["chat"])
 
 
-def _enrich_tool_calls(tool_calls: list[dict], results: dict[str, str]) -> list[dict]:
-    """Add result summaries to tool calls in the frontend-friendly format.
+def _enrich_tool_calls(tool_calls: list[dict], results: dict[str, tuple[str, str] | str]) -> list[dict]:
+    """Add result summaries and raw results to tool calls.
 
-    Converts from OpenAI format ({id, type, function: {name, arguments}})
-    to the display format ({name, arguments, result}) that ToolCallCard expects.
+    results values are either (summary, raw_content) tuples or plain summary strings
+    for backwards compatibility.
     """
     enriched = []
     for tc in tool_calls:
         func = tc.get("function", {})
         name = func.get("name", tc.get("name", ""))
-        # Parse arguments from JSON string (OpenAI format) or dict (already parsed)
         raw_args = func.get("arguments", tc.get("arguments", {}))
         if isinstance(raw_args, str):
             try:
@@ -59,11 +58,18 @@ def _enrich_tool_calls(tool_calls: list[dict], results: dict[str, str]) -> list[
         else:
             args = raw_args
         tc_id = tc.get("id", "")
+        result_val = results.get(tc_id)
+        if isinstance(result_val, tuple):
+            summary, raw_result = result_val
+        else:
+            summary = result_val
+            raw_result = None
         enriched.append(
             {
                 "name": name,
                 "arguments": args,
-                "result": results.get(tc_id),
+                "result": summary,
+                "raw_result": raw_result,
             }
         )
     return enriched
@@ -129,10 +135,10 @@ async def get_conversation(
     # Build a lookup of tool_call_id → result summary for enrichment.
     # This uses the already-fetched message set (no extra query), and the
     # idx_messages_conv(conversation_id, created_at) index covers the query.
-    tool_results_by_id: dict[str, str] = {}
+    tool_results_by_id: dict[str, tuple[str, str]] = {}
     for m in all_msgs:
         if m.role == "tool" and m.tool_call_id and m.content:
-            tool_results_by_id[m.tool_call_id] = summarize_tool_result(m.content)
+            tool_results_by_id[m.tool_call_id] = (summarize_tool_result(m.content), m.content)
 
     messages = []
     for m in all_msgs:

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -135,10 +135,10 @@ async def get_research(
     from harbor_clerk.api.routes.chat import _enrich_tool_calls
     from harbor_clerk.llm.tools import summarize_tool_result as _summarize_tool_result
 
-    tool_results_by_id: dict[str, str] = {}
+    tool_results_by_id: dict[str, tuple[str, str]] = {}
     for m in all_msgs:
         if m.role == "tool" and m.tool_call_id and m.content:
-            tool_results_by_id[m.tool_call_id] = _summarize_tool_result(m.content)
+            tool_results_by_id[m.tool_call_id] = (_summarize_tool_result(m.content), m.content)
 
     # Build message dicts
     messages: list[dict] = []

--- a/src/harbor_clerk/llm/chat.py
+++ b/src/harbor_clerk/llm/chat.py
@@ -447,7 +447,7 @@ async def chat_stream(
 
                     result_str = await execute_tool(fn_name, fn_args, user_id)
 
-                    yield f"data: {json.dumps({'type': 'tool_result', 'name': fn_name, 'summary': summarize_tool_result(result_str)})}\n\n"
+                    yield f"data: {json.dumps({'type': 'tool_result', 'name': fn_name, 'summary': summarize_tool_result(result_str), 'raw_result': result_str})}\n\n"
 
                     # Save full result to DB, but truncate for LLM context
                     tool_msg = ChatMessage(

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -383,7 +383,7 @@ async def research_stream(
                     observation = str(step.observation or step.output)
                     summary = summarize_tool_result(observation[:500])
                     tc_name = step.tool_call.name if step.tool_call else "unknown"
-                    yield f"data: {json.dumps({'type': 'tool_result', 'name': tc_name, 'summary': summary})}\n\n"
+                    yield f"data: {json.dumps({'type': 'tool_result', 'name': tc_name, 'summary': summary, 'raw_result': observation})}\n\n"
                     # Save tool result as tool message for persistence
                     session.add(
                         ChatMessage(


### PR DESCRIPTION
## Summary
- Add full tool results to SSE events and API responses (`raw_result` field)
- New `ToolResultDisplay` component with tool-specific formatted views + raw JSON toggle
- Chat `ToolCallCard` shows formatted results in disclosure body
- Research `ToolLogEntry` converts to disclosure triangle when result is available

### Tool-specific formatters
- **Search tools**: hit list with doc title, page, score, snippet preview
- **Passage tools**: text blocks with doc title + page header
- **Entity tools**: tagged pill list with name + type
- **Generic fallback**: recursive key-value renderer for all other tools

### Data flow
- SSE `tool_result` events now include `raw_result` (full JSON string)
- API reload responses include `raw_result` via enriched tool calls
- Frontend maps `raw_result` (snake_case) to `rawResult` (camelCase) on both paths

## Test plan
- [ ] Chat: ask a question, expand tool call card, verify formatted search results
- [ ] Chat: click Show raw toggle, verify JSON view with scroll
- [ ] Chat: reload page, verify disclosures still work with API data
- [ ] Research: run a task, verify disclosure triangles appear on completed tool calls
- [ ] Research: reload completed research, verify disclosures work from API data