### PR TITLE
feat: research detail=full, k from settings, proper resume

### DIFF
--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -277,6 +277,11 @@ async def research_stream(
 
         strategy = state.strategy
 
+        # If resuming an interrupted task that has accumulated notes, skip the
+        # agent loop and go straight to synthesis. The agent loop is expensive
+        # and rerunning it on a bad LLM state usually hits the same failure.
+        resume_from_synthesis = resume and state.notes and len(state.notes) > 200
+
         # Mark as running
         state.status = "running"
         state.heartbeat_at = datetime.now(UTC)
@@ -346,6 +351,19 @@ async def research_stream(
         current_round = 0
 
         try:
+            if resume_from_synthesis:
+                # Skip the agent loop — use accumulated notes directly.
+                # This avoids re-running tool calls when only synthesis failed.
+                logger.info(
+                    "Resuming research %s from synthesis (notes len=%d)",
+                    conversation_id,
+                    len(state.notes or ""),
+                )
+                final_answer_text = ""  # keep empty; synthesis uses notes directly
+                step_count = state.current_round or 0
+                # Fall through to synthesis pass below; agent loop block is guarded
+                # by `not resume_from_synthesis`.
+
             # Run agent in thread, stream steps via queue
             step_queue: queue_mod.Queue = queue_mod.Queue()
 
@@ -367,9 +385,9 @@ async def research_stream(
                     step_queue.put(("done", None))
 
             loop = asyncio.get_running_loop()
-            executor_future = loop.run_in_executor(None, _run_agent)
+            executor_future = loop.run_in_executor(None, _run_agent) if not resume_from_synthesis else None
 
-            while True:
+            while not resume_from_synthesis:
                 try:
                     msg = await asyncio.wait_for(
                         loop.run_in_executor(None, lambda: step_queue.get(timeout=30)),
@@ -504,13 +522,14 @@ async def research_stream(
                         final_answer_text = str(step.output)
 
             # Wait for executor to finish
-            try:
-                await asyncio.wait_for(asyncio.shield(executor_future), timeout=10)
-            except Exception:
-                pass
+            if executor_future is not None:
+                try:
+                    await asyncio.wait_for(asyncio.shield(executor_future), timeout=10)
+                except Exception:
+                    pass
 
             # If no final answer from agent, try to extract from memory
-            if not final_answer_text and hasattr(agent, "memory") and agent.memory:
+            if not resume_from_synthesis and not final_answer_text and hasattr(agent, "memory") and agent.memory:
                 try:
                     for mem_step in reversed(agent.memory.steps):
                         if hasattr(mem_step, "action_output") and mem_step.action_output:
@@ -547,15 +566,19 @@ async def research_stream(
             # is unreliable — the agent often gives up at the end even when it
             # found good results during the run). Cap total length so we don't
             # blow up the synthesis context.
-            collected_text = "\n\n".join(collected_notes)
-            if len(collected_text) > 60_000:
-                collected_text = collected_text[:60_000] + "\n... [truncated]"
-            if collected_text.strip():
-                notes = collected_text
-                if final_answer_text:
-                    notes += f"\n\n## Agent's final answer\n{final_answer_text}"
+            if resume_from_synthesis:
+                # Use previously-saved notes instead of the (empty) collected_notes
+                notes = state.notes or "No relevant findings were discovered during the research."
             else:
-                notes = final_answer_text or "No relevant findings were discovered during the research."
+                collected_text = "\n\n".join(collected_notes)
+                if len(collected_text) > 60_000:
+                    collected_text = collected_text[:60_000] + "\n... [truncated]"
+                if collected_text.strip():
+                    notes = collected_text
+                    if final_answer_text:
+                        notes += f"\n\n## Agent's final answer\n{final_answer_text}"
+                else:
+                    notes = final_answer_text or "No relevant findings were discovered during the research."
 
             yield f"data: {json.dumps({'type': 'synthesis', 'status': 'started'})}\n\n"
 

--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -496,16 +496,19 @@ def get_research_tools() -> list[dict]:
 
 
 def _map_args_search_research(args: dict) -> dict:
-    """Search arg mapper for research — uses settings for k/offset, brief detail."""
+    """Search arg mapper for research — uses settings for k/offset, full detail."""
     from harbor_clerk.config import get_settings
 
     s = get_settings()
     max_k = 100 if s.research_search_paginated else s.research_search_k
+    # Default k reflects the user's configured research_search_k so preferences
+    # control result volume (matches how users expect the setting to behave).
+    default_k = min(s.research_search_k, max_k) if not s.research_search_paginated else 10
     mapped: dict = {
         "query": args["query"],
-        "k": min(args.get("k", 10), max_k),
+        "k": min(args.get("k", default_k), max_k),
         "doc_id": args.get("doc_id"),
-        "detail": "brief",
+        "detail": "full",
     }
     if s.research_search_paginated and args.get("offset"):
         mapped["offset"] = args["offset"]


### PR DESCRIPTION
## Three fixes

**1. Research tool uses `detail='full'`** (was `'brief'`, 200-char snippets). Chat uses full already. The brief snippets forced the agent to spend rounds doing `read_passages` to get actual evidence, reducing corpus coverage per round. Likely explains the observation that Ask gets more exhaustive results than Research for the same query.

**2. Default `k` reflects `research_search_k` setting.** Previously hardcoded to 10 when paginated=false, ignoring the setting. Now the preference controls result volume as users naively expect.

**3. Resume actually resumes.** Previously the `resume` param was unused — retry just reran the full agent loop, usually hitting the same LLM error. Now when state.notes is populated, retry skips the agent loop and goes straight to synthesis using the already-gathered notes. This is the right behavior when llama.cpp returns a 500 Compute error mid-synthesis.

## About the 500
Root cause: `llama-server` returned `{error: {code: 500, message: 'Compute error.'}}` during synthesis. That's a numerical issue inside llama.cpp during inference — likely specific to the quantized Gemma 4 MoE architecture at certain attention patterns. Not something we can fix at our layer; but this PR makes retry viable so it's less painful when it happens.