### PR TITLE
fix(queue-tray): periodic resync + ghost-removal so Active count doesn't drift

### DIFF
--- a/frontend/src/hooks/useQueueTray.ts
+++ b/frontend/src/hooks/useQueueTray.ts
@@ -252,28 +252,67 @@ export function useQueueTray() {
 
   useJobEvents(onEvent)
 
-  // Backfill: fetch all active jobs on mount so the queue tray shows
-  // current state immediately instead of waiting for new SSE events.
+  // Backfill + periodic resync. Fetches /api/jobs/active to (a) populate
+  // initial state on mount and (b) correct drift caused by missed SSE
+  // events.
+  //
+  // Drift happens because the SSE connection auto-reconnects after a
+  // disconnect (network blip, sleep/wake, idle TCP timeout, backend
+  // hiccup during model switch) and starts streaming from "now" — every
+  // job event that fired during the gap is lost. With long ingestion
+  // runs the Active count can diverge from reality by hundreds of items.
+  //
+  // The fix runs the same backfill on a 15 s interval, and after each
+  // response any vid in activeItems that is NOT in the response gets
+  // removed silently (no toast, no completed-list entry — those events
+  // already fired in the past, the user has moved on). SSE remains the
+  // primary update channel; this is the truth-correction layer.
   useEffect(() => {
     if (!token) return
     let cancelled = false
-    async function backfill() {
+
+    async function resync() {
       try {
         const res = await fetch('/api/jobs/active', {
           headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok || cancelled) return
         const events: JobEvent[] = await res.json()
+
+        // Apply each event through the normal handler so create/update
+        // logic stays in one place. Backfill events are always for
+        // queued/running stages, so they never trigger the finalize-done
+        // or error branches in onEvent.
         for (const event of events) {
-          if (!cancelled) onEvent(event)
+          if (cancelled) return
+          onEvent(event)
         }
+
+        // Ghost-removal: anything in activeItems that's not in the
+        // backfill response has finished (or errored) and we missed the
+        // notification. Drop it silently.
+        const liveVids = new Set(events.map((e) => e.version_id))
+        setActiveItems((prev) => {
+          let changed = false
+          const next = new Map(prev)
+          for (const vid of next.keys()) {
+            if (!liveVids.has(vid)) {
+              next.delete(vid)
+              changed = true
+            }
+          }
+          return changed ? next : prev
+        })
       } catch {
-        // non-fatal — SSE will catch up
+        // non-fatal — next tick will retry; SSE may be carrying the load.
       }
     }
-    backfill()
+
+    resync()
+    const id = setInterval(resync, 15_000)
     return () => {
       cancelled = true
+      clearInterval(id)
     }
   }, [token, onEvent])
 


### PR DESCRIPTION
## Summary

Fixes Active count divergence in the queue tray. Reported symptom: Active tab shows **210** items in flight but the Pipeline tab shows **96** (`1 running + 95 queued in Summarize`, all other stages 0). Page refresh corrects it.

## Root cause

`useQueueTray.ts` ran its `/api/jobs/active` backfill **exactly once on mount**. The SSE stream from `/api/jobs/stream` auto-reconnects after a 5 s timeout when it drops, but reconnections start streaming from *now* — every event that fired during the disconnect gap is lost forever. There's no replay mechanism.

Long-running pages accumulate ghosts in Active as docs finalize during connection gaps. Disconnects happen for plenty of mundane reasons:
- Laptop sleep/wake (~10 s reconnect)
- Network blip
- Idle TCP timeout (60+ minutes)
- Backend hiccup during model switch

The Pipeline tab is unaffected because `useQueueSnapshot` polls `/api/jobs/snapshot` every 3 s — pull, not push.

## Fix

Extends the existing one-shot backfill into a periodic resync on a 15 s interval:

1. Fetch `/api/jobs/active` (returns one event per `IngestionJob` in `queued`/`running`).
2. Apply each event through the existing `onEvent` handler (no behaviour change for the live path — backfill events are always for queued/running stages and never trigger the finalize-done or error branches).
3. **Ghost-removal:** build a `Set` of vids from the response. For any vid in `activeItems` not in the set → silently `delete` from the Map.

Silent on purpose:
- No toast (those events fired in the past; toasting now would be a misleading lag-display)
- No completed-list entry (we don't have page_count / chunk_count from a backfill response, and the user has moved on from those docs)
- The Documents page still shows the finished docs correctly via its own data source

SSE remains the primary update channel for snappy live UX; this is the truth-correction layer that catches missed events.

## Cadence

15 s — conservative. The Pipeline tab uses 3 s for its snapshot, but the queue tray doesn't need it that fast since SSE covers the live case under normal operation. 15 s caps drift at ~15 s lag during disconnects, which feels right for a sidebar status panel.

## Test plan

- [x] `npm run lint` (13 pre-existing warnings, 0 errors), `tsc --noEmit`, `format:check`, `build` — all clean
- [ ] Manual smoke: open queue tray with a few hundred docs in flight, simulate SSE drop (toggle Wi-Fi off and on), confirm Active count corrects within ~15 s without a page refresh.
- [ ] Visual check: ghost-removal doesn't toast (no "completed" indicator for items that finished long ago).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
