### PR TITLE
fix(summarize): suppress chain-of-thought on summarize LLM calls

### DIFF
--- a/src/harbor_clerk/llm/summarize.py
+++ b/src/harbor_clerk/llm/summarize.py
@@ -139,6 +139,20 @@ def _call_llm(
         "stream": False,
         "temperature": 0.3,
         "max_tokens": max_tokens,
+        # Suppress chain-of-thought on chat templates that support the
+        # kwarg (Qwen3.x, Gemma 4, etc.). Without this, newer Qwen
+        # variants (e.g. Qwen3.6 35B-A3B) ignore the older Qwen3
+        # /no_think marker baked into our prompts and burn the entire
+        # max_tokens budget on `<thinking>…</thinking>` before ever
+        # emitting the JSON response — the cap fires INSIDE the
+        # thinking block, content comes back empty, and the
+        # `reasoning_content` fallback below catches truncated thinking
+        # rather than the actual answer. Symptom in the wild was
+        # multi-minute summarize stages on long docs because every
+        # map-reduce call paid that cost. Same fix as the research
+        # pipeline shipped in PR #218. Templates that don't recognise
+        # the kwarg ignore it harmlessly.
+        "chat_template_kwargs": {"enable_thinking": False},
     }
     if json_schema:
         # Use json_object mode (simpler, better compatibility with thinking models)


### PR DESCRIPTION
Same content as the wedged #237. Re-landed cleanly off latest main on a fresh branch with new commit SHAs to test whether GH Actions dispatch is back after the billing bump.

If CI fires here and #237 still doesn't, we'll close #237 in favour of this. If neither fires, the bump hasn't propagated yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)