### PR TITLE
chore: promote research Agent step logs to INFO

### DIFF
--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -354,7 +354,7 @@ async def research_stream(
                     logger.info("Agent thread starting: task=%s max_steps=%d", task[:100], max_steps)
                     for step in agent.run(task=task, stream=True, max_steps=max_steps):
                         step_queue.put(("step", step))
-                        logger.debug("Agent step: %s", type(step).__name__)
+                        logger.info("Agent step: %s", type(step).__name__)
                         # Wall-time check
                         elapsed = (datetime.now(UTC) - start_time).total_seconds()
                         if elapsed >= time_limit_s:
@@ -383,7 +383,7 @@ async def research_stream(
                     continue
 
                 msg_type, msg_data = msg
-                logger.debug(
+                logger.info(
                     "Queue message: type=%s data_type=%s", msg_type, type(msg_data).__name__ if msg_data else None
                 )
 


### PR DESCRIPTION
Previously at DEBUG, invisible at default INFO level. These are the canonical per-round markers — useful when diagnosing research flow without needing to crank logging to DEBUG (which filled the stdout pipe and caused the deadlock we just fixed).