### PR TITLE
fix: API event loop deadlock — stdout pipe fills, write() blocks

### DIFF
--- a/src/harbor_clerk/log_setup.py
+++ b/src/harbor_clerk/log_setup.py
@@ -22,16 +22,12 @@ def setup_logging(service_name: str, level: str = "INFO") -> None:
     fmt = "%(asctime)s %(levelname)s %(name)s %(message)s"
     formatter = logging.Formatter(fmt)
 
-    # Console handler (always)
-    console = logging.StreamHandler()
-    console.setFormatter(formatter)
-
     root = logging.getLogger()
     root.setLevel(log_level)
-    root.addHandler(console)
 
     # File handler (only when running as macOS native app)
     config_file = os.environ.get("NATIVE_CONFIG_FILE", "")
+    file_handler_installed = False
     if config_file:
         logs_dir = Path(config_file).parent / "logs"
         try:
@@ -43,5 +39,15 @@ def setup_logging(service_name: str, level: str = "INFO") -> None:
             )
             file_handler.setFormatter(formatter)
             root.addHandler(file_handler)
+            file_handler_installed = True
         except OSError:
             logging.warning("Could not create log file in %s", logs_dir)
+
+    # Console handler — skipped in native app mode because the Swift-side pipe
+    # has a finite buffer (64KB) and Python's blocking stdio write() will
+    # deadlock the event loop if the Swift reader falls behind. The file
+    # handler above captures everything we need.
+    if not file_handler_installed:
+        console = logging.StreamHandler()
+        console.setFormatter(formatter)
+        root.addHandler(console)


### PR DESCRIPTION
## Root cause (confirmed with sample(1))
Main thread stuck in `_io_FileIO_write -> write() syscall`. The Swift-side Pipe that captures Python stdout has a finite buffer (~64KB on macOS). If the Swift readabilityHandler falls behind, the pipe fills and Python's stdio write() blocks forever — on the MAIN thread. That blocks uvloop's entire event loop, so HTTP requests hang, health checks time out, and the whole API looks dead (but the process is alive).

## Symptoms this explains
- API 'goes away' mid-research, recovers after 30-90s (when Swift eventually drains)
- Health check needed process-alive fallback
- Research tasks hang, UI spins, other API requests hang too
- Worse at DEBUG level (more log volume)

## Fix
When the rotating file handler is installed (native app mode), drop the StreamHandler entirely. All logs still go to the rotating file. Docker/dev mode unchanged.