### PR TITLE
fix: static Bondi Blue dot for Topic Keywords cards

### DIFF
--- a/frontend/src/components/stats/TopicKeywords.tsx
+++ b/frontend/src/components/stats/TopicKeywords.tsx
@@ -5,7 +5,9 @@ interface TopicCluster {
   doc_count: number
 }
 
-const PIE_COLORS = ['#007aff', '#34c759', '#ff9500', '#ff3b30', '#af52de', '#5ac8fa', '#ff2d55', '#ffcc00']
+// Bondi Blue — classic early OS X. Purely decorative accent; the dot
+// doesn't encode anything about the topic.
+const DOT_COLOR = '#5ac8fa'
 
 export default function TopicKeywords({ topics }: { topics: TopicCluster[] }) {
   if (topics.length === 0) {
@@ -14,13 +16,10 @@ export default function TopicKeywords({ topics }: { topics: TopicCluster[] }) {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {topics.map((topic, i) => (
+      {topics.map((topic) => (
         <div key={topic.cluster_id} className="rounded-lg bg-(--color-bg-secondary) p-3">
           <div className="flex items-center gap-2 mb-2">
-            <span
-              className="inline-block h-2.5 w-2.5 rounded-full shrink-0"
-              style={{ backgroundColor: PIE_COLORS[i % PIE_COLORS.length] }}
-            />
+            <span className="inline-block h-2.5 w-2.5 rounded-full shrink-0" style={{ backgroundColor: DOT_COLOR }} />
             <h4 className="text-[13px] font-medium text-(--color-text-primary) leading-snug">{topic.name}</h4>
           </div>
           <p className="text-[11px] text-(--color-text-secondary) mb-1.5">


### PR DESCRIPTION
The rotating palette in `TopicKeywords` implied a semantic meaning the dots didn't carry (and didn't align with ClusterMap's palette anyway). ClusterMap keeps its legend-style colors — this change only affects Topic Keywords cards.