### PR TITLE
feat: update llama.cpp b8149 -> b8770 for Gemma 4 support

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -546,9 +546,14 @@ final class ServiceManager: ObservableObject {
         }
         notifyStateChanged()
 
-        // 2. Stop infrastructure services
+        // 2. Stop infrastructure services (reset errored state + flap history for fresh start)
         for svc in infraToRestart {
-            await svc.stop()
+            if svc.state == .errored {
+                svc.state = .stopped
+                restartHistory.removeValue(forKey: svc.name)
+            } else {
+                await svc.stop()
+            }
         }
         notifyStateChanged()
 
@@ -693,11 +698,16 @@ final class ServiceManager: ObservableObject {
 
         configChangeTask?.cancel()
         configChangeTask = Task {
-            // Stop current llama-server if running
+            // Stop current llama-server if running or errored
             if llamaService.state == .running || llamaService.state == .starting {
                 await llamaService.stop()
                 notifyStateChanged()
                 try? await Task.sleep(for: .seconds(1))
+            } else if llamaService.state == .errored {
+                // Reset errored state and clear flap history so the new model gets a fresh start
+                llamaService.state = .stopped
+                restartHistory.removeValue(forKey: llamaService.name)
+                notifyStateChanged()
             }
 
             if newModelId.isEmpty {

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -43,6 +43,7 @@ final class LlamaService: ManagedService {
             "--host", "127.0.0.1",
             "--port", String(port),
             "-ngl", "99",
+            "-np", "1",
             "-c", String(contextWindow),
             "--threads", String(max(1, ProcessInfo.processInfo.processorCount / 2)),
         ]

--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -121,7 +121,7 @@ final class AppSettings: @unchecked Sendable {
             "smollm3-3b": 65536,
             "gpt-oss-20b": 128000,
             "qwen3-30b-a3b": 262144,
-            "gemma4-26b-a4b": 32768,
+            "gemma4-26b-a4b": 128000,
         ]
         return contextWindows[modelId] ?? 32768
     }

--- a/macos/scripts/build-llama.sh
+++ b/macos/scripts/build-llama.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DEST_DIR="${DEST_DIR:?DEST_DIR must be set}"
 BUILD_DIR="${BUILD_DIR:-/tmp/llama-build}"
-LLAMA_CPP_TAG="${LLAMA_CPP_TAG:-b8149}"
+LLAMA_CPP_TAG="${LLAMA_CPP_TAG:-b8770}"
 
 mkdir -p "$DEST_DIR" "$BUILD_DIR"
 DEST_DIR="$(cd "$DEST_DIR" && pwd)"

--- a/src/harbor_clerk/llm/models.py
+++ b/src/harbor_clerk/llm/models.py
@@ -75,7 +75,7 @@ MODELS: dict[str, ModelInfo] = {
             huggingface_repo="bartowski/google_gemma-4-26B-A4B-it-GGUF",
             filename="google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
             size_bytes=17_000_000_000,
-            context_window=32768,
+            context_window=128000,
             supports_tools=True,
         ),
         ModelInfo(


### PR DESCRIPTION
## Summary
- Update bundled llama.cpp from b8149 to b8770 — adds gemma4 architecture support
- Restore Gemma 4 context_window to 128K (was capped to 32K as a workaround)
- Add -np 1 (single parallel slot) to save KV cache memory

## Root cause
The GGUF file declares architecture 'gemma4' which b8149 didn't recognize. b8770 has full gemma4 support.

## Test plan
- [ ] Gemma 4 model loads and starts successfully
- [ ] Other models still work (Qwen3, etc.)
- [ ] Chat and Research produce output with Gemma 4