### PR TITLE
fix: research/chat token expiry and report display

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -55,7 +55,11 @@ function showReloadToast() {
   document.body.appendChild(bar)
 }
 
-async function refreshToken(): Promise<boolean> {
+export function currentToken(): string | null {
+  return getToken()
+}
+
+export async function refreshToken(): Promise<boolean> {
   try {
     const res = await fetch('/api/auth/refresh', {
       method: 'POST',

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react'
+import { currentToken, refreshToken } from '../api'
 import { useAuth } from '../auth'
 
 export interface RagContextChunk {
@@ -104,7 +105,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
 
       try {
-        const res = await fetch(`/api/chat/conversations/${conversationId}/messages`, {
+        let res = await fetch(`/api/chat/conversations/${conversationId}/messages`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -113,6 +114,21 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           body: JSON.stringify({ content }),
           signal: controller.signal,
         })
+
+        if (res.status === 401) {
+          const refreshed = await refreshToken()
+          if (refreshed) {
+            res = await fetch(`/api/chat/conversations/${conversationId}/messages`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${currentToken()}`,
+              },
+              body: JSON.stringify({ content }),
+              signal: controller.signal,
+            })
+          }
+        }
 
         if (!res.ok) {
           const err = await res.json().catch(() => ({ detail: res.statusText }))

--- a/frontend/src/contexts/ResearchContext.tsx
+++ b/frontend/src/contexts/ResearchContext.tsx
@@ -30,7 +30,7 @@ interface ResearchState {
   error: string | null
   conversationId: string | null
   completedToolCalls: ToolCallEntry[]
-  startResearch: (question: string, strategy?: string, timeLimitMinutes?: number, depth?: string) => Promise<void>
+  startResearch: (question: string, strategy?: string, timeLimitMinutes?: number, depth?: string) => Promise<boolean>
   resumeResearch: (convId: string) => Promise<void>
   cancelResearch: () => void
   reset: () => void
@@ -162,14 +162,13 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const startResearch = useCallback(
-    async (question: string, strategy?: string, timeLimitMinutes?: number, depth?: string) => {
-      if (!token) return
+    async (question: string, strategy?: string, timeLimitMinutes?: number, depth?: string): Promise<boolean> => {
+      if (!token) return false
 
-      // Clear error from previous attempts (e.g. 409) but don't touch
-      // running state — the old SSE stream may still be alive.
       setError(null)
 
       const controller = new AbortController()
+      let accepted = false
 
       try {
         const body: Record<string, unknown> = { question }
@@ -192,10 +191,10 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
           throw new Error(err.detail || `Research request failed (${res.status})`)
         }
 
-        // Server accepted — now safe to reset state for the new task
+        accepted = true
         const researchId = res.headers.get('X-Research-Id')
 
-        abortRef.current?.abort() // cancel previous stream if any
+        abortRef.current?.abort()
         abortRef.current = controller
         setIsRunning(true)
         setIsSynthesizing(false)
@@ -206,13 +205,14 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
 
         await processStream(res)
       } catch (e) {
-        if (e instanceof DOMException && e.name === 'AbortError') return
+        if (e instanceof DOMException && e.name === 'AbortError') return accepted
         setError(e instanceof Error ? e.message : 'An error occurred')
       } finally {
         setIsRunning(false)
         setIsSynthesizing(false)
         abortRef.current = null
       }
+      return accepted
     },
     [token, fetchWithRefresh, processStream],
   )

--- a/frontend/src/contexts/ResearchContext.tsx
+++ b/frontend/src/contexts/ResearchContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react'
+import { currentToken, refreshToken } from '../api'
 import { useAuth } from '../auth'
 
 export interface ToolCallEntry {
@@ -47,6 +48,19 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [completedToolCalls, setCompletedToolCalls] = useState<ToolCallEntry[]>([])
   const abortRef = useRef<AbortController | null>(null)
+
+  const fetchWithRefresh = useCallback(async (url: string, init: RequestInit): Promise<Response> => {
+    const res = await fetch(url, init)
+    if (res.status === 401) {
+      const refreshed = await refreshToken()
+      if (refreshed) {
+        const headers = new Headers(init.headers)
+        headers.set('Authorization', `Bearer ${currentToken()}`)
+        return fetch(url, { ...init, headers })
+      }
+    }
+    return res
+  }, [])
 
   const processStream = useCallback(async (res: Response) => {
     if (!res.ok) {
@@ -163,7 +177,7 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
         if (timeLimitMinutes) body.time_limit_minutes = timeLimitMinutes
         if (depth) body.depth = depth
 
-        const res = await fetch('/api/research', {
+        const res = await fetchWithRefresh('/api/research', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -200,7 +214,7 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
         abortRef.current = null
       }
     },
-    [token, processStream],
+    [token, fetchWithRefresh, processStream],
   )
 
   const resumeResearch = useCallback(
@@ -212,7 +226,7 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
       const controller = new AbortController()
 
       try {
-        const res = await fetch(`/api/research/${convId}/resume`, {
+        const res = await fetchWithRefresh(`/api/research/${convId}/resume`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -245,7 +259,7 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
         abortRef.current = null
       }
     },
-    [token, isRunning, processStream],
+    [token, isRunning, fetchWithRefresh, processStream],
   )
 
   const cancelResearch = useCallback(() => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -43,7 +43,12 @@ export default function ChatPage() {
   const { conversationId } = useParams<{ conversationId?: string }>()
   const navigate = useNavigate()
   const [conversations, setConversations] = useState<ConversationSummary[]>([])
-  const [input, setInput] = useState('')
+  const [input, setInputRaw] = useState(() => sessionStorage.getItem('chat_draft') ?? '')
+  const setInput = useCallback((v: string) => {
+    setInputRaw(v)
+    if (v) sessionStorage.setItem('chat_draft', v)
+    else sessionStorage.removeItem('chat_draft')
+  }, [])
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -179,36 +184,37 @@ export default function ChatPage() {
       if (!text || isStreaming || !hasActiveModel || contextFull) return
       setInput('')
 
-      // Reset textarea height
       if (inputRef.current) {
         inputRef.current.style.height = 'auto'
       }
 
-      let activeConvId = conversationId
-      if (!activeConvId) {
-        // Use the user's query as the title immediately (truncated)
-        const eagerTitle = text.length > 80 ? text.slice(0, 77) + '...' : text
-        const conv = await post<ConversationSummary>('/api/chat/conversations', {
-          title: eagerTitle,
-        })
-        activeConvId = conv.conversation_id
-        setConversations((prev) => [conv, ...prev])
-        // Navigate to the new conversation — context preserves streaming state across remount
-        navigate(`/c/${activeConvId}`, { replace: true })
-      }
-
-      await sendMessage(activeConvId, text, activeModelId || undefined).finally(() => {
-        if (lastTitle.current && activeConvId) {
-          setConversations((prev) =>
-            prev.map((c) => (c.conversation_id === activeConvId ? { ...c, title: lastTitle.current! } : c)),
-          )
+      try {
+        let activeConvId = conversationId
+        if (!activeConvId) {
+          const eagerTitle = text.length > 80 ? text.slice(0, 77) + '...' : text
+          const conv = await post<ConversationSummary>('/api/chat/conversations', {
+            title: eagerTitle,
+          })
+          activeConvId = conv.conversation_id
+          setConversations((prev) => [conv, ...prev])
+          navigate(`/c/${activeConvId}`, { replace: true })
         }
-        get<ConversationSummary[]>('/api/chat/conversations')
-          .then(setConversations)
-          .catch(() => {})
-      })
+
+        await sendMessage(activeConvId, text, activeModelId || undefined).finally(() => {
+          if (lastTitle.current && activeConvId) {
+            setConversations((prev) =>
+              prev.map((c) => (c.conversation_id === activeConvId ? { ...c, title: lastTitle.current! } : c)),
+            )
+          }
+          get<ConversationSummary[]>('/api/chat/conversations')
+            .then(setConversations)
+            .catch(() => {})
+        })
+      } catch {
+        setInput(text)
+      }
     },
-    [isStreaming, conversationId, sendMessage, lastTitle, hasActiveModel, activeModelId, contextFull],
+    [isStreaming, conversationId, sendMessage, lastTitle, hasActiveModel, activeModelId, contextFull, setInput],
   )
 
   const handleNewChat = useCallback(() => {

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -31,6 +31,8 @@ interface ResearchMessage {
 
 interface ResearchDetail extends ResearchSummary {
   question: string
+  depth: string | null
+  time_limit_minutes: number | null
   notes: string | null
   report: string | null
   model_id: string | null
@@ -712,6 +714,7 @@ export default function ResearchPage() {
                 <div className="mt-4 flex flex-wrap items-center gap-3 text-[11px] text-gray-400 dark:text-gray-500">
                   {selectedTask.model_id && <span>Model: {selectedTask.model_id}</span>}
                   <span className="capitalize">Strategy: {selectedTask.strategy}</span>
+                  {selectedTask.depth && <span className="capitalize">Depth: {selectedTask.depth}</span>}
                   <span>Rounds: {selectedTask.current_round}</span>
                   {selectedTask.completed_at && selectedTask.created_at && (
                     <span>
@@ -723,6 +726,7 @@ export default function ResearchPage() {
                             1000,
                         ),
                       )}
+                      {selectedTask.time_limit_minutes != null && ` / ${selectedTask.time_limit_minutes}m limit`}
                     </span>
                   )}
                 </div>

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -99,7 +99,12 @@ export default function ResearchPage() {
   const { isStreaming: chatStreaming } = useChat()
   const [history, setHistory] = useState<ResearchSummary[]>([])
   const [selectedTask, setSelectedTask] = useState<ResearchDetail | null>(null)
-  const [question, setQuestion] = useState('')
+  const [question, setQuestionRaw] = useState(() => sessionStorage.getItem('research_draft') ?? '')
+  const setQuestion = useCallback((v: string) => {
+    setQuestionRaw(v)
+    if (v) sessionStorage.setItem('research_draft', v)
+    else sessionStorage.removeItem('research_draft')
+  }, [])
   const [strategy, setStrategy] = useState<'search' | 'sweep'>('search')
   const [depth, setDepth] = useState<'light' | 'standard' | 'thorough'>('standard')
   const [timeLimit, setTimeLimit] = useState(30)
@@ -245,11 +250,11 @@ export default function ResearchPage() {
     const q = question.trim()
     if (!q) return
     setSelectedTask(null)
-    setQuestion('')
     setShowNewForm(false)
     hasAutoNavigatedRef.current = null
-    await startResearch(q, strategy, timeLimit, depth)
-  }, [question, strategy, timeLimit, depth, startResearch])
+    const accepted = await startResearch(q, strategy, timeLimit, depth)
+    if (accepted) setQuestion('')
+  }, [question, strategy, timeLimit, depth, startResearch, setQuestion])
 
   const handleResume = useCallback(
     async (convId: string) => {
@@ -281,7 +286,6 @@ export default function ResearchPage() {
 
   const handleNewResearch = useCallback(() => {
     setSelectedTask(null)
-    setQuestion('')
     if (!isRunning) reset()
     setShowNewForm(true)
     navigate('/research')

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -685,9 +685,15 @@ export default function ResearchPage() {
                 </div>
               )}
 
-              {/* Report — use context data only for the live/just-completed task */}
+              {/* Report — prefer context stream for the live/just-completed task,
+                 fall back to API data, and bridge the gap where selectedTask
+                 hasn't loaded yet but context report is still in memory */}
               {(() => {
-                const displayReport = isViewingLiveTask ? report || selectedTask?.report : selectedTask?.report
+                const sameTask = conversationId && selectedTask?.conversation_id === conversationId
+                const displayReport =
+                  sameTask || isViewingLiveTask
+                    ? report || selectedTask?.report
+                    : selectedTask?.report || (conversationId && !selectedTask ? report : null)
                 return displayReport ? (
                   <div className="rounded-xl bg-gray-50 dark:bg-gray-800/60 ring-1 ring-gray-100 dark:ring-gray-700/50 px-6 py-5">
                     <div className="prose-chat">

--- a/uv.lock
+++ b/uv.lock
@@ -2208,11 +2208,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Research and Chat SSE endpoints used raw `fetch()` bypassing the `api.ts` 401→refresh→retry logic — expired JWT after idle time showed "Token Expired" instead of silently refreshing
- Research report was invisible after completion until navigating away, because the auto-navigate race left a gap where neither the context `report` nor `selectedTask.report` was used for display
- Also fixed the same token-expiry issue in ChatContext for consistency

## Test plan
- [ ] Let session idle until JWT expires (~15 min), then start a Research task — should succeed without "Token Expired"
- [ ] Complete a Research task and verify the report renders immediately without needing to navigate away
- [ ] Same idle-token test for Chat
- [ ] Verify normal (non-expired) Research and Chat flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)