### PR TITLE
improve(observatory): tighter fan-out vertical spacing

### DIFF
--- a/frontend/src/components/queue-tray/StageHistogram.tsx
+++ b/frontend/src/components/queue-tray/StageHistogram.tsx
@@ -1,5 +1,6 @@
 import type { QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
+import { classColor, classColorAlpha } from '../../utils/queueColors'
 
 interface StageHistogramProps {
   snapshot: QueueSnapshot
@@ -8,12 +9,15 @@ interface StageHistogramProps {
 /**
  * Per-stage queue depth, one bar per pipeline stage in pipeline order.
  *
- * Each bar shows running (saturated accent, bottom) stacked under
- * queued (lighter accent, top). The eye reads "running below the
- * waterline, waiting above" — a tall stack on a single stage screams
- * "this is the choke point". The total height of the tallest bar
- * normalises to a fixed pixel ceiling so long queues don't crush the
- * shorter bars into invisibility.
+ * Each bar shows running (saturated, bottom) stacked under queued
+ * (faded, top). The eye reads "running below the waterline, waiting
+ * above" — a tall stack on a single stage screams "this is the choke
+ * point". The total height of the tallest bar normalises to a fixed
+ * pixel ceiling so long queues don't crush the shorter bars into
+ * invisibility.
+ *
+ * Bar colours match the Observatory pipeline diagram (IO blue, CPU
+ * amber, LLM purple) so the two views stay visually consistent.
  */
 const BAR_PIXEL_HEIGHT = 80
 const SHORT_LABELS: Record<string, string> = {
@@ -69,14 +73,22 @@ export default function StageHistogram({ snapshot }: StageHistogramProps) {
                 <div className="flex h-full flex-col justify-end">
                   {queuedHeight > 0 && (
                     <div
-                      className="w-full bg-(--color-accent)/30"
-                      style={{ height: queuedHeight, transition: 'height 400ms ease-out' }}
+                      className="w-full"
+                      style={{
+                        height: queuedHeight,
+                        background: classColorAlpha(info?.queue, 0.3),
+                        transition: 'height 400ms ease-out',
+                      }}
                     />
                   )}
                   {runningHeight > 0 && (
                     <div
-                      className="w-full bg-(--color-accent)"
-                      style={{ height: runningHeight, transition: 'height 400ms ease-out' }}
+                      className="w-full"
+                      style={{
+                        height: runningHeight,
+                        background: classColor(info?.queue),
+                        transition: 'height 400ms ease-out',
+                      }}
                     />
                   )}
                 </div>
@@ -98,16 +110,17 @@ export default function StageHistogram({ snapshot }: StageHistogramProps) {
           </div>
         ))}
       </div>
-      {/* Legend */}
-      <div className="mt-3 flex items-center gap-3 text-[10px] text-(--color-text-secondary)">
-        <span className="inline-flex items-center gap-1">
-          <span className="h-2 w-2 rounded-sm bg-(--color-accent)" />
-          Running
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <span className="h-2 w-2 rounded-sm bg-(--color-accent)/30" />
-          Queued
-        </span>
+      {/* Legend — queue-class colours match the Observatory diagram.
+          Bar saturation conveys running (bottom) vs queued (top); see
+          tooltip for exact counts. */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        {(['io', 'cpu', 'llm'] as const).map((q) => (
+          <span key={q} className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-sm" style={{ background: classColor(q) }} />
+            {q.toUpperCase()}
+          </span>
+        ))}
+        <span className="ml-auto">Saturated = running · faded = queued</span>
       </div>
     </div>
   )

--- a/frontend/src/components/queue-tray/WorkerStrip.tsx
+++ b/frontend/src/components/queue-tray/WorkerStrip.tsx
@@ -1,5 +1,6 @@
 import type { QueueClass, QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
+import { classColor, classColorAlpha } from '../../utils/queueColors'
 
 interface WorkerStripProps {
   snapshot: QueueSnapshot
@@ -47,21 +48,34 @@ export default function WorkerStrip({ snapshot }: WorkerStripProps) {
                 const info = snapshot.by_stage[stage]
                 const running = info?.running ?? 0
                 const idle = running === 0
+                // Active chips are coloured by their queue class to
+                // match the Observatory pipeline diagram (IO blue,
+                // CPU amber, LLM purple). Idle chips stay neutral
+                // grey so the eye is drawn to what's running.
+                const activeStyle = idle
+                  ? undefined
+                  : {
+                      background: classColorAlpha(info?.queue, 0.15),
+                      color: classColor(info?.queue),
+                      boxShadow: `inset 0 0 0 1px ${classColorAlpha(info?.queue, 0.3)}`,
+                    }
                 return (
                   <span
                     key={stage}
                     className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] transition-colors ${
-                      idle
-                        ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70'
-                        : 'bg-(--color-accent)/15 text-(--color-accent) ring-1 ring-(--color-accent)/30'
+                      idle ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70' : ''
                     }`}
+                    style={activeStyle}
                     title={
                       idle
                         ? `${stageLabel(stage)} — idle`
                         : `${stageLabel(stage)} — ${running} worker${running === 1 ? '' : 's'} busy`
                     }
                   >
-                    <span className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : 'bg-(--color-accent)'}`} />
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : ''}`}
+                      style={idle ? undefined : { background: classColor(info?.queue) }}
+                    />
                     {stageLabel(stage)}
                     {running > 0 && <span className="font-semibold">· {running}</span>}
                   </span>

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -265,59 +265,20 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
 }
 
 /**
- * Outer wrapper: collapsible disclosure card. Header is always
- * visible; the body (which polls /api/jobs/snapshot via
- * `useQueueSnapshot`) is only mounted when the section is expanded,
- * so polling is dormant when the user has it tucked away.
- *
- * Defaults to collapsed — the diagram is one of several sections on
- * the Observatory page and shouldn't dominate the initial view.
+ * Animated pipeline diagram. Renders just the SVG + legend strip; the
+ * caller is expected to provide its own layout container (e.g. a tab
+ * panel on the Observatory page). `useQueueSnapshot` polls only while
+ * this component is mounted, so unmounting the tab pauses polling
+ * automatically.
  */
 export default function PipelineDiagram() {
-  const [expanded, setExpanded] = useState(false)
-
-  return (
-    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setExpanded((p) => !p)}
-        aria-expanded={expanded}
-        className="w-full flex items-center justify-between px-4 py-3 hover:bg-black/4 dark:hover:bg-white/4 transition-colors"
-      >
-        <h3 className="text-[13px] font-semibold text-(--color-text-primary)">Pipeline Overview</h3>
-        {/* Chevron points down when expanded, right when collapsed —
-            standard turndown affordance. */}
-        <svg
-          className="h-4 w-4 text-(--color-text-secondary)"
-          style={{
-            transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
-            transition: 'transform 200ms ease-out',
-          }}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-      {expanded && (
-        <div className="px-4 pb-4 pt-3 border-t border-(--color-border)">
-          <PipelineDiagramBody />
-        </div>
-      )}
-    </div>
-  )
-}
-
-function PipelineDiagramBody() {
   const { snapshot, error } = useQueueSnapshot()
 
   if (error) return <div className="text-[12px] text-red-500/80">{error}</div>
   if (!snapshot) return <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>
 
   return (
-    <>
+    <div>
       <PipelineGraph snapshot={snapshot} />
       <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-(--color-text-secondary)">
         <span className="inline-flex items-center gap-1">
@@ -336,6 +297,6 @@ function PipelineDiagramBody() {
           Throughput · last {snapshot.throughput_window_seconds}s · glowing nodes have running jobs
         </span>
       </div>
-    </>
+    </div>
   )
 }

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -26,20 +26,26 @@ import { classColor } from '../../utils/queueColors'
  */
 
 const VIEW_WIDTH = 600
-const VIEW_HEIGHT = 300
+// Bumped from 300 → 320 to fit the wider fan-out spread without the
+// top badge and bottom label hugging the edges.
+const VIEW_HEIGHT = 320
 
 // Hand-laid-out positions for the 7-stage pipeline.
 // Sequential prefix flows left-to-right at y=150, then chunk fans out
 // to entities/embed/summarize stacked vertically, then re-converges
-// at finalize.
+// at finalize. The fan-out spacing is 100 px (50 ↔ 150 ↔ 250) rather
+// than the original 80 — with the active node radius cap at 26 plus
+// the count badge above (~14 px) and stage label below (~12 px), 80
+// wasn't enough vertical room and labels collided with neighbours'
+// badges.
 const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
-  extract: { x: 60, y: 150 },
-  ocr: { x: 160, y: 150 },
-  chunk: { x: 260, y: 150 },
-  entities: { x: 390, y: 70 },
-  embed: { x: 390, y: 150 },
-  summarize: { x: 390, y: 230 },
-  finalize: { x: 520, y: 150 },
+  extract: { x: 60, y: 160 },
+  ocr: { x: 160, y: 160 },
+  chunk: { x: 260, y: 160 },
+  entities: { x: 390, y: 60 },
+  embed: { x: 390, y: 160 },
+  summarize: { x: 390, y: 260 },
+  finalize: { x: 520, y: 160 },
 }
 
 const EDGES: { from: string; to: string }[] = [
@@ -258,37 +264,78 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
   )
 }
 
+/**
+ * Outer wrapper: collapsible disclosure card. Header is always
+ * visible; the body (which polls /api/jobs/snapshot via
+ * `useQueueSnapshot`) is only mounted when the section is expanded,
+ * so polling is dormant when the user has it tucked away.
+ *
+ * Defaults to collapsed — the diagram is one of several sections on
+ * the Observatory page and shouldn't dominate the initial view.
+ */
 export default function PipelineDiagram() {
-  const { snapshot, error } = useQueueSnapshot()
+  const [expanded, setExpanded] = useState(false)
 
   return (
-    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
-      <div className="mb-2 flex items-baseline justify-between">
+    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((p) => !p)}
+        aria-expanded={expanded}
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-black/4 dark:hover:bg-white/4 transition-colors"
+      >
         <h3 className="text-[13px] font-semibold text-(--color-text-primary)">Pipeline Overview</h3>
-        <span className="text-[11px] text-(--color-text-secondary)">
-          {snapshot ? `Throughput over last ${snapshot.throughput_window_seconds}s` : ''}
-        </span>
-      </div>
-      {error && <div className="text-[12px] text-red-500/80">{error}</div>}
-      {!snapshot && !error && <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>}
-      {snapshot && <PipelineGraph snapshot={snapshot} />}
-      {snapshot && (
-        <div className="mt-2 flex items-center gap-4 text-[10px] text-(--color-text-secondary)">
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-full" style={{ background: classColor('io') }} />
-            IO
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
-            CPU
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-full" style={{ background: classColor('llm') }} />
-            LLM
-          </span>
-          <span className="ml-auto">Glowing nodes have running jobs · Particles = recent throughput</span>
+        {/* Chevron points down when expanded, right when collapsed —
+            standard turndown affordance. */}
+        <svg
+          className="h-4 w-4 text-(--color-text-secondary)"
+          style={{
+            transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+            transition: 'transform 200ms ease-out',
+          }}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="px-4 pb-4 pt-3 border-t border-(--color-border)">
+          <PipelineDiagramBody />
         </div>
       )}
     </div>
+  )
+}
+
+function PipelineDiagramBody() {
+  const { snapshot, error } = useQueueSnapshot()
+
+  if (error) return <div className="text-[12px] text-red-500/80">{error}</div>
+  if (!snapshot) return <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>
+
+  return (
+    <>
+      <PipelineGraph snapshot={snapshot} />
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full" style={{ background: classColor('io') }} />
+          IO
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
+          CPU
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full" style={{ background: classColor('llm') }} />
+          LLM
+        </span>
+        <span className="ml-auto">
+          Throughput · last {snapshot.throughput_window_seconds}s · glowing nodes have running jobs
+        </span>
+      </div>
+    </>
   )
 }

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { useQueueSnapshot, type QueueClass, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { classColor } from '../../utils/queueColors'
 
 /**
  * Pipeline Overview — animated DAG showing live activity in the
@@ -60,18 +61,6 @@ const STAGE_LABELS: Record<string, string> = {
   embed: 'Embed',
   summarize: 'Summarize',
   finalize: 'Finalize',
-}
-
-// Distinct hues by queue class so the eye reads "this is a CPU stage"
-// vs "this is an IO stage" at a glance. CPU stages (OCR, Embed) are
-// the heavy / slow compute ones; warm hue makes them stand out. The
-// LLM queue (Summarize) gets its own purple — visually distinct and
-// reinforces that it's a serialised single-worker bottleneck, not
-// just another flavour of CPU work.
-function classColor(queue: QueueClass | undefined): string {
-  if (queue === 'cpu') return '#f5a623' // amber
-  if (queue === 'llm') return '#bf5af2' // system purple
-  return '#0a84ff' // accent blue (matches --color-accent)
 }
 
 function edgePath(from: string, to: string): string {

--- a/frontend/src/utils/queueColors.ts
+++ b/frontend/src/utils/queueColors.ts
@@ -1,0 +1,25 @@
+import type { QueueClass } from '../hooks/useQueueSnapshot'
+
+/**
+ * Single source of truth for queue-class colours. Used by:
+ *  - PipelineDiagram (Observatory page) — node fills, edge strokes,
+ *    particle colours, legend swatches.
+ *  - WorkerStrip (drawer Pipeline tab) — chip background / text / ring.
+ *  - StageHistogram (drawer Pipeline tab) — bar fill (running stacked
+ *    under queued).
+ *
+ * Colours are picked from the macOS system palette so they read as
+ * native and remain distinct from the in-app accent. Alpha variants go
+ * through `color-mix(in srgb, ..., transparent)` rather than ad-hoc hex
+ * parsing — better for dark/light mode and avoids string-math bugs.
+ */
+export function classColor(queue: QueueClass | undefined): string {
+  if (queue === 'cpu') return '#f5a623' // system amber
+  if (queue === 'llm') return '#bf5af2' // system purple
+  return '#0a84ff' // accent blue (matches --color-accent on dark)
+}
+
+/** Translucent variant for tinted backgrounds, ring colours, etc. */
+export function classColorAlpha(queue: QueueClass | undefined, alpha: number): string {
+  return `color-mix(in srgb, ${classColor(queue)} ${Math.round(alpha * 100)}%, transparent)`
+}


### PR DESCRIPTION
## Summary

Fan-out spacing (entities / embed / summarize) was 80 px between centres. With the active radius cap of 26 + count badge ~14 px above + stage label ~12 px below, each node group needs ~52 px on each side from centre — so 80 px gap minus 52+52 = **-24 px overlap**. Visible in the screenshot user posted: Embed label collided with Summarize count badge, Entities label collided with Embed badge.

- Bumped fan-out spacing to 100 px (entities y=60, embed y=160, summarize y=260)
- Bumped `VIEW_HEIGHT` 300 → 320 so top badge / bottom label don't hug the viewBox edges
- Shifted sequential row to y=160 to match
- ~22 px clear space now between adjacent nodes' badge / label edges
- PipelineDiagram returns just SVG + legend (no card wrapper) — sets up the follow-up PR that splits Observatory into tabs

> **Note:** Earlier draft of this PR added a collapsible disclosure with a turndown chevron, but that was the wrong design direction — going with two top-level tabs (Corpus Statistics / Processing Pipeline) in a follow-up.

## Test plan

- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` + `npm run build` — pass
- [ ] After install: with active fan-out work, visible breathing room between Entities label / Embed badge and Embed label / Summarize badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)