### PR TITLE
improve(queue-tray): match status panel colours to Observatory diagram

### DIFF
--- a/frontend/src/components/queue-tray/StageHistogram.tsx
+++ b/frontend/src/components/queue-tray/StageHistogram.tsx
@@ -1,5 +1,6 @@
 import type { QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
+import { classColor, classColorAlpha } from '../../utils/queueColors'
 
 interface StageHistogramProps {
   snapshot: QueueSnapshot
@@ -8,12 +9,15 @@ interface StageHistogramProps {
 /**
  * Per-stage queue depth, one bar per pipeline stage in pipeline order.
  *
- * Each bar shows running (saturated accent, bottom) stacked under
- * queued (lighter accent, top). The eye reads "running below the
- * waterline, waiting above" — a tall stack on a single stage screams
- * "this is the choke point". The total height of the tallest bar
- * normalises to a fixed pixel ceiling so long queues don't crush the
- * shorter bars into invisibility.
+ * Each bar shows running (saturated, bottom) stacked under queued
+ * (faded, top). The eye reads "running below the waterline, waiting
+ * above" — a tall stack on a single stage screams "this is the choke
+ * point". The total height of the tallest bar normalises to a fixed
+ * pixel ceiling so long queues don't crush the shorter bars into
+ * invisibility.
+ *
+ * Bar colours match the Observatory pipeline diagram (IO blue, CPU
+ * amber, LLM purple) so the two views stay visually consistent.
  */
 const BAR_PIXEL_HEIGHT = 80
 const SHORT_LABELS: Record<string, string> = {
@@ -69,14 +73,22 @@ export default function StageHistogram({ snapshot }: StageHistogramProps) {
                 <div className="flex h-full flex-col justify-end">
                   {queuedHeight > 0 && (
                     <div
-                      className="w-full bg-(--color-accent)/30"
-                      style={{ height: queuedHeight, transition: 'height 400ms ease-out' }}
+                      className="w-full"
+                      style={{
+                        height: queuedHeight,
+                        background: classColorAlpha(info?.queue, 0.3),
+                        transition: 'height 400ms ease-out',
+                      }}
                     />
                   )}
                   {runningHeight > 0 && (
                     <div
-                      className="w-full bg-(--color-accent)"
-                      style={{ height: runningHeight, transition: 'height 400ms ease-out' }}
+                      className="w-full"
+                      style={{
+                        height: runningHeight,
+                        background: classColor(info?.queue),
+                        transition: 'height 400ms ease-out',
+                      }}
                     />
                   )}
                 </div>
@@ -98,16 +110,17 @@ export default function StageHistogram({ snapshot }: StageHistogramProps) {
           </div>
         ))}
       </div>
-      {/* Legend */}
-      <div className="mt-3 flex items-center gap-3 text-[10px] text-(--color-text-secondary)">
-        <span className="inline-flex items-center gap-1">
-          <span className="h-2 w-2 rounded-sm bg-(--color-accent)" />
-          Running
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <span className="h-2 w-2 rounded-sm bg-(--color-accent)/30" />
-          Queued
-        </span>
+      {/* Legend — queue-class colours match the Observatory diagram.
+          Bar saturation conveys running (bottom) vs queued (top); see
+          tooltip for exact counts. */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        {(['io', 'cpu', 'llm'] as const).map((q) => (
+          <span key={q} className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-sm" style={{ background: classColor(q) }} />
+            {q.toUpperCase()}
+          </span>
+        ))}
+        <span className="ml-auto">Saturated = running · faded = queued</span>
       </div>
     </div>
   )

--- a/frontend/src/components/queue-tray/WorkerStrip.tsx
+++ b/frontend/src/components/queue-tray/WorkerStrip.tsx
@@ -1,5 +1,6 @@
 import type { QueueClass, QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
+import { classColor, classColorAlpha } from '../../utils/queueColors'
 
 interface WorkerStripProps {
   snapshot: QueueSnapshot
@@ -47,21 +48,34 @@ export default function WorkerStrip({ snapshot }: WorkerStripProps) {
                 const info = snapshot.by_stage[stage]
                 const running = info?.running ?? 0
                 const idle = running === 0
+                // Active chips are coloured by their queue class to
+                // match the Observatory pipeline diagram (IO blue,
+                // CPU amber, LLM purple). Idle chips stay neutral
+                // grey so the eye is drawn to what's running.
+                const activeStyle = idle
+                  ? undefined
+                  : {
+                      background: classColorAlpha(info?.queue, 0.15),
+                      color: classColor(info?.queue),
+                      boxShadow: `inset 0 0 0 1px ${classColorAlpha(info?.queue, 0.3)}`,
+                    }
                 return (
                   <span
                     key={stage}
                     className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] transition-colors ${
-                      idle
-                        ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70'
-                        : 'bg-(--color-accent)/15 text-(--color-accent) ring-1 ring-(--color-accent)/30'
+                      idle ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70' : ''
                     }`}
+                    style={activeStyle}
                     title={
                       idle
                         ? `${stageLabel(stage)} — idle`
                         : `${stageLabel(stage)} — ${running} worker${running === 1 ? '' : 's'} busy`
                     }
                   >
-                    <span className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : 'bg-(--color-accent)'}`} />
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : ''}`}
+                      style={idle ? undefined : { background: classColor(info?.queue) }}
+                    />
                     {stageLabel(stage)}
                     {running > 0 && <span className="font-semibold">· {running}</span>}
                   </span>

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { useQueueSnapshot, type QueueClass, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { classColor } from '../../utils/queueColors'
 
 /**
  * Pipeline Overview — animated DAG showing live activity in the
@@ -60,18 +61,6 @@ const STAGE_LABELS: Record<string, string> = {
   embed: 'Embed',
   summarize: 'Summarize',
   finalize: 'Finalize',
-}
-
-// Distinct hues by queue class so the eye reads "this is a CPU stage"
-// vs "this is an IO stage" at a glance. CPU stages (OCR, Embed) are
-// the heavy / slow compute ones; warm hue makes them stand out. The
-// LLM queue (Summarize) gets its own purple — visually distinct and
-// reinforces that it's a serialised single-worker bottleneck, not
-// just another flavour of CPU work.
-function classColor(queue: QueueClass | undefined): string {
-  if (queue === 'cpu') return '#f5a623' // amber
-  if (queue === 'llm') return '#bf5af2' // system purple
-  return '#0a84ff' // accent blue (matches --color-accent)
 }
 
 function edgePath(from: string, to: string): string {

--- a/frontend/src/utils/queueColors.ts
+++ b/frontend/src/utils/queueColors.ts
@@ -1,0 +1,25 @@
+import type { QueueClass } from '../hooks/useQueueSnapshot'
+
+/**
+ * Single source of truth for queue-class colours. Used by:
+ *  - PipelineDiagram (Observatory page) — node fills, edge strokes,
+ *    particle colours, legend swatches.
+ *  - WorkerStrip (drawer Pipeline tab) — chip background / text / ring.
+ *  - StageHistogram (drawer Pipeline tab) — bar fill (running stacked
+ *    under queued).
+ *
+ * Colours are picked from the macOS system palette so they read as
+ * native and remain distinct from the in-app accent. Alpha variants go
+ * through `color-mix(in srgb, ..., transparent)` rather than ad-hoc hex
+ * parsing — better for dark/light mode and avoids string-math bugs.
+ */
+export function classColor(queue: QueueClass | undefined): string {
+  if (queue === 'cpu') return '#f5a623' // system amber
+  if (queue === 'llm') return '#bf5af2' // system purple
+  return '#0a84ff' // accent blue (matches --color-accent on dark)
+}
+
+/** Translucent variant for tinted backgrounds, ring colours, etc. */
+export function classColorAlpha(queue: QueueClass | undefined, alpha: number): string {
+  return `color-mix(in srgb, ${classColor(queue)} ${Math.round(alpha * 100)}%, transparent)`
+}


### PR DESCRIPTION
## Summary

Worker chips and queue-depth histogram in the drawer were all rendered in the same accent blue regardless of queue class, so the visual link to the Observatory pipeline diagram (IO blue / CPU amber / LLM purple) was lost. This wires them up to the same palette.

### Changes

- **New shared util** `frontend/src/utils/queueColors.ts` — single source of truth for queue-class colours. Used by `PipelineDiagram`, `WorkerStrip`, `StageHistogram`. Alpha variants go through CSS `color-mix(in srgb, ..., transparent)` rather than ad-hoc hex parsing.
- **`WorkerStrip`** — active chips take their background / text / ring colour from the stage's queue class. Idle chips stay neutral grey so the eye is drawn to what's running.
- **`StageHistogram`** — bars now coloured per stage's queue class. Running portion saturated, queued portion at 30% alpha. Same scheme as the diagram.
- **Histogram legend** — swaps the now-misleading Running/Queued accent swatches for IO/CPU/LLM swatches, with a brief note about saturation conveying running-vs-queued.
- **`PipelineDiagram`** — drops its local `classColor` and imports from the shared util.

No data or behaviour change.

## Test plan

- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` + `npm run build` — pass
- [ ] After install + reload: drawer's Pipeline tab shows Extracting / Chunking / Finalizing / Extracting entities chips in blue, OCR / Embedding in amber, Summarizing in purple
- [ ] Histogram bars match: Ext/Chk/Ent/Fin blue, OCR/Emb amber, Sum purple
- [ ] Legend below histogram shows IO/CPU/LLM swatches in matching colours
- [ ] Observatory diagram still renders correctly (it now imports from the shared util)

🤖 Generated with [Claude Code](https://claude.com/claude-code)