### PR TITLE
feat(observatory): split into Corpus / Processing tabs + per-stage timing charts

### DIFF
--- a/frontend/src/components/stats/PipelineTimingChart.tsx
+++ b/frontend/src/components/stats/PipelineTimingChart.tsx
@@ -1,0 +1,95 @@
+import { classColor, classColorAlpha, queueForStage } from '../../utils/queueColors'
+
+export interface StageTiming {
+  avg_run_secs: number
+  p50_run_secs: number
+  p95_run_secs: number
+  max_run_secs: number
+  avg_wait_secs: number
+  count: number
+}
+
+interface PipelineTimingChartProps {
+  pipelineTiming: Record<string, StageTiming>
+}
+
+const STAGES = ['extract', 'ocr', 'chunk', 'entities', 'embed', 'summarize', 'finalize'] as const
+const STAGE_LABELS: Record<string, string> = {
+  extract: 'Extract',
+  ocr: 'OCR',
+  chunk: 'Chunk',
+  entities: 'Entities',
+  embed: 'Embed',
+  summarize: 'Summarize',
+  finalize: 'Finalize',
+}
+
+function fmtSecs(secs: number): string {
+  if (secs < 1) return `${Math.round(secs * 1000)}ms`
+  if (secs < 60) return `${secs.toFixed(1)}s`
+  const m = Math.floor(secs / 60)
+  const s = Math.round(secs % 60)
+  return `${m}m ${s}s`
+}
+
+/**
+ * Per-stage processing time as a horizontal bar chart with a
+ * within-bar p50 marker. The faded portion of each bar runs out to
+ * p95; the saturated portion runs out to p50, so the eye reads
+ * "median where it's filled, tail where it fades". Colour is the
+ * stage's queue class for visual consistency with the diagram.
+ *
+ * The avg row's primary value is signalling spread, not centre — when
+ * the saturated p50 bar is much shorter than the faded p95 bar, the
+ * stage has a long tail (typical for OCR with mixed scan quality);
+ * when they're close the stage is tightly clustered (chunk, finalize).
+ */
+export default function PipelineTimingChart({ pipelineTiming }: PipelineTimingChartProps) {
+  const visibleStages = STAGES.filter((s) => pipelineTiming[s]?.count)
+  if (visibleStages.length === 0) {
+    return (
+      <div className="text-[12px] text-(--color-text-secondary)">
+        No completed jobs yet — process a document to populate.
+      </div>
+    )
+  }
+  const maxP95 = Math.max(0.001, ...visibleStages.map((s) => pipelineTiming[s].p95_run_secs))
+
+  return (
+    <div className="space-y-1.5">
+      {visibleStages.map((stage) => {
+        const t = pipelineTiming[stage]
+        const queue = queueForStage(stage)
+        const p50Width = Math.min(100, (t.p50_run_secs / maxP95) * 100)
+        const p95Width = Math.min(100, (t.p95_run_secs / maxP95) * 100)
+        return (
+          <div key={stage} className="flex items-center gap-2 text-[12px]">
+            <span className="w-16 shrink-0 text-(--color-text-secondary) text-right">{STAGE_LABELS[stage]}</span>
+            <div
+              className="relative flex-1 h-4 rounded-sm overflow-hidden"
+              style={{ background: 'rgba(128,128,128,0.12)' }}
+              title={`${STAGE_LABELS[stage]} — p50 ${fmtSecs(t.p50_run_secs)}, p95 ${fmtSecs(t.p95_run_secs)}, max ${fmtSecs(t.max_run_secs)}, avg ${fmtSecs(t.avg_run_secs)}, n=${t.count}`}
+            >
+              {/* p95 (faded outer reach) */}
+              <div
+                className="absolute left-0 top-0 h-full rounded-sm"
+                style={{ width: `${p95Width}%`, background: classColorAlpha(queue, 0.3) }}
+              />
+              {/* p50 (saturated up to median) */}
+              <div
+                className="absolute left-0 top-0 h-full rounded-sm"
+                style={{ width: `${p50Width}%`, background: classColor(queue) }}
+              />
+            </div>
+            <span className="w-44 shrink-0 text-right tabular-nums text-(--color-text-secondary) text-[11px]">
+              p50 {fmtSecs(t.p50_run_secs)} · p95 {fmtSecs(t.p95_run_secs)} · n={t.count}
+            </span>
+          </div>
+        )
+      })}
+      <div className="pt-1 text-[10px] text-(--color-text-secondary)">
+        Saturated bar = median (p50) · faded extension = p95 · numbers on the right show exact values
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/stats/QueueWaitChart.tsx
+++ b/frontend/src/components/stats/QueueWaitChart.tsx
@@ -1,0 +1,90 @@
+import { classColor, queueForStage } from '../../utils/queueColors'
+import type { StageTiming } from './PipelineTimingChart'
+
+interface QueueWaitChartProps {
+  pipelineTiming: Record<string, StageTiming>
+}
+
+const STAGES = ['extract', 'ocr', 'chunk', 'entities', 'embed', 'summarize', 'finalize'] as const
+const STAGE_LABELS: Record<string, string> = {
+  extract: 'Extract',
+  ocr: 'OCR',
+  chunk: 'Chunk',
+  entities: 'Entities',
+  embed: 'Embed',
+  summarize: 'Summarize',
+  finalize: 'Finalize',
+}
+
+function fmtSecs(secs: number): string {
+  if (secs < 1) return `${Math.round(secs * 1000)}ms`
+  if (secs < 60) return `${secs.toFixed(1)}s`
+  const m = Math.floor(secs / 60)
+  const s = Math.round(secs % 60)
+  return `${m}m ${s}s`
+}
+
+const WAIT_FILL = 'rgba(128, 128, 128, 0.45)'
+
+/**
+ * Per-stage wait-vs-run breakdown as a stacked horizontal bar.
+ *
+ * Different signal from the timing-distribution chart: this answers
+ * "where does a job spend its life" — sitting in the queue (waiting
+ * for a free worker) vs actually being processed. A long grey wait
+ * segment on a stage means workers are saturated upstream of it; a
+ * long coloured run segment means the work itself is slow.
+ */
+export default function QueueWaitChart({ pipelineTiming }: QueueWaitChartProps) {
+  const visibleStages = STAGES.filter((s) => pipelineTiming[s]?.count)
+  if (visibleStages.length === 0) {
+    return (
+      <div className="text-[12px] text-(--color-text-secondary)">
+        No completed jobs yet — process a document to populate.
+      </div>
+    )
+  }
+  const maxTotal = Math.max(
+    0.001,
+    ...visibleStages.map((s) => pipelineTiming[s].avg_wait_secs + pipelineTiming[s].avg_run_secs),
+  )
+
+  return (
+    <div className="space-y-1.5">
+      {visibleStages.map((stage) => {
+        const t = pipelineTiming[stage]
+        const queue = queueForStage(stage)
+        const waitWidth = Math.min(100, (t.avg_wait_secs / maxTotal) * 100)
+        const runWidth = Math.min(100, (t.avg_run_secs / maxTotal) * 100)
+        return (
+          <div key={stage} className="flex items-center gap-2 text-[12px]">
+            <span className="w-16 shrink-0 text-(--color-text-secondary) text-right">{STAGE_LABELS[stage]}</span>
+            <div
+              className="relative flex-1 h-4 rounded-sm overflow-hidden"
+              style={{ background: 'rgba(128,128,128,0.12)' }}
+              title={`${STAGE_LABELS[stage]} — wait ${fmtSecs(t.avg_wait_secs)}, run ${fmtSecs(t.avg_run_secs)} (avg over n=${t.count})`}
+            >
+              <div className="flex h-full">
+                {waitWidth > 0 && <div style={{ width: `${waitWidth}%`, background: WAIT_FILL }} />}
+                {runWidth > 0 && <div style={{ width: `${runWidth}%`, background: classColor(queue) }} />}
+              </div>
+            </div>
+            <span className="w-44 shrink-0 text-right tabular-nums text-(--color-text-secondary) text-[11px]">
+              wait {fmtSecs(t.avg_wait_secs)} · run {fmtSecs(t.avg_run_secs)}
+            </span>
+          </div>
+        )
+      })}
+      <div className="pt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-(--color-text-secondary)">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-sm" style={{ background: WAIT_FILL }} />
+          Time queued
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-sm" style={{ background: classColor('io') }} />
+          Processing (coloured by queue class)
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -7,6 +7,8 @@ import TopicTreemap from '../components/stats/TopicTreemap'
 import TopicBarChart from '../components/stats/TopicBarChart'
 import TopicKeywords from '../components/stats/TopicKeywords'
 import PipelineDiagram from '../components/stats/PipelineDiagram'
+import PipelineTimingChart, { type StageTiming } from '../components/stats/PipelineTimingChart'
+import QueueWaitChart from '../components/stats/QueueWaitChart'
 import { InfoTip } from '../components/InfoTip'
 
 interface TopicCluster {
@@ -31,10 +33,12 @@ interface CorpusStats {
   ocr_breakdown: { born_digital: number; ocr_used: number; unknown: number }
   size_buckets: { label: string; count: number }[]
   growth_timeline: { month: string; count: number }[]
-  pipeline_timing: Record<string, { avg_secs: number; count: number }>
+  pipeline_timing: Record<string, StageTiming & { avg_secs: number }>
   entity_type_counts: Record<string, number>
   top_entities: { text: string; type: string; mentions: number }[]
 }
+
+type TabId = 'corpus' | 'pipeline'
 
 function StatBadge({ label, value, tip }: { label: string; value: string | number; tip?: string }) {
   return (
@@ -50,11 +54,37 @@ function StatBadge({ label, value, tip }: { label: string; value: string | numbe
   )
 }
 
+interface TabButtonProps {
+  id: TabId
+  current: TabId
+  onClick: (id: TabId) => void
+  children: React.ReactNode
+}
+
+function TabButton({ id, current, onClick, children }: TabButtonProps) {
+  const active = id === current
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(id)}
+      aria-selected={active}
+      role="tab"
+      className={`relative px-4 py-2 text-[14px] font-medium transition-colors ${
+        active ? 'text-(--color-text-primary)' : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+      }`}
+    >
+      {children}
+      {active && <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-(--color-accent)" />}
+    </button>
+  )
+}
+
 export default function StatsPage() {
   const [stats, setStats] = useState<CorpusStats | null>(null)
   const [topics, setTopics] = useState<TopicsData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [tab, setTab] = useState<TabId>('corpus')
 
   useEffect(() => {
     let cancelled = false
@@ -100,10 +130,29 @@ export default function StatsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-lg font-semibold text-(--color-text-primary)">
-        Corpus Statistics
+      {/* Tab bar */}
+      <div role="tablist" className="flex border-b border-(--color-border)">
+        <TabButton id="corpus" current={tab} onClick={setTab}>
+          Corpus Statistics
+        </TabButton>
+        <TabButton id="pipeline" current={tab} onClick={setTab}>
+          Processing Pipeline
+        </TabButton>
+      </div>
+
+      {tab === 'corpus' && <CorpusTab stats={stats} topics={topics} />}
+      {tab === 'pipeline' && <PipelineTab pipelineTiming={stats.pipeline_timing} />}
+    </div>
+  )
+}
+
+function CorpusTab({ stats, topics }: { stats: CorpusStats; topics: TopicsData | null }) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-base font-semibold text-(--color-text-primary)">
+        About your collection
         <InfoTip text="These are facts and statistics about your entire document collection — how many documents, pages, and text segments (chunks) have been processed." />
-      </h1>
+      </h2>
 
       {/* Summary badges */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -124,9 +173,6 @@ export default function StatsPage() {
           tip="Named entities — people, organizations, places, dates, etc. — automatically extracted from your documents using natural language processing."
         />
       </div>
-
-      {/* Live pipeline activity */}
-      <PipelineDiagram />
 
       {/* Charts */}
       <CorpusCharts stats={stats} />
@@ -159,6 +205,42 @@ export default function StatsPage() {
 
       {/* Document Clusters */}
       <ClusterMap />
+    </div>
+  )
+}
+
+function PipelineTab({ pipelineTiming }: { pipelineTiming: CorpusStats['pipeline_timing'] }) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-base font-semibold text-(--color-text-primary)">
+        Processing pipeline
+        <InfoTip text="How your documents move through the ingestion pipeline. Live activity above; aggregated processing time and queue-wait breakdowns below, computed across all completed jobs." />
+      </h2>
+
+      {/* Live diagram */}
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <h3 className="mb-3 text-[13px] font-semibold text-(--color-text-primary)">Live activity</h3>
+        <PipelineDiagram />
+      </div>
+
+      {/* Per-stage timing */}
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <h3 className="mb-1 text-[13px] font-semibold text-(--color-text-primary)">Processing time per stage</h3>
+        <p className="mb-3 text-[12px] text-(--color-text-secondary)">
+          How long each stage takes once it starts running, across all completed jobs.
+        </p>
+        <PipelineTimingChart pipelineTiming={pipelineTiming} />
+      </div>
+
+      {/* Queue wait vs run time */}
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <h3 className="mb-1 text-[13px] font-semibold text-(--color-text-primary)">Queue wait vs processing time</h3>
+        <p className="mb-3 text-[12px] text-(--color-text-secondary)">
+          How long jobs wait in the queue before a worker picks them up, vs how long the work itself takes. A long grey
+          tail on a stage means workers are saturated.
+        </p>
+        <QueueWaitChart pipelineTiming={pipelineTiming} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/utils/queueColors.ts
+++ b/frontend/src/utils/queueColors.ts
@@ -23,3 +23,15 @@ export function classColor(queue: QueueClass | undefined): string {
 export function classColorAlpha(queue: QueueClass | undefined, alpha: number): string {
   return `color-mix(in srgb, ${classColor(queue)} ${Math.round(alpha * 100)}%, transparent)`
 }
+
+/**
+ * Stage → queue-class mapping. Mirrors `STAGE_CONFIG` in
+ * `src/harbor_clerk/worker/pipeline.py`. Mapping is stable so duplicating
+ * it is safe and saves a backend round-trip in places that already have
+ * a stage name (e.g. timing charts on the Observatory page).
+ */
+export function queueForStage(stage: string): QueueClass {
+  if (stage === 'ocr' || stage === 'embed') return 'cpu'
+  if (stage === 'summarize') return 'llm'
+  return 'io'
+}

--- a/src/harbor_clerk/api/routes/stats.py
+++ b/src/harbor_clerk/api/routes/stats.py
@@ -170,26 +170,44 @@ async def corpus_stats(
     ).all()
     growth_timeline = [{"month": row[0], "count": row[1]} for row in growth_rows]
 
-    # Pipeline timing from completed jobs
+    # Pipeline timing from completed jobs — avg + percentiles + max for
+    # the per-stage timing distribution chart, plus average queue wait
+    # (created → started) for the wait-vs-run breakdown chart.
+    run_secs = extract("epoch", IngestionJob.finished_at) - extract("epoch", IngestionJob.started_at)
+    wait_secs = extract("epoch", IngestionJob.started_at) - extract("epoch", IngestionJob.created_at)
     timing_rows = (
         await session.execute(
             select(
                 IngestionJob.stage,
-                func.avg(extract("epoch", IngestionJob.finished_at) - extract("epoch", IngestionJob.started_at)).label(
-                    "avg_secs"
-                ),
+                func.avg(run_secs).label("avg_run_secs"),
+                func.percentile_cont(0.5).within_group(run_secs.asc()).label("p50_run_secs"),
+                func.percentile_cont(0.95).within_group(run_secs.asc()).label("p95_run_secs"),
+                func.max(run_secs).label("max_run_secs"),
+                func.avg(wait_secs).label("avg_wait_secs"),
                 func.count(),
             )
             .where(
-                IngestionJob.status == "done", IngestionJob.started_at.isnot(None), IngestionJob.finished_at.isnot(None)
+                IngestionJob.status == "done",
+                IngestionJob.started_at.isnot(None),
+                IngestionJob.finished_at.isnot(None),
             )
             .group_by(IngestionJob.stage)
         )
     ).all()
     pipeline_timing = {}
-    for stage, avg_secs, count in timing_rows:
+    for stage, avg_run, p50_run, p95_run, max_run, avg_wait, count in timing_rows:
         stage_name = stage.value if hasattr(stage, "value") else str(stage)
-        pipeline_timing[stage_name] = {"avg_secs": round(float(avg_secs), 2), "count": count}
+        # `avg_secs` kept as a back-compat alias for clients that haven't
+        # been updated; new clients should read `avg_run_secs` directly.
+        pipeline_timing[stage_name] = {
+            "avg_secs": round(float(avg_run), 2),
+            "avg_run_secs": round(float(avg_run), 2),
+            "p50_run_secs": round(float(p50_run), 2) if p50_run is not None else 0.0,
+            "p95_run_secs": round(float(p95_run), 2) if p95_run is not None else 0.0,
+            "max_run_secs": round(float(max_run), 2) if max_run is not None else 0.0,
+            "avg_wait_secs": round(float(avg_wait), 2) if avg_wait is not None else 0.0,
+            "count": count,
+        }
 
     # Entity type counts
     entity_type_q = (


### PR DESCRIPTION
Re-land of #236 on a fresh branch — original branch had tangled history that confused CI dispatch.

Same content as PR #236 (now closed). See commit message for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)