### PR TITLE
improve(research): supports_research flag + curated-model recommendations

### DIFF
--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -8,6 +8,7 @@ interface ModelInfo {
   size_bytes: number
   context_window: number
   supports_tools: boolean
+  supports_research: boolean
   downloaded: boolean
   active: boolean
   downloading: boolean
@@ -267,6 +268,7 @@ export default function ModelsPage() {
               <th className="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-300">Size</th>
               <th className="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-300">Context</th>
               <th className="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-300">Tools</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-300">Research</th>
               <th className="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-300">Status</th>
               <th className="px-4 py-3 text-right font-medium text-gray-700 dark:text-gray-300">Actions</th>
             </tr>
@@ -290,7 +292,7 @@ export default function ModelsPage() {
                 <Fragment key={tier.label}>
                   <tr>
                     <td
-                      colSpan={6}
+                      colSpan={7}
                       className="bg-(--color-bg-secondary) px-4 py-2 text-left text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                     >
                       {tier.label}
@@ -323,6 +325,20 @@ export default function ModelsPage() {
                           ) : (
                             <span className="inline-flex items-center rounded-md bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-[11px] text-gray-500 dark:text-gray-400">
                               No
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3">
+                          {model.supports_research ? (
+                            <span className="inline-flex items-center rounded-md bg-green-100 dark:bg-green-900/30 px-2 py-0.5 text-[11px] font-medium text-green-700 dark:text-green-400">
+                              Yes
+                            </span>
+                          ) : (
+                            <span
+                              className="inline-flex items-center rounded-md bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-400"
+                              title="Not recommended for Research mode — chat works fine"
+                            >
+                              Chat only
                             </span>
                           )}
                         </td>

--- a/src/harbor_clerk/api/routes/chat.py
+++ b/src/harbor_clerk/api/routes/chat.py
@@ -294,6 +294,7 @@ async def list_available_models(
             size_bytes=m.size_bytes,
             context_window=m.context_window,
             supports_tools=m.supports_tools,
+            supports_research=m.supports_research,
             downloaded=m.id in downloaded,
             active=m.id == settings.llm_model_id,
             downloading=is_downloading(m.id),

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -214,6 +214,23 @@ async def start_research(
             detail="No LLM model configured. Select and activate a model in Settings.",
         )
 
+    # Block research on models that aren't reliable in research mode (e.g.
+    # SmolLM3 3B, which confabulates without citations on most topics).
+    # Chat mode is unaffected — only POST /research enforces this.
+    from harbor_clerk.llm.models import get_model
+
+    active_model = get_model(settings.llm_model_id)
+    if active_model is not None and not active_model.supports_research:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"The active model ({active_model.name}) is not recommended for "
+                "Research mode and is disabled for it. Activate a different model "
+                "(e.g. Qwen3.6 35B-A3B for narrative summaries, GPT-OSS 20B for "
+                "comparative reports, Gemma 4 26B-A4B for general use) in Settings."
+            ),
+        )
+
     # Determine strategy
     strategy = body.strategy or default_research_strategy(settings.llm_model_id)
 

--- a/src/harbor_clerk/api/schemas/chat.py
+++ b/src/harbor_clerk/api/schemas/chat.py
@@ -53,6 +53,7 @@ class ModelOut(BaseModel):
     size_bytes: int
     context_window: int
     supports_tools: bool
+    supports_research: bool = True
     downloaded: bool
     active: bool
     downloading: bool = False

--- a/src/harbor_clerk/llm/models.py
+++ b/src/harbor_clerk/llm/models.py
@@ -1,4 +1,19 @@
-"""Curated model registry for local LLM inference."""
+"""Curated model registry for local LLM inference.
+
+Notes from the cross-topic research sweep (research-debugging/
+cross-topic-analysis.md, 2026-04-28):
+
+- Best for narrative/historical questions: Qwen3.6 35B-A3B. Strongest
+  document-shaped output (executive summary, themed sections). Prefer
+  for questions like "trace the evolution of X" or "what does the
+  corpus document about Y over time".
+- Best for comparative/tabular questions: GPT-OSS 20B. Natively uses
+  markdown tables; highest citation density across the sweep.
+- Reliable mid-size pick: Gemma 4 26B-A4B. Consistent, somewhat terse.
+- Not recommended for research mode: SmolLM3 3B. Confabulated
+  off-topic content from query keywords without producing citations
+  on 2 of 3 sweep topics. Marked supports_research=False below.
+"""
 
 from __future__ import annotations
 
@@ -25,6 +40,12 @@ class ModelInfo:
     context_window: int
     supports_tools: bool
     yarn: YarnConfig | None = None  # None = YaRN not applicable
+    # Whether this model is recommended for Research mode. Set False for
+    # models that have demonstrated unreliable behaviour in research (e.g.
+    # confabulating from query keywords without citations). Chat mode and
+    # MCP-driven external use is unaffected. The API blocks starting a
+    # Research task when the active model has supports_research=False.
+    supports_research: bool = True
 
 
 MODELS: dict[str, ModelInfo] = {
@@ -87,6 +108,11 @@ MODELS: dict[str, ModelInfo] = {
             context_window=65536,
             supports_tools=True,
             yarn=YarnConfig(extended_context=131072, rope_scale=2.0, original_context=65536),
+            # Disabled for research mode: in the cross-topic sweep, SmolLM3
+            # produced 0 citations on 2 of 3 topics and confabulated content
+            # from seeded query keywords (e.g. presented "Argan and Levain
+            # cultures" as cheese-making traditions). Chat-mode use is fine.
+            supports_research=False,
         ),
         ModelInfo(
             id="gpt-oss-20b",


### PR DESCRIPTION
## Summary

Combines the last two analysis items into one small PR — both touch the model registry.

### `supports_research` flag (item 3)

A new boolean on `ModelInfo`, default `True`. Set to `False` for SmolLM3 3B based on its cross-topic sweep behaviour: 0 citations on 2 of 3 topics, confabulated content from seeded query keywords (`Argan and Levain cultures` presented as cheese traditions in the cheese run, etc.). Chat-mode use is fine — only Research mode is gated.

The flag flows through:
- `api/schemas/chat.py:ModelOut.supports_research`
- `GET /chat/models` returns it
- `POST /research` returns **HTTP 400** when the active model has the flag `False`, with a message recommending the alternatives that performed well in the sweep (Qwen3.6 35B-A3B for narrative, GPT-OSS 20B for comparative, Gemma 4 26B-A4B for general)
- Frontend Models page gets a new **Research** column showing "Yes" (green) or "Chat only" (amber)

Per-model overrides aren't part of this PR — if there's demand to force-enable research on a gated model, it can be added later as a deliberate opt-in.

### Curated-model documentation (item 6)

Module docstring on `llm/models.py` records the cross-topic-sweep recommendations:

- **Best for narrative/historical** questions ("trace the evolution of X"): Qwen3.6 35B-A3B
- **Best for comparative/tabular** questions ("compare X across Y"): GPT-OSS 20B
- **Reliable mid-size pick**: Gemma 4 26B-A4B
- **Not recommended for research**: SmolLM3 3B

Inline comment on the SmolLM3 `ModelInfo` explains the flag so a future maintainer doesn't undo it without checking the data.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] `npm run lint` (warnings only, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run build` — pass
- [ ] After install + Mac client restart: verify `POST /research` while SmolLM3 is the active model returns 400 with the helpful message
- [ ] Verify Models page shows "Chat only" amber badge on the SmolLM3 row and "Yes" green on the others
- [ ] Verify chat with SmolLM3 still works (gating is research-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
