### PR TITLE
feat: Bondi dots in Explore + Topic default in Document Clusters

### DIFF
--- a/frontend/src/components/stats/ClusterMap.tsx
+++ b/frontend/src/components/stats/ClusterMap.tsx
@@ -67,7 +67,7 @@ export default function ClusterMap() {
   const [positions, setPositions] = useState<[number, number][]>([])
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
   const [dimensions, setDimensions] = useState({ width: 800, height: 500 })
-  const [colorMode, setColorMode] = useState<ColorMode>('mime')
+  const [colorMode, setColorMode] = useState<ColorMode>('topic')
   const navigate = useNavigate()
 
   const hasTopics = docs.some((d) => d.topic_id != null)
@@ -235,16 +235,16 @@ export default function ClusterMap() {
         {hasTopics && (
           <div className="flex rounded-lg bg-(--color-bg-secondary) p-0.5 text-[11px] font-medium">
             <button
-              className={`rounded-md px-2.5 py-1 transition-colors ${colorMode === 'mime' ? 'bg-white dark:bg-[#3a3a3c] shadow-sm text-(--color-text-primary)' : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'}`}
-              onClick={() => setColorMode('mime')}
-            >
-              File Type
-            </button>
-            <button
               className={`rounded-md px-2.5 py-1 transition-colors ${colorMode === 'topic' ? 'bg-white dark:bg-[#3a3a3c] shadow-sm text-(--color-text-primary)' : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'}`}
               onClick={() => setColorMode('topic')}
             >
               Topic
+            </button>
+            <button
+              className={`rounded-md px-2.5 py-1 transition-colors ${colorMode === 'mime' ? 'bg-white dark:bg-[#3a3a3c] shadow-sm text-(--color-text-primary)' : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'}`}
+              onClick={() => setColorMode('mime')}
+            >
+              File Type
             </button>
           </div>
         )}

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -340,7 +340,13 @@ function ExploreMain({
                   className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) px-5 py-4 hover:shadow-mac-lg hover:ring-(--color-border)/80 transition-all text-left group"
                 >
                   <div className="flex items-center justify-between mb-1">
-                    <h3 className="text-[13px] font-semibold text-(--color-text-primary)">{cluster.name}</h3>
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: '#5ac8fa' }}
+                      />
+                      <h3 className="text-[13px] font-semibold text-(--color-text-primary) truncate">{cluster.name}</h3>
+                    </div>
                     <svg
                       className="h-3.5 w-3.5 text-(--color-text-secondary) opacity-0 group-hover:opacity-100 transition-opacity"
                       fill="none"


### PR DESCRIPTION
- Static Bondi Blue dot on Explore topic cluster cards (matches Observatory)
- Swap Topic/File Type toggle order, Topic on left
- Default colorMode to 'topic' in Document Clusters (restore prior behavior)