### PR TITLE
fix(summarize): blank summary attributed to model when LLM is degraded

### DIFF
--- a/src/harbor_clerk/llm/summarize.py
+++ b/src/harbor_clerk/llm/summarize.py
@@ -73,6 +73,30 @@ _DOC_TYPE_SCHEMA = {
 # --- Helpers ---
 
 
+# Format-category Unicode characters that survive str.strip() (which only
+# strips Zs whitespace per str.isspace()) but render as nothing — zero-width
+# space, joiner / non-joiner, word joiner, BOM. A wedged or degraded LLM can
+# emit these as the entire response body, and without filtering they'd sneak
+# past the truthiness checks below and into the DB as a "blank summary
+# attributed to the current model" (the symptom that motivated this filter).
+_INVISIBLE_CHARS = "​‌‍⁠﻿"
+_INVISIBLE_TRANSLATION = str.maketrans("", "", _INVISIBLE_CHARS)
+
+
+def _has_visible_content(text: str | None) -> bool:
+    """Return True iff `text` has at least one character that visibly renders.
+
+    Strips Python-recognised whitespace AND the format-category Unicode chars
+    above. Used by `_call_llm` and `generate_summary` so a misbehaving model
+    that emits e.g. `"\\u200b"` or `"   "` as its `summary` JSON value is
+    treated as a no-result (and the AFM / extractive fallbacks fire) rather
+    than persisted as an empty summary attributed to the model.
+    """
+    if not text:
+        return False
+    return bool(text.strip().translate(_INVISIBLE_TRANSLATION).strip())
+
+
 def _extract_marked_answer(text: str) -> str:
     """Extract the final answer from LLM output using ANSWER: or TYPE: markers.
 
@@ -211,14 +235,21 @@ def _call_llm(
                 try:
                     parsed = _json.loads(json_text)
                     extracted = parsed.get(response_key, "")
-                    return str(extracted).strip() if extracted else None
+                    # Strip first, THEN check truthiness — a value of
+                    # "   " or " " is truthy as an unstripped string
+                    # but blank after strip; without this, _call_llm would
+                    # return "" which the summarize callers treat as falsy
+                    # but `_has_visible_content` covers exotic format-only
+                    # characters too.
+                    candidate = str(extracted).strip() if extracted else ""
+                    return candidate if _has_visible_content(candidate) else None
                 except (ValueError, AttributeError):
                     logger.warning("LLM call phase=%s JSON parse failed: %s", phase, content[:200])
                     return None
 
             # Non-JSON mode: extract marked answer
             content = _extract_marked_answer(content)
-            return content if content else None
+            return content if _has_visible_content(content) else None
         except (httpx.TimeoutException, httpx.ConnectError) as e:
             elapsed = time.perf_counter() - call_started
             last_err = e
@@ -635,9 +666,9 @@ def generate_summary(chunks: list[str], max_chars: int | None = None) -> tuple[s
             len(chunks),
         )
 
-        if result:
+        if _has_visible_content(result):
             return _truncate_at_sentence(result, max_chars), settings.llm_model_id
-        logger.warning("LLM summarization returned no result — trying Apple Intelligence")
+        logger.warning("LLM summarization returned no visible content — trying Apple Intelligence")
     else:
         logger.info("No language model active — trying Apple Intelligence fallback")
 

--- a/src/harbor_clerk/worker/stages/summarize.py
+++ b/src/harbor_clerk/worker/stages/summarize.py
@@ -41,7 +41,13 @@ def run_summarize(version_id: uuid.UUID) -> None:
                 logger.warning("Summary generation failed for %s", version_id, exc_info=True)
                 summary, model_used = None, None
 
-            if summary:
+            # Require visible content — not just truthiness — so a degraded
+            # LLM that returns whitespace or zero-width characters can't
+            # persist a "blank summary attributed to the current model".
+            # generate_summary should already filter these via
+            # _has_visible_content, but a check here is a cheap belt-and-
+            # suspenders against any future regression.
+            if summary and summary.strip():
                 version.summary = summary
                 version.summary_model = model_used
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -331,6 +331,34 @@ class TestGenerateSummary:
             summary, model = generate_summary(chunks, max_chars=100)
             assert len(summary) <= 100
 
+    def test_zero_width_space_summary_falls_back(self):
+        """Regression: a wedged LLM emitting only a zero-width space (or other
+        invisible Unicode) must NOT persist as a "blank summary attributed to
+        the current model" — should fall through to extractive instead."""
+        with (
+            patch("harbor_clerk.llm.summarize.get_settings", return_value=_mock_settings()),
+            patch("harbor_clerk.llm.summarize.get_model", return_value=MagicMock(context_window=32768)),
+            # Simulate LLM returning a single zero-width space as the summary value.
+            patch("harbor_clerk.llm.summarize._call_llm", return_value="​"),
+        ):
+            chunks = ["A" * 100]
+            summary, model = generate_summary(chunks)
+            # Must NOT attribute to the model — should fall back.
+            assert model == "extractive"
+            assert summary  # extractive always returns content for non-empty chunks
+
+    def test_whitespace_only_summary_falls_back(self):
+        """Regression: a model returning whitespace-only summary must fall back."""
+        with (
+            patch("harbor_clerk.llm.summarize.get_settings", return_value=_mock_settings()),
+            patch("harbor_clerk.llm.summarize.get_model", return_value=MagicMock(context_window=32768)),
+            patch("harbor_clerk.llm.summarize._call_llm", return_value="   \n\t"),
+        ):
+            chunks = ["A" * 100]
+            summary, model = generate_summary(chunks)
+            assert model == "extractive"
+            assert summary
+
 
 class TestTruncateAtSentence:
     def test_short_text_unchanged(self):


### PR DESCRIPTION
## Summary

User-reported bug: with LlamaService in the `.errored` state (llama-server crashed / wedged / mid-restart), summarize was no longer falling back to Apple Intelligence or extractive. Instead a **blank summary** was persisting in the DB **attributed to the currently-selected LLM model**.

## Root cause

`_call_llm`'s JSON-mode return path stripped AFTER the truthiness check:

```python
return str(extracted).strip() if extracted else None
```

When the model emits `{"summary": "   "}` or `{"summary": "​"}` (a wedged llama-server can return JSON with whitespace-only or invisible content during a transition), `extracted` is truthy as an unstripped string. After `strip()` it becomes `""` for normal whitespace — but for **format-category Unicode** (zero-width space, BOM, ZWJ/ZWNJ, word joiner), `str.strip()` doesn't touch them at all. So `_call_llm` returned a one-character invisible string that:

1. Passed `if result:` in `generate_summary` (truthy)
2. Survived `_truncate_at_sentence` (length 1 ≤ max_chars)
3. Got persisted by the worker as `version.summary = "​"` with `version.summary_model = <currently-selected-model>`
4. Renders as blank in the UI with the model name as attribution

## Fix — three layers of defense

1. **New `_has_visible_content(text)` predicate** in `summarize.py`. Strips Python-recognised whitespace AND a small denylist of common invisible format chars (ZWSP / ZWJ / ZWNJ / WJ / BOM). Returns False for any input that wouldn't render visibly.

2. **`_call_llm` validates before returning:** both the JSON-mode path (line 213-217) and the marked-answer path (line 220-221) now require `_has_visible_content` before treating the call as a success. A wedged model emitting whitespace or zero-width chars returns `None`, the callers treat it as a no-result, and the AFM / extractive fallback fires as expected.

3. **`generate_summary` swaps `if result:` for `if _has_visible_content(result):`** at the LLM-success branch (line 638). Defense in depth in case some other path produces a value the predicate would reject.

4. **`worker/stages/summarize.py` adds `summary.strip()` to its persist guard.** Cheap belt-and-suspenders against any future regression that re-introduces the upstream issue.

## Regression tests

Two new tests in `test_summarize.py`:
- `test_zero_width_space_summary_falls_back` — patches `_call_llm` to return a single zero-width space, asserts that `generate_summary` returns `("...", "extractive")`, never `("​", "test-model")`.
- `test_whitespace_only_summary_falls_back` — same but for `"   \n\t"`.

Both fail without this patch and pass with it.

## Test plan

- [x] `uv run pytest tests/test_summarize.py -v` — 52 passed (50 prior + 2 new)
- [x] `uv run pytest tests/` — 372 passed, 6 skipped (was 370+6 before; new = +2)
- [x] `uv run ruff check .` and `ruff format --check .` — clean
- [ ] Manual smoke after the next install: stop llama-server (or activate a model that fails to load), trigger reprocessing on a doc, confirm `version.summary_model` ends up as `"extractive"` or `"apple-intelligence"`, never the LLM model id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
