### PR TITLE
improve(observatory + summarize): per-call timing logs + max in timing chart

### DIFF
--- a/frontend/src/components/queue-tray/StageHistogram.tsx
+++ b/frontend/src/components/queue-tray/StageHistogram.tsx
@@ -1,5 +1,6 @@
 import type { QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
+import { classColor, classColorAlpha } from '../../utils/queueColors'
 
 interface StageHistogramProps {
   snapshot: QueueSnapshot
@@ -8,12 +9,15 @@ interface StageHistogramProps {
 /**
  * Per-stage queue depth, one bar per pipeline stage in pipeline order.
  *
- * Each bar shows running (saturated accent, bottom) stacked under
- * queued (lighter accent, top). The eye reads "running below the
- * waterline, waiting above" — a tall stack on a single stage screams
- * "this is the choke point". The total height of the tallest bar
- * normalises to a fixed pixel ceiling so long queues don't crush the
- * shorter bars into invisibility.
+ * Each bar shows running (saturated, bottom) stacked under queued
+ * (faded, top). The eye reads "running below the waterline, waiting
+ * above" — a tall stack on a single stage screams "this is the choke
+ * point". The total height of the tallest bar normalises to a fixed
+ * pixel ceiling so long queues don't crush the shorter bars into
+ * invisibility.
+ *
+ * Bar colours match the Observatory pipeline diagram (IO blue, CPU
+ * amber, LLM purple) so the two views stay visually consistent.
  */
 const BAR_PIXEL_HEIGHT = 80
 const SHORT_LABELS: Record<string, string> = {
@@ -69,14 +73,22 @@ export default function StageHistogram({ snapshot }: StageHistogramProps) {
                 <div className="flex h-full flex-col justify-end">
                   {queuedHeight > 0 && (
                     <div
-                      className="w-full bg-(--color-accent)/30"
-                      style={{ height: queuedHeight, transition: 'height 400ms ease-out' }}
+                      className="w-full"
+                      style={{
+                        height: queuedHeight,
+                        background: classColorAlpha(info?.queue, 0.3),
+                        transition: 'height 400ms ease-out',
+                      }}
                     />
                   )}
                   {runningHeight > 0 && (
                     <div
-                      className="w-full bg-(--color-accent)"
-                      style={{ height: runningHeight, transition: 'height 400ms ease-out' }}
+                      className="w-full"
+                      style={{
+                        height: runningHeight,
+                        background: classColor(info?.queue),
+                        transition: 'height 400ms ease-out',
+                      }}
                     />
                   )}
                 </div>
@@ -98,16 +110,17 @@ export default function StageHistogram({ snapshot }: StageHistogramProps) {
           </div>
         ))}
       </div>
-      {/* Legend */}
-      <div className="mt-3 flex items-center gap-3 text-[10px] text-(--color-text-secondary)">
-        <span className="inline-flex items-center gap-1">
-          <span className="h-2 w-2 rounded-sm bg-(--color-accent)" />
-          Running
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <span className="h-2 w-2 rounded-sm bg-(--color-accent)/30" />
-          Queued
-        </span>
+      {/* Legend — queue-class colours match the Observatory diagram.
+          Bar saturation conveys running (bottom) vs queued (top); see
+          tooltip for exact counts. */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        {(['io', 'cpu', 'llm'] as const).map((q) => (
+          <span key={q} className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-sm" style={{ background: classColor(q) }} />
+            {q.toUpperCase()}
+          </span>
+        ))}
+        <span className="ml-auto">Saturated = running · faded = queued</span>
       </div>
     </div>
   )

--- a/frontend/src/components/queue-tray/WorkerStrip.tsx
+++ b/frontend/src/components/queue-tray/WorkerStrip.tsx
@@ -1,5 +1,6 @@
 import type { QueueClass, QueueSnapshot } from '../../hooks/useQueueSnapshot'
 import { stageLabel } from '../../utils/stageLabel'
+import { classColor, classColorAlpha } from '../../utils/queueColors'
 
 interface WorkerStripProps {
   snapshot: QueueSnapshot
@@ -47,21 +48,34 @@ export default function WorkerStrip({ snapshot }: WorkerStripProps) {
                 const info = snapshot.by_stage[stage]
                 const running = info?.running ?? 0
                 const idle = running === 0
+                // Active chips are coloured by their queue class to
+                // match the Observatory pipeline diagram (IO blue,
+                // CPU amber, LLM purple). Idle chips stay neutral
+                // grey so the eye is drawn to what's running.
+                const activeStyle = idle
+                  ? undefined
+                  : {
+                      background: classColorAlpha(info?.queue, 0.15),
+                      color: classColor(info?.queue),
+                      boxShadow: `inset 0 0 0 1px ${classColorAlpha(info?.queue, 0.3)}`,
+                    }
                 return (
                   <span
                     key={stage}
                     className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] transition-colors ${
-                      idle
-                        ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70'
-                        : 'bg-(--color-accent)/15 text-(--color-accent) ring-1 ring-(--color-accent)/30'
+                      idle ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary)/70' : ''
                     }`}
+                    style={activeStyle}
                     title={
                       idle
                         ? `${stageLabel(stage)} — idle`
                         : `${stageLabel(stage)} — ${running} worker${running === 1 ? '' : 's'} busy`
                     }
                   >
-                    <span className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : 'bg-(--color-accent)'}`} />
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${idle ? 'bg-current/40' : ''}`}
+                      style={idle ? undefined : { background: classColor(info?.queue) }}
+                    />
                     {stageLabel(stage)}
                     {running > 0 && <span className="font-semibold">· {running}</span>}
                   </span>

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -7,14 +7,20 @@ import { classColor } from '../../utils/queueColors'
  * ingestion pipeline.
  *
  * Visual encoding:
- *   - Node radius scales with sqrt(queued + running) — a bottleneck
- *     swells without crushing other nodes.
- *   - Node hue distinguishes IO / CPU / LLM queue classes.
- *   - Soft glow filter on nodes with at least one running job — the
- *     "I am alive" cue.
- *   - Edges thicken with recent throughput on the downstream stage.
+ *   - Each stage is rendered as a thin outline circle whose radius
+ *     scales with sqrt(queued + running) — a bottleneck swells
+ *     without crushing other nodes.
+ *   - Outline hue = queue class (IO blue / CPU amber / LLM purple).
+ *   - When the stage has running jobs, an inner concentric "particle"
+ *     appears — same hue as the outline, with a soft glow and a slow
+ *     heartbeat pulse (radius + opacity). Idle stages are bare rings
+ *     so the eye is drawn to active work.
+ *   - Edges are a fixed green so the connecting "pipes" read as their
+ *     own visual layer. Edges thicken and brighten with recent
+ *     throughput on the downstream stage.
  *   - Particles flow along edges at a rate proportional to recent
- *     throughput. Each particle inherits the upstream stage's colour.
+ *     throughput. Each particle inherits the upstream stage's colour
+ *     (coloured payload moving through green plumbing).
  *
  * Polls the same /api/jobs/snapshot endpoint as the drawer's Pipeline
  * tab. The snapshot includes `recent_completed` per stage (last 30 s),
@@ -29,6 +35,12 @@ const VIEW_WIDTH = 600
 // Bumped from 300 → 320 to fit the wider fan-out spread without the
 // top badge and bottom label hugging the edges.
 const VIEW_HEIGHT = 320
+
+// Connecting edges all use the same neutral colour so the "pipes" read
+// as their own visual layer, separate from the queue-class hues on the
+// nodes. System green reads as flow / activity without competing with
+// the IO-blue / CPU-amber / LLM-purple node palette.
+const EDGE_COLOR = '#30d158'
 
 // Hand-laid-out positions for the 7-stage pipeline.
 // Sequential prefix flows left-to-right at y=150, then chunk fans out
@@ -160,21 +172,24 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
         </filter>
       </defs>
 
-      {/* Edges */}
+      {/* Edges — fixed system green so the connecting "pipes" read as
+          their own visual layer, separate from the nodes' queue-class
+          hues. Particles flowing through them still inherit the
+          upstream node's colour, which gives the impression of
+          coloured payload moving through a green plumbing graph. */}
       {EDGES.map((edge) => {
         const downstream = snapshot.by_stage[edge.to]
         const throughput = downstream?.recent_completed ?? 0
         const baseWidth = 1.5
         const width = Math.min(8, baseWidth + throughput * 0.4)
-        const color = classColor(downstream?.queue)
-        const opacity = throughput > 0 ? 0.5 : 0.15
+        const opacity = throughput > 0 ? 0.55 : 0.2
         return (
           <path
             key={`${edge.from}-${edge.to}`}
             id={`edge-${edge.from}-${edge.to}`}
             d={edgePath(edge.from, edge.to)}
             fill="none"
-            stroke={color}
+            stroke={EDGE_COLOR}
             strokeWidth={width}
             strokeOpacity={opacity}
             strokeLinecap="round"
@@ -209,21 +224,53 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
         const total = info ? info.queued + info.running : 0
         const isBusy = (info?.running ?? 0) > 0
 
+        // Inner "particle" radius — proportional to the outer ring so
+        // both grow together as the queue depth scales the node size.
+        const innerR = r * 0.55
+        // Heartbeat amplitude: small expansion + slight opacity dip,
+        // ~1.6 s cycle for a calm 'breathing' rather than an urgent
+        // alarm.
+        const innerRMin = innerR * 0.86
+        const innerRMax = innerR * 1.04
         return (
           <g key={stage}>
+            {/* Outer ring — always rendered, same thin outline whether
+                idle or busy. The activity signal is the inner particle,
+                not a fill colour change. */}
             <circle
               cx={pos.x}
               cy={pos.y}
               r={r}
-              fill={color}
-              fillOpacity={isBusy ? 0.85 : 0.2}
+              fill="none"
               stroke={color}
-              strokeWidth={isBusy ? 2 : 1}
-              style={{
-                filter: isBusy ? 'url(#pipeline-glow)' : undefined,
-                transition: 'r 400ms ease-out, fill-opacity 400ms',
-              }}
+              strokeWidth={1.2}
+              strokeOpacity={isBusy ? 0.75 : 0.45}
+              style={{ transition: 'r 400ms ease-out, stroke-opacity 400ms' }}
             />
+            {/* Inner particle — only when busy. Concentric with the
+                ring, glow filter applied, and a slow heartbeat
+                (radius + opacity) so the eye reads "this stage is
+                alive" without the diagram feeling frantic. */}
+            {isBusy && (
+              <circle cx={pos.x} cy={pos.y} fill={color} style={{ filter: 'url(#pipeline-glow)' }}>
+                <animate
+                  attributeName="r"
+                  values={`${innerRMin};${innerRMax};${innerRMin}`}
+                  dur="1.6s"
+                  repeatCount="indefinite"
+                  calcMode="spline"
+                  keySplines="0.4 0 0.6 1; 0.4 0 0.6 1"
+                />
+                <animate
+                  attributeName="opacity"
+                  values="0.78;1;0.78"
+                  dur="1.6s"
+                  repeatCount="indefinite"
+                  calcMode="spline"
+                  keySplines="0.4 0 0.6 1; 0.4 0 0.6 1"
+                />
+              </circle>
+            )}
             {/* Count badge above the node, only when there's activity */}
             {total > 0 && (
               <g>
@@ -294,7 +341,7 @@ export default function PipelineDiagram() {
           LLM
         </span>
         <span className="ml-auto">
-          Throughput · last {snapshot.throughput_window_seconds}s · glowing nodes have running jobs
+          Throughput · last {snapshot.throughput_window_seconds}s · pulsing particles inside a node = running jobs
         </span>
       </div>
     </div>

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -265,59 +265,20 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
 }
 
 /**
- * Outer wrapper: collapsible disclosure card. Header is always
- * visible; the body (which polls /api/jobs/snapshot via
- * `useQueueSnapshot`) is only mounted when the section is expanded,
- * so polling is dormant when the user has it tucked away.
- *
- * Defaults to collapsed — the diagram is one of several sections on
- * the Observatory page and shouldn't dominate the initial view.
+ * Animated pipeline diagram. Renders just the SVG + legend strip; the
+ * caller is expected to provide its own layout container (e.g. a tab
+ * panel on the Observatory page). `useQueueSnapshot` polls only while
+ * this component is mounted, so unmounting the tab pauses polling
+ * automatically.
  */
 export default function PipelineDiagram() {
-  const [expanded, setExpanded] = useState(false)
-
-  return (
-    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setExpanded((p) => !p)}
-        aria-expanded={expanded}
-        className="w-full flex items-center justify-between px-4 py-3 hover:bg-black/4 dark:hover:bg-white/4 transition-colors"
-      >
-        <h3 className="text-[13px] font-semibold text-(--color-text-primary)">Pipeline Overview</h3>
-        {/* Chevron points down when expanded, right when collapsed —
-            standard turndown affordance. */}
-        <svg
-          className="h-4 w-4 text-(--color-text-secondary)"
-          style={{
-            transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
-            transition: 'transform 200ms ease-out',
-          }}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-      {expanded && (
-        <div className="px-4 pb-4 pt-3 border-t border-(--color-border)">
-          <PipelineDiagramBody />
-        </div>
-      )}
-    </div>
-  )
-}
-
-function PipelineDiagramBody() {
   const { snapshot, error } = useQueueSnapshot()
 
   if (error) return <div className="text-[12px] text-red-500/80">{error}</div>
   if (!snapshot) return <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>
 
   return (
-    <>
+    <div>
       <PipelineGraph snapshot={snapshot} />
       <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-(--color-text-secondary)">
         <span className="inline-flex items-center gap-1">
@@ -336,6 +297,6 @@ function PipelineDiagramBody() {
           Throughput · last {snapshot.throughput_window_seconds}s · glowing nodes have running jobs
         </span>
       </div>
-    </>
+    </div>
   )
 }

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -26,20 +26,26 @@ import { classColor } from '../../utils/queueColors'
  */
 
 const VIEW_WIDTH = 600
-const VIEW_HEIGHT = 300
+// Bumped from 300 → 320 to fit the wider fan-out spread without the
+// top badge and bottom label hugging the edges.
+const VIEW_HEIGHT = 320
 
 // Hand-laid-out positions for the 7-stage pipeline.
 // Sequential prefix flows left-to-right at y=150, then chunk fans out
 // to entities/embed/summarize stacked vertically, then re-converges
-// at finalize.
+// at finalize. The fan-out spacing is 100 px (50 ↔ 150 ↔ 250) rather
+// than the original 80 — with the active node radius cap at 26 plus
+// the count badge above (~14 px) and stage label below (~12 px), 80
+// wasn't enough vertical room and labels collided with neighbours'
+// badges.
 const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
-  extract: { x: 60, y: 150 },
-  ocr: { x: 160, y: 150 },
-  chunk: { x: 260, y: 150 },
-  entities: { x: 390, y: 70 },
-  embed: { x: 390, y: 150 },
-  summarize: { x: 390, y: 230 },
-  finalize: { x: 520, y: 150 },
+  extract: { x: 60, y: 160 },
+  ocr: { x: 160, y: 160 },
+  chunk: { x: 260, y: 160 },
+  entities: { x: 390, y: 60 },
+  embed: { x: 390, y: 160 },
+  summarize: { x: 390, y: 260 },
+  finalize: { x: 520, y: 160 },
 }
 
 const EDGES: { from: string; to: string }[] = [
@@ -258,37 +264,78 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
   )
 }
 
+/**
+ * Outer wrapper: collapsible disclosure card. Header is always
+ * visible; the body (which polls /api/jobs/snapshot via
+ * `useQueueSnapshot`) is only mounted when the section is expanded,
+ * so polling is dormant when the user has it tucked away.
+ *
+ * Defaults to collapsed — the diagram is one of several sections on
+ * the Observatory page and shouldn't dominate the initial view.
+ */
 export default function PipelineDiagram() {
-  const { snapshot, error } = useQueueSnapshot()
+  const [expanded, setExpanded] = useState(false)
 
   return (
-    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
-      <div className="mb-2 flex items-baseline justify-between">
+    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((p) => !p)}
+        aria-expanded={expanded}
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-black/4 dark:hover:bg-white/4 transition-colors"
+      >
         <h3 className="text-[13px] font-semibold text-(--color-text-primary)">Pipeline Overview</h3>
-        <span className="text-[11px] text-(--color-text-secondary)">
-          {snapshot ? `Throughput over last ${snapshot.throughput_window_seconds}s` : ''}
-        </span>
-      </div>
-      {error && <div className="text-[12px] text-red-500/80">{error}</div>}
-      {!snapshot && !error && <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>}
-      {snapshot && <PipelineGraph snapshot={snapshot} />}
-      {snapshot && (
-        <div className="mt-2 flex items-center gap-4 text-[10px] text-(--color-text-secondary)">
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-full" style={{ background: classColor('io') }} />
-            IO
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
-            CPU
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-full" style={{ background: classColor('llm') }} />
-            LLM
-          </span>
-          <span className="ml-auto">Glowing nodes have running jobs · Particles = recent throughput</span>
+        {/* Chevron points down when expanded, right when collapsed —
+            standard turndown affordance. */}
+        <svg
+          className="h-4 w-4 text-(--color-text-secondary)"
+          style={{
+            transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+            transition: 'transform 200ms ease-out',
+          }}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="px-4 pb-4 pt-3 border-t border-(--color-border)">
+          <PipelineDiagramBody />
         </div>
       )}
     </div>
+  )
+}
+
+function PipelineDiagramBody() {
+  const { snapshot, error } = useQueueSnapshot()
+
+  if (error) return <div className="text-[12px] text-red-500/80">{error}</div>
+  if (!snapshot) return <div className="text-[12px] text-(--color-text-secondary)">Loading…</div>
+
+  return (
+    <>
+      <PipelineGraph snapshot={snapshot} />
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full" style={{ background: classColor('io') }} />
+          IO
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full" style={{ background: classColor('cpu') }} />
+          CPU
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full" style={{ background: classColor('llm') }} />
+          LLM
+        </span>
+        <span className="ml-auto">
+          Throughput · last {snapshot.throughput_window_seconds}s · glowing nodes have running jobs
+        </span>
+      </div>
+    </>
   )
 }

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -81,17 +81,24 @@ const STAGE_LABELS: Record<string, string> = {
   finalize: 'Finalize',
 }
 
-function edgePath(from: string, to: string): string {
+function edgePath(from: string, to: string, rFrom: number, rTo: number): string {
   const a = NODE_POSITIONS[from]
   const b = NODE_POSITIONS[to]
   const dx = b.x - a.x
   // Cubic Bezier with horizontally-pulled control points → smooth
-  // S-curve when y differs, near-straight when y matches.
+  // S-curve when y differs, near-straight when y matches. Because
+  // the control points are pulled purely horizontally, the curve's
+  // tangent at each endpoint is also purely horizontal — which is
+  // why we can trim the endpoints by ±r along the x axis to land
+  // them exactly on each node's perimeter without bending the curve.
+  const sign = Math.sign(dx) || 1
+  const startX = a.x + sign * rFrom
+  const endX = b.x - sign * rTo
   const c1x = a.x + dx * 0.5
   const c1y = a.y
   const c2x = b.x - dx * 0.5
   const c2y = b.y
-  return `M ${a.x} ${a.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${b.x} ${b.y}`
+  return `M ${startX} ${a.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${endX} ${b.y}`
 }
 
 function nodeRadius(info: StageSnapshot | undefined): number {
@@ -176,18 +183,23 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
           their own visual layer, separate from the nodes' queue-class
           hues. Particles flowing through them still inherit the
           upstream node's colour, which gives the impression of
-          coloured payload moving through a green plumbing graph. */}
+          coloured payload moving through a green plumbing graph.
+          Endpoints are trimmed to each node's current perimeter so
+          the line stops at the ring rather than passing through the
+          disc. */}
       {EDGES.map((edge) => {
         const downstream = snapshot.by_stage[edge.to]
         const throughput = downstream?.recent_completed ?? 0
         const baseWidth = 1.5
         const width = Math.min(8, baseWidth + throughput * 0.4)
         const opacity = throughput > 0 ? 0.55 : 0.2
+        const rFrom = nodeRadius(snapshot.by_stage[edge.from])
+        const rTo = nodeRadius(snapshot.by_stage[edge.to])
         return (
           <path
             key={`${edge.from}-${edge.to}`}
             id={`edge-${edge.from}-${edge.to}`}
-            d={edgePath(edge.from, edge.to)}
+            d={edgePath(edge.from, edge.to, rFrom, rTo)}
             fill="none"
             stroke={EDGE_COLOR}
             strokeWidth={width}

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { useQueueSnapshot, type QueueClass, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { useQueueSnapshot, type QueueSnapshot, type StageSnapshot } from '../../hooks/useQueueSnapshot'
+import { classColor } from '../../utils/queueColors'
 
 /**
  * Pipeline Overview — animated DAG showing live activity in the
@@ -60,18 +61,6 @@ const STAGE_LABELS: Record<string, string> = {
   embed: 'Embed',
   summarize: 'Summarize',
   finalize: 'Finalize',
-}
-
-// Distinct hues by queue class so the eye reads "this is a CPU stage"
-// vs "this is an IO stage" at a glance. CPU stages (OCR, Embed) are
-// the heavy / slow compute ones; warm hue makes them stand out. The
-// LLM queue (Summarize) gets its own purple — visually distinct and
-// reinforces that it's a serialised single-worker bottleneck, not
-// just another flavour of CPU work.
-function classColor(queue: QueueClass | undefined): string {
-  if (queue === 'cpu') return '#f5a623' // amber
-  if (queue === 'llm') return '#bf5af2' // system purple
-  return '#0a84ff' // accent blue (matches --color-accent)
 }
 
 function edgePath(from: string, to: string): string {

--- a/frontend/src/components/stats/PipelineTimingChart.tsx
+++ b/frontend/src/components/stats/PipelineTimingChart.tsx
@@ -1,0 +1,95 @@
+import { classColor, classColorAlpha, queueForStage } from '../../utils/queueColors'
+
+export interface StageTiming {
+  avg_run_secs: number
+  p50_run_secs: number
+  p95_run_secs: number
+  max_run_secs: number
+  avg_wait_secs: number
+  count: number
+}
+
+interface PipelineTimingChartProps {
+  pipelineTiming: Record<string, StageTiming>
+}
+
+const STAGES = ['extract', 'ocr', 'chunk', 'entities', 'embed', 'summarize', 'finalize'] as const
+const STAGE_LABELS: Record<string, string> = {
+  extract: 'Extract',
+  ocr: 'OCR',
+  chunk: 'Chunk',
+  entities: 'Entities',
+  embed: 'Embed',
+  summarize: 'Summarize',
+  finalize: 'Finalize',
+}
+
+function fmtSecs(secs: number): string {
+  if (secs < 1) return `${Math.round(secs * 1000)}ms`
+  if (secs < 60) return `${secs.toFixed(1)}s`
+  const m = Math.floor(secs / 60)
+  const s = Math.round(secs % 60)
+  return `${m}m ${s}s`
+}
+
+/**
+ * Per-stage processing time as a horizontal bar chart with a
+ * within-bar p50 marker. The faded portion of each bar runs out to
+ * p95; the saturated portion runs out to p50, so the eye reads
+ * "median where it's filled, tail where it fades". Colour is the
+ * stage's queue class for visual consistency with the diagram.
+ *
+ * The avg row's primary value is signalling spread, not centre — when
+ * the saturated p50 bar is much shorter than the faded p95 bar, the
+ * stage has a long tail (typical for OCR with mixed scan quality);
+ * when they're close the stage is tightly clustered (chunk, finalize).
+ */
+export default function PipelineTimingChart({ pipelineTiming }: PipelineTimingChartProps) {
+  const visibleStages = STAGES.filter((s) => pipelineTiming[s]?.count)
+  if (visibleStages.length === 0) {
+    return (
+      <div className="text-[12px] text-(--color-text-secondary)">
+        No completed jobs yet — process a document to populate.
+      </div>
+    )
+  }
+  const maxP95 = Math.max(0.001, ...visibleStages.map((s) => pipelineTiming[s].p95_run_secs))
+
+  return (
+    <div className="space-y-1.5">
+      {visibleStages.map((stage) => {
+        const t = pipelineTiming[stage]
+        const queue = queueForStage(stage)
+        const p50Width = Math.min(100, (t.p50_run_secs / maxP95) * 100)
+        const p95Width = Math.min(100, (t.p95_run_secs / maxP95) * 100)
+        return (
+          <div key={stage} className="flex items-center gap-2 text-[12px]">
+            <span className="w-16 shrink-0 text-(--color-text-secondary) text-right">{STAGE_LABELS[stage]}</span>
+            <div
+              className="relative flex-1 h-4 rounded-sm overflow-hidden"
+              style={{ background: 'rgba(128,128,128,0.12)' }}
+              title={`${STAGE_LABELS[stage]} — p50 ${fmtSecs(t.p50_run_secs)}, p95 ${fmtSecs(t.p95_run_secs)}, max ${fmtSecs(t.max_run_secs)}, avg ${fmtSecs(t.avg_run_secs)}, n=${t.count}`}
+            >
+              {/* p95 (faded outer reach) */}
+              <div
+                className="absolute left-0 top-0 h-full rounded-sm"
+                style={{ width: `${p95Width}%`, background: classColorAlpha(queue, 0.3) }}
+              />
+              {/* p50 (saturated up to median) */}
+              <div
+                className="absolute left-0 top-0 h-full rounded-sm"
+                style={{ width: `${p50Width}%`, background: classColor(queue) }}
+              />
+            </div>
+            <span className="w-44 shrink-0 text-right tabular-nums text-(--color-text-secondary) text-[11px]">
+              p50 {fmtSecs(t.p50_run_secs)} · p95 {fmtSecs(t.p95_run_secs)} · n={t.count}
+            </span>
+          </div>
+        )
+      })}
+      <div className="pt-1 text-[10px] text-(--color-text-secondary)">
+        Saturated bar = median (p50) · faded extension = p95 · numbers on the right show exact values
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/stats/PipelineTimingChart.tsx
+++ b/frontend/src/components/stats/PipelineTimingChart.tsx
@@ -33,16 +33,23 @@ function fmtSecs(secs: number): string {
 }
 
 /**
- * Per-stage processing time as a horizontal bar chart with a
- * within-bar p50 marker. The faded portion of each bar runs out to
- * p95; the saturated portion runs out to p50, so the eye reads
- * "median where it's filled, tail where it fades". Colour is the
- * stage's queue class for visual consistency with the diagram.
+ * Per-stage processing time as a horizontal bar chart that breaks the
+ * distribution into median / typical / outlier zones. Reading guide:
  *
- * The avg row's primary value is signalling spread, not centre — when
- * the saturated p50 bar is much shorter than the faded p95 bar, the
- * stage has a long tail (typical for OCR with mixed scan quality);
- * when they're close the stage is tightly clustered (chunk, finalize).
+ *   ▰▰▰  saturated  : median (p50) — half of jobs finished in this much time
+ *   ▰░░  faded ext. : 95th percentile — almost everyone is in by here
+ *   ┊    tick mark  : maximum — the slowest single run we've seen
+ *
+ * When the saturated p50 fills most of the bar, the stage is tightly
+ * clustered. When the saturated portion is short and the faded
+ * extension is long, the stage is bimodal — typical case is fast,
+ * but with a heavy tail (this is what map-reduce summarize does on
+ * long docs: each call is normal, but the *job* multiplies that by
+ * however many groups were needed). The max tick gives you the
+ * actual worst-case wall time so you can spot pathological outliers
+ * even when p95 looks reasonable.
+ *
+ * Colour matches the queue class on the Observatory diagram.
  */
 export default function PipelineTimingChart({ pipelineTiming }: PipelineTimingChartProps) {
   const visibleStages = STAGES.filter((s) => pipelineTiming[s]?.count)
@@ -53,15 +60,25 @@ export default function PipelineTimingChart({ pipelineTiming }: PipelineTimingCh
       </div>
     )
   }
-  const maxP95 = Math.max(0.001, ...visibleStages.map((s) => pipelineTiming[s].p95_run_secs))
+  // Scale the bar width by the largest max across visible stages
+  // (rather than p95) so the max tick has a stable home on the
+  // axis; otherwise a wild outlier in one stage would push the tick
+  // off the right edge or compress everyone else into invisibility.
+  const axisMax = Math.max(0.001, ...visibleStages.map((s) => pipelineTiming[s].max_run_secs))
 
   return (
     <div className="space-y-1.5">
       {visibleStages.map((stage) => {
         const t = pipelineTiming[stage]
         const queue = queueForStage(stage)
-        const p50Width = Math.min(100, (t.p50_run_secs / maxP95) * 100)
-        const p95Width = Math.min(100, (t.p95_run_secs / maxP95) * 100)
+        const p50Width = Math.min(100, (t.p50_run_secs / axisMax) * 100)
+        const p95Width = Math.min(100, (t.p95_run_secs / axisMax) * 100)
+        const maxLeft = Math.min(100, (t.max_run_secs / axisMax) * 100)
+        // Flag a notably long tail — saturated bar way shorter than
+        // the max, suggesting a bimodal distribution (typical run is
+        // fine, worst run is wildly slower). Useful for spotting
+        // map-reduce blow-ups on summarize.
+        const longTail = t.max_run_secs > t.p50_run_secs * 5 && t.max_run_secs > 5
         return (
           <div key={stage} className="flex items-center gap-2 text-[12px]">
             <span className="w-16 shrink-0 text-(--color-text-secondary) text-right">{STAGE_LABELS[stage]}</span>
@@ -80,15 +97,31 @@ export default function PipelineTimingChart({ pipelineTiming }: PipelineTimingCh
                 className="absolute left-0 top-0 h-full rounded-sm"
                 style={{ width: `${p50Width}%`, background: classColor(queue) }}
               />
+              {/* max tick — vertical line at the longest single-run
+                  position. Positioned on the centre of the line so a
+                  max equal to p95 sits cleanly at the p95 edge. */}
+              <div
+                className="absolute top-0 h-full"
+                style={{
+                  left: `calc(${maxLeft}% - 1px)`,
+                  width: '2px',
+                  background: classColor(queue),
+                }}
+              />
             </div>
-            <span className="w-44 shrink-0 text-right tabular-nums text-(--color-text-secondary) text-[11px]">
-              p50 {fmtSecs(t.p50_run_secs)} · p95 {fmtSecs(t.p95_run_secs)} · n={t.count}
+            <span
+              className={`w-56 shrink-0 text-right tabular-nums text-[11px] ${
+                longTail ? 'text-(--color-text-primary)' : 'text-(--color-text-secondary)'
+              }`}
+            >
+              p50 {fmtSecs(t.p50_run_secs)} · p95 {fmtSecs(t.p95_run_secs)} ·{' '}
+              <span className={longTail ? 'font-semibold' : ''}>max {fmtSecs(t.max_run_secs)}</span> · n={t.count}
             </span>
           </div>
         )
       })}
       <div className="pt-1 text-[10px] text-(--color-text-secondary)">
-        Saturated bar = median (p50) · faded extension = p95 · numbers on the right show exact values
+        Saturated bar = p50 (median) · faded extension = p95 · vertical tick = max single run · max bolded when ≥ 5× p50
       </div>
     </div>
   )

--- a/frontend/src/components/stats/QueueWaitChart.tsx
+++ b/frontend/src/components/stats/QueueWaitChart.tsx
@@ -1,0 +1,90 @@
+import { classColor, queueForStage } from '../../utils/queueColors'
+import type { StageTiming } from './PipelineTimingChart'
+
+interface QueueWaitChartProps {
+  pipelineTiming: Record<string, StageTiming>
+}
+
+const STAGES = ['extract', 'ocr', 'chunk', 'entities', 'embed', 'summarize', 'finalize'] as const
+const STAGE_LABELS: Record<string, string> = {
+  extract: 'Extract',
+  ocr: 'OCR',
+  chunk: 'Chunk',
+  entities: 'Entities',
+  embed: 'Embed',
+  summarize: 'Summarize',
+  finalize: 'Finalize',
+}
+
+function fmtSecs(secs: number): string {
+  if (secs < 1) return `${Math.round(secs * 1000)}ms`
+  if (secs < 60) return `${secs.toFixed(1)}s`
+  const m = Math.floor(secs / 60)
+  const s = Math.round(secs % 60)
+  return `${m}m ${s}s`
+}
+
+const WAIT_FILL = 'rgba(128, 128, 128, 0.45)'
+
+/**
+ * Per-stage wait-vs-run breakdown as a stacked horizontal bar.
+ *
+ * Different signal from the timing-distribution chart: this answers
+ * "where does a job spend its life" — sitting in the queue (waiting
+ * for a free worker) vs actually being processed. A long grey wait
+ * segment on a stage means workers are saturated upstream of it; a
+ * long coloured run segment means the work itself is slow.
+ */
+export default function QueueWaitChart({ pipelineTiming }: QueueWaitChartProps) {
+  const visibleStages = STAGES.filter((s) => pipelineTiming[s]?.count)
+  if (visibleStages.length === 0) {
+    return (
+      <div className="text-[12px] text-(--color-text-secondary)">
+        No completed jobs yet — process a document to populate.
+      </div>
+    )
+  }
+  const maxTotal = Math.max(
+    0.001,
+    ...visibleStages.map((s) => pipelineTiming[s].avg_wait_secs + pipelineTiming[s].avg_run_secs),
+  )
+
+  return (
+    <div className="space-y-1.5">
+      {visibleStages.map((stage) => {
+        const t = pipelineTiming[stage]
+        const queue = queueForStage(stage)
+        const waitWidth = Math.min(100, (t.avg_wait_secs / maxTotal) * 100)
+        const runWidth = Math.min(100, (t.avg_run_secs / maxTotal) * 100)
+        return (
+          <div key={stage} className="flex items-center gap-2 text-[12px]">
+            <span className="w-16 shrink-0 text-(--color-text-secondary) text-right">{STAGE_LABELS[stage]}</span>
+            <div
+              className="relative flex-1 h-4 rounded-sm overflow-hidden"
+              style={{ background: 'rgba(128,128,128,0.12)' }}
+              title={`${STAGE_LABELS[stage]} — wait ${fmtSecs(t.avg_wait_secs)}, run ${fmtSecs(t.avg_run_secs)} (avg over n=${t.count})`}
+            >
+              <div className="flex h-full">
+                {waitWidth > 0 && <div style={{ width: `${waitWidth}%`, background: WAIT_FILL }} />}
+                {runWidth > 0 && <div style={{ width: `${runWidth}%`, background: classColor(queue) }} />}
+              </div>
+            </div>
+            <span className="w-44 shrink-0 text-right tabular-nums text-(--color-text-secondary) text-[11px]">
+              wait {fmtSecs(t.avg_wait_secs)} · run {fmtSecs(t.avg_run_secs)}
+            </span>
+          </div>
+        )
+      })}
+      <div className="pt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-sm" style={{ background: WAIT_FILL }} />
+          Time queued
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-sm" style={{ background: classColor('io') }} />
+          Processing (coloured by queue class)
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -7,6 +7,8 @@ import TopicTreemap from '../components/stats/TopicTreemap'
 import TopicBarChart from '../components/stats/TopicBarChart'
 import TopicKeywords from '../components/stats/TopicKeywords'
 import PipelineDiagram from '../components/stats/PipelineDiagram'
+import PipelineTimingChart, { type StageTiming } from '../components/stats/PipelineTimingChart'
+import QueueWaitChart from '../components/stats/QueueWaitChart'
 import { InfoTip } from '../components/InfoTip'
 
 interface TopicCluster {
@@ -31,10 +33,12 @@ interface CorpusStats {
   ocr_breakdown: { born_digital: number; ocr_used: number; unknown: number }
   size_buckets: { label: string; count: number }[]
   growth_timeline: { month: string; count: number }[]
-  pipeline_timing: Record<string, { avg_secs: number; count: number }>
+  pipeline_timing: Record<string, StageTiming & { avg_secs: number }>
   entity_type_counts: Record<string, number>
   top_entities: { text: string; type: string; mentions: number }[]
 }
+
+type TabId = 'corpus' | 'pipeline'
 
 function StatBadge({ label, value, tip }: { label: string; value: string | number; tip?: string }) {
   return (
@@ -50,11 +54,37 @@ function StatBadge({ label, value, tip }: { label: string; value: string | numbe
   )
 }
 
+interface TabButtonProps {
+  id: TabId
+  current: TabId
+  onClick: (id: TabId) => void
+  children: React.ReactNode
+}
+
+function TabButton({ id, current, onClick, children }: TabButtonProps) {
+  const active = id === current
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(id)}
+      aria-selected={active}
+      role="tab"
+      className={`relative px-4 py-2 text-[14px] font-medium transition-colors ${
+        active ? 'text-(--color-text-primary)' : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+      }`}
+    >
+      {children}
+      {active && <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-(--color-accent)" />}
+    </button>
+  )
+}
+
 export default function StatsPage() {
   const [stats, setStats] = useState<CorpusStats | null>(null)
   const [topics, setTopics] = useState<TopicsData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [tab, setTab] = useState<TabId>('corpus')
 
   useEffect(() => {
     let cancelled = false
@@ -100,10 +130,29 @@ export default function StatsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-lg font-semibold text-(--color-text-primary)">
-        Corpus Statistics
+      {/* Tab bar */}
+      <div role="tablist" className="flex border-b border-(--color-border)">
+        <TabButton id="corpus" current={tab} onClick={setTab}>
+          Corpus Statistics
+        </TabButton>
+        <TabButton id="pipeline" current={tab} onClick={setTab}>
+          Processing Pipeline
+        </TabButton>
+      </div>
+
+      {tab === 'corpus' && <CorpusTab stats={stats} topics={topics} />}
+      {tab === 'pipeline' && <PipelineTab pipelineTiming={stats.pipeline_timing} />}
+    </div>
+  )
+}
+
+function CorpusTab({ stats, topics }: { stats: CorpusStats; topics: TopicsData | null }) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-base font-semibold text-(--color-text-primary)">
+        About your collection
         <InfoTip text="These are facts and statistics about your entire document collection — how many documents, pages, and text segments (chunks) have been processed." />
-      </h1>
+      </h2>
 
       {/* Summary badges */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -124,9 +173,6 @@ export default function StatsPage() {
           tip="Named entities — people, organizations, places, dates, etc. — automatically extracted from your documents using natural language processing."
         />
       </div>
-
-      {/* Live pipeline activity */}
-      <PipelineDiagram />
 
       {/* Charts */}
       <CorpusCharts stats={stats} />
@@ -159,6 +205,42 @@ export default function StatsPage() {
 
       {/* Document Clusters */}
       <ClusterMap />
+    </div>
+  )
+}
+
+function PipelineTab({ pipelineTiming }: { pipelineTiming: CorpusStats['pipeline_timing'] }) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-base font-semibold text-(--color-text-primary)">
+        Processing pipeline
+        <InfoTip text="How your documents move through the ingestion pipeline. Live activity above; aggregated processing time and queue-wait breakdowns below, computed across all completed jobs." />
+      </h2>
+
+      {/* Live diagram */}
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <h3 className="mb-3 text-[13px] font-semibold text-(--color-text-primary)">Live activity</h3>
+        <PipelineDiagram />
+      </div>
+
+      {/* Per-stage timing */}
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <h3 className="mb-1 text-[13px] font-semibold text-(--color-text-primary)">Processing time per stage</h3>
+        <p className="mb-3 text-[12px] text-(--color-text-secondary)">
+          How long each stage takes once it starts running, across all completed jobs.
+        </p>
+        <PipelineTimingChart pipelineTiming={pipelineTiming} />
+      </div>
+
+      {/* Queue wait vs run time */}
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <h3 className="mb-1 text-[13px] font-semibold text-(--color-text-primary)">Queue wait vs processing time</h3>
+        <p className="mb-3 text-[12px] text-(--color-text-secondary)">
+          How long jobs wait in the queue before a worker picks them up, vs how long the work itself takes. A long grey
+          tail on a stage means workers are saturated.
+        </p>
+        <QueueWaitChart pipelineTiming={pipelineTiming} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/utils/queueColors.ts
+++ b/frontend/src/utils/queueColors.ts
@@ -23,3 +23,15 @@ export function classColor(queue: QueueClass | undefined): string {
 export function classColorAlpha(queue: QueueClass | undefined, alpha: number): string {
   return `color-mix(in srgb, ${classColor(queue)} ${Math.round(alpha * 100)}%, transparent)`
 }
+
+/**
+ * Stage → queue-class mapping. Mirrors `STAGE_CONFIG` in
+ * `src/harbor_clerk/worker/pipeline.py`. Mapping is stable so duplicating
+ * it is safe and saves a backend round-trip in places that already have
+ * a stage name (e.g. timing charts on the Observatory page).
+ */
+export function queueForStage(stage: string): QueueClass {
+  if (stage === 'ocr' || stage === 'embed') return 'cpu'
+  if (stage === 'summarize') return 'llm'
+  return 'io'
+}

--- a/frontend/src/utils/queueColors.ts
+++ b/frontend/src/utils/queueColors.ts
@@ -1,0 +1,25 @@
+import type { QueueClass } from '../hooks/useQueueSnapshot'
+
+/**
+ * Single source of truth for queue-class colours. Used by:
+ *  - PipelineDiagram (Observatory page) — node fills, edge strokes,
+ *    particle colours, legend swatches.
+ *  - WorkerStrip (drawer Pipeline tab) — chip background / text / ring.
+ *  - StageHistogram (drawer Pipeline tab) — bar fill (running stacked
+ *    under queued).
+ *
+ * Colours are picked from the macOS system palette so they read as
+ * native and remain distinct from the in-app accent. Alpha variants go
+ * through `color-mix(in srgb, ..., transparent)` rather than ad-hoc hex
+ * parsing — better for dark/light mode and avoids string-math bugs.
+ */
+export function classColor(queue: QueueClass | undefined): string {
+  if (queue === 'cpu') return '#f5a623' // system amber
+  if (queue === 'llm') return '#bf5af2' // system purple
+  return '#0a84ff' // accent blue (matches --color-accent on dark)
+}
+
+/** Translucent variant for tinted backgrounds, ring colours, etc. */
+export function classColorAlpha(queue: QueueClass | undefined, alpha: number): string {
+  return `color-mix(in srgb, ${classColor(queue)} ${Math.round(alpha * 100)}%, transparent)`
+}

--- a/src/harbor_clerk/api/routes/stats.py
+++ b/src/harbor_clerk/api/routes/stats.py
@@ -170,26 +170,44 @@ async def corpus_stats(
     ).all()
     growth_timeline = [{"month": row[0], "count": row[1]} for row in growth_rows]
 
-    # Pipeline timing from completed jobs
+    # Pipeline timing from completed jobs — avg + percentiles + max for
+    # the per-stage timing distribution chart, plus average queue wait
+    # (created → started) for the wait-vs-run breakdown chart.
+    run_secs = extract("epoch", IngestionJob.finished_at) - extract("epoch", IngestionJob.started_at)
+    wait_secs = extract("epoch", IngestionJob.started_at) - extract("epoch", IngestionJob.created_at)
     timing_rows = (
         await session.execute(
             select(
                 IngestionJob.stage,
-                func.avg(extract("epoch", IngestionJob.finished_at) - extract("epoch", IngestionJob.started_at)).label(
-                    "avg_secs"
-                ),
+                func.avg(run_secs).label("avg_run_secs"),
+                func.percentile_cont(0.5).within_group(run_secs.asc()).label("p50_run_secs"),
+                func.percentile_cont(0.95).within_group(run_secs.asc()).label("p95_run_secs"),
+                func.max(run_secs).label("max_run_secs"),
+                func.avg(wait_secs).label("avg_wait_secs"),
                 func.count(),
             )
             .where(
-                IngestionJob.status == "done", IngestionJob.started_at.isnot(None), IngestionJob.finished_at.isnot(None)
+                IngestionJob.status == "done",
+                IngestionJob.started_at.isnot(None),
+                IngestionJob.finished_at.isnot(None),
             )
             .group_by(IngestionJob.stage)
         )
     ).all()
     pipeline_timing = {}
-    for stage, avg_secs, count in timing_rows:
+    for stage, avg_run, p50_run, p95_run, max_run, avg_wait, count in timing_rows:
         stage_name = stage.value if hasattr(stage, "value") else str(stage)
-        pipeline_timing[stage_name] = {"avg_secs": round(float(avg_secs), 2), "count": count}
+        # `avg_secs` kept as a back-compat alias for clients that haven't
+        # been updated; new clients should read `avg_run_secs` directly.
+        pipeline_timing[stage_name] = {
+            "avg_secs": round(float(avg_run), 2),
+            "avg_run_secs": round(float(avg_run), 2),
+            "p50_run_secs": round(float(p50_run), 2) if p50_run is not None else 0.0,
+            "p95_run_secs": round(float(p95_run), 2) if p95_run is not None else 0.0,
+            "max_run_secs": round(float(max_run), 2) if max_run is not None else 0.0,
+            "avg_wait_secs": round(float(avg_wait), 2) if avg_wait is not None else 0.0,
+            "count": count,
+        }
 
     # Entity type counts
     entity_type_q = (

--- a/src/harbor_clerk/llm/summarize.py
+++ b/src/harbor_clerk/llm/summarize.py
@@ -118,6 +118,7 @@ def _call_llm(
     max_attempts: int = 3,
     response_key: str | None = None,
     json_schema: dict | None = None,
+    phase: str = "summarize",
 ) -> str | None:
     """Make an LLM call with retries for transient failures.
 
@@ -128,6 +129,10 @@ def _call_llm(
 
     llama-server runs single-slot, so concurrent summarize requests queue up.
     Retries with jittered delays give the queue time to drain.
+
+    The `phase` argument is purely for log attribution — it shows up in
+    the per-call timing log line so a `tail -f` of worker-llm.log can
+    distinguish short/medium/map/reduce/doc-type calls from each other.
     """
     settings = get_settings()
     url = f"{settings.llama_server_url}/v1/chat/completions"
@@ -147,12 +152,16 @@ def _call_llm(
 
     last_err: Exception | None = None
     for attempt in range(1, max_attempts + 1):
+        call_started = time.perf_counter()
         try:
             resp = httpx.post(url, json=payload, timeout=timeout)
+            elapsed = time.perf_counter() - call_started
             if resp.status_code in {503, 429} and attempt < max_attempts:
                 delay = 5 + random.uniform(0, 10 * attempt)
                 logger.info(
-                    "LLM returned %d on attempt %d/%d, retrying in %.0fs",
+                    "LLM call phase=%s elapsed=%.1fs http_status=%d (attempt %d/%d, retrying in %.0fs)",
+                    phase,
+                    elapsed,
                     resp.status_code,
                     attempt,
                     max_attempts,
@@ -161,8 +170,24 @@ def _call_llm(
                 time.sleep(delay)
                 continue
             resp.raise_for_status()
-            msg = resp.json()["choices"][0]["message"]
+            data = resp.json()
+            msg = data["choices"][0]["message"]
             content = (msg.get("content") or "").strip()
+            usage = data.get("usage") or {}
+            prompt_tokens = usage.get("prompt_tokens")
+            completion_tokens = usage.get("completion_tokens")
+            cap_hit = (
+                isinstance(completion_tokens, int) and isinstance(max_tokens, int) and completion_tokens >= max_tokens
+            )
+            logger.info(
+                "LLM call phase=%s elapsed=%.1fs prompt_tokens=%s completion_tokens=%s max_tokens=%s%s",
+                phase,
+                elapsed,
+                prompt_tokens,
+                completion_tokens,
+                max_tokens,
+                " CAP_HIT" if cap_hit else "",
+            )
             # Thinking models (DeepSeek R1, gpt-oss) may return empty content
             # with the answer embedded in reasoning_content
             if not content and msg.get("reasoning_content"):
@@ -188,30 +213,34 @@ def _call_llm(
                     extracted = parsed.get(response_key, "")
                     return str(extracted).strip() if extracted else None
                 except (ValueError, AttributeError):
-                    logger.warning("Failed to parse JSON response: %s", content[:200])
+                    logger.warning("LLM call phase=%s JSON parse failed: %s", phase, content[:200])
                     return None
 
             # Non-JSON mode: extract marked answer
             content = _extract_marked_answer(content)
             return content if content else None
         except (httpx.TimeoutException, httpx.ConnectError) as e:
+            elapsed = time.perf_counter() - call_started
             last_err = e
             if attempt < max_attempts:
                 delay = 5 + random.uniform(0, 10 * attempt)
                 logger.info(
-                    "LLM call attempt %d/%d failed (%s), retrying in %.0fs",
+                    "LLM call phase=%s elapsed=%.1fs failed (%s), attempt %d/%d, retrying in %.0fs",
+                    phase,
+                    elapsed,
+                    type(e).__name__,
                     attempt,
                     max_attempts,
-                    type(e).__name__,
                     delay,
                 )
                 time.sleep(delay)
                 continue
         except Exception:
-            logger.warning("LLM call failed (non-retryable)", exc_info=True)
+            elapsed = time.perf_counter() - call_started
+            logger.warning("LLM call phase=%s elapsed=%.1fs failed (non-retryable)", phase, elapsed, exc_info=True)
             return None
 
-    logger.warning("LLM call failed after %d attempts: %s", max_attempts, last_err)
+    logger.warning("LLM call phase=%s failed after %d attempts: %s", phase, max_attempts, last_err)
     return None
 
 
@@ -410,6 +439,7 @@ def _summarize_short(chunks: list[str], max_input_chars: int) -> str | None:
         timeout=120.0,
         response_key="summary",
         json_schema=_SUMMARY_SCHEMA,
+        phase="summarize-short",
     )
 
 
@@ -423,6 +453,7 @@ def _summarize_medium(chunks: list[str], max_input_chars: int) -> str | None:
         timeout=120.0,
         response_key="summary",
         json_schema=_SUMMARY_SCHEMA,
+        phase="summarize-medium",
     )
 
 
@@ -433,7 +464,7 @@ def _summarize_long(chunks: list[str], max_input_chars: int) -> str | None:
 
     # Map step: summarize each group (fewer retries to stay within stage timeout)
     section_summaries: list[str] = []
-    for group in groups:
+    for idx, group in enumerate(groups):
         result = _call_llm(
             _PROMPT_MAP,
             group,
@@ -442,6 +473,7 @@ def _summarize_long(chunks: list[str], max_input_chars: int) -> str | None:
             max_attempts=2,
             response_key="summary",
             json_schema=_SUMMARY_SCHEMA,
+            phase=f"summarize-map[{idx + 1}/{len(groups)}]",
         )
         if result:
             section_summaries.append(result[:300])
@@ -464,6 +496,7 @@ def _summarize_long(chunks: list[str], max_input_chars: int) -> str | None:
         timeout=120.0,
         response_key="summary",
         json_schema=_SUMMARY_SCHEMA,
+        phase="summarize-reduce",
     )
 
 
@@ -521,6 +554,7 @@ def classify_doc_type(chunks: list[str], mime_type: str = "") -> str:
             max_attempts=1,
             response_key="document_type",
             json_schema=_DOC_TYPE_SCHEMA,
+            phase="doc-type",
         )
         if result:
             doc_type = result.strip().strip("\"'.")
@@ -577,12 +611,29 @@ def generate_summary(chunks: list[str], max_chars: int | None = None) -> tuple[s
             max_input_chars,
         )
 
+        stage_started = time.perf_counter()
         if tier == _Tier.SHORT:
             result = _summarize_short(chunks, max_input_chars)
         elif tier == _Tier.MEDIUM:
             result = _summarize_medium(chunks, max_input_chars)
         else:
             result = _summarize_long(chunks, max_input_chars)
+        stage_elapsed = time.perf_counter() - stage_started
+
+        # One-line per-doc summary so a `tail -f` of worker-llm.log yields
+        # an at-a-glance view of how long each summarize stage really took
+        # (the per-call lines above add up to the totals here, but having
+        # both makes diagnosis quick — grep for "Summarize complete" to
+        # see total wall time per doc, drill into per-call lines for the
+        # breakdown).
+        logger.info(
+            "Summarize complete: tier=%s elapsed=%.1fs result=%s model=%s chunks=%d",
+            tier.value,
+            stage_elapsed,
+            "ok" if result else "no-result",
+            settings.llm_model_id,
+            len(chunks),
+        )
 
         if result:
             return _truncate_at_sentence(result, max_chars), settings.llm_model_id


### PR DESCRIPTION
## Summary

Two related changes for diagnosing slow long-doc summarize stages.

> **Note:** Branched off PR #236. Will rebase cleanly once #236 lands.

### Backend — `summarize.py` per-call timing logs

The existing summarize logger only fired on retries / failures, not on healthy calls. A `tail` of `worker-llm.log` told you nothing about how long individual map / reduce calls were taking. Mirrored research.py's pattern:

- `_call_llm` now takes a `phase` arg and times each attempt with `perf_counter`
- Per-attempt log line:
  ```
  LLM call phase=summarize-map[2/5] elapsed=14.3s prompt_tokens=22034 completion_tokens=312 max_tokens=300 CAP_HIT
  ```
- `CAP_HIT` suffix when completion_tokens hit max_tokens — useful for confirming `enable_thinking=False` is doing its job on a given model
- Retries and connection errors include elapsed in their log lines too
- `generate_summary` adds a one-line per-doc summary at the end:
  ```
  Summarize complete: tier=long elapsed=87.4s result=ok model=qwen36-35b-a3b chunks=247
  ```
  → grep `Summarize complete` for at-a-glance per-doc wall time

Phase tags: `summarize-short`, `summarize-medium`, `summarize-map[i/N]`, `summarize-reduce`, `doc-type` so per-call lines are attributable.

### Frontend — `PipelineTimingChart` exposes max

The chart's right-hand label was `p50 X · p95 Y · n=N` — no max. Long-tail outliers (a single multi-minute summarize) were invisible: p50 / p95 could look fine while the max was minutes of pathological burn.

Visual encoding:
- **`▰▰▰` saturated** — median (p50)
- **`▰░░` faded extension** — p95
- **`┊` vertical tick** — max single-run wall time

Bar width scales by the largest `max` across visible stages (rather than the largest p95). Keeps the max tick on-axis even for stages with extreme outliers, without compressing other stages into invisibility.

Right-hand label gains a `max …` term. When max ≥ 5 × p50 (long-tail indicator), the max value is bolded and the whole row uses primary text colour to draw the eye to the bimodal stage.

Caption explains saturated / faded / tick semantics.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` — pass
- [x] Backend import sanity — pass
- [x] `npm run lint` (12 warnings, all pre-existing) + `tsc --noEmit` — pass
- [x] `npm run format:check` + `npm run build` — pass
- [ ] After install + restart: `tail -f` worker-llm.log while reprocessing a long doc. Expect to see `LLM call phase=summarize-map[i/N] elapsed=Xs prompt_tokens=Y completion_tokens=Z` lines per group, then `Summarize complete: tier=long elapsed=Ms result=ok ...` at the end.
- [ ] Observatory → Processing Pipeline → timing chart now shows `max` value in the right-hand text and a vertical tick on each bar. Long-tail stages (where max ≥ 5 × p50) render the max value in bold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
