### PR TITLE
security: redact admin password leaked in forward-plan.md

### DIFF
--- a/research-debugging/forward-plan.md
+++ b/research-debugging/forward-plan.md
@@ -56,11 +56,17 @@ The helper script `/tmp/hc-research-debug/mcp.py` won't survive a reboot — re-
 
 ## Re-creating credentials (when the JWT expires or the session restarts)
 
+Ask the user for the admin email + password (do NOT hard-code them in any
+file, especially not one that will be checked in). The earlier revision of
+this file accidentally committed a literal password — that has since been
+redacted; the credential it contained should be considered compromised and
+rotated.
+
 ```bash
-# Login (admin)
+# Login (admin) — request the actual credentials from the user out-of-band
 JWT=$(curl -s -X POST http://127.0.0.1:8100/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"alex@bitblot.com","password":"Ceksos-gufsih-qubxu1"}' \
+  -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" \
   | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
 echo "$JWT" > /tmp/hc-research-debug/jwt
 


### PR DESCRIPTION
## Summary

**Hotfix.** PR #218 included `research-debugging/forward-plan.md`, which contained a literal admin password that the user had supplied out-of-band during the research debugging session. That file landed in main at commit 0303a22.

This PR replaces the literal credential with `$ADMIN_EMAIL` / `$ADMIN_PASSWORD` placeholder variables and adds an explicit note in the file flagging that the prior revision leaked a password and that the credential should be rotated.

## ⚠️ Action required: rotate the admin password

Redacting the file in a new commit does **not** remove the credential from git history. It remains visible at the merge commit 0303a22 of PR #218 (path `research-debugging/forward-plan.md` line 63 of that revision). The credential should be considered compromised and rotated.

If the repo is private and no one else has cloned/forked it, an alternative is to rewrite history (force-push) — but the simpler / safer move is to rotate the password.

## Why this happened, and how I will prevent it

I wrote the credential into the forward-plan doc as a "how to resume the work" note for the next conversation, treating the conversation context as ephemeral. I did not consider that the doc would land in the public-history of a committed PR. Adding a personal-memory rule to never write credentials into a checked-in file regardless of intended scope; future credential-recreation recipes will require the credential to be supplied at use-time (from the environment, from the user, or from a secrets manager).

## Test plan

- [x] `grep -rn "Ceksos-gufsih-qubxu1" .` in the worktree — no hits
- [x] Same grep against `/tmp/hc-research-debug/` — no hits (also wiped the local sweep scripts that contained it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
