### PR TITLE
fix(docs): filename-filter textbox vs applied-filter desync after remount

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -221,6 +221,12 @@ export default function DocumentsPage() {
   const [sortField, setSortField] = useState<'updated' | 'created' | 'title'>(() => initField('sortField', 'updated'))
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(() => initField('sortDir', 'desc'))
 
+  // Filename filter input — declared up here (above the sessionStorage
+  // save useEffect that reads it) so the dependency array doesn't trip
+  // a use-before-declaration error. The handler + debounce timer live
+  // further down with the other filter handlers.
+  const [filterInput, setFilterInput] = useState(() => initField('filterInput', ''))
+
   // Entity autocomplete
   const [entityInput, setEntityInput] = useState(() => initField('entityInput', '', 'entity'))
   const [entitySuggestions, setEntitySuggestions] = useState<
@@ -267,7 +273,12 @@ export default function DocumentsPage() {
     const state: SavedDocsState = {
       currentPage,
       filter,
-      filterInput: entityInput,
+      // filterInput is the filename-filter textbox value. It MUST be
+      // saved as itself, not as entityInput — those are two different
+      // textboxes. Mixing them caused the textbox to render empty after
+      // a remount while the underlying `filter` was still applied,
+      // leaving no visible way to clear the filter.
+      filterInput,
       mimeFilter,
       langFilter,
       docTypeFilter,
@@ -284,6 +295,7 @@ export default function DocumentsPage() {
   }, [
     currentPage,
     filter,
+    filterInput,
     mimeFilter,
     langFilter,
     docTypeFilter,
@@ -386,9 +398,9 @@ export default function DocumentsPage() {
     loadDocs(currentPage, pageSize, filter)
   }, [loadDocs, currentPage, pageSize, filter])
 
-  // Debounce filter input
+  // Debounce filter input. (filterInput state itself is declared higher up
+  // alongside entityInput so the save useEffect can include it in its deps.)
   const filterTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  const [filterInput, setFilterInput] = useState(() => initField('filterInput', ''))
 
   function handleFilterChange(value: string) {
     setFilterInput(value)


### PR DESCRIPTION
## Summary

Fixes a state-desync bug on the Documents page: after applying a filename filter (e.g. "spinoza") and then navigating away and back, the filter is still applied (you can see the narrowed row count) but the textbox renders empty — leaving no visible way to clear it.

## Root cause

In the sessionStorage save block of `DocumentsPage.tsx`:

```tsx
const state: SavedDocsState = {
  ...
  filterInput: entityInput,  // ← bug
  ...
}
```

The entity-autocomplete textbox value (`entityInput`) was being written into the filename-filter slot (`filterInput`). The two are separate textboxes and separate state vars; mixing them at the persistence layer meant:

1. Type "spinoza" → `filter` and `filterInput` both = "spinoza" in memory.
2. Save fires → writes `{filter: "spinoza", filterInput: ""}` (entityInput is empty) to sessionStorage.
3. Navigate away + back → `DocumentsPage` remounts → `useState(() => initField('filterInput', ''))` reads `""` → textbox is empty. `filter` correctly initializes from its (correctly-saved) value → query stays filtered.
4. Backspace can't delete what isn't there. Typing fresh content + deleting works because the change handler updates both `filter` and `filterInput` in lockstep.

## Fix

- `filterInput: entityInput` → `filterInput,` (write the real value into its real slot).
- Added `filterInput` to the save `useEffect`'s dep array so saves happen when the textbox changes, not only when the debounced applied filter ticks.
- Hoisted the `filterInput` `useState` declaration up next to `entityInput` (above the save `useEffect`) so the new dep reference doesn't trip a TDZ / TypeScript "use before declaration" error. Only the state declaration moved; the handler and debounce timer stay where they were.

## Test plan

- [x] `npm run lint` (13 pre-existing warnings, 0 errors), `tsc --noEmit`, `format:check`, `build` — all clean
- [ ] Manual: filter Documents page on "spinoza", navigate to /chat or /folders, return to /docs → textbox should show "spinoza" with the filter still applied. Clear via backspace works.
- [ ] Reload check: hard-refresh after applying a filter → textbox should re-populate with the saved value (this was already working since `filter` was saved correctly; this PR also makes `filterInput` survive the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
