### PR TITLE
fix: health checker kills API server during research tasks

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/HealthChecker.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/HealthChecker.swift
@@ -15,7 +15,8 @@ final class HealthChecker {
     /// Consecutive health check failure count per service name.
     private var failureCounts: [String: Int] = [:]
     /// Number of consecutive failures before marking a service as errored.
-    private let consecutiveFailuresBeforeError = 3 // 30s at 10s interval
+    /// Set to 6 (60s) to avoid false positives when API is busy with research/synthesis.
+    private let consecutiveFailuresBeforeError = 6 // 60s at 10s interval
 
     init(serviceManager: ServiceManager) {
         self.serviceManager = serviceManager

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PythonService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PythonService.swift
@@ -9,7 +9,8 @@ class PythonService: ManagedService {
     var baseEnvironment: [String: String] = [:]
 
     /// Seconds to wait after SIGTERM before sending SIGKILL.
-    var shutdownGracePeriod: TimeInterval = 5.0
+    /// API server needs more time when mid-research (SSE streams, agent threads, DB sessions).
+    var shutdownGracePeriod: TimeInterval = 30.0
     /// Called after process exits unexpectedly and internal restarts are exhausted.
     var onUnexpectedExit: (@MainActor () -> Void)?
 


### PR DESCRIPTION
## Root cause
The API health check times out during research (event loop busy with LLM streaming + DB commits). After 3 failures in 30s the health checker marks the API as errored, triggers auto-restart, and SIGKILL's it after only 5s grace — mid-research.

## Fixes
- Increase PythonService shutdown grace period from 5s to 30s
- Increase consecutive failures threshold from 3 to 6 (60s window)

## Symptoms this fixes
- UI shows 'please start HarborClerk Server' mid-research
- Research tasks get stuck as running with no output
- Postgres briefly shows as stopping (cascade from API restart)