### PR TITLE
feat(workers): dedicated `llm` queue for summarize — never serialise behind LLM lock

### DIFF
--- a/frontend/src/components/queue-tray/WorkerStrip.tsx
+++ b/frontend/src/components/queue-tray/WorkerStrip.tsx
@@ -1,12 +1,14 @@
-import type { QueueSnapshot } from '../../hooks/useQueueSnapshot'
+import type { QueueClass, QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
 
 interface WorkerStripProps {
   snapshot: QueueSnapshot
 }
 
+const QUEUE_ORDER: readonly QueueClass[] = ['io', 'cpu', 'llm'] as const
+
 /**
- * Per-stage activity chips, grouped by queue class (IO vs CPU).
+ * Per-stage activity chips, grouped by queue class (IO vs CPU vs LLM).
  *
  * We don't have stable worker IDs — workers are inferred from the
  * count of running jobs at each stage. So chips are per-stage, not
@@ -18,7 +20,7 @@ interface WorkerStripProps {
  */
 export default function WorkerStrip({ snapshot }: WorkerStripProps) {
   // Group stages by their queue class while preserving pipeline order.
-  const groups: Record<'io' | 'cpu', string[]> = { io: [], cpu: [] }
+  const groups: Record<QueueClass, string[]> = { io: [], cpu: [], llm: [] }
   for (const stage of snapshot.stage_order) {
     const info = snapshot.by_stage[stage]
     if (!info) continue
@@ -27,7 +29,7 @@ export default function WorkerStrip({ snapshot }: WorkerStripProps) {
 
   return (
     <div className="space-y-1.5">
-      {(['io', 'cpu'] as const).map((queue) => {
+      {QUEUE_ORDER.map((queue) => {
         const stages = groups[queue]
         if (stages.length === 0) return null
         const totalRunning = snapshot.queues[queue]?.running ?? 0

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { useQueueSnapshot, type QueueClass, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
 
 /**
  * Pipeline Overview — animated DAG showing live activity in the
@@ -8,7 +8,7 @@ import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../
  * Visual encoding:
  *   - Node radius scales with sqrt(queued + running) — a bottleneck
  *     swells without crushing other nodes.
- *   - Node hue distinguishes IO vs CPU stages.
+ *   - Node hue distinguishes IO / CPU / LLM queue classes.
  *   - Soft glow filter on nodes with at least one running job — the
  *     "I am alive" cue.
  *   - Edges thicken with recent throughput on the downstream stage.
@@ -64,9 +64,13 @@ const STAGE_LABELS: Record<string, string> = {
 
 // Distinct hues by queue class so the eye reads "this is a CPU stage"
 // vs "this is an IO stage" at a glance. CPU stages (OCR, Embed) are
-// the heavy / slow ones; warm hue makes them stand out.
-function classColor(queue: 'io' | 'cpu' | undefined): string {
+// the heavy / slow compute ones; warm hue makes them stand out. The
+// LLM queue (Summarize) gets its own purple — visually distinct and
+// reinforces that it's a serialised single-worker bottleneck, not
+// just another flavour of CPU work.
+function classColor(queue: QueueClass | undefined): string {
   if (queue === 'cpu') return '#f5a623' // amber
+  if (queue === 'llm') return '#bf5af2' // system purple
   return '#0a84ff' // accent blue (matches --color-accent)
 }
 
@@ -283,6 +287,10 @@ export default function PipelineDiagram() {
           <span className="inline-flex items-center gap-1">
             <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
             CPU
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full" style={{ background: classColor('llm') }} />
+            LLM
           </span>
           <span className="ml-auto">Glowing nodes have running jobs · Particles = recent throughput</span>
         </div>

--- a/frontend/src/hooks/useQueueSnapshot.ts
+++ b/frontend/src/hooks/useQueueSnapshot.ts
@@ -1,17 +1,19 @@
 import { useEffect, useState } from 'react'
 import { useAuth } from '../auth'
 
+export type QueueClass = 'io' | 'cpu' | 'llm'
+
 export interface StageSnapshot {
   queued: number
   running: number
-  queue: 'io' | 'cpu'
+  queue: QueueClass
   /** Jobs that completed at this stage within `throughput_window_seconds`. */
   recent_completed: number
 }
 
 export interface QueueSnapshot {
   by_stage: Record<string, StageSnapshot>
-  queues: Record<'io' | 'cpu', { queued: number; running: number }>
+  queues: Record<QueueClass, { queued: number; running: number }>
   stage_order: string[]
   /** Window over which `recent_completed` is computed. */
   throughput_window_seconds: number

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -32,6 +32,16 @@ final class ServiceManager: ObservableObject {
     let apiService: APIService
     private var ioWorkers: [WorkerService] = []
     private var cpuWorkers: [WorkerService] = []
+    /// Single-worker pool dedicated to LLM-bound stages (currently just
+    /// `summarize`). llama-server runs with -np 1 on heavy models, so
+    /// allowing multiple workers to pull summarize jobs would just have
+    /// them busy-wait on the LLM lock and starve other IO/CPU work.
+    /// Always exactly one worker; doesn't scale with preset.
+    private var llmWorkers: [WorkerService] = []
+
+    /// All worker services regardless of queue. Use this anywhere a
+    /// generic "stop / restart / iterate over workers" is needed.
+    private var allWorkers: [WorkerService] { ioWorkers + cpuWorkers + llmWorkers }
 
     /// Set by AppDelegate after creating the HealthChecker.
     weak var healthChecker: HealthChecker?
@@ -84,27 +94,32 @@ final class ServiceManager: ObservableObject {
 
         // Worker counts based on preset
         let cpuCount = ProcessInfo.processInfo.processorCount
-        let (ioCount, cpuWorkerCount) = Self.workerCounts(preset: settings.workerPreset, cores: cpuCount)
+        let counts = Self.workerCounts(preset: settings.workerPreset, cores: cpuCount)
 
-        for i in 0..<ioCount {
+        for i in 0..<counts.io {
             ioWorkers.append(WorkerService(queue: "io", index: i))
         }
-        for i in 0..<cpuWorkerCount {
+        for i in 0..<counts.cpu {
             cpuWorkers.append(WorkerService(queue: "cpu", index: i))
+        }
+        for i in 0..<counts.llm {
+            llmWorkers.append(WorkerService(queue: "llm", index: i))
         }
 
         services = [postgresService, tikaService, embedderService, llamaService, apiService]
-            + ioWorkers + cpuWorkers
+            + ioWorkers + cpuWorkers + llmWorkers
     }
 
-    nonisolated static func workerCounts(preset: String, cores: Int) -> (io: Int, cpu: Int) {
+    nonisolated static func workerCounts(preset: String, cores: Int) -> (io: Int, cpu: Int, llm: Int) {
+        // LLM worker count is intentionally constant (1) regardless of
+        // preset — see `llmWorkers` property doc for why.
         switch preset {
         case "quiet":
-            return (1, 1)
+            return (1, 1, 1)
         case "fast":
-            return (min(8, max(2, cores / 2)), 3)
+            return (min(8, max(2, cores / 2)), 3, 1)
         default: // balanced
-            return (min(8, max(2, cores / 4)), 2)
+            return (min(8, max(2, cores / 4)), 2, 1)
         }
     }
 
@@ -251,7 +266,7 @@ final class ServiceManager: ObservableObject {
         await startService(apiService)
 
         // 7. Workers
-        for worker in ioWorkers + cpuWorkers {
+        for worker in allWorkers {
             await startService(worker)
         }
 
@@ -286,7 +301,6 @@ final class ServiceManager: ObservableObject {
         notifyStateChanged()
 
         // Stop workers in parallel (SIGTERM all, then wait) — same as restartForChangedSettings
-        let allWorkers = ioWorkers + cpuWorkers
         for worker in allWorkers {
             worker.state = .stopping
             worker.process?.terminate()
@@ -504,18 +518,18 @@ final class ServiceManager: ObservableObject {
             case "postgres_port":
                 infraToRestart.append(postgresService)
                 pythonToRestart.insert(ObjectIdentifier(apiService))
-                for w in ioWorkers + cpuWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
+                for w in allWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
                 needsMigrations = true
 
             case "tika_port":
                 infraToRestart.append(tikaService)
                 pythonToRestart.insert(ObjectIdentifier(apiService))
-                for w in ioWorkers + cpuWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
+                for w in allWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
 
             case "embedder_port":
                 infraToRestart.append(embedderService)
                 pythonToRestart.insert(ObjectIdentifier(apiService))
-                for w in ioWorkers + cpuWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
+                for w in allWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
 
             case "llama_port":
                 infraToRestart.append(llamaService)
@@ -533,7 +547,7 @@ final class ServiceManager: ObservableObject {
             case "log_level":
                 pythonToRestart.insert(ObjectIdentifier(apiService))
                 pythonToRestart.insert(ObjectIdentifier(embedderService))
-                for w in ioWorkers + cpuWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
+                for w in allWorkers { pythonToRestart.insert(ObjectIdentifier(w)) }
 
             default:
                 break
@@ -545,7 +559,7 @@ final class ServiceManager: ObservableObject {
         infraToRestart = infraToRestart.filter { seenInfra.insert(ObjectIdentifier($0)).inserted }
 
         // Collect python services to restart (excluding workers if we're recreating them)
-        let workersToStop: [WorkerService] = needsWorkerRecreate ? ioWorkers + cpuWorkers : (ioWorkers + cpuWorkers).filter { pythonToRestart.contains(ObjectIdentifier($0)) }
+        let workersToStop: [WorkerService] = needsWorkerRecreate ? allWorkers : allWorkers.filter { pythonToRestart.contains(ObjectIdentifier($0)) }
         // Embedder before API to match startAll() ordering
         let nonWorkerPython: [any ManagedService] = [embedderService, apiService].filter { pythonToRestart.contains(ObjectIdentifier($0)) }
 
@@ -610,7 +624,7 @@ final class ServiceManager: ObservableObject {
             }
         }
         // Workers always get fresh env (whether recreated or restarted)
-        for worker in ioWorkers + cpuWorkers {
+        for worker in allWorkers {
             worker.baseEnvironment = env
         }
 
@@ -619,7 +633,7 @@ final class ServiceManager: ObservableObject {
         for svc in nonWorkerPython {
             (svc as? PythonService)?.resetRestartCount()
         }
-        for worker in ioWorkers + cpuWorkers {
+        for worker in allWorkers {
             worker.resetRestartCount()
         }
 
@@ -627,7 +641,6 @@ final class ServiceManager: ObservableObject {
         for svc in nonWorkerPython {
             await startService(svc)
         }
-        let allWorkers = ioWorkers + cpuWorkers
         let workersToStart = needsWorkerRecreate ? allWorkers : allWorkers.filter { pythonToRestart.contains(ObjectIdentifier($0)) }
         for worker in workersToStart {
             await startService(worker)
@@ -639,26 +652,27 @@ final class ServiceManager: ObservableObject {
     /// Tear down old workers and create new ones based on current preset.
     func recreateWorkers() {
         // Clear restart history for old workers so new ones don't inherit stale flap state
-        for worker in ioWorkers + cpuWorkers {
+        for worker in allWorkers {
             restartHistory[worker.name] = nil
         }
 
         // Remove old workers from services array
-        let oldWorkerIds = Set((ioWorkers + cpuWorkers).map { ObjectIdentifier($0) })
+        let oldWorkerIds = Set(allWorkers.map { ObjectIdentifier($0) })
         services.removeAll { oldWorkerIds.contains(ObjectIdentifier($0)) }
 
         // Create new workers
         let cpuCount = ProcessInfo.processInfo.processorCount
         let settings = AppSettings.shared
-        let (ioCount, cpuWorkerCount) = Self.workerCounts(preset: settings.workerPreset, cores: cpuCount)
+        let counts = Self.workerCounts(preset: settings.workerPreset, cores: cpuCount)
 
-        ioWorkers = (0..<ioCount).map { WorkerService(queue: "io", index: $0) }
-        cpuWorkers = (0..<cpuWorkerCount).map { WorkerService(queue: "cpu", index: $0) }
+        ioWorkers = (0..<counts.io).map { WorkerService(queue: "io", index: $0) }
+        cpuWorkers = (0..<counts.cpu).map { WorkerService(queue: "cpu", index: $0) }
+        llmWorkers = (0..<counts.llm).map { WorkerService(queue: "llm", index: $0) }
 
-        services.append(contentsOf: ioWorkers + cpuWorkers)
+        services.append(contentsOf: allWorkers)
 
         Log.logger("lifecycle").info(
-            "Recreated workers: \(ioCount, privacy: .public) io, \(cpuWorkerCount, privacy: .public) cpu (preset: \(settings.workerPreset, privacy: .public))"
+            "Recreated workers: \(counts.io, privacy: .public) io, \(counts.cpu, privacy: .public) cpu, \(counts.llm, privacy: .public) llm (preset: \(settings.workerPreset, privacy: .public))"
         )
     }
 

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -43,6 +43,13 @@ final class LlamaService: ManagedService {
             "--host", "127.0.0.1",
             "--port", String(port),
             "-ngl", "99",
+            // -np 1: single parallel slot. Heavy models (Qwen 35B etc.)
+            // need ~3-5 GB extra GPU memory per additional slot for KV
+            // cache, which is unaffordable on most Macs. The dedicated
+            // `llm` worker queue serialises summarize jobs so this isn't
+            // a throughput bottleneck. Future work: tune -np per-model
+            // (small models like SmolLM 3B can comfortably run -np 4 on
+            // an M-series Mac and would benefit from real parallelism).
             "-np", "1",
             "-c", String(contextWindow),
             "--threads", String(max(1, ProcessInfo.processInfo.processorCount / 2)),

--- a/macos/HarborClerkServer/HarborClerkServerTests/WorkerCountsTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/WorkerCountsTests.swift
@@ -84,4 +84,21 @@ final class WorkerCountsTests: XCTestCase {
         XCTAssertEqual(result.io, balanced.io)
         XCTAssertEqual(result.cpu, balanced.cpu)
     }
+
+    // MARK: - LLM worker count is constant 1 across all presets and core counts
+
+    func testLLMCountIsAlwaysOneQuiet() {
+        XCTAssertEqual(ServiceManager.workerCounts(preset: "quiet", cores: 1).llm, 1)
+        XCTAssertEqual(ServiceManager.workerCounts(preset: "quiet", cores: 32).llm, 1)
+    }
+
+    func testLLMCountIsAlwaysOneBalanced() {
+        XCTAssertEqual(ServiceManager.workerCounts(preset: "balanced", cores: 1).llm, 1)
+        XCTAssertEqual(ServiceManager.workerCounts(preset: "balanced", cores: 32).llm, 1)
+    }
+
+    func testLLMCountIsAlwaysOneFast() {
+        XCTAssertEqual(ServiceManager.workerCounts(preset: "fast", cores: 1).llm, 1)
+        XCTAssertEqual(ServiceManager.workerCounts(preset: "fast", cores: 32).llm, 1)
+    }
 }

--- a/src/harbor_clerk/api/routes/jobs.py
+++ b/src/harbor_clerk/api/routes/jobs.py
@@ -175,7 +175,11 @@ async def jobs_snapshot(
     ).all()
 
     by_stage: dict[str, dict[str, int | str]] = {}
-    queues: dict[str, dict[str, int]] = {"io": {"queued": 0, "running": 0}, "cpu": {"queued": 0, "running": 0}}
+    queues: dict[str, dict[str, int]] = {
+        "io": {"queued": 0, "running": 0},
+        "cpu": {"queued": 0, "running": 0},
+        "llm": {"queued": 0, "running": 0},
+    }
 
     # Seed every stage with zeros so the frontend doesn't need to
     # special-case "stage absent from response = no work".

--- a/src/harbor_clerk/worker/entry.py
+++ b/src/harbor_clerk/worker/entry.py
@@ -33,10 +33,16 @@ QUEUE_STAGES: dict[str, list[JobStage]] = {
         JobStage.extract,
         JobStage.chunk,
         JobStage.entities,
-        JobStage.summarize,
         JobStage.finalize,
     ],
     "cpu": [JobStage.ocr, JobStage.embed],
+    # `summarize` calls llama-server, which has a single parallel slot
+    # (-np 1) on the heavy 22 GB+ models we target. Putting it on its
+    # own queue with a dedicated single-worker process means at most one
+    # summarize job ever runs at a time, so the IO/CPU pools don't get
+    # tied up busy-waiting on the LLM lock and other work (extract,
+    # chunk, finalize, OCR, embed) keeps flowing.
+    "llm": [JobStage.summarize],
 }
 
 HEARTBEAT_INTERVAL = 30  # seconds

--- a/src/harbor_clerk/worker/pipeline.py
+++ b/src/harbor_clerk/worker/pipeline.py
@@ -43,7 +43,7 @@ STAGE_CONFIG: dict[JobStage, tuple[str, int, VersionStatus]] = {
     JobStage.chunk: ("io", 1200, VersionStatus.chunking),
     JobStage.entities: ("io", 900, VersionStatus.extracting_entities),
     JobStage.embed: ("cpu", 1800, VersionStatus.embedding),
-    JobStage.summarize: ("io", 900, VersionStatus.summarizing),
+    JobStage.summarize: ("llm", 900, VersionStatus.summarizing),
     JobStage.finalize: ("io", 600, VersionStatus.finalizing),
 }
 


### PR DESCRIPTION
## Summary

Adds a third worker queue class (`llm`) alongside `io`/`cpu`, with a single dedicated worker. `summarize` is the only stage on it for now.

### Why

`summarize` calls llama-server, which runs with `-np 1` on heavy models (Qwen 35B etc. can't afford multiple KV caches on consumer GPUs). Today summarize lives on the IO queue, so under `fast` preset on a multi-core Mac, **up to 6–8 IO workers can simultaneously claim summarize jobs** and all queue at the single-slot LLM. Result: a fan-out into summarize during a batch upload **wedges every IO worker** — no extract / chunk / finalize work can flow until the LLM unblocks them one by one.

A dedicated `llm` queue with one worker means at most one summarize ever runs, and the IO/CPU pools stay fully productive on non-LLM work.

### What

- New queue class `llm`, count constant `1` regardless of preset
- `STAGE_CONFIG[JobStage.summarize] = ("llm", ...)` (was `"io"`)
- `QUEUE_STAGES["llm"] = [JobStage.summarize]`; removed from `"io"`
- `ServiceManager` spawns one `WorkerService(queue: "llm", index: 0)`. New `allWorkers` computed property cleans up the eight call sites that were doing `ioWorkers + cpuWorkers`
- `workerCounts(preset:cores:)` now returns `(io, cpu, llm)`. Existing tests pass unchanged (Swift labelled tuples); added new tests for the LLM-count-is-1 invariant
- Frontend `QueueClass = 'io' | 'cpu' | 'llm'`. WorkerStrip renders a third row; `PipelineDiagram` colours the LLM-class node in **system purple** (`#bf5af2`) so it visually reads as a distinct bottleneck rather than just another flavour of CPU work. Legend gets a third swatch
- Snapshot endpoint includes the llm queue in its rollup

### User-visible effect

- Drawer's Pipeline tab grows a third row: `LLM · Summarize · N` (N ≤ 1)
- Observatory diagram's Summarize node is purple, visually grouped against the IO blue and CPU amber
- With 100+ docs queued you'll see at most one summarize running, freeing IO workers to keep extract / chunk / finalize flowing

### Out of scope (future work)

Tuning llama-server's `-np` per-model. SmolLM 3B can comfortably do `-np 4` on an M-series Mac and would benefit from real parallelism; heavy models stay at `-np 1`. Documented inline in [LlamaService.swift:46](macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift:46).

## Test plan

- [x] `uv run ruff check src/harbor_clerk/` + `ruff format --check` — pass
- [x] Python sanity: `STAGE_CONFIG[JobStage.summarize][0] == "llm"`, `QUEUE_STAGES["llm"] == [JobStage.summarize]`
- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` + `npm run build` — pass
- [x] `xcodebuild build` + `xcodebuild test` — 52/52 passing (49 + 3 new LLM-count tests)
- [ ] After `make apps` + reinstall: kick off a 50+ doc upload. Confirm summarize never has more than 1 running on the Pipeline tab. Confirm IO chips for extract/chunk/finalize stay productive while summarize backlog drains
- [ ] Confirm Observatory diagram renders Summarize in purple and the legend has three swatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
