### PR TITLE
fix: Research retrieval policy — breadth prompt, batch_search, no clip

### DIFF
--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -324,16 +324,47 @@ async def research_stream(
             planning_interval=planning_interval,
         )
 
-        # Build task description with citation instructions
+        # Build task description with citation + retrieval-policy instructions.
+        # Kept in parity with chat's SYSTEM_PROMPT (broad-query strategy,
+        # has_more/total_candidates pagination, query branching) so Research
+        # doesn't stop too early. Topic hint is appended below.
+        from harbor_clerk.topics import get_topic_summary
+
+        topic_hint = await get_topic_summary()
+
         task = (
             f"{user_question}\n\n"
-            "IMPORTANT INSTRUCTIONS:\n"
-            "- Search the knowledge base thoroughly using varied queries\n"
-            "- Every finding MUST include its source citation as [Document Title, page X]\n"
-            "- Never paraphrase citations — preserve them exactly as they appear in search results\n"
-            "- When you call final_answer, include ALL findings with their citations\n"
-            "- Do not use generic references like 'Research Note 1' — always cite the actual document\n"
+            "## How to research\n\n"
+            "Ground every claim in retrieved passages. Cite sources exactly as they appear: "
+            "[Document Title, page X]. Never fabricate citations.\n\n"
+            "### Breadth first, then depth\n"
+            "- For broad or comparative questions, run MANY varied queries. Do not stop "
+            "after one search — covering a topic thoroughly requires 5–15+ queries "
+            "with different phrasings, synonyms, entities, and angles.\n"
+            "- Use batch_search to fan out 3–5 related queries in a single call when "
+            "exploring a topic from multiple angles. It is far more efficient than "
+            "one-query-at-a-time search_documents.\n"
+            "- For each search result, check has_more and total_candidates. If the "
+            "corpus has more candidates than you retrieved, either page forward with "
+            "offset or try more specific queries to reach uncovered material.\n"
+            "- When a user asks about a specific topic, entity, or region, search "
+            "for it directly. Do not assume the corpus lacks it just because it was "
+            "not in earlier results.\n\n"
+            "### Workflow\n"
+            "1. search_documents / batch_search to discover relevant passages\n"
+            "2. read_passages on the chunk_ids of the most promising hits to get full text\n"
+            "3. expand_context around a passage only when a hit is ambiguous\n"
+            "4. Repeat with new queries to fill gaps — aim for broad document coverage "
+            "before synthesis\n\n"
+            "### Citation rules\n"
+            "- Every finding in your notes/final answer MUST cite its source as "
+            "[Document Title, page X].\n"
+            "- Preserve citations exactly as returned by the search tools.\n"
+            "- Never use generic references like 'Research Note 1'.\n"
+            "- If evidence is incomplete or contradictory, say so explicitly.\n"
         )
+        if topic_hint:
+            task += f"\n## Corpus topics\n{topic_hint}\n"
         if strategy == "sweep":
             doc_list = await _fetch_document_list(user_id)
             if doc_list:
@@ -444,8 +475,10 @@ async def research_stream(
                     observation = str(step.observation or step.output)
                     summary = summarize_tool_result(observation[:500])
                     tc_name = step.tool_call.name if step.tool_call else "unknown"
-                    # Track for collected_notes — include first chunk of observation as evidence
-                    collected_notes.append(f"Result: {summary}\n\n{observation[:1500]}")
+                    # Track for collected_notes with a generous per-observation cap
+                    # (was 1500, which regularly cut off search hits after the first
+                    # 2–3 results). The 60KB global cap below still bounds total size.
+                    collected_notes.append(f"Result: {summary}\n\n{observation[:12000]}")
                     yield f"data: {json.dumps({'type': 'tool_result', 'name': tc_name, 'summary': summary, 'raw_result': observation})}\n\n"
                     # Save tool result as tool message for persistence
                     session.add(

--- a/src/harbor_clerk/llm/research_tools.py
+++ b/src/harbor_clerk/llm/research_tools.py
@@ -76,6 +76,44 @@ class SearchDocumentsTool(_ResearchTool):
         return self._call_tool(args)
 
 
+class BatchSearchTool(_ResearchTool):
+    name = "batch_search"
+    description = (
+        "Run up to 5 search queries in a single call. Returns results grouped "
+        "by query — ideal for exploring a topic from multiple angles without "
+        "sequential round-trips. Prefer this over repeated single-query "
+        "search_documents when you have several related queries in mind. "
+        "Returns brief previews; follow up with read_passages on interesting "
+        "chunk_ids for full text."
+    )
+    inputs = {
+        "queries": {
+            "type": "string",
+            "description": "Comma-separated list of search queries (max 5)",
+        },
+        "k": {
+            "type": "integer",
+            "description": "Results per query (default 10, max 100)",
+            "nullable": True,
+        },
+        "doc_id": {
+            "type": "string",
+            "description": "Restrict all queries to a specific document ID",
+            "nullable": True,
+        },
+    }
+    _tool_name = "batch_search"
+
+    def forward(self, queries: str, k: int | None = None, doc_id: str | None = None) -> str:
+        # smolagents passes the string as-is; mapper splits on comma
+        args: dict = {"queries": queries}
+        if k is not None:
+            args["k"] = k
+        if doc_id is not None:
+            args["doc_id"] = doc_id
+        return self._call_tool(args)
+
+
 class ReadPassagesTool(_ResearchTool):
     name = "read_passages"
     description = (
@@ -374,6 +412,7 @@ def build_research_tools(user_id=None, main_loop=None) -> list[Tool]:
     """
     return [
         SearchDocumentsTool(user_id, main_loop=main_loop),
+        BatchSearchTool(user_id, main_loop=main_loop),
         ReadPassagesTool(user_id, main_loop=main_loop),
         ExpandContextTool(user_id, main_loop=main_loop),
         GetDocumentTool(user_id, main_loop=main_loop),

--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -515,9 +515,33 @@ def _map_args_search_research(args: dict) -> dict:
     return mapped
 
 
+def _map_args_batch_search_research(args: dict) -> dict:
+    """Batch search for research — clamps k and forces brief detail.
+
+    Brief detail keeps multi-query output manageable; the agent can follow up
+    with read_passages on interesting chunk_ids.
+    """
+    from harbor_clerk.config import get_settings
+
+    s = get_settings()
+    max_k = 100 if s.research_search_paginated else s.research_search_k
+    queries = args.get("queries") or []
+    if isinstance(queries, str):
+        queries = [q.strip() for q in queries.split(",") if q.strip()]
+    mapped: dict = {
+        "queries": queries[:5],
+        "k": min(args.get("k", 10), max_k),
+        "detail": "brief",
+    }
+    if args.get("doc_id"):
+        mapped["doc_id"] = args["doc_id"]
+    return mapped
+
+
 _RESEARCH_TOOL_DISPATCH: dict[str, tuple[str, callable]] = {
     **_TOOL_DISPATCH,
     "search_documents": ("kb_search", _map_args_search_research),
+    "batch_search": ("kb_batch_search", _map_args_batch_search_research),
 }
 
 


### PR DESCRIPTION
## Summary

Three targeted fixes so Research produces more exhaustive results, closer to parity with Chat. Does not change the agent framework (still smolagents) — changes the retrieval policy and what synthesis gets to see.

- **Stop clipping observations.** `research.py` was writing only `observation[:1500]` into the per-round notes buffer. For any search returning more than ~2 hits, synthesis never saw the tail. Raised to 12000/observation. Global 60KB notes cap still bounds total size.
- **Expose `batch_search`.** `kb_batch_search` already existed on the MCP side but wasn't in the Research tool set. Added a smolagents `BatchSearchTool` wrapper plus the `_map_args_batch_search_research` dispatcher. Agent can now fan out up to 5 queries per call.
- **Stronger Research prompt.** The old "IMPORTANT INSTRUCTIONS" stanza was much thinner than Chat's `SYSTEM_PROMPT`. Rewrote with: breadth-first rule (5–15+ varied queries for broad questions), explicit `has_more`/`total_candidates` pagination guidance, query-branching for follow-ups, recommendation to prefer `batch_search` for multi-angle exploration. Also injects `get_topic_summary()` as a "Corpus topics" section the same way Chat does.

## Why

Users have observed Research returning smaller document sets than Chat on the same query. Primary suspected causes (diagnosed and agreed offline with a second agent review):

1. Synthesis was systematically blind to most retrieved evidence (the 1500 clip).
2. No batch-search tool meant the agent paid per-round cost for each phrasing it tried.
3. The prompt didn't explicitly tell the agent to go wide before going deep.

Not yet addressed (deliberately): the recall harness to measure the actual effect. That's a follow-up (#148) before any larger framework decisions.

## Test plan
- [ ] Run a broad Research query ("what does the corpus say about X") and confirm the agent uses `batch_search` at least once
- [ ] Confirm final report cites more distinct documents than before on the same query
- [ ] Confirm research notes in the UI show more than the first 2–3 hits per search result
- [ ] Confirm no regression on narrow factual queries
- [ ] Lint + format still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)