### PR TITLE
feat(queue-tray + observatory): Pipeline activity tab + animated pipeline diagram

### DIFF
--- a/frontend/src/components/queue-tray/PipelineTab.tsx
+++ b/frontend/src/components/queue-tray/PipelineTab.tsx
@@ -1,0 +1,53 @@
+import { useQueueSnapshot } from '../../hooks/useQueueSnapshot'
+import WorkerStrip from './WorkerStrip'
+import StageHistogram from './StageHistogram'
+
+/**
+ * "Pipeline" tab inside the drawer — info-dense at-a-glance view of
+ * what every queue is doing right now.
+ *
+ * Top: per-stage activity chips grouped by queue class (IO/CPU).
+ * Bottom: per-stage queue-depth histogram (running stacked under queued).
+ *
+ * The full graphical "panache" view of the pipeline DAG lives on the
+ * Observatory page, not here — this tab is the practical
+ * status-watcher.
+ */
+export default function PipelineTab() {
+  const { snapshot, error } = useQueueSnapshot()
+
+  if (!snapshot && !error) {
+    return <div className="px-4 py-6 text-center text-[12px] text-(--color-text-secondary)">Loading…</div>
+  }
+
+  if (error) {
+    return <div className="px-4 py-6 text-center text-[12px] text-red-500/80">{error}</div>
+  }
+
+  if (!snapshot) return null
+
+  const totalActivity =
+    snapshot.queues.io.queued + snapshot.queues.io.running + snapshot.queues.cpu.queued + snapshot.queues.cpu.running
+
+  return (
+    <div className="px-4 py-3 space-y-4">
+      <div>
+        <div className="text-[11px] font-medium uppercase tracking-wider text-(--color-text-secondary) mb-2">
+          Workers
+        </div>
+        <WorkerStrip snapshot={snapshot} />
+      </div>
+
+      <div>
+        <div className="text-[11px] font-medium uppercase tracking-wider text-(--color-text-secondary) mb-2">
+          Queue depth by stage
+        </div>
+        <StageHistogram snapshot={snapshot} />
+      </div>
+
+      {totalActivity === 0 && (
+        <div className="text-center text-[12px] text-(--color-text-secondary)">Pipeline is idle</div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/queue-tray/QueuePanel.tsx
+++ b/frontend/src/components/queue-tray/QueuePanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { DocumentQueueItem, CompletedItem } from '../../hooks/useQueueTray'
 import DocumentRow from './DocumentRow'
 import CompletedRow from './CompletedRow'
+import PipelineTab from './PipelineTab'
 
 interface QueuePanelProps {
   activeItems: Map<string, DocumentQueueItem>
@@ -9,8 +10,11 @@ interface QueuePanelProps {
   onClose: () => void
 }
 
+type TabId = 'active' | 'pipeline'
+
 export default function QueuePanel({ activeItems, completed, onClose }: QueuePanelProps) {
   const [exiting, setExiting] = useState(false)
+  const [tab, setTab] = useState<TabId>('active')
 
   const handleClose = () => {
     setExiting(true)
@@ -33,6 +37,7 @@ export default function QueuePanel({ activeItems, completed, onClose }: QueuePan
   const hasActive = active.length > 0
   const hasCompleted = completedDone.length > 0
   const hasErrors = completedErrors.length > 0
+  const activeCount = active.length
 
   return (
     <div className={`mb-2 ${exiting ? 'panel-exit' : 'panel-enter'}`} onAnimationEnd={handleAnimationEnd}>
@@ -42,70 +47,112 @@ export default function QueuePanel({ activeItems, completed, onClose }: QueuePan
           <span className="text-[13px] font-semibold text-(--color-text-primary)">Processing</span>
           <button
             onClick={handleClose}
+            aria-label="Tuck drawer away"
+            title="Tuck away"
             className="rounded-md p-0.5 text-(--color-text-secondary) hover:text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6 transition-colors"
           >
+            {/* Chevron-down: dismissal reads as "tuck away into a drawer",
+                not "destroy". The drawer reopens with current state when
+                the queue pill is clicked again. */}
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
             </svg>
           </button>
         </div>
 
+        {/* Tab bar */}
+        <div className="flex border-b border-(--color-border) px-2">
+          <TabButton id="active" current={tab} onClick={setTab}>
+            Active{activeCount > 0 && <span className="ml-1 tabular-nums">({activeCount})</span>}
+          </TabButton>
+          <TabButton id="pipeline" current={tab} onClick={setTab}>
+            Pipeline
+          </TabButton>
+        </div>
+
         {/* Body */}
         <div className="overflow-y-auto queue-panel-scroll flex-1">
-          {/* Active section */}
-          {hasActive && (
-            <div className="px-4 py-2">
-              <div className="text-[11px] font-medium uppercase tracking-wider text-(--color-text-secondary) mb-2">
-                Active
-              </div>
-              <div className="space-y-1">
-                {active.map((item) => (
-                  <DocumentRow key={item.version_id} item={item} />
-                ))}
-              </div>
-            </div>
-          )}
+          {tab === 'pipeline' && <PipelineTab />}
+          {tab === 'active' && (
+            <>
+              {/* Active section */}
+              {hasActive && (
+                <div className="px-4 py-2">
+                  <div className="text-[11px] font-medium uppercase tracking-wider text-(--color-text-secondary) mb-2">
+                    Active
+                  </div>
+                  <div className="space-y-1">
+                    {active.map((item) => (
+                      <DocumentRow key={item.version_id} item={item} />
+                    ))}
+                  </div>
+                </div>
+              )}
 
-          {/* Divider */}
-          {hasActive && hasCompleted && <div className="border-b border-(--color-border)" />}
+              {/* Divider */}
+              {hasActive && hasCompleted && <div className="border-b border-(--color-border)" />}
 
-          {/* Completed section (done items only) */}
-          {hasCompleted && (
-            <div className="px-4 py-2">
-              <div className="text-[11px] font-medium uppercase tracking-wider text-(--color-text-secondary) mb-2">
-                Completed ({completedDone.length})
-              </div>
-              <div className="space-y-2">
-                {completedDone.map((item) => (
-                  <CompletedRow key={item.version_id} item={item} />
-                ))}
-              </div>
-            </div>
-          )}
+              {/* Completed section (done items only) */}
+              {hasCompleted && (
+                <div className="px-4 py-2">
+                  <div className="text-[11px] font-medium uppercase tracking-wider text-(--color-text-secondary) mb-2">
+                    Completed ({completedDone.length})
+                  </div>
+                  <div className="space-y-2">
+                    {completedDone.map((item) => (
+                      <CompletedRow key={item.version_id} item={item} />
+                    ))}
+                  </div>
+                </div>
+              )}
 
-          {/* Divider */}
-          {(hasActive || hasCompleted) && hasErrors && <div className="border-b border-(--color-border)" />}
+              {/* Divider */}
+              {(hasActive || hasCompleted) && hasErrors && <div className="border-b border-(--color-border)" />}
 
-          {/* Errors section */}
-          {hasErrors && (
-            <div className="px-4 py-2">
-              <div className="text-[11px] font-medium uppercase tracking-wider text-red-500/80 mb-2">
-                Errors ({completedErrors.length})
-              </div>
-              <div className="space-y-2">
-                {completedErrors.map((item) => (
-                  <CompletedRow key={item.version_id} item={item} />
-                ))}
-              </div>
-            </div>
-          )}
+              {/* Errors section */}
+              {hasErrors && (
+                <div className="px-4 py-2">
+                  <div className="text-[11px] font-medium uppercase tracking-wider text-red-500/80 mb-2">
+                    Errors ({completedErrors.length})
+                  </div>
+                  <div className="space-y-2">
+                    {completedErrors.map((item) => (
+                      <CompletedRow key={item.version_id} item={item} />
+                    ))}
+                  </div>
+                </div>
+              )}
 
-          {/* Empty state */}
-          {!hasActive && !hasCompleted && !hasErrors && (
-            <div className="px-4 py-6 text-center text-[13px] text-(--color-text-secondary)">No items in queue</div>
+              {/* Empty state */}
+              {!hasActive && !hasCompleted && !hasErrors && (
+                <div className="px-4 py-6 text-center text-[13px] text-(--color-text-secondary)">No items in queue</div>
+              )}
+            </>
           )}
         </div>
       </div>
     </div>
+  )
+}
+
+interface TabButtonProps {
+  id: TabId
+  current: TabId
+  onClick: (id: TabId) => void
+  children: React.ReactNode
+}
+
+function TabButton({ id, current, onClick, children }: TabButtonProps) {
+  const active = id === current
+  return (
+    <button
+      onClick={() => onClick(id)}
+      className={`relative px-3 py-2 text-[12px] font-medium transition-colors ${
+        active ? 'text-(--color-text-primary)' : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+      }`}
+    >
+      {children}
+      {active && <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-(--color-accent)" />}
+    </button>
   )
 }

--- a/frontend/src/components/queue-tray/StageHistogram.tsx
+++ b/frontend/src/components/queue-tray/StageHistogram.tsx
@@ -1,0 +1,114 @@
+import type { QueueSnapshot } from '../../hooks/useQueueSnapshot'
+import { stageLabel } from '../../utils/stageLabel'
+
+interface StageHistogramProps {
+  snapshot: QueueSnapshot
+}
+
+/**
+ * Per-stage queue depth, one bar per pipeline stage in pipeline order.
+ *
+ * Each bar shows running (saturated accent, bottom) stacked under
+ * queued (lighter accent, top). The eye reads "running below the
+ * waterline, waiting above" — a tall stack on a single stage screams
+ * "this is the choke point". The total height of the tallest bar
+ * normalises to a fixed pixel ceiling so long queues don't crush the
+ * shorter bars into invisibility.
+ */
+const BAR_PIXEL_HEIGHT = 80
+const SHORT_LABELS: Record<string, string> = {
+  extract: 'Ext',
+  ocr: 'OCR',
+  chunk: 'Chk',
+  entities: 'Ent',
+  embed: 'Emb',
+  summarize: 'Sum',
+  finalize: 'Fin',
+}
+
+export default function StageHistogram({ snapshot }: StageHistogramProps) {
+  const totals = snapshot.stage_order.map((stage) => {
+    const info = snapshot.by_stage[stage]
+    return (info?.queued ?? 0) + (info?.running ?? 0)
+  })
+  const max = Math.max(1, ...totals)
+
+  return (
+    <div>
+      <div className="mb-1 flex items-end gap-1.5" style={{ height: BAR_PIXEL_HEIGHT + 16 }}>
+        {snapshot.stage_order.map((stage, idx) => {
+          const info = snapshot.by_stage[stage]
+          const queued = info?.queued ?? 0
+          const running = info?.running ?? 0
+          const total = totals[idx]
+          const barHeight = total > 0 ? Math.max(2, (total / max) * BAR_PIXEL_HEIGHT) : 0
+          const runningHeight = total > 0 ? (running / total) * barHeight : 0
+          const queuedHeight = barHeight - runningHeight
+          const isEmpty = total === 0
+
+          return (
+            <div key={stage} className="flex flex-1 flex-col items-center justify-end" style={{ minWidth: 0 }}>
+              {/* Numeric label above bar */}
+              <div
+                className={`mb-0.5 text-[10px] tabular-nums leading-none ${
+                  isEmpty ? 'text-(--color-text-secondary)/50' : 'text-(--color-text-primary)'
+                }`}
+              >
+                {total}
+              </div>
+              {/* Bar (running below, queued above) */}
+              <div
+                className="w-full overflow-hidden rounded-sm"
+                style={{ height: BAR_PIXEL_HEIGHT }}
+                title={
+                  isEmpty
+                    ? `${stageLabel(stage)} — idle`
+                    : `${stageLabel(stage)} — ${running} running, ${queued} queued`
+                }
+              >
+                <div className="flex h-full flex-col justify-end">
+                  {queuedHeight > 0 && (
+                    <div
+                      className="w-full bg-(--color-accent)/30"
+                      style={{ height: queuedHeight, transition: 'height 400ms ease-out' }}
+                    />
+                  )}
+                  {runningHeight > 0 && (
+                    <div
+                      className="w-full bg-(--color-accent)"
+                      style={{ height: runningHeight, transition: 'height 400ms ease-out' }}
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      {/* X-axis labels */}
+      <div className="flex gap-1.5">
+        {snapshot.stage_order.map((stage) => (
+          <div
+            key={stage}
+            className="flex-1 text-center text-[10px] text-(--color-text-secondary)"
+            style={{ minWidth: 0 }}
+            title={stageLabel(stage)}
+          >
+            {SHORT_LABELS[stage] ?? stage}
+          </div>
+        ))}
+      </div>
+      {/* Legend */}
+      <div className="mt-3 flex items-center gap-3 text-[10px] text-(--color-text-secondary)">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-sm bg-(--color-accent)" />
+          Running
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-sm bg-(--color-accent)/30" />
+          Queued
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/queue-tray/WorkerStrip.tsx
+++ b/frontend/src/components/queue-tray/WorkerStrip.tsx
@@ -1,0 +1,74 @@
+import type { QueueSnapshot } from '../../hooks/useQueueSnapshot'
+import { stageLabel } from '../../utils/stageLabel'
+
+interface WorkerStripProps {
+  snapshot: QueueSnapshot
+}
+
+/**
+ * Per-stage activity chips, grouped by queue class (IO vs CPU).
+ *
+ * We don't have stable worker IDs — workers are inferred from the
+ * count of running jobs at each stage. So chips are per-stage, not
+ * per-worker: "Embed · 3" means three workers are currently running
+ * embed jobs, regardless of which worker pids those are.
+ *
+ * Idle stages (no running jobs) render dimmer to draw the eye to
+ * what's actually happening.
+ */
+export default function WorkerStrip({ snapshot }: WorkerStripProps) {
+  // Group stages by their queue class while preserving pipeline order.
+  const groups: Record<'io' | 'cpu', string[]> = { io: [], cpu: [] }
+  for (const stage of snapshot.stage_order) {
+    const info = snapshot.by_stage[stage]
+    if (!info) continue
+    groups[info.queue].push(stage)
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {(['io', 'cpu'] as const).map((queue) => {
+        const stages = groups[queue]
+        if (stages.length === 0) return null
+        const totalRunning = snapshot.queues[queue]?.running ?? 0
+        return (
+          <div key={queue} className="flex items-center gap-2">
+            <span
+              className={`shrink-0 w-7 text-[10px] font-semibold uppercase tracking-wider ${
+                totalRunning > 0 ? 'text-(--color-text-primary)' : 'text-(--color-text-secondary)'
+              }`}
+            >
+              {queue}
+            </span>
+            <div className="flex flex-wrap gap-1">
+              {stages.map((stage) => {
+                const info = snapshot.by_stage[stage]
+                const running = info?.running ?? 0
+                const idle = running === 0
+                return (
+                  <span
+                    key={stage}
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] transition-colors ${
+                      idle
+                        ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70'
+                        : 'bg-(--color-accent)/15 text-(--color-accent) ring-1 ring-(--color-accent)/30'
+                    }`}
+                    title={
+                      idle
+                        ? `${stageLabel(stage)} — idle`
+                        : `${stageLabel(stage)} — ${running} worker${running === 1 ? '' : 's'} busy`
+                    }
+                  >
+                    <span className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : 'bg-(--color-accent)'}`} />
+                    {stageLabel(stage)}
+                    {running > 0 && <span className="font-semibold">· {running}</span>}
+                  </span>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+
+/**
+ * Pipeline Overview — animated DAG showing live activity in the
+ * ingestion pipeline.
+ *
+ * Visual encoding:
+ *   - Node radius scales with sqrt(queued + running) — a bottleneck
+ *     swells without crushing other nodes.
+ *   - Node hue distinguishes IO vs CPU stages.
+ *   - Soft glow filter on nodes with at least one running job — the
+ *     "I am alive" cue.
+ *   - Edges thicken with recent throughput on the downstream stage.
+ *   - Particles flow along edges at a rate proportional to recent
+ *     throughput. Each particle inherits the upstream stage's colour.
+ *
+ * Polls the same /api/jobs/snapshot endpoint as the drawer's Pipeline
+ * tab. The snapshot includes `recent_completed` per stage (last 30 s),
+ * which drives both edge thickness and particle spawn rate.
+ *
+ * No filenames or per-document text — by design. This is the
+ * graphical-flow view; the drawer's Pipeline tab is the
+ * info-dense status-watcher.
+ */
+
+const VIEW_WIDTH = 600
+const VIEW_HEIGHT = 300
+
+// Hand-laid-out positions for the 7-stage pipeline.
+// Sequential prefix flows left-to-right at y=150, then chunk fans out
+// to entities/embed/summarize stacked vertically, then re-converges
+// at finalize.
+const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
+  extract: { x: 60, y: 150 },
+  ocr: { x: 160, y: 150 },
+  chunk: { x: 260, y: 150 },
+  entities: { x: 390, y: 70 },
+  embed: { x: 390, y: 150 },
+  summarize: { x: 390, y: 230 },
+  finalize: { x: 520, y: 150 },
+}
+
+const EDGES: { from: string; to: string }[] = [
+  { from: 'extract', to: 'ocr' },
+  { from: 'ocr', to: 'chunk' },
+  { from: 'chunk', to: 'entities' },
+  { from: 'chunk', to: 'embed' },
+  { from: 'chunk', to: 'summarize' },
+  { from: 'entities', to: 'finalize' },
+  { from: 'embed', to: 'finalize' },
+  { from: 'summarize', to: 'finalize' },
+]
+
+const STAGE_LABELS: Record<string, string> = {
+  extract: 'Extract',
+  ocr: 'OCR',
+  chunk: 'Chunk',
+  entities: 'Entities',
+  embed: 'Embed',
+  summarize: 'Summarize',
+  finalize: 'Finalize',
+}
+
+// Distinct hues by queue class so the eye reads "this is a CPU stage"
+// vs "this is an IO stage" at a glance. CPU stages (OCR, Embed) are
+// the heavy / slow ones; warm hue makes them stand out.
+function classColor(queue: 'io' | 'cpu' | undefined): string {
+  if (queue === 'cpu') return '#f5a623' // amber
+  return '#0a84ff' // accent blue (matches --color-accent)
+}
+
+function edgePath(from: string, to: string): string {
+  const a = NODE_POSITIONS[from]
+  const b = NODE_POSITIONS[to]
+  const dx = b.x - a.x
+  // Cubic Bezier with horizontally-pulled control points → smooth
+  // S-curve when y differs, near-straight when y matches.
+  const c1x = a.x + dx * 0.5
+  const c1y = a.y
+  const c2x = b.x - dx * 0.5
+  const c2y = b.y
+  return `M ${a.x} ${a.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${b.x} ${b.y}`
+}
+
+function nodeRadius(info: StageSnapshot | undefined): number {
+  if (!info) return 18
+  const total = info.queued + info.running
+  // sqrt scale so a long queue grows but doesn't overwhelm
+  return Math.min(36, 18 + Math.sqrt(total) * 3)
+}
+
+interface Particle {
+  id: string
+  edgeKey: string
+  color: string
+}
+
+const PARTICLE_DURATION_MS = 1100
+
+function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
+  const [particles, setParticles] = useState<Particle[]>([])
+  const idCounterRef = useRef(0)
+
+  // Spawn particles per edge based on the downstream stage's
+  // recent throughput. Inter-particle interval = window / count.
+  useEffect(() => {
+    const windowMs = snapshot.throughput_window_seconds * 1000
+    const intervals: ReturnType<typeof setInterval>[] = []
+    const timeouts: ReturnType<typeof setTimeout>[] = []
+
+    for (const edge of EDGES) {
+      const downstream = snapshot.by_stage[edge.to]
+      if (!downstream || downstream.recent_completed <= 0) continue
+
+      const intervalMs = Math.max(180, Math.round(windowMs / downstream.recent_completed))
+      const upstream = snapshot.by_stage[edge.from]
+      const color = classColor(upstream?.queue)
+      const edgeKey = `${edge.from}-${edge.to}`
+
+      const id = setInterval(() => {
+        const p: Particle = {
+          id: `p-${idCounterRef.current++}`,
+          edgeKey,
+          color,
+        }
+        setParticles((prev) => [...prev, p])
+        const t = setTimeout(() => {
+          setParticles((prev) => prev.filter((x) => x.id !== p.id))
+        }, PARTICLE_DURATION_MS)
+        timeouts.push(t)
+      }, intervalMs)
+      intervals.push(id)
+    }
+
+    return () => {
+      intervals.forEach(clearInterval)
+      timeouts.forEach(clearTimeout)
+    }
+  }, [snapshot])
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+      className="w-full"
+      style={{ aspectRatio: `${VIEW_WIDTH} / ${VIEW_HEIGHT}` }}
+    >
+      <defs>
+        {/* Glow filter for active nodes */}
+        <filter id="pipeline-glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="3.5" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      {/* Edges */}
+      {EDGES.map((edge) => {
+        const downstream = snapshot.by_stage[edge.to]
+        const throughput = downstream?.recent_completed ?? 0
+        const baseWidth = 1.5
+        const width = Math.min(8, baseWidth + throughput * 0.4)
+        const color = classColor(downstream?.queue)
+        const opacity = throughput > 0 ? 0.5 : 0.15
+        return (
+          <path
+            key={`${edge.from}-${edge.to}`}
+            id={`edge-${edge.from}-${edge.to}`}
+            d={edgePath(edge.from, edge.to)}
+            fill="none"
+            stroke={color}
+            strokeWidth={width}
+            strokeOpacity={opacity}
+            strokeLinecap="round"
+            style={{ transition: 'stroke-width 500ms, stroke-opacity 500ms' }}
+          />
+        )
+      })}
+
+      {/* Particles flowing along edges */}
+      {particles.map((p) => (
+        <circle key={p.id} r={3.5} fill={p.color}>
+          <animateMotion dur={`${PARTICLE_DURATION_MS}ms`} repeatCount="1" fill="freeze">
+            <mpath href={`#edge-${p.edgeKey}`} />
+          </animateMotion>
+          {/* Fade in then out so spawn / arrival are visually soft */}
+          <animate
+            attributeName="opacity"
+            values="0;1;1;0"
+            keyTimes="0;0.15;0.85;1"
+            dur={`${PARTICLE_DURATION_MS}ms`}
+            repeatCount="1"
+            fill="freeze"
+          />
+        </circle>
+      ))}
+
+      {/* Nodes */}
+      {Object.entries(NODE_POSITIONS).map(([stage, pos]) => {
+        const info = snapshot.by_stage[stage]
+        const r = nodeRadius(info)
+        const color = classColor(info?.queue)
+        const total = info ? info.queued + info.running : 0
+        const isBusy = (info?.running ?? 0) > 0
+
+        return (
+          <g key={stage}>
+            <circle
+              cx={pos.x}
+              cy={pos.y}
+              r={r}
+              fill={color}
+              fillOpacity={isBusy ? 0.85 : 0.2}
+              stroke={color}
+              strokeWidth={isBusy ? 2 : 1}
+              style={{
+                filter: isBusy ? 'url(#pipeline-glow)' : undefined,
+                transition: 'r 400ms ease-out, fill-opacity 400ms',
+              }}
+            />
+            {/* Count badge above the node, only when there's activity */}
+            {total > 0 && (
+              <g>
+                <rect x={pos.x - 18} y={pos.y - r - 18} width={36} height={16} rx={8} fill="rgba(0,0,0,0.55)" />
+                <text
+                  x={pos.x}
+                  y={pos.y - r - 7}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fontWeight={600}
+                  fill="white"
+                  style={{ pointerEvents: 'none' }}
+                >
+                  {info!.running > 0 && info!.queued > 0
+                    ? `${info!.running} • +${info!.queued}`
+                    : info!.running > 0
+                      ? `${info!.running}`
+                      : `${info!.queued}`}
+                </text>
+              </g>
+            )}
+            {/* Stage label below the node */}
+            <text
+              x={pos.x}
+              y={pos.y + r + 14}
+              textAnchor="middle"
+              fontSize={11}
+              fontWeight={500}
+              className="fill-(--color-text-primary)"
+              style={{ pointerEvents: 'none' }}
+            >
+              {STAGE_LABELS[stage]}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default function PipelineDiagram() {
+  const { snapshot, error } = useQueueSnapshot()
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+      <div className="mb-2 flex items-baseline justify-between">
+        <h3 className="text-[13px] font-semibold text-(--color-text-primary)">Pipeline Overview</h3>
+        <span className="text-[11px] text-(--color-text-secondary)">
+          {snapshot ? `Throughput over last ${snapshot.throughput_window_seconds}s` : ''}
+        </span>
+      </div>
+      {error && <div className="text-[12px] text-red-500/80">{error}</div>}
+      {!snapshot && !error && <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>}
+      {snapshot && <PipelineGraph snapshot={snapshot} />}
+      {snapshot && (
+        <div className="mt-2 flex items-center gap-4 text-[10px] text-(--color-text-secondary)">
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full" style={{ background: classColor('io') }} />
+            IO
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
+            CPU
+          </span>
+          <span className="ml-auto">Glowing nodes have running jobs · Particles = recent throughput</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useQueueSnapshot.ts
+++ b/frontend/src/hooks/useQueueSnapshot.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+import { useAuth } from '../auth'
+
+export interface StageSnapshot {
+  queued: number
+  running: number
+  queue: 'io' | 'cpu'
+}
+
+export interface QueueSnapshot {
+  by_stage: Record<string, StageSnapshot>
+  queues: Record<'io' | 'cpu', { queued: number; running: number }>
+  stage_order: string[]
+}
+
+const POLL_INTERVAL_MS = 3000
+
+/**
+ * Polls /api/jobs/snapshot for per-stage queued/running counts.
+ *
+ * Polling (rather than SSE) is intentional: the snapshot is one indexed
+ * COUNT GROUP BY per call, the frontend only needs a value every few
+ * seconds for the histogram, and a separate live channel just for stage
+ * counts isn't worth the operational complexity. The per-document SSE
+ * stream from `useJobEvents` continues to drive the per-document state.
+ *
+ * Polling only runs while the hook is mounted, so this is dormant when
+ * the Pipeline tab isn't on screen.
+ */
+export function useQueueSnapshot() {
+  const { token } = useAuth()
+  const [snapshot, setSnapshot] = useState<QueueSnapshot | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    let cancelled = false
+
+    async function fetchSnapshot() {
+      try {
+        const res = await fetch('/api/jobs/snapshot', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok || cancelled) return
+        const data: QueueSnapshot = await res.json()
+        if (!cancelled) {
+          setSnapshot(data)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load snapshot')
+      }
+    }
+
+    fetchSnapshot()
+    const id = setInterval(fetchSnapshot, POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [token])
+
+  return { snapshot, error }
+}

--- a/frontend/src/hooks/useQueueSnapshot.ts
+++ b/frontend/src/hooks/useQueueSnapshot.ts
@@ -5,12 +5,16 @@ export interface StageSnapshot {
   queued: number
   running: number
   queue: 'io' | 'cpu'
+  /** Jobs that completed at this stage within `throughput_window_seconds`. */
+  recent_completed: number
 }
 
 export interface QueueSnapshot {
   by_stage: Record<string, StageSnapshot>
   queues: Record<'io' | 'cpu', { queued: number; running: number }>
   stage_order: string[]
+  /** Window over which `recent_completed` is computed. */
+  throughput_window_seconds: number
 }
 
 const POLL_INTERVAL_MS = 3000

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -6,6 +6,7 @@ import ClusterMap from '../components/stats/ClusterMap'
 import TopicTreemap from '../components/stats/TopicTreemap'
 import TopicBarChart from '../components/stats/TopicBarChart'
 import TopicKeywords from '../components/stats/TopicKeywords'
+import PipelineDiagram from '../components/stats/PipelineDiagram'
 import { InfoTip } from '../components/InfoTip'
 
 interface TopicCluster {
@@ -123,6 +124,9 @@ export default function StatsPage() {
           tip="Named entities — people, organizations, places, dates, etc. — automatically extracted from your documents using natural language processing."
         />
       </div>
+
+      {/* Live pipeline activity */}
+      <PipelineDiagram />
 
       {/* Charts */}
       <CorpusCharts stats={stats} />

--- a/src/harbor_clerk/api/routes/jobs.py
+++ b/src/harbor_clerk/api/routes/jobs.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
 
 import asyncpg
 from fastapi import APIRouter, Depends
@@ -124,13 +125,15 @@ async def jobs_snapshot(
     principal: Principal = Depends(require_read_access),
     session: AsyncSession = Depends(get_session),
 ):
-    """Per-stage queued/running counts for the queue tray's Pipeline tab.
+    """Per-stage queued/running counts and recent throughput.
 
     Returns:
         {
             "by_stage": {
-                "extract": {"queued": 0, "running": 1, "queue": "io"},
-                "ocr":     {"queued": 3, "running": 0, "queue": "cpu"},
+                "extract": {"queued": 0, "running": 1, "queue": "io",
+                            "recent_completed": 5},
+                "ocr":     {"queued": 3, "running": 0, "queue": "cpu",
+                            "recent_completed": 0},
                 ...
             },
             "queues": {
@@ -138,17 +141,36 @@ async def jobs_snapshot(
                 "cpu": {"queued": 3, "running": 0},
             },
             "stage_order": ["extract", "ocr", "chunk", ...],  // pipeline order
+            "throughput_window_seconds": 30,
         }
 
-    Polled by the frontend every few seconds while the Pipeline tab is
-    open. Cheap (one indexed COUNT GROUP BY per call) so polling is
-    fine; we don't need a separate SSE channel for this.
+    `recent_completed` is the count of jobs that finished at each stage
+    in the last `throughput_window_seconds`. Drives the Observatory
+    pipeline-flow visualisation (edge thickness, particle spawn rate).
+
+    Polled by the frontend every few seconds. Cheap: two indexed
+    aggregations on `ingestion_jobs`, no joins.
     """
+    # Counts of currently-queued / currently-running jobs by stage.
     rows = (
         await session.execute(
             select(IngestionJob.stage, IngestionJob.status, func.count())
             .where(IngestionJob.status.in_([JobStatus.queued, JobStatus.running]))
             .group_by(IngestionJob.stage, IngestionJob.status)
+        )
+    ).all()
+
+    # Recently-completed jobs by stage for the throughput indicator.
+    # 30 s window matches the rolling visualisation cadence — long
+    # enough to smooth bursts, short enough that the diagram tracks
+    # current activity rather than historical state.
+    window_seconds = 30
+    cutoff = datetime.now(UTC) - timedelta(seconds=window_seconds)
+    completion_rows = (
+        await session.execute(
+            select(IngestionJob.stage, func.count())
+            .where(IngestionJob.status == JobStatus.done, IngestionJob.finished_at >= cutoff)
+            .group_by(IngestionJob.stage)
         )
     ).all()
 
@@ -159,7 +181,7 @@ async def jobs_snapshot(
     # special-case "stage absent from response = no work".
     for stage in STAGE_ORDER:
         queue_name, _, _ = STAGE_CONFIG[stage]
-        by_stage[stage.value] = {"queued": 0, "running": 0, "queue": queue_name}
+        by_stage[stage.value] = {"queued": 0, "running": 0, "queue": queue_name, "recent_completed": 0}
 
     for stage, status, count in rows:
         stage_key = stage.value if hasattr(stage, "value") else str(stage)
@@ -172,8 +194,14 @@ async def jobs_snapshot(
         if queue_name in queues:
             queues[queue_name][status_key] += int(count)
 
+    for stage, count in completion_rows:
+        stage_key = stage.value if hasattr(stage, "value") else str(stage)
+        if stage_key in by_stage:
+            by_stage[stage_key]["recent_completed"] = int(count)
+
     return {
         "by_stage": by_stage,
         "queues": queues,
         "stage_order": [s.value for s in STAGE_ORDER],
+        "throughput_window_seconds": window_seconds,
     }

--- a/src/harbor_clerk/api/routes/jobs.py
+++ b/src/harbor_clerk/api/routes/jobs.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 import asyncpg
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.api.deps import Principal, require_read_access
@@ -16,7 +16,8 @@ from harbor_clerk.db import get_session
 from harbor_clerk.events import CHANNEL
 from harbor_clerk.models.document import Document
 from harbor_clerk.models.document_version import DocumentVersion
-from harbor_clerk.models.ingestion_job import IngestionJob
+from harbor_clerk.models.ingestion_job import IngestionJob, JobStatus
+from harbor_clerk.worker.pipeline import STAGE_CONFIG, STAGE_ORDER
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["jobs"])
@@ -116,3 +117,63 @@ async def active_jobs(
         events.append(event)
 
     return events
+
+
+@router.get("/jobs/snapshot")
+async def jobs_snapshot(
+    principal: Principal = Depends(require_read_access),
+    session: AsyncSession = Depends(get_session),
+):
+    """Per-stage queued/running counts for the queue tray's Pipeline tab.
+
+    Returns:
+        {
+            "by_stage": {
+                "extract": {"queued": 0, "running": 1, "queue": "io"},
+                "ocr":     {"queued": 3, "running": 0, "queue": "cpu"},
+                ...
+            },
+            "queues": {
+                "io":  {"queued": 0, "running": 1},
+                "cpu": {"queued": 3, "running": 0},
+            },
+            "stage_order": ["extract", "ocr", "chunk", ...],  // pipeline order
+        }
+
+    Polled by the frontend every few seconds while the Pipeline tab is
+    open. Cheap (one indexed COUNT GROUP BY per call) so polling is
+    fine; we don't need a separate SSE channel for this.
+    """
+    rows = (
+        await session.execute(
+            select(IngestionJob.stage, IngestionJob.status, func.count())
+            .where(IngestionJob.status.in_([JobStatus.queued, JobStatus.running]))
+            .group_by(IngestionJob.stage, IngestionJob.status)
+        )
+    ).all()
+
+    by_stage: dict[str, dict[str, int | str]] = {}
+    queues: dict[str, dict[str, int]] = {"io": {"queued": 0, "running": 0}, "cpu": {"queued": 0, "running": 0}}
+
+    # Seed every stage with zeros so the frontend doesn't need to
+    # special-case "stage absent from response = no work".
+    for stage in STAGE_ORDER:
+        queue_name, _, _ = STAGE_CONFIG[stage]
+        by_stage[stage.value] = {"queued": 0, "running": 0, "queue": queue_name}
+
+    for stage, status, count in rows:
+        stage_key = stage.value if hasattr(stage, "value") else str(stage)
+        status_key = status.value if hasattr(status, "value") else str(status)
+        if stage_key not in by_stage or status_key not in ("queued", "running"):
+            continue
+        by_stage[stage_key][status_key] = int(count)
+        # Mirror into the IO/CPU rollup.
+        queue_name = by_stage[stage_key]["queue"]
+        if queue_name in queues:
+            queues[queue_name][status_key] += int(count)
+
+    return {
+        "by_stage": by_stage,
+        "queues": queues,
+        "stage_order": [s.value for s in STAGE_ORDER],
+    }


### PR DESCRIPTION
## Summary

Third of four PRs from the queue-status redesign. Adds a **Pipeline** tab inside the drawer for the at-a-glance "where is everything waiting" view.

This is the practical, info-dense status-watcher. The graphical "panache" view of the pipeline DAG (animated flow particles, dynamic node sizes, glowing busy stages) is the follow-up PR G that lives on the Observatory page.

### Backend

New endpoint `GET /api/jobs/snapshot` returning per-stage `queued`/`running` counts plus an IO/CPU rollup:

```json
{
  "by_stage": {
    "extract": {"queued": 0, "running": 1, "queue": "io"},
    "ocr":     {"queued": 3, "running": 0, "queue": "cpu"},
    ...
  },
  "queues": {
    "io":  {"queued": 0, "running": 1},
    "cpu": {"queued": 3, "running": 0}
  },
  "stage_order": ["extract", "ocr", "chunk", "entities", "embed", "summarize", "finalize"]
}
```

One indexed `COUNT GROUP BY` per call, so polling at 3 s is cheap. The per-document SSE channel (`/api/jobs/stream` via `useJobEvents`) continues to drive the per-document state — no second live channel needed for the histogram.

### Frontend

- **`useQueueSnapshot`** — hook that polls every 3 s while mounted (so it's dormant when the Pipeline tab isn't on screen).
- **`WorkerStrip`** — per-stage activity chips grouped by queue class. No stable worker IDs exist, so chips show busy-count per stage (`Embed · 3`) rather than per-worker. Idle stages render dimmer.
- **`StageHistogram`** — one bar per pipeline stage, in pipeline order. Running is the saturated bottom segment, queued is a lighter tint stacked above. Numeric label above each bar; hover tooltip with exact counts. Bar height normalises to the tallest in the set so a long queue doesn't crush the others.
- **`PipelineTab`** — orchestrates the two and handles loading / error / idle-pipeline empty states.
- **`QueuePanel`** — grows a tab bar (Active / Pipeline). Active tab now shows a count badge (`Active (3)`).

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run build` — pass
- [ ] After install + restart: open the drawer, switch to **Pipeline** tab. With nothing happening, expect "Pipeline is idle" and dim chips.
- [ ] Upload a batch (~50 docs) and watch the histogram populate. Run-of-the-mill expectation: Extract bar tall briefly, then chunk, then OCR/embed bars build up depending on queue.
- [ ] Confirm the worker strip shows accent-coloured chips for stages with running jobs and dim chips for idle ones, with `· N` busy counts.
- [ ] Switch back to **Active** tab — confirm per-document rows still render correctly and the Pipeline polling stops (verify via Network tab that requests cease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
