### PR TITLE
fix(macos): bundle install pipeline — llama dylibs + portable pip

### DIFF
--- a/macos/scripts/build-llama.sh
+++ b/macos/scripts/build-llama.sh
@@ -31,6 +31,28 @@ echo "==> Copying llama-server binary"
 cp build/bin/llama-server "$DEST_DIR/llama-server"
 chmod +x "$DEST_DIR/llama-server"
 
+# Copy the sibling dylibs (libllama, libggml*, libmtmd, ...) that
+# llama-server links against. Without these, the binary's @rpath load
+# commands fail (the build-time rpath points to the build directory,
+# which is gone after `make clean`), and dyld errors out before the
+# server can start. The `-a` flag preserves symlinks so the major-version
+# and unversioned symlinks remain valid.
+echo "==> Copying llama dylibs"
+cp -a build/bin/*.dylib "$DEST_DIR/"
+
+# Make llama-server's rpath portable: drop the build-time absolute path
+# and add @loader_path so dyld resolves the dylibs next to the binary
+# regardless of where the bundle ends up installed. Without this, the
+# binary fails to launch with "Library not loaded: @rpath/libmtmd.0.dylib"
+# the moment the build directory is cleaned. `-delete_rpath` is
+# best-effort: clobber-tolerant for the case where the build-time
+# absolute path isn't actually present (e.g. a future cmake change).
+echo "==> Fixing llama-server rpath"
+BUILD_RPATH="$BUILD_DIR/llama.cpp/build/bin"
+install_name_tool -delete_rpath "$BUILD_RPATH" "$DEST_DIR/llama-server" 2>/dev/null || true
+install_name_tool -add_rpath @loader_path "$DEST_DIR/llama-server"
+codesign --force --sign - "$DEST_DIR/llama-server"
+
 # Copy Metal shader library if present
 if [ -f build/bin/default.metallib ]; then
     cp build/bin/default.metallib "$DEST_DIR/default.metallib"

--- a/macos/scripts/build-venv.sh
+++ b/macos/scripts/build-venv.sh
@@ -81,5 +81,22 @@ for script in "$VENV_DIR/bin/"*; do
     fi
 done
 
+# The shebang patch above (#!/usr/bin/env python3) is fine for entry
+# points launched by the bundled app via known absolute paths, but it's
+# a footgun for `pip`: an operator running the venv's pip from a shell
+# where another `python3` (Homebrew, asdf, system) is first on PATH will
+# silently install into THAT Python's site-packages and assume the
+# bundled venv was updated. The wrapper below resolves the venv's python
+# relative to the wrapper's own location, which is stable wherever the
+# bundle ends up installed.
+for pip_script in "$VENV_DIR/bin/"pip*; do
+    [ -f "$pip_script" ] || continue
+    cat > "$pip_script" <<'SH'
+#!/bin/sh
+exec "$(dirname "$0")/python3" -m pip "$@"
+SH
+    chmod +x "$pip_script"
+done
+
 echo "==> Venv installed to ${VENV_DIR}"
 echo "==> Size: $(du -sh "$VENV_DIR" | cut -f1)"


### PR DESCRIPTION
## Summary

Two bundle-install bugs that have bitten us repeatedly during recent install cycles. Both surfaced cleanly this session — fixing at the source.

### 1. `build-llama.sh` — dylibs left behind, rpath unportable

The script copied only `llama-server` to `$DEST_DIR`. Every sibling dylib (`libllama`, `libggml-*`, `libmtmd`, …) stayed in the build directory. The binary's only `LC_RPATH` was that absolute build-time path. Once `make clean` ran, dyld couldn't load any dependency and the server failed at launch with `Library not loaded: @rpath/libmtmd.0.dylib`.

Fix: copy every `*.dylib` from `build/bin/` (preserving symlinks for the major-version aliases), drop the build-time rpath via `install_name_tool -delete_rpath`, and add `@loader_path` so the dylibs resolve next to the binary regardless of where the bundle ends up. Re-codesign after rewriting load commands.

### 2. `build-venv.sh` — `pip` invokes the wrong Python

The shebang patch (`#!/usr/bin/env python3`, lines 78-82) is fine for entry points launched by the bundled app via known absolute paths, but it's a footgun for `pip` invoked manually from a shell: whatever `python3` is first on `PATH` (Homebrew, asdf, system) wins, and `pip install` silently writes to **that** Python's site-packages instead of the bundled venv. The operator sees "Successfully installed" and assumes the bundle was updated.

Concretely, this caused the password-change rollout to require a manual file-copy fallback because `pip show -f harbor-clerk` reported `Location: /opt/homebrew/lib/python3.14/site-packages` despite being run from the bundled venv's pip.

Fix: replace `pip`, `pip3`, `pip3.12` with a one-line shell wrapper that exec's the bundled venv's `python3` via the wrapper's own directory, so it always targets the bundled venv regardless of PATH:

```sh
#!/bin/sh
exec "$(dirname "$0")/python3" -m pip "$@"
```

Other entry points (alembic, harbor-clerk-api, …) keep the `#!/usr/bin/env python3` patch since they're invoked via known absolute paths.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Applied the pip wrapper fix to the running bundle as a one-off; `pip show harbor-clerk` now reports the bundled venv's site-packages
- [ ] After merge: full `make clean && make all` to verify the build produces a launchable bundle on a fresh build dir (the failure mode is `make clean` deleting the rpath target)
- [ ] Confirm `bundle/.../venv/bin/pip install --upgrade /path/to/harbor-clerk` actually updates files under `bundle/.../venv/lib/python3.12/site-packages/harbor_clerk/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
