### PR TITLE
feat(observatory): live pipeline overview — animated DAG with flow particles

### DIFF
--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+
+/**
+ * Pipeline Overview — animated DAG showing live activity in the
+ * ingestion pipeline.
+ *
+ * Visual encoding:
+ *   - Node radius scales with sqrt(queued + running) — a bottleneck
+ *     swells without crushing other nodes.
+ *   - Node hue distinguishes IO vs CPU stages.
+ *   - Soft glow filter on nodes with at least one running job — the
+ *     "I am alive" cue.
+ *   - Edges thicken with recent throughput on the downstream stage.
+ *   - Particles flow along edges at a rate proportional to recent
+ *     throughput. Each particle inherits the upstream stage's colour.
+ *
+ * Polls the same /api/jobs/snapshot endpoint as the drawer's Pipeline
+ * tab. The snapshot includes `recent_completed` per stage (last 30 s),
+ * which drives both edge thickness and particle spawn rate.
+ *
+ * No filenames or per-document text — by design. This is the
+ * graphical-flow view; the drawer's Pipeline tab is the
+ * info-dense status-watcher.
+ */
+
+const VIEW_WIDTH = 600
+const VIEW_HEIGHT = 300
+
+// Hand-laid-out positions for the 7-stage pipeline.
+// Sequential prefix flows left-to-right at y=150, then chunk fans out
+// to entities/embed/summarize stacked vertically, then re-converges
+// at finalize.
+const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
+  extract: { x: 60, y: 150 },
+  ocr: { x: 160, y: 150 },
+  chunk: { x: 260, y: 150 },
+  entities: { x: 390, y: 70 },
+  embed: { x: 390, y: 150 },
+  summarize: { x: 390, y: 230 },
+  finalize: { x: 520, y: 150 },
+}
+
+const EDGES: { from: string; to: string }[] = [
+  { from: 'extract', to: 'ocr' },
+  { from: 'ocr', to: 'chunk' },
+  { from: 'chunk', to: 'entities' },
+  { from: 'chunk', to: 'embed' },
+  { from: 'chunk', to: 'summarize' },
+  { from: 'entities', to: 'finalize' },
+  { from: 'embed', to: 'finalize' },
+  { from: 'summarize', to: 'finalize' },
+]
+
+const STAGE_LABELS: Record<string, string> = {
+  extract: 'Extract',
+  ocr: 'OCR',
+  chunk: 'Chunk',
+  entities: 'Entities',
+  embed: 'Embed',
+  summarize: 'Summarize',
+  finalize: 'Finalize',
+}
+
+// Distinct hues by queue class so the eye reads "this is a CPU stage"
+// vs "this is an IO stage" at a glance. CPU stages (OCR, Embed) are
+// the heavy / slow ones; warm hue makes them stand out.
+function classColor(queue: 'io' | 'cpu' | undefined): string {
+  if (queue === 'cpu') return '#f5a623' // amber
+  return '#0a84ff' // accent blue (matches --color-accent)
+}
+
+function edgePath(from: string, to: string): string {
+  const a = NODE_POSITIONS[from]
+  const b = NODE_POSITIONS[to]
+  const dx = b.x - a.x
+  // Cubic Bezier with horizontally-pulled control points → smooth
+  // S-curve when y differs, near-straight when y matches.
+  const c1x = a.x + dx * 0.5
+  const c1y = a.y
+  const c2x = b.x - dx * 0.5
+  const c2y = b.y
+  return `M ${a.x} ${a.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${b.x} ${b.y}`
+}
+
+function nodeRadius(info: StageSnapshot | undefined): number {
+  if (!info) return 18
+  const total = info.queued + info.running
+  // sqrt scale so a long queue grows but doesn't overwhelm
+  return Math.min(36, 18 + Math.sqrt(total) * 3)
+}
+
+interface Particle {
+  id: string
+  edgeKey: string
+  color: string
+}
+
+const PARTICLE_DURATION_MS = 1100
+
+function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
+  const [particles, setParticles] = useState<Particle[]>([])
+  const idCounterRef = useRef(0)
+
+  // Spawn particles per edge based on the downstream stage's
+  // recent throughput. Inter-particle interval = window / count.
+  useEffect(() => {
+    const windowMs = snapshot.throughput_window_seconds * 1000
+    const intervals: ReturnType<typeof setInterval>[] = []
+    const timeouts: ReturnType<typeof setTimeout>[] = []
+
+    for (const edge of EDGES) {
+      const downstream = snapshot.by_stage[edge.to]
+      if (!downstream || downstream.recent_completed <= 0) continue
+
+      const intervalMs = Math.max(180, Math.round(windowMs / downstream.recent_completed))
+      const upstream = snapshot.by_stage[edge.from]
+      const color = classColor(upstream?.queue)
+      const edgeKey = `${edge.from}-${edge.to}`
+
+      const id = setInterval(() => {
+        const p: Particle = {
+          id: `p-${idCounterRef.current++}`,
+          edgeKey,
+          color,
+        }
+        setParticles((prev) => [...prev, p])
+        const t = setTimeout(() => {
+          setParticles((prev) => prev.filter((x) => x.id !== p.id))
+        }, PARTICLE_DURATION_MS)
+        timeouts.push(t)
+      }, intervalMs)
+      intervals.push(id)
+    }
+
+    return () => {
+      intervals.forEach(clearInterval)
+      timeouts.forEach(clearTimeout)
+    }
+  }, [snapshot])
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+      className="w-full"
+      style={{ aspectRatio: `${VIEW_WIDTH} / ${VIEW_HEIGHT}` }}
+    >
+      <defs>
+        {/* Glow filter for active nodes */}
+        <filter id="pipeline-glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="3.5" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      {/* Edges */}
+      {EDGES.map((edge) => {
+        const downstream = snapshot.by_stage[edge.to]
+        const throughput = downstream?.recent_completed ?? 0
+        const baseWidth = 1.5
+        const width = Math.min(8, baseWidth + throughput * 0.4)
+        const color = classColor(downstream?.queue)
+        const opacity = throughput > 0 ? 0.5 : 0.15
+        return (
+          <path
+            key={`${edge.from}-${edge.to}`}
+            id={`edge-${edge.from}-${edge.to}`}
+            d={edgePath(edge.from, edge.to)}
+            fill="none"
+            stroke={color}
+            strokeWidth={width}
+            strokeOpacity={opacity}
+            strokeLinecap="round"
+            style={{ transition: 'stroke-width 500ms, stroke-opacity 500ms' }}
+          />
+        )
+      })}
+
+      {/* Particles flowing along edges */}
+      {particles.map((p) => (
+        <circle key={p.id} r={3.5} fill={p.color}>
+          <animateMotion dur={`${PARTICLE_DURATION_MS}ms`} repeatCount="1" fill="freeze">
+            <mpath href={`#edge-${p.edgeKey}`} />
+          </animateMotion>
+          {/* Fade in then out so spawn / arrival are visually soft */}
+          <animate
+            attributeName="opacity"
+            values="0;1;1;0"
+            keyTimes="0;0.15;0.85;1"
+            dur={`${PARTICLE_DURATION_MS}ms`}
+            repeatCount="1"
+            fill="freeze"
+          />
+        </circle>
+      ))}
+
+      {/* Nodes */}
+      {Object.entries(NODE_POSITIONS).map(([stage, pos]) => {
+        const info = snapshot.by_stage[stage]
+        const r = nodeRadius(info)
+        const color = classColor(info?.queue)
+        const total = info ? info.queued + info.running : 0
+        const isBusy = (info?.running ?? 0) > 0
+
+        return (
+          <g key={stage}>
+            <circle
+              cx={pos.x}
+              cy={pos.y}
+              r={r}
+              fill={color}
+              fillOpacity={isBusy ? 0.85 : 0.2}
+              stroke={color}
+              strokeWidth={isBusy ? 2 : 1}
+              style={{
+                filter: isBusy ? 'url(#pipeline-glow)' : undefined,
+                transition: 'r 400ms ease-out, fill-opacity 400ms',
+              }}
+            />
+            {/* Count badge above the node, only when there's activity */}
+            {total > 0 && (
+              <g>
+                <rect x={pos.x - 18} y={pos.y - r - 18} width={36} height={16} rx={8} fill="rgba(0,0,0,0.55)" />
+                <text
+                  x={pos.x}
+                  y={pos.y - r - 7}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fontWeight={600}
+                  fill="white"
+                  style={{ pointerEvents: 'none' }}
+                >
+                  {info!.running > 0 && info!.queued > 0
+                    ? `${info!.running} • +${info!.queued}`
+                    : info!.running > 0
+                      ? `${info!.running}`
+                      : `${info!.queued}`}
+                </text>
+              </g>
+            )}
+            {/* Stage label below the node */}
+            <text
+              x={pos.x}
+              y={pos.y + r + 14}
+              textAnchor="middle"
+              fontSize={11}
+              fontWeight={500}
+              className="fill-(--color-text-primary)"
+              style={{ pointerEvents: 'none' }}
+            >
+              {STAGE_LABELS[stage]}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default function PipelineDiagram() {
+  const { snapshot, error } = useQueueSnapshot()
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+      <div className="mb-2 flex items-baseline justify-between">
+        <h3 className="text-[13px] font-semibold text-(--color-text-primary)">Pipeline Overview</h3>
+        <span className="text-[11px] text-(--color-text-secondary)">
+          {snapshot ? `Throughput over last ${snapshot.throughput_window_seconds}s` : ''}
+        </span>
+      </div>
+      {error && <div className="text-[12px] text-red-500/80">{error}</div>}
+      {!snapshot && !error && <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>}
+      {snapshot && <PipelineGraph snapshot={snapshot} />}
+      {snapshot && (
+        <div className="mt-2 flex items-center gap-4 text-[10px] text-(--color-text-secondary)">
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full" style={{ background: classColor('io') }} />
+            IO
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
+            CPU
+          </span>
+          <span className="ml-auto">Glowing nodes have running jobs · Particles = recent throughput</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useQueueSnapshot.ts
+++ b/frontend/src/hooks/useQueueSnapshot.ts
@@ -5,12 +5,16 @@ export interface StageSnapshot {
   queued: number
   running: number
   queue: 'io' | 'cpu'
+  /** Jobs that completed at this stage within `throughput_window_seconds`. */
+  recent_completed: number
 }
 
 export interface QueueSnapshot {
   by_stage: Record<string, StageSnapshot>
   queues: Record<'io' | 'cpu', { queued: number; running: number }>
   stage_order: string[]
+  /** Window over which `recent_completed` is computed. */
+  throughput_window_seconds: number
 }
 
 const POLL_INTERVAL_MS = 3000

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -6,6 +6,7 @@ import ClusterMap from '../components/stats/ClusterMap'
 import TopicTreemap from '../components/stats/TopicTreemap'
 import TopicBarChart from '../components/stats/TopicBarChart'
 import TopicKeywords from '../components/stats/TopicKeywords'
+import PipelineDiagram from '../components/stats/PipelineDiagram'
 import { InfoTip } from '../components/InfoTip'
 
 interface TopicCluster {
@@ -123,6 +124,9 @@ export default function StatsPage() {
           tip="Named entities — people, organizations, places, dates, etc. — automatically extracted from your documents using natural language processing."
         />
       </div>
+
+      {/* Live pipeline activity */}
+      <PipelineDiagram />
 
       {/* Charts */}
       <CorpusCharts stats={stats} />

--- a/src/harbor_clerk/api/routes/jobs.py
+++ b/src/harbor_clerk/api/routes/jobs.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
 
 import asyncpg
 from fastapi import APIRouter, Depends
@@ -124,13 +125,15 @@ async def jobs_snapshot(
     principal: Principal = Depends(require_read_access),
     session: AsyncSession = Depends(get_session),
 ):
-    """Per-stage queued/running counts for the queue tray's Pipeline tab.
+    """Per-stage queued/running counts and recent throughput.
 
     Returns:
         {
             "by_stage": {
-                "extract": {"queued": 0, "running": 1, "queue": "io"},
-                "ocr":     {"queued": 3, "running": 0, "queue": "cpu"},
+                "extract": {"queued": 0, "running": 1, "queue": "io",
+                            "recent_completed": 5},
+                "ocr":     {"queued": 3, "running": 0, "queue": "cpu",
+                            "recent_completed": 0},
                 ...
             },
             "queues": {
@@ -138,17 +141,36 @@ async def jobs_snapshot(
                 "cpu": {"queued": 3, "running": 0},
             },
             "stage_order": ["extract", "ocr", "chunk", ...],  // pipeline order
+            "throughput_window_seconds": 30,
         }
 
-    Polled by the frontend every few seconds while the Pipeline tab is
-    open. Cheap (one indexed COUNT GROUP BY per call) so polling is
-    fine; we don't need a separate SSE channel for this.
+    `recent_completed` is the count of jobs that finished at each stage
+    in the last `throughput_window_seconds`. Drives the Observatory
+    pipeline-flow visualisation (edge thickness, particle spawn rate).
+
+    Polled by the frontend every few seconds. Cheap: two indexed
+    aggregations on `ingestion_jobs`, no joins.
     """
+    # Counts of currently-queued / currently-running jobs by stage.
     rows = (
         await session.execute(
             select(IngestionJob.stage, IngestionJob.status, func.count())
             .where(IngestionJob.status.in_([JobStatus.queued, JobStatus.running]))
             .group_by(IngestionJob.stage, IngestionJob.status)
+        )
+    ).all()
+
+    # Recently-completed jobs by stage for the throughput indicator.
+    # 30 s window matches the rolling visualisation cadence — long
+    # enough to smooth bursts, short enough that the diagram tracks
+    # current activity rather than historical state.
+    window_seconds = 30
+    cutoff = datetime.now(UTC) - timedelta(seconds=window_seconds)
+    completion_rows = (
+        await session.execute(
+            select(IngestionJob.stage, func.count())
+            .where(IngestionJob.status == JobStatus.done, IngestionJob.finished_at >= cutoff)
+            .group_by(IngestionJob.stage)
         )
     ).all()
 
@@ -159,7 +181,7 @@ async def jobs_snapshot(
     # special-case "stage absent from response = no work".
     for stage in STAGE_ORDER:
         queue_name, _, _ = STAGE_CONFIG[stage]
-        by_stage[stage.value] = {"queued": 0, "running": 0, "queue": queue_name}
+        by_stage[stage.value] = {"queued": 0, "running": 0, "queue": queue_name, "recent_completed": 0}
 
     for stage, status, count in rows:
         stage_key = stage.value if hasattr(stage, "value") else str(stage)
@@ -172,8 +194,14 @@ async def jobs_snapshot(
         if queue_name in queues:
             queues[queue_name][status_key] += int(count)
 
+    for stage, count in completion_rows:
+        stage_key = stage.value if hasattr(stage, "value") else str(stage)
+        if stage_key in by_stage:
+            by_stage[stage_key]["recent_completed"] = int(count)
+
     return {
         "by_stage": by_stage,
         "queues": queues,
         "stage_order": [s.value for s in STAGE_ORDER],
+        "throughput_window_seconds": window_seconds,
     }


### PR DESCRIPTION
## Summary

Last of four PRs from the queue-status redesign — the graphical "panache" view of the ingestion pipeline that lives on the **Observatory** page. Companion to the drawer's Pipeline tab in PR #229; this is the visual-flow view, that one is the info-dense status-watcher.

> **Note:** Branched off PR #229 (which adds the `/api/jobs/snapshot` endpoint). Will rebase cleanly once #229 merges.

### Backend

Extends `GET /api/jobs/snapshot` with `recent_completed` per stage — count of jobs that finished in the last `throughput_window_seconds` (30 s). Drives edge thickness and particle spawn rate in the diagram. One additional aggregation per call.

### Frontend — `PipelineDiagram`

Custom SVG, **no react-flow**. The graph is fixed (7 nodes, hand-laid-out), so we don't need auto-layout, pan/zoom, or a minimap. Custom SVG keeps full creative control over the aesthetic.

Visual encoding:

- **Node radius** scales with `sqrt(queued + running)` — bottlenecks swell without crushing smaller nodes.
- **Node hue** distinguishes IO vs CPU stages (accent blue / amber).
- **`feGaussianBlur` glow filter** on nodes with at least one running job — the "I am alive" cue.
- **Edges** as cubic Beziers; stroke width + opacity scale with downstream stage's recent throughput.
- **Particles** flow along each edge via SMIL `<animateMotion>` + `<mpath xlink:href>` referencing the edge path. Spawn rate ∝ recent throughput. Each particle fades in / out so spawn and arrival are visually soft.
- **Count badge** above the node when active (`3 • +5` for 3 running, 5 queued); stage name below.

Reuses the same `useQueueSnapshot` hook as the drawer's Pipeline tab so both views poll the same endpoint.

### Layout

```
[Extract] → [OCR] → [Chunk] ─┬→ [Entities] ─┐
                              ├→ [Embed]    ─┼→ [Finalize]
                              └→ [Summarize]─┘
```

Mounted on the Observatory page under the summary badges, above the corpus charts, so it's the first thing the user sees.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run build` — pass
- [ ] After install + restart: navigate to Observatory. Pipeline overview should render at idle (dim nodes, thin edges, no particles).
- [ ] Trigger an upload of ~50 docs. Watch nodes glow as workers pick up jobs, particles flow along edges, edge thickness grows on busy paths.
- [ ] Verify CPU stages (OCR, Embed) render in amber and IO stages render in blue.
- [ ] Verify the count badge above active nodes (`3 • +5`-style) updates as jobs progress.
- [ ] Verify particles are smooth (no jank) under sustained activity (~hundred-deep queue).

## Future polish (not in scope)

- Drag-to-reorder layout (probably never want this — fixed layout is correct)
- Hover tooltips with extra detail per node
- Time-window selector (30 s / 60 s / 5 min) for the throughput indicator
- Subtle background pulse to show "system is breathing" even at idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
