### PR TITLE
improve(research): retry synthesis on ConnectError; downgrade fallback log

### DIFF
--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -216,9 +216,14 @@ async def _llm_complete(
             # than nothing for downstream synthesis or parsing.
             reasoning_content = message.get("reasoning_content") or ""
             if not content.strip() and reasoning_content.strip():
-                logger.warning(
-                    "LLM phase=%s: content empty but reasoning_content has %d chars; "
-                    "falling back to reasoning_content (model likely capped during thinking).",
+                # Confirmed via the cross-topic sweep that this is a
+                # normal path on reasoning-tuned models (GPT-OSS 20B in
+                # particular routes the entire response through the
+                # reasoning channel even with enable_thinking=False).
+                # Logged at INFO rather than WARNING so it doesn't show
+                # up as an alert-worthy event in normal operation.
+                logger.info(
+                    "LLM phase=%s: content empty, falling back to reasoning_content (%d chars).",
                     phase,
                     len(reasoning_content),
                 )
@@ -280,15 +285,29 @@ async def _stream_llm_tokens(
 
     response_obj = None
     for _attempt in range(2):
-        response_obj = await client.send(
-            client.build_request(
-                "POST",
-                url,
-                json=payload,
-                extensions={"timeout": {"connect": 10.0, "read": timeout, "write": 10.0, "pool": 10.0}},
-            ),
-            stream=True,
-        )
+        try:
+            response_obj = await client.send(
+                client.build_request(
+                    "POST",
+                    url,
+                    json=payload,
+                    extensions={"timeout": {"connect": 10.0, "read": timeout, "write": 10.0, "pool": 10.0}},
+                ),
+                stream=True,
+            )
+        except httpx.ConnectError as exc:
+            # Transient: llama-server briefly unreachable between requests
+            # (observed once on cheese × Qwen3.6 35B-A3B during the
+            # cross-topic sweep — succeeded on retry). Mirror the 5xx
+            # branch's semantics: one extra attempt with 2s backoff. Read
+            # and write timeouts are intentionally NOT retried — those
+            # mean the model itself stalled mid-stream and starting over
+            # would discard partial output for no gain.
+            if _attempt == 1:
+                raise
+            logger.warning("LLM connect error in synthesis: %r, retrying in 2s", exc)
+            await asyncio.sleep(2)
+            continue
         if response_obj.status_code < 500 or _attempt == 1:
             break
         await response_obj.aclose()
@@ -328,10 +347,11 @@ async def _stream_llm_tokens(
         # empty report.
         if content_emitted_chars == 0 and reasoning_buffer:
             joined = "".join(reasoning_buffer)
-            logger.warning(
-                "Synthesis stream produced no content tokens; falling back to "
-                "%d chars of reasoning_content. Model likely ignores "
-                "enable_thinking=False or capped during thinking.",
+            # Same rationale as the fallback in `_llm_complete`: confirmed
+            # to be a normal path on GPT-OSS / DeepSeek-R1 streaming;
+            # logged at INFO so a normal run doesn't look alarming.
+            logger.info(
+                "Synthesis stream emitted no content tokens; falling back to %d chars of reasoning_content.",
                 len(joined),
             )
             yield joined


### PR DESCRIPTION
## Summary

Two follow-ups from `research-debugging/cross-topic-analysis.md`:

### 1. Retry streaming synthesis on `ConnectError`

The non-streaming LLM path (`_llm_complete`) already retries once on `httpx.ConnectError` / `TimeoutException`. The streaming path (`_stream_llm_tokens`) only retried on 5xx. During the cross-topic sweep one run (cheese × Qwen3.6 35B-A3B) was marked `interrupted` because llama-server was briefly unreachable between requests — the same prompt succeeded on manual retry. `_stream_llm_tokens` now mirrors `_llm_complete`: catch `ConnectError` (which includes `ConnectTimeout`), 2 s backoff, retry once, then re-raise.

Read/write timeouts mid-stream are intentionally **not** retried — those mean the model itself stalled, and restarting would discard partial output for no gain.

### 2. Downgrade the `reasoning_content` fallback log: WARNING → INFO

When `content` is empty but `reasoning_content` has text, both LLM paths fall back to the reasoning channel. Originally logged at WARNING because we didn't know how often it would fire. The cross-topic sweep confirmed it's a normal path on reasoning-tuned models (GPT-OSS 20B in particular routes the entire response through the reasoning channel even with `enable_thinking=False`). INFO is the right level for "normal operation on certain models."

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] Import sanity (`from harbor_clerk.llm.research import _stream_llm_tokens, _llm_complete`) — pass
- [ ] After install + restart: kick off a research run on GPT-OSS 20B and confirm the fallback log line shows up at INFO, not WARNING
- [ ] (Hard to reproduce intentionally) verify a synthesis run survives a transient connection refusal — would need to bounce llama-server during a synthesis stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
