### PR TITLE
improve(queue-tray): persistent drawer, chevron-down dismissal

### DIFF
--- a/frontend/src/components/queue-tray/QueuePanel.tsx
+++ b/frontend/src/components/queue-tray/QueuePanel.tsx
@@ -42,10 +42,15 @@ export default function QueuePanel({ activeItems, completed, onClose }: QueuePan
           <span className="text-[13px] font-semibold text-(--color-text-primary)">Processing</span>
           <button
             onClick={handleClose}
+            aria-label="Tuck drawer away"
+            title="Tuck away"
             className="rounded-md p-0.5 text-(--color-text-secondary) hover:text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6 transition-colors"
           >
+            {/* Chevron-down: dismissal reads as "tuck away into a drawer",
+                not "destroy". The drawer reopens with current state when
+                the queue pill is clicked again. */}
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
             </svg>
           </button>
         </div>

--- a/frontend/src/components/queue-tray/QueueTray.tsx
+++ b/frontend/src/components/queue-tray/QueueTray.tsx
@@ -1,27 +1,23 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useQueueTray } from '../../hooks/useQueueTray'
 import QueuePill from './QueuePill'
 import QueueToastPopup from './QueueToastPopup'
 import QueuePanel from './QueuePanel'
 
+// Drawer behaviour: persists until the user dismisses it (chevron-down or
+// Esc). Click-outside no longer collapses — the drawer is meant to stay
+// open while the user works elsewhere in the app, so they can monitor
+// the queue while uploading / browsing. Route changes do NOT auto-dismiss
+// either. Structurally generic enough that other utility content could
+// live here later; if a second tab/use lands, rename QueueTray /
+// QueuePanel to Drawer / DrawerPanel and update this note.
 export default function QueueTray() {
   const { trayState, activeItems, completed, toggleExpanded, collapse } = useQueueTray()
-  const containerRef = useRef<HTMLDivElement>(null)
 
   const activeCount = activeItems.size
   const completedCount = completed.length
 
-  // Click outside to collapse
-  const handleClickOutside = useCallback(
-    (e: MouseEvent) => {
-      if (trayState === 'expanded' && containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        collapse()
-      }
-    },
-    [trayState, collapse],
-  )
-
-  // Escape to collapse
+  // Escape collapses the drawer — keep this as a discoverable shortcut.
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape' && trayState === 'expanded') {
@@ -33,14 +29,12 @@ export default function QueueTray() {
 
   useEffect(() => {
     if (trayState === 'expanded') {
-      document.addEventListener('mousedown', handleClickOutside)
       document.addEventListener('keydown', handleKeyDown)
     }
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [trayState, handleClickOutside, handleKeyDown])
+  }, [trayState, handleKeyDown])
 
   // Don't render anything if nothing to show
   if (activeCount === 0 && completedCount === 0 && trayState === 'collapsed') {
@@ -48,7 +42,7 @@ export default function QueueTray() {
   }
 
   return (
-    <div ref={containerRef} className="fixed bottom-4 left-4 z-50 flex flex-col items-start">
+    <div className="fixed bottom-4 left-4 z-50 flex flex-col items-start">
       {/* Panel (expanded state) */}
       {trayState === 'expanded' && <QueuePanel activeItems={activeItems} completed={completed} onClose={collapse} />}
 


### PR DESCRIPTION
## Summary

First of four PRs from a queue-status redesign brainstorm. Reframes the queue-tray expanded panel as a **persistent drawer** — stays open until the user dismisses it, instead of vanishing on any click-outside.

### Changes

- **Persistence:** dropped the document-level mousedown listener that collapsed the panel on outside clicks. The drawer now stays open across navigation and other UI interaction. Route changes don't auto-dismiss either.
- **Dismissal icon:** ✕ → chevron-down. Reads as "tuck away into the bottom of the screen", not "destroy". Reopens with full state when the user clicks the queue pill.
- **Esc** still closes — discoverable shortcut, kept.
- **Naming:** left `QueueTray`/`QueuePanel` filenames as-is for now (the drawer only hosts the queue today). Added a comment noting that if a second utility tab lands here, the names should be generalised to `Drawer`/`DrawerPanel`.

### Out of scope (coming in follow-up PRs)

- E — replace circular `StageRing` with horizontal segmented bar
- F — new "Pipeline activity" tab in the drawer (per-stage histogram + worker chips)
- G — animated pipeline-flow visualisation in Observatory

## Test plan

- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run build` — pass
- [ ] After install + restart: open the drawer, click around the rest of the app — drawer should stay open
- [ ] Click chevron-down — drawer collapses
- [ ] Press Esc while open — drawer collapses
- [ ] Click pill while drawer is open — drawer collapses (existing toggle behaviour)
- [ ] Navigate between routes (Documents → Search → back) — drawer should stay open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
