### PR TITLE
improve(observatory): restore green edges + perimeter trim on pipeline diagram

### DIFF
--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -7,14 +7,20 @@ import { classColor } from '../../utils/queueColors'
  * ingestion pipeline.
  *
  * Visual encoding:
- *   - Node radius scales with sqrt(queued + running) — a bottleneck
- *     swells without crushing other nodes.
- *   - Node hue distinguishes IO / CPU / LLM queue classes.
- *   - Soft glow filter on nodes with at least one running job — the
- *     "I am alive" cue.
- *   - Edges thicken with recent throughput on the downstream stage.
+ *   - Each stage is rendered as a thin outline circle whose radius
+ *     scales with sqrt(queued + running) — a bottleneck swells
+ *     without crushing other nodes.
+ *   - Outline hue = queue class (IO blue / CPU amber / LLM purple).
+ *   - When the stage has running jobs, an inner concentric "particle"
+ *     appears — same hue as the outline, with a soft glow and a slow
+ *     heartbeat pulse (radius + opacity). Idle stages are bare rings
+ *     so the eye is drawn to active work.
+ *   - Edges are a fixed green so the connecting "pipes" read as their
+ *     own visual layer. Edges thicken and brighten with recent
+ *     throughput on the downstream stage.
  *   - Particles flow along edges at a rate proportional to recent
- *     throughput. Each particle inherits the upstream stage's colour.
+ *     throughput. Each particle inherits the upstream stage's colour
+ *     (coloured payload moving through green plumbing).
  *
  * Polls the same /api/jobs/snapshot endpoint as the drawer's Pipeline
  * tab. The snapshot includes `recent_completed` per stage (last 30 s),
@@ -29,6 +35,12 @@ const VIEW_WIDTH = 600
 // Bumped from 300 → 320 to fit the wider fan-out spread without the
 // top badge and bottom label hugging the edges.
 const VIEW_HEIGHT = 320
+
+// Connecting edges all use the same neutral colour so the "pipes" read
+// as their own visual layer, separate from the queue-class hues on the
+// nodes. System green reads as flow / activity without competing with
+// the IO-blue / CPU-amber / LLM-purple node palette.
+const EDGE_COLOR = '#30d158'
 
 // Hand-laid-out positions for the 7-stage pipeline.
 // Sequential prefix flows left-to-right at y=150, then chunk fans out
@@ -160,21 +172,24 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
         </filter>
       </defs>
 
-      {/* Edges */}
+      {/* Edges — fixed system green so the connecting "pipes" read as
+          their own visual layer, separate from the nodes' queue-class
+          hues. Particles flowing through them still inherit the
+          upstream node's colour, which gives the impression of
+          coloured payload moving through a green plumbing graph. */}
       {EDGES.map((edge) => {
         const downstream = snapshot.by_stage[edge.to]
         const throughput = downstream?.recent_completed ?? 0
         const baseWidth = 1.5
         const width = Math.min(8, baseWidth + throughput * 0.4)
-        const color = classColor(downstream?.queue)
-        const opacity = throughput > 0 ? 0.5 : 0.15
+        const opacity = throughput > 0 ? 0.55 : 0.2
         return (
           <path
             key={`${edge.from}-${edge.to}`}
             id={`edge-${edge.from}-${edge.to}`}
             d={edgePath(edge.from, edge.to)}
             fill="none"
-            stroke={color}
+            stroke={EDGE_COLOR}
             strokeWidth={width}
             strokeOpacity={opacity}
             strokeLinecap="round"
@@ -209,21 +224,53 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
         const total = info ? info.queued + info.running : 0
         const isBusy = (info?.running ?? 0) > 0
 
+        // Inner "particle" radius — proportional to the outer ring so
+        // both grow together as the queue depth scales the node size.
+        const innerR = r * 0.55
+        // Heartbeat amplitude: small expansion + slight opacity dip,
+        // ~1.6 s cycle for a calm 'breathing' rather than an urgent
+        // alarm.
+        const innerRMin = innerR * 0.86
+        const innerRMax = innerR * 1.04
         return (
           <g key={stage}>
+            {/* Outer ring — always rendered, same thin outline whether
+                idle or busy. The activity signal is the inner particle,
+                not a fill colour change. */}
             <circle
               cx={pos.x}
               cy={pos.y}
               r={r}
-              fill={color}
-              fillOpacity={isBusy ? 0.85 : 0.2}
+              fill="none"
               stroke={color}
-              strokeWidth={isBusy ? 2 : 1}
-              style={{
-                filter: isBusy ? 'url(#pipeline-glow)' : undefined,
-                transition: 'r 400ms ease-out, fill-opacity 400ms',
-              }}
+              strokeWidth={1.2}
+              strokeOpacity={isBusy ? 0.75 : 0.45}
+              style={{ transition: 'r 400ms ease-out, stroke-opacity 400ms' }}
             />
+            {/* Inner particle — only when busy. Concentric with the
+                ring, glow filter applied, and a slow heartbeat
+                (radius + opacity) so the eye reads "this stage is
+                alive" without the diagram feeling frantic. */}
+            {isBusy && (
+              <circle cx={pos.x} cy={pos.y} fill={color} style={{ filter: 'url(#pipeline-glow)' }}>
+                <animate
+                  attributeName="r"
+                  values={`${innerRMin};${innerRMax};${innerRMin}`}
+                  dur="1.6s"
+                  repeatCount="indefinite"
+                  calcMode="spline"
+                  keySplines="0.4 0 0.6 1; 0.4 0 0.6 1"
+                />
+                <animate
+                  attributeName="opacity"
+                  values="0.78;1;0.78"
+                  dur="1.6s"
+                  repeatCount="indefinite"
+                  calcMode="spline"
+                  keySplines="0.4 0 0.6 1; 0.4 0 0.6 1"
+                />
+              </circle>
+            )}
             {/* Count badge above the node, only when there's activity */}
             {total > 0 && (
               <g>
@@ -294,7 +341,7 @@ export default function PipelineDiagram() {
           LLM
         </span>
         <span className="ml-auto">
-          Throughput · last {snapshot.throughput_window_seconds}s · glowing nodes have running jobs
+          Throughput · last {snapshot.throughput_window_seconds}s · pulsing particles inside a node = running jobs
         </span>
       </div>
     </div>

--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -81,17 +81,24 @@ const STAGE_LABELS: Record<string, string> = {
   finalize: 'Finalize',
 }
 
-function edgePath(from: string, to: string): string {
+function edgePath(from: string, to: string, rFrom: number, rTo: number): string {
   const a = NODE_POSITIONS[from]
   const b = NODE_POSITIONS[to]
   const dx = b.x - a.x
   // Cubic Bezier with horizontally-pulled control points → smooth
-  // S-curve when y differs, near-straight when y matches.
+  // S-curve when y differs, near-straight when y matches. Because
+  // the control points are pulled purely horizontally, the curve's
+  // tangent at each endpoint is also purely horizontal — which is
+  // why we can trim the endpoints by ±r along the x axis to land
+  // them exactly on each node's perimeter without bending the curve.
+  const sign = Math.sign(dx) || 1
+  const startX = a.x + sign * rFrom
+  const endX = b.x - sign * rTo
   const c1x = a.x + dx * 0.5
   const c1y = a.y
   const c2x = b.x - dx * 0.5
   const c2y = b.y
-  return `M ${a.x} ${a.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${b.x} ${b.y}`
+  return `M ${startX} ${a.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${endX} ${b.y}`
 }
 
 function nodeRadius(info: StageSnapshot | undefined): number {
@@ -176,18 +183,23 @@ function PipelineGraph({ snapshot }: { snapshot: QueueSnapshot }) {
           their own visual layer, separate from the nodes' queue-class
           hues. Particles flowing through them still inherit the
           upstream node's colour, which gives the impression of
-          coloured payload moving through a green plumbing graph. */}
+          coloured payload moving through a green plumbing graph.
+          Endpoints are trimmed to each node's current perimeter so
+          the line stops at the ring rather than passing through the
+          disc. */}
       {EDGES.map((edge) => {
         const downstream = snapshot.by_stage[edge.to]
         const throughput = downstream?.recent_completed ?? 0
         const baseWidth = 1.5
         const width = Math.min(8, baseWidth + throughput * 0.4)
         const opacity = throughput > 0 ? 0.55 : 0.2
+        const rFrom = nodeRadius(snapshot.by_stage[edge.from])
+        const rTo = nodeRadius(snapshot.by_stage[edge.to])
         return (
           <path
             key={`${edge.from}-${edge.to}`}
             id={`edge-${edge.from}-${edge.to}`}
-            d={edgePath(edge.from, edge.to)}
+            d={edgePath(edge.from, edge.to, rFrom, rTo)}
             fill="none"
             stroke={EDGE_COLOR}
             strokeWidth={width}


### PR DESCRIPTION
## Summary

Restores two PipelineDiagram improvements that were lost when the wedged Observatory PR was re-landed off a fresh branch off main.

### What's back

1. **Green edges + concentric pulsing particle on busy nodes** — original commit `904710f`.
   - Edges use a fixed `#30d158` (system green) regardless of which queue they feed into. The connecting "pipes" now read as their own visual layer, with the IO-blue / CPU-amber / LLM-purple palette reserved for the things that carry the distinction (nodes + flowing particles).
   - Active nodes are no longer fully-filled discs with a glow. Instead the outer ring is always rendered (thin outline, queue-class colour) and busy stages get an inner concentric "particle" at 55% of the outer radius with a 1.6s heartbeat (radius oscillates 86%–104%, opacity 0.78–1.0).
   - Particles flowing through pipes still inherit the upstream node's hue → "coloured payload moving through green plumbing".

2. **Edges terminate at node perimeters** — original commit `c000d3f`.
   - `edgePath(from, to, rFrom, rTo)` now offsets each endpoint by ±r along the x-axis. Because the cubic Bezier control points are pulled purely horizontally, the tangent at each endpoint is also horizontal — so the trim doesn't bend the curve.
   - Perimeter trim scales with current node radius, so the visible gap stays consistent as queue depth grows the node.

## Provenance

Both commits authored 2026-04-29 on the original `improve/pipeline-overview-collapsible` branch. They sat in reflog only — never made it onto a merged PR. Cherry-picked verbatim onto a clean branch off latest `main`.

## Test plan

- [x] `npm run type-check`, `npm run lint` (13 pre-existing warnings, 0 errors), `npm run format:check`, `npm run build` — all pass.
- [ ] Manual: visit Observatory → Processing Pipeline tab. Edges should be green; an active stage should show a pulsing inner dot rather than a glowing filled circle; edge endpoints should land on the node perimeter rather than passing through the disc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
