### PR TITLE
fix(watcher): AppleDouble filter + initial folder scan + delete-button two-click

### DIFF
--- a/frontend/src/pages/FoldersPage.tsx
+++ b/frontend/src/pages/FoldersPage.tsx
@@ -49,6 +49,11 @@ export default function FoldersPage() {
   const [progress, setProgress] = useState<Record<string, ProgressInfo>>({})
   const [expanded, setExpanded] = useState<string | null>(null)
   const [error, setError] = useState('')
+  // Two-click delete confirmation. WKWebView (the macOS native app's
+  // chrome) returns false from window.confirm() silently, which made
+  // the Delete button look broken. The state tracks which folder is
+  // armed for delete; first click sets it, second confirms.
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
 
   async function reload() {
     try {
@@ -122,8 +127,17 @@ export default function FoldersPage() {
     }
   }
 
-  async function handleDelete(folderId: string) {
-    if (!confirm('Remove this folder? Documents already ingested will stay queryable.')) return
+  async function handleDeleteClick(folderId: string) {
+    // First click: arm. Second click on the same row: actually delete.
+    if (pendingDeleteId !== folderId) {
+      setPendingDeleteId(folderId)
+      // Auto-cancel after 5 s so the row doesn't sit in a "Confirm?" state forever.
+      setTimeout(() => {
+        setPendingDeleteId((cur) => (cur === folderId ? null : cur))
+      }, 5000)
+      return
+    }
+    setPendingDeleteId(null)
     try {
       await del(`/api/watch/folders/${folderId}`)
       reload()
@@ -204,9 +218,11 @@ export default function FoldersPage() {
                   progress={p}
                   isExpanded={isExpanded}
                   deleteDisabled={deleteDisabled}
+                  pendingDelete={pendingDeleteId === f.folder_id}
                   onToggleExpand={() => setExpanded(isExpanded ? null : f.folder_id)}
                   onToggleEnabled={() => handleToggle(f)}
-                  onDelete={() => handleDelete(f.folder_id)}
+                  onDelete={() => handleDeleteClick(f.folder_id)}
+                  onCancelDelete={() => setPendingDeleteId(null)}
                 />
               )
             })}
@@ -222,9 +238,11 @@ interface FolderRowProps {
   progress?: ProgressInfo
   isExpanded: boolean
   deleteDisabled: boolean
+  pendingDelete: boolean
   onToggleExpand: () => void
   onToggleEnabled: () => void
   onDelete: () => void
+  onCancelDelete: () => void
 }
 
 function FolderRow({
@@ -232,9 +250,11 @@ function FolderRow({
   progress: p,
   isExpanded,
   deleteDisabled,
+  pendingDelete,
   onToggleExpand,
   onToggleEnabled,
   onDelete,
+  onCancelDelete,
 }: FolderRowProps) {
   return (
     <>
@@ -251,26 +271,51 @@ function FolderRow({
         <td className="px-4 py-3">{renderStatusPill(f, p)}</td>
         <td className="px-4 py-3 text-xs">{p ? `${p.completed_files} / ${p.total_files}` : '—'}</td>
         <td className="px-4 py-3 text-right">
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onToggleEnabled()
-            }}
-            className="mr-2 rounded-lg border border-gray-400 px-2 py-1 text-xs"
-          >
-            {f.enabled ? 'Disable' : 'Enable'}
-          </button>
-          <button
-            disabled={deleteDisabled}
-            title={deleteDisabled ? 'Active Docker mount — unmount first' : ''}
-            onClick={(e) => {
-              e.stopPropagation()
-              onDelete()
-            }}
-            className="rounded-lg bg-red-600 px-2 py-1 text-xs text-white disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Delete
-          </button>
+          {!pendingDelete && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggleEnabled()
+              }}
+              className="mr-2 rounded-lg border border-gray-400 px-2 py-1 text-xs"
+            >
+              {f.enabled ? 'Disable' : 'Enable'}
+            </button>
+          )}
+          {pendingDelete ? (
+            <>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onCancelDelete()
+                }}
+                className="mr-2 rounded-lg border border-gray-400 px-2 py-1 text-xs"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDelete()
+                }}
+                className="rounded-lg bg-red-600 px-2 py-1 text-xs font-medium text-white"
+              >
+                Confirm Delete
+              </button>
+            </>
+          ) : (
+            <button
+              disabled={deleteDisabled}
+              title={deleteDisabled ? 'Active Docker mount — unmount first' : ''}
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete()
+              }}
+              className="rounded-lg bg-red-600 px-2 py-1 text-xs text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Delete
+            </button>
+          )}
         </td>
       </tr>
       {isExpanded && p && (

--- a/src/harbor_clerk/watcher/events.py
+++ b/src/harbor_clerk/watcher/events.py
@@ -6,6 +6,7 @@ provided session. Caller is responsible for commit.
 """
 
 import hashlib
+import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -14,11 +15,14 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
+from harbor_clerk.api.routes.uploads import ALLOWED_EXTENSIONS
 from harbor_clerk.models.document import Document
 from harbor_clerk.models.document_version import DocumentVersion
 from harbor_clerk.models.enums import JobStage, JobStatus, VersionStatus
 from harbor_clerk.models.ingestion_job import IngestionJob
 from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
+
+logger = logging.getLogger(__name__)
 
 
 class EventKind(str, Enum):
@@ -33,6 +37,39 @@ class FileEvent:
     folder_id: uuid.UUID
     relative_path: str
     absolute_path: str
+
+
+def _should_ignore(relative_path: str) -> bool:
+    """Filter filesystem noise that should never be ingested.
+
+    Catches:
+      - AppleDouble shadow files (`._<name>`) created when macOS writes
+        to non-Mac filesystems (network shares, FAT, exFAT, NFS, SMB).
+        These have a real extension like `.pdf` so an extension-only
+        filter would let them through.
+      - macOS metadata files / directories: `.DS_Store`,
+        `.Spotlight-V100`, `.Trashes`, `.fseventsd`, `.TemporaryItems`.
+      - `__MACOSX/` archive metadata directories (left over from
+        unzipping a Mac-created archive on a non-Mac).
+      - Other dotfiles (`.git/*`, `.svn/*`, vim swap files, etc.) — not
+        documents, never useful to ingest.
+      - Files whose extension isn't in the document allowlist
+        (the watcher path historically had no such check; the legacy
+        Swift implementation did).
+    """
+    parts = relative_path.split("/")
+    if any(p == "__MACOSX" for p in parts):
+        return True
+    # AppleDouble shadow files at any depth.
+    if any(p.startswith("._") for p in parts):
+        return True
+    # Any dotfile component (catches .DS_Store, .git/, .svn/, .Trashes/, etc.)
+    # at any depth.
+    if any(p.startswith(".") and p not in ("", ".", "..") for p in parts):
+        return True
+    # Extension allowlist (lowercase comparison).
+    suffix = Path(relative_path).suffix.lower()
+    return suffix not in ALLOWED_EXTENSIONS
 
 
 def _sha256_of(path: str) -> bytes:
@@ -60,6 +97,10 @@ def _new_version_on_doc(session: Session, doc_id: uuid.UUID, sha: bytes, source_
 
 def handle_event(session: Session, event: FileEvent) -> None:
     """Apply a FileEvent to the database. Caller is responsible for commit."""
+    if _should_ignore(event.relative_path):
+        logger.debug("watcher: ignored event for %s", event.relative_path)
+        return
+
     existing = (
         session.query(WatchedFile).filter_by(folder_id=event.folder_id, relative_path=event.relative_path).one_or_none()
     )

--- a/src/harbor_clerk/watcher/main.py
+++ b/src/harbor_clerk/watcher/main.py
@@ -9,11 +9,13 @@ Lifecycle:
 """
 
 import logging
+import os
 import signal
 import sys
 import threading
 import time
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy.orm import sessionmaker
 
@@ -23,7 +25,7 @@ from harbor_clerk.log_setup import setup_logging
 from harbor_clerk.models.watched import WatchedFolder
 from harbor_clerk.watcher.db_listener import listen_for_folder_changes
 from harbor_clerk.watcher.discovery import scan_watch_root
-from harbor_clerk.watcher.events import FileEvent, handle_event
+from harbor_clerk.watcher.events import EventKind, FileEvent, handle_event
 from harbor_clerk.watcher.observer import FolderObserver
 
 logger = logging.getLogger(__name__)
@@ -74,6 +76,68 @@ class WatcherDaemon:
                     self._observers[fid] = obs
                 except Exception:
                     logger.exception("watcher: failed to start observer for %s (%s)", fid, path)
+                    continue
+                # Run an initial scan in a daemon thread so the sync loop
+                # doesn't block on it. The observer is already registered
+                # so any files added DURING the scan get caught by both
+                # paths — handle_event's sha-based dedup makes the overlap
+                # a no-op.
+                threading.Thread(
+                    target=self._scan_folder,
+                    args=(fid, path),
+                    daemon=True,
+                    name=f"initial-scan-{str(fid)[:8]}",
+                ).start()
+
+    def _scan_folder(self, folder_id: uuid.UUID, root: str) -> None:
+        """Walk an existing folder and emit synthetic `created` events for
+        every file already on disk. Required because watchdog only delivers
+        events for changes that happen AFTER the observer starts — files
+        already in the folder when it was added would never be ingested.
+
+        Updates `watched_folders.last_scan_at` when done so the API's
+        scan_status flips from "scanning" to "idle".
+        """
+        logger.info("watcher: initial scan of %s starting", root)
+        count = 0
+        try:
+            for dirpath, dirnames, filenames in os.walk(root):
+                # Prune dotfile / __MACOSX directories so we don't recurse
+                # into them — both for speed and to avoid the cost of
+                # invoking _on_event for every file in a .git tree.
+                dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "__MACOSX"]
+                for fname in filenames:
+                    abs_path = os.path.join(dirpath, fname)
+                    rel_path = os.path.relpath(abs_path, root).replace(os.sep, "/")
+                    self._on_event(
+                        FileEvent(
+                            kind=EventKind.created,
+                            folder_id=folder_id,
+                            relative_path=rel_path,
+                            absolute_path=abs_path,
+                        )
+                    )
+                    count += 1
+                    if self._stop.is_set():
+                        return
+        except Exception:
+            logger.exception("watcher: initial scan of %s failed", root)
+            return
+
+        # Mark scan complete on the folder row.
+        sess = self._session_factory()
+        try:
+            folder = sess.query(WatchedFolder).filter_by(folder_id=folder_id).one_or_none()
+            if folder is not None:
+                folder.last_scan_at = datetime.now(UTC)
+                sess.commit()
+        except Exception:
+            sess.rollback()
+            logger.exception("watcher: failed to update last_scan_at for %s", folder_id)
+        finally:
+            sess.close()
+
+        logger.info("watcher: initial scan of %s complete (%d files visited)", root, count)
 
     def _discovery_loop(self) -> None:
         watch_root = get_settings().watch_root

--- a/tests/watcher/test_events.py
+++ b/tests/watcher/test_events.py
@@ -7,7 +7,7 @@ from harbor_clerk.models.document_version import DocumentVersion
 from harbor_clerk.models.enums import JobStage, JobStatus
 from harbor_clerk.models.ingestion_job import IngestionJob
 from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
-from harbor_clerk.watcher.events import EventKind, FileEvent, handle_event
+from harbor_clerk.watcher.events import EventKind, FileEvent, _should_ignore, handle_event
 
 
 @pytest.fixture
@@ -174,3 +174,77 @@ def test_resurrect_with_new_sha_creates_new_version_on_same_doc(sync_session, fo
     assert wf.removed_at is None
     assert wf.doc_id == original_doc_id  # same Document
     assert wf.version_id != original_version_id  # new Version
+
+
+# --- _should_ignore filter tests ---
+
+
+class TestShouldIgnore:
+    def test_apple_double_top_level_ignored(self):
+        assert _should_ignore("._Document.pdf") is True
+
+    def test_apple_double_nested_ignored(self):
+        assert _should_ignore("subfolder/._Document.pdf") is True
+
+    def test_ds_store_ignored(self):
+        assert _should_ignore(".DS_Store") is True
+        assert _should_ignore("subdir/.DS_Store") is True
+
+    def test_macosx_metadata_dir_ignored(self):
+        assert _should_ignore("__MACOSX/foo.pdf") is True
+
+    def test_dotfile_ignored(self):
+        assert _should_ignore(".gitignore") is True
+        assert _should_ignore(".git/HEAD") is True
+
+    def test_unsupported_extension_ignored(self):
+        assert _should_ignore("malware.exe") is True
+        assert _should_ignore("library.dll") is True
+        assert _should_ignore("vimswap.swp") is True
+
+    def test_no_extension_ignored(self):
+        # Files without an extension can't be classified — skip.
+        assert _should_ignore("README") is True
+
+    def test_allowed_files_pass(self):
+        assert _should_ignore("contract.pdf") is False
+        assert _should_ignore("notes.md") is False
+        assert _should_ignore("subdir/photo.jpg") is False
+        assert _should_ignore("Spreadsheet.XLSX") is False  # case insensitive
+
+
+def test_handle_event_ignores_apple_double(sync_session, folder, tmp_path):
+    """._foo.pdf events MUST NOT create a WatchedFile or IngestionJob."""
+    f = tmp_path / "._stuff.pdf"
+    f.write_bytes(b"binary metadata garbage")
+    handle_event(
+        sync_session,
+        FileEvent(EventKind.created, folder.folder_id, "._stuff.pdf", str(f)),
+    )
+    sync_session.commit()
+    assert sync_session.query(WatchedFile).count() == 0
+    assert sync_session.query(IngestionJob).count() == 0
+
+
+def test_handle_event_ignores_unsupported_extension(sync_session, folder, tmp_path):
+    f = tmp_path / "malware.exe"
+    f.write_bytes(b"MZ...")
+    handle_event(
+        sync_session,
+        FileEvent(EventKind.created, folder.folder_id, "malware.exe", str(f)),
+    )
+    sync_session.commit()
+    assert sync_session.query(WatchedFile).count() == 0
+
+
+def test_handle_event_ignores_macosx_archive_metadata(sync_session, folder, tmp_path):
+    sub = tmp_path / "__MACOSX"
+    sub.mkdir()
+    f = sub / "foo.pdf"
+    f.write_bytes(b"metadata")
+    handle_event(
+        sync_session,
+        FileEvent(EventKind.created, folder.folder_id, "__MACOSX/foo.pdf", str(f)),
+    )
+    sync_session.commit()
+    assert sync_session.query(WatchedFile).count() == 0

--- a/tests/watcher/test_main.py
+++ b/tests/watcher/test_main.py
@@ -122,3 +122,48 @@ def test_daemon_reacts_to_folder_added_via_notify(factory, tmp_path, monkeypatch
     finally:
         daemon.stop()
         _truncate_watched(factory)
+
+
+def test_daemon_scans_existing_files_when_observer_registers(factory, tmp_path, monkeypatch):
+    """Files already present in the folder when the daemon registers the
+    observer must be ingested via the initial scan path (regression: prior to
+    this fix, only files added AFTER observer-start were caught)."""
+    monkeypatch.setenv("WATCH_ROOT", "")
+    _truncate_watched(factory)
+
+    # Create files BEFORE the daemon starts watching the folder.
+    (tmp_path / "pre-existing.pdf").write_bytes(b"existing content")
+    (tmp_path / "ignored.exe").write_bytes(b"binary noise")  # filtered by extension allowlist
+    (tmp_path / "._stuff.pdf").write_bytes(b"AppleDouble junk")  # filtered by AppleDouble check
+
+    folder_id = _commit_folder(factory, str(tmp_path))
+
+    daemon = WatcherDaemon(factory)
+    daemon.start()
+    try:
+        # Wait for the initial scan thread to finish — bounded.
+        deadline = time.time() + 10.0
+        rows: list[WatchedFile] = []
+        while time.time() < deadline:
+            sess = factory()
+            try:
+                rows = list(sess.query(WatchedFile).filter_by(folder_id=folder_id).all())
+            finally:
+                sess.close()
+            if rows:
+                break
+            time.sleep(0.1)
+
+        assert len(rows) == 1, f"expected exactly one ingested file, got {[r.relative_path for r in rows]}"
+        assert rows[0].relative_path == "pre-existing.pdf"
+
+        # Also verify last_scan_at flipped (scan_status idle in the API).
+        sess = factory()
+        try:
+            folder = sess.query(WatchedFolder).filter_by(folder_id=folder_id).one()
+            assert folder.last_scan_at is not None, "last_scan_at must be set after initial scan completes"
+        finally:
+            sess.close()
+    finally:
+        daemon.stop()
+        _truncate_watched(factory)


### PR DESCRIPTION
## Summary

Three Stage 1 watcher follow-ups from real-world macOS usage. Bundled because they're all small and in the same area.

### 1. Filter AppleDouble / dotfile / non-document files (`events.py`)

The new Python watcher's `events.py` had **zero** filename filtering. On a network share or non-Mac filesystem, AppleDouble shadow files (`._<name>`) appear alongside the real ones and would get ingested as PDFs (with binary metadata as "content"). Same for `.DS_Store`, `__MACOSX/`, `.git/`, `.exe`, `.dll`, etc. The legacy Swift watcher had partial protection (`FileManager.enumerator(.skipsHiddenFiles)` + UTType check); the Python rewrite dropped both.

New `_should_ignore(relative_path)` called from `handle_event` filters:
- `._*` at any depth (AppleDouble shadow files)
- Any path component starting with `.` (`.DS_Store`, `.git`, `.svn`, swap files)
- `__MACOSX/` archive metadata directories
- Extensions not in `ALLOWED_EXTENSIONS` (reuses the upload-route allowlist)

### 2. Initial directory scan when a folder gains an observer (`main.py`)

`WatcherDaemon._sync_observers` registered a watchdog `Observer` for each new folder, but watchdog only delivers events for changes that happen **after** the observer starts. Files already on disk when the folder was added were never ingested — user-visible symptom: drop a folder of 100 PDFs into a freshly-watched dir, watch it ingest exactly zero of them.

Added `_scan_folder()` that runs in a daemon thread immediately after `obs.start()`:
- `os.walk()` the directory, prune `.*` and `__MACOSX/` subdirs upfront
- emit a synthetic `FileEvent(EventKind.created, …)` per file through `_on_event` so `_should_ignore` + sha-dedup + Document/Version reuse all apply
- on completion, set `watched_folders.last_scan_at` so the API's `scan_status` flips from `"scanning"` to `"idle"`

Overlap with watchdog events fired during the scan is harmless — `handle_event`'s active-and-same-sha branch is a no-op.

### 3. Folders page Delete button broken in WKWebView (`FoldersPage.tsx`)

`window.confirm()` returns `false` silently in WKWebView (the macOS native app's web container — there's a CLAUDE.md memory note from earlier fixes). The FoldersPage Delete handler short-circuited on `if (!confirm(...)) return;` so the button was a no-op in exactly the environment where it most needed to work.

Replaced with the two-click pattern already used by `DocumentsPage.handleBulkDelete` and `SystemMaintenancePage`:
- first click → row swaps **Disable + Delete** for **Cancel + Confirm Delete**
- second click on Confirm → DELETE fires
- 5-second auto-revert backstop so a row doesn't sit "armed" forever

## Verification

- [x] `uv run pytest tests/` → **384 passed, 6 skipped** (was 372 + 6 — net +12 new tests across `test_events.py` and `test_main.py`)
- [x] `uv run ruff check . && ruff format --check .` — clean
- [x] `npm run lint` (13 pre-existing warnings, 0 errors), `type-check`, `format:check`, `build` — all clean
- [ ] Manual smoke after install: drop a populated folder via Folders → Add Folder, see the existing PDFs get ingested with `scanning → idle` status, drop an `._foo.pdf` and confirm it's filtered, click Delete and confirm the two-click works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
