### PR TITLE
fix(macos): LLM port release on stop; remove dead config FSEvents path

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -37,16 +37,15 @@ final class ServiceManager: ObservableObject {
     weak var healthChecker: HealthChecker?
 
     private var startAllInProgress = false
-    private var configWatcherSource: DispatchSourceFileSystemObject?
-    private var configFileDescriptor: Int32 = -1
     private var configChangeTask: Task<Void, Never>?
     private var configWatcherActive = false
     private var lastLlmModelId: String = ""
-    /// Belt-and-suspenders mtime poller — the FSEvents-based watcher
-    /// drops events in practice (cause unclear; see project memory note
-    /// "Swift config watcher silently drops config.json events"), and
-    /// the user has to restart the whole app to pick up model switches.
-    /// This poller catches anything the dispatch source missed.
+    /// 3-second mtime poller for config.json. We previously had a
+    /// DispatchSource FSEvents watcher in addition, but it dropped events
+    /// in practice (cause never diagnosed), forcing the user to relaunch
+    /// the app to pick up model switches. The poller proved sufficient
+    /// across the cross-topic research sweep, so the FSEvents path was
+    /// removed to leave one source of truth.
     private var configPollTimer: DispatchSourceTimer?
     private var lastConfigMtime: Date = .distantPast
 
@@ -666,53 +665,29 @@ final class ServiceManager: ObservableObject {
     // MARK: - Config file watcher
 
     /// Start watching config.json for changes from the Python side.
+    ///
+    /// Implementation: a 3-second mtime poller. We previously also wired
+    /// a DispatchSource FSEvents watcher for instant response, but it
+    /// silently dropped events in practice (cause never diagnosed) and
+    /// the user had to relaunch the whole app to pick up model switches.
+    /// The poller covered every observed change across the cross-topic
+    /// sweep, so the FSEvents path was removed to leave one code path
+    /// to reason about. 3 s is fast enough for the model-switch UX
+    /// (the full restart costs ~5 s anyway) and cheap (one stat per
+    /// tick).
     func startConfigWatcher() {
         configWatcherActive = true
         let settings = AppSettings.shared
         lastLlmModelId = settings.llmModelId
         let path = settings.configURL.path
 
-        // Capture initial mtime so the poller has a starting baseline.
+        // Seed the mtime baseline so the first tick doesn't fire on
+        // whatever the file already contains.
         if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
            let mtime = attrs[.modificationDate] as? Date {
             lastConfigMtime = mtime
         }
 
-        let fd = open(path, O_EVTONLY)
-        guard fd >= 0 else {
-            Log.logger("lifecycle").error("Cannot open config.json for watching")
-            return
-        }
-        configFileDescriptor = fd
-
-        let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fd,
-            eventMask: [.write, .rename],
-            queue: .global(qos: .utility)
-        )
-        source.setEventHandler { [weak self] in
-            // After an atomic write (rename), the fd points to the old inode.
-            // Re-create the watcher to track the new file.
-            let flags = source.data
-            Task { @MainActor in
-                Log.logger("lifecycle").info("config.json watcher fired (flags: \(flags.rawValue, privacy: .public))")
-                self?.handleConfigChange()
-                if flags.contains(.rename) {
-                    self?.stopConfigWatcher()
-                    self?.startConfigWatcher()
-                }
-            }
-        }
-        source.setCancelHandler {
-            close(fd)
-        }
-        source.resume()
-        configWatcherSource = source
-
-        // Belt-and-suspenders: poll mtime every 3s. The dispatch-source path
-        // above is preferred (instant), but it has been observed to silently
-        // drop events. The poller guarantees model-switch / llm_restart
-        // signals from Python eventually take effect.
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
         timer.schedule(deadline: .now() + .seconds(3), repeating: .seconds(3))
         timer.setEventHandler { [weak self] in
@@ -725,7 +700,7 @@ final class ServiceManager: ObservableObject {
                 self.lastConfigMtime = mtime
                 Task { @MainActor in
                     Log.logger("lifecycle").info(
-                        "config.json mtime changed (\(prev.timeIntervalSince1970, privacy: .public) → \(mtime.timeIntervalSince1970, privacy: .public)) — running handleConfigChange via poller")
+                        "config.json mtime changed (\(prev.timeIntervalSince1970, privacy: .public) → \(mtime.timeIntervalSince1970, privacy: .public)) — running handleConfigChange")
                     self.handleConfigChange()
                 }
             }
@@ -738,9 +713,6 @@ final class ServiceManager: ObservableObject {
         configWatcherActive = false
         configChangeTask?.cancel()
         configChangeTask = nil
-        configWatcherSource?.cancel()
-        configWatcherSource = nil
-        configFileDescriptor = -1
         configPollTimer?.cancel()
         configPollTimer = nil
     }

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -79,25 +79,82 @@ final class LlamaService: ManagedService {
 
     func stop() async {
         state = .stopping
-        guard let proc = process, proc.isRunning else {
-            state = .stopped
-            return
-        }
-        proc.terminate() // SIGTERM
-        // Model unload can be slow — 10s grace, then SIGKILL
-        DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
-            guard proc.isRunning else { return }
-            Log.logger("lifecycle").warning("LLM still running after 10s, sending SIGKILL")
-            kill(proc.processIdentifier, SIGKILL)
-        }
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                c.resume()
+
+        if let proc = process, proc.isRunning {
+            proc.terminate() // SIGTERM
+            // Model unload can be slow — 10s grace, then SIGKILL
+            DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
+                guard proc.isRunning else { return }
+                Log.logger("lifecycle").warning("LLM still running after 10s, sending SIGKILL")
+                kill(proc.processIdentifier, SIGKILL)
+            }
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                DispatchQueue.global().async {
+                    proc.waitUntilExit()
+                    c.resume()
+                }
             }
         }
         process = nil
+
+        // Belt-and-suspenders: confirm the LLM port is actually released
+        // before declaring stop complete. waitUntilExit() returns when the
+        // tracked Process tears down, but in practice subsequent start()s
+        // have failed with "couldn't bind HTTP server socket" — usually an
+        // orphan llama-server from an earlier crash that the Process
+        // object never knew about (e.g. across an app relaunch). Probe
+        // the port and force-kill any straggler before returning, so the
+        // next start() always begins with a free socket.
+        await ensurePortReleased(timeout: 5.0)
+
         state = .stopped
+    }
+
+    /// Wait up to `timeout` for the LLM port to be released, then
+    /// SIGKILL anything still holding it. Cheap when the port is
+    /// already free.
+    private func ensurePortReleased(timeout: TimeInterval) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await pidsHoldingPort().isEmpty { return }
+            try? await Task.sleep(nanoseconds: 200_000_000) // 200 ms
+        }
+        let stragglers = await pidsHoldingPort()
+        guard !stragglers.isEmpty else { return }
+        Log.logger("lifecycle").warning(
+            "LLM port \(self.port, privacy: .public) still held after stop; force-killing pids \(stragglers, privacy: .public)"
+        )
+        for pid in stragglers {
+            kill(pid, SIGKILL)
+        }
+        // Brief pause for the kernel to release the socket.
+        try? await Task.sleep(nanoseconds: 500_000_000) // 500 ms
+    }
+
+    /// Return PIDs (if any) currently bound to the LLM port. Uses lsof
+    /// off the main thread.
+    private func pidsHoldingPort() async -> [Int32] {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        proc.arguments = ["-ti", "tcp:\(self.port)"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+        } catch {
+            return []
+        }
+        return await withCheckedContinuation { (c: CheckedContinuation<[Int32], Never>) in
+            DispatchQueue.global().async {
+                proc.waitUntilExit()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let pids = (String(data: data, encoding: .utf8) ?? "")
+                    .split(whereSeparator: \.isNewline)
+                    .compactMap { Int32($0.trimmingCharacters(in: .whitespaces)) }
+                c.resume(returning: pids)
+            }
+        }
     }
 
     func healthCheck() async -> Bool {


### PR DESCRIPTION
## Summary

Two follow-ups from `research-debugging/cross-topic-analysis.md` "Known issues remaining" — items 1 and 3.

### 1. `LlamaService.stop()` now confirms the LLM port is free before returning

`waitUntilExit()` blocks until the tracked `Process` tears down, but the next `start()` has been observed to fail with *"couldn't bind HTTP server socket, port: 8102"* — most commonly because an orphan llama-server from an earlier crash is still holding the port and the macOS app's `Process` object has no record of it (orphan persists across app relaunches). The sweep script worked around it with a defensive force-kill; this is the proper fix in the app.

After `waitUntilExit`, the new `ensurePortReleased(timeout:)` probes the port via `lsof` (200 ms cadence, up to 5 s) and `SIGKILL`s any remaining holder before declaring stop complete. Cheap when the port is already free — the first lsof returns no PIDs and we return immediately. Only the rare orphan path actually exercises the kill.

### 2. Remove the DispatchSource FSEvents config-watcher

We previously ran an `FSEventsFileSystemObject` watcher *plus* a 3-second mtime poller, because the FSEvents path silently dropped events (cause never diagnosed) and forced full app restarts to pick up model switches. The mtime poller covered every observed change across the cross-topic research sweep, so the FSEvents code is no longer load-bearing.

Removing it: dead code rotted on us once already (`handleConfigChange` never firing); keeping it as "belt-and-suspenders" just clutters the lifecycle path. 3-second detection latency is fine — the actual model-switch restart costs ~5 s anyway.

Removed:
- `configWatcherSource: DispatchSourceFileSystemObject?` field
- `configFileDescriptor: Int32` field
- `DispatchSource.makeFileSystemObjectSource` setup in `startConfigWatcher`
- The matching `source.cancel()` / `close(fd)` cleanup in `stopConfigWatcher`

Kept (still needed for the poller): `configPollTimer`, `lastConfigMtime`, `lastLlmModelId`, `configWatcherActive`, `configChangeTask`.

## Test plan

- [x] `xcodebuild build -scheme HarborClerkServer` — pass
- [x] `xcodebuild test` — 49/49 passing
- [ ] After `make apps` + reinstall: switch model from Preferences and confirm the LLM service comes up on the new model within ~5 s (no app relaunch needed)
- [ ] Stop and immediately restart the LLM service multiple times in quick succession — no "couldn't bind port" failures
- [ ] If you can manufacture an orphan (`pkill -STOP llama-server` then quit the app), restart the app and start the LLM — expect the orphan to get killed and the new server to bind cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
