### PR TITLE
fix: reaper import path + cap Gemma 4 context to 32K

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -121,7 +121,7 @@ final class AppSettings: @unchecked Sendable {
             "smollm3-3b": 65536,
             "gpt-oss-20b": 128000,
             "qwen3-30b-a3b": 262144,
-            "gemma4-26b-a4b": 128000,
+            "gemma4-26b-a4b": 32768,
         ]
         return contextWindows[modelId] ?? 32768
     }

--- a/src/harbor_clerk/api/app.py
+++ b/src/harbor_clerk/api/app.py
@@ -109,7 +109,7 @@ async def _session_reaper_loop() -> None:
 
                 # Re-queue orphaned ingestion jobs (running with stale heartbeat >90s)
                 from harbor_clerk.models import IngestionJob
-                from harbor_clerk.models.ingestion import JobStatus
+                from harbor_clerk.models.enums import JobStatus
 
                 heartbeat_cutoff = now - timedelta(seconds=90)
                 orphan_result = await db.execute(

--- a/src/harbor_clerk/llm/models.py
+++ b/src/harbor_clerk/llm/models.py
@@ -75,7 +75,7 @@ MODELS: dict[str, ModelInfo] = {
             huggingface_repo="bartowski/google_gemma-4-26B-A4B-it-GGUF",
             filename="google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
             size_bytes=17_000_000_000,
-            context_window=128000,
+            context_window=32768,
             supports_tools=True,
         ),
         ModelInfo(


### PR DESCRIPTION
## Summary
- Fix ModuleNotFoundError in reaper: `harbor_clerk.models.ingestion` -> `harbor_clerk.models.enums` (JobStatus). Crashed every 5 min.
- Cap Gemma 4 26B-A4B context_window from 128K to 32K. At 128K the KV cache is too large and llama-server hangs on startup.

## Test plan
- [ ] Reaper no longer logs ModuleNotFoundError
- [ ] Gemma 4 model starts successfully with 32K context