### PR TITLE
feat(auth): user-facing password change flow

### DIFF
--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -1,4 +1,6 @@
+import { FormEvent, useState } from 'react'
 import { useAuth } from '../auth'
+import { post } from '../api'
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
 
@@ -54,7 +56,114 @@ export default function PreferencesPage() {
             ))}
           </select>
         </div>
+
+        <ChangePasswordCard />
       </div>
+    </div>
+  )
+}
+
+function ChangePasswordCard() {
+  const [current, setCurrent] = useState('')
+  const [next, setNext] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSuccess(false)
+    if (next !== confirm) {
+      setError('New password and confirmation do not match.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await post('/api/me/password', { current_password: current, new_password: next })
+      setSuccess(true)
+      setCurrent('')
+      setNext('')
+      setConfirm('')
+    } catch (e) {
+      // The api.post helper rejects on non-2xx with the response text.
+      // The endpoint returns either a string detail or {detail: {errors: [...]}}
+      // for password-validation failures.
+      let msg = 'Failed to change password.'
+      if (e instanceof Error) {
+        msg = e.message
+        try {
+          const parsed = JSON.parse(msg)
+          if (parsed?.detail?.errors && Array.isArray(parsed.detail.errors)) {
+            msg = parsed.detail.errors.join(' • ')
+          } else if (typeof parsed?.detail === 'string') {
+            msg = parsed.detail
+          }
+        } catch {
+          // not JSON — leave msg as-is
+        }
+      }
+      setError(msg)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-6">
+      <h2 className="mb-1 text-sm font-medium text-gray-900 dark:text-gray-100">Change password</h2>
+      <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        Requires your current password. New password must be at least 12 characters and contain upper, lower, and digit.
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-3 max-w-md">
+        <input
+          type="password"
+          autoComplete="current-password"
+          placeholder="Current password"
+          value={current}
+          onChange={(e) => setCurrent(e.target.value)}
+          required
+          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+        />
+        <input
+          type="password"
+          autoComplete="new-password"
+          placeholder="New password"
+          value={next}
+          onChange={(e) => setNext(e.target.value)}
+          required
+          minLength={12}
+          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+        />
+        <input
+          type="password"
+          autoComplete="new-password"
+          placeholder="Confirm new password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          required
+          minLength={12}
+          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+        />
+        {error && (
+          <div className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="rounded-md bg-green-50 dark:bg-green-900/20 px-3 py-2 text-sm text-green-700 dark:text-green-400">
+            Password updated.
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={submitting || !current || !next || !confirm}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? 'Updating…' : 'Update password'}
+        </button>
+      </form>
     </div>
   )
 }

--- a/src/harbor_clerk/api/routes/auth.py
+++ b/src/harbor_clerk/api/routes/auth.py
@@ -8,17 +8,25 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.api.deps import Principal, get_current_principal
-from harbor_clerk.api.schemas.auth import LoginRequest, LoginResponse, PreferencesUpdate, UserInfo
+from harbor_clerk.api.schemas.auth import (
+    LoginRequest,
+    LoginResponse,
+    PasswordChangeRequest,
+    PreferencesUpdate,
+    UserInfo,
+)
 from harbor_clerk.audit import log_audit
 from harbor_clerk.auth import (
     create_access_token,
     create_refresh_token,
     decode_token,
+    hash_password,
     verify_password,
 )
 from harbor_clerk.config import get_settings
 from harbor_clerk.db import get_session
 from harbor_clerk.models import User
+from harbor_clerk.password_validation import validate_password
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["auth"])
@@ -211,3 +219,69 @@ async def update_preferences(
         role=user.role.value,
         preferences=user.preferences or {},
     )
+
+
+@router.post("/me/password", status_code=status.HTTP_204_NO_CONTENT)
+async def change_password(
+    body: PasswordChangeRequest,
+    principal: Principal = Depends(get_current_principal),
+    session: AsyncSession = Depends(get_session),
+):
+    """Change the authenticated user's password.
+
+    Requires the current password to be supplied. The new password is
+    validated by `password_validation.validate_password` and stored as a
+    fresh bcrypt hash. The existing access token remains valid until
+    expiry; the refresh-token cookie is unchanged. Other sessions for
+    this user are NOT invalidated by this endpoint — that's a follow-up
+    when there's a session-revocation surface to plumb into.
+    """
+    if principal.type != "user":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="API keys cannot change a user's password",
+        )
+
+    result = await session.execute(select(User).where(User.user_id == principal.id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    # Verify the current password before allowing the change. This both
+    # confirms the request is from a still-authorised holder of the
+    # password (not just someone who stole an access token) and gives a
+    # clear error path if the user is mistaken about what their current
+    # password is.
+    if not verify_password(body.current_password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Current password is incorrect",
+        )
+
+    # Reject reusing the same password
+    if verify_password(body.new_password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="New password must differ from the current password",
+        )
+
+    errors = validate_password(body.new_password, user.email)
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"errors": errors},
+        )
+
+    new_hash = hash_password(body.new_password)
+    await session.execute(
+        update(User).where(User.user_id == principal.id).values(password_hash=new_hash),
+    )
+    await log_audit(
+        session,
+        user_id=user.user_id,
+        action="change_password",
+        target_type="user",
+        target_id=user.user_id,
+    )
+    await session.commit()
+    return None

--- a/src/harbor_clerk/api/schemas/auth.py
+++ b/src/harbor_clerk/api/schemas/auth.py
@@ -26,3 +26,8 @@ class UserInfo(BaseModel):
 class PreferencesUpdate(BaseModel):
     theme: str | None = None
     page_size: int | None = None
+
+
+class PasswordChangeRequest(BaseModel):
+    current_password: str
+    new_password: str


### PR DESCRIPTION
## Summary

Adds a self-service password change flow so a logged-in user can rotate their own password without admin intervention. There was previously no way for a user to change their password through the API or UI — admin-set passwords could only be changed by going around the app.

### Backend — `POST /api/me/password`

- New `PasswordChangeRequest` schema (`current_password`, `new_password`)
- Endpoint returns `204 No Content` on success
- Rejects API-key principals (humans only — keeps key surface read-only)
- Verifies the supplied current password before allowing any change
- Rejects re-using the existing password (`422`)
- Runs `validate_password()` against the new password (length, character classes, email-similarity) and returns `422` with `{detail: {errors: [...]}}` so the UI can list each rule violation
- Logs an `audit_log` row with `action="change_password"`
- Hashes via the same bcrypt helper used at user creation

### Frontend — Preferences page

- New "Change password" card below the existing Theme / Page-size cards
- Three password inputs (current / new / confirm), client-side mismatch guard
- Parses the structured 422 body so the UI shows the policy reasons in one readable line
- Inputs clear on success, success/error banners shown inline

### Out of scope

- Admin-resets-other-user
- Session / refresh-token revocation on password change (existing tokens stay valid until natural expiry — documented in the route docstring)
- Forgotten-password reset flow

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] `npm run lint` (warnings only, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run build` — pass
- [ ] After install + restart: log in, navigate to Preferences, change password, log out, log in with the new one
- [ ] Verify wrong current password returns 401 with "Current password is incorrect"
- [ ] Verify mismatched confirmation surfaces a client-side error (no API call)
- [ ] Verify a too-short / weak new password surfaces the validator's list of violated rules
- [ ] Verify reusing the existing password is rejected (422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
