### PR TITLE
feat(models): always-use-Apple-Intelligence-for-summaries toggle

### DIFF
--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -38,6 +38,7 @@ export default function ModelsPage() {
   const [downloading, setDownloading] = useState<Set<string>>(new Set())
   const [downloadProgress, setDownloadProgress] = useState<Map<string, number>>(new Map())
   const [yarnEnabled, setYarnEnabled] = useState(false)
+  const [summaryForceAfm, setSummaryForceAfm] = useState(false)
 
   const loadModelsRef = useRef(loadModels)
   useEffect(() => {
@@ -50,6 +51,8 @@ export default function ModelsPage() {
       setModels(data)
       const yarnStatus = await get<{ yarn_enabled: boolean }>('/api/chat/models/yarn')
       setYarnEnabled(yarnStatus.yarn_enabled)
+      const afmStatus = await get<{ summary_force_apple_intelligence: boolean }>('/api/chat/models/summary-afm')
+      setSummaryForceAfm(afmStatus.summary_force_apple_intelligence)
       const orphanList = await get<OrphanInfo[]>('/api/chat/models/orphaned')
       setOrphans(orphanList)
       // Seed downloading set from server state
@@ -237,6 +240,16 @@ export default function ModelsPage() {
       setYarnEnabled(enabled)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to toggle YaRN')
+    }
+  }
+
+  async function handleSummaryForceAfmToggle(enabled: boolean) {
+    setError('')
+    try {
+      await put(`/api/chat/models/summary-afm?enabled=${enabled}`)
+      setSummaryForceAfm(enabled)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to toggle Apple Intelligence summaries')
     }
   }
 
@@ -485,6 +498,35 @@ export default function ModelsPage() {
           )}
         </div>
       )}
+
+      {/* Always use Apple Intelligence for summaries */}
+      <div className="mt-4 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="font-medium text-gray-900 dark:text-gray-100">
+              Always use Apple Intelligence for summaries
+            </div>
+            <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+              Skips the local LLM for the summarize stage and uses Apple Intelligence instead. Faster and lower-power on
+              Apple Silicon. Chat, research, and document-type classification still use the active model.
+            </p>
+          </div>
+          <button
+            onClick={() => handleSummaryForceAfmToggle(!summaryForceAfm)}
+            className={`relative ml-4 inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors duration-200 ${
+              summaryForceAfm ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+            }`}
+            role="switch"
+            aria-checked={summaryForceAfm}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                summaryForceAfm ? 'translate-x-[22px]' : 'translate-x-[2px]'
+              } mt-[2px]`}
+            />
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/harbor_clerk/api/routes/chat.py
+++ b/src/harbor_clerk/api/routes/chat.py
@@ -433,6 +433,32 @@ async def get_yarn_status(
     return {"yarn_enabled": settings.llm_yarn_enabled}
 
 
+@router.put("/chat/models/summary-afm", status_code=200)
+async def toggle_summary_force_afm(
+    principal: Principal = Depends(require_admin),
+    enabled: bool = True,
+):
+    """Toggle "Always use Apple Intelligence for summaries". When enabled,
+    the summarize pipeline stage skips the local LLM and goes straight to
+    AFM (or extractive fallback if AFM unavailable). doc_type and chat
+    still use the active LLM model."""
+    settings = get_settings()
+    settings.summary_force_apple_intelligence = enabled
+    sync_native_config("summary_force_apple_intelligence", enabled)
+    return {
+        "status": "enabled" if enabled else "disabled",
+        "summary_force_apple_intelligence": enabled,
+    }
+
+
+@router.get("/chat/models/summary-afm", status_code=200)
+async def get_summary_force_afm(
+    principal: Principal = Depends(require_user),
+):
+    settings = get_settings()
+    return {"summary_force_apple_intelligence": settings.summary_force_apple_intelligence}
+
+
 @router.delete("/chat/models/{model_id}", status_code=204)
 async def remove_model(
     model_id: str,

--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -71,6 +71,11 @@ class Settings(BaseSettings):
     llama_server_url: str = Field(default="http://localhost:8102")
     llm_model_id: str = Field(default="")
     llm_yarn_enabled: bool = Field(default=False)
+    # When true, the summarize pipeline stage skips the local LLM entirely
+    # and goes straight to Apple Intelligence (or extractive fallback if
+    # AFM is unavailable). Useful when the user prefers AFM's speed/quality
+    # for summaries while still wanting the LLM for chat / research.
+    summary_force_apple_intelligence: bool = Field(default=False)
     models_dir: str = Field(default="./data/models")
 
     # Native macOS app config file (set by Swift via env var)
@@ -135,6 +140,8 @@ def refresh_llm_settings() -> None:
             settings.llm_model_id = data["llm_model_id"]
         if "llm_yarn_enabled" in data:
             settings.llm_yarn_enabled = bool(data["llm_yarn_enabled"])
+        if "summary_force_apple_intelligence" in data:
+            settings.summary_force_apple_intelligence = bool(data["summary_force_apple_intelligence"])
     except Exception:
         logger.debug("Failed to refresh LLM settings from %s", path, exc_info=True)
 

--- a/src/harbor_clerk/llm/summarize.py
+++ b/src/harbor_clerk/llm/summarize.py
@@ -627,6 +627,18 @@ def generate_summary(chunks: list[str], max_chars: int | None = None) -> tuple[s
     if not chunks:
         return "", ""
 
+    # User has opted to skip the local LLM for summaries entirely
+    # (Models page → "Always use Apple Intelligence for summaries"). Skip
+    # straight to AFM. If AFM is unavailable for any reason (binary not
+    # found, macOS version too old, timeout), fall through to extractive.
+    if settings.summary_force_apple_intelligence:
+        logger.info("Summarize forced to Apple Intelligence by setting (skipping local LLM)")
+        ai_summary = _apple_intelligence_summary(chunks, max_chars)
+        if _has_visible_content(ai_summary):
+            return ai_summary, "apple-intelligence"  # type: ignore[return-value]
+        logger.warning("Apple Intelligence unavailable while forced; falling back to extractive")
+        return _extractive_fallback(chunks, max_chars), "extractive"
+
     # Try LLM if a model is active
     if settings.llm_model_id:
         model = get_model(settings.llm_model_id)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -239,11 +239,12 @@ class TestCallLlmRetry:
 # --- generate_summary tests ---
 
 
-def _mock_settings(llm_model_id="test-model"):
+def _mock_settings(llm_model_id="test-model", summary_force_apple_intelligence=False):
     s = MagicMock()
     s.llm_model_id = llm_model_id
     s.summary_max_chars = 500
     s.llama_server_url = "http://localhost:8102"
+    s.summary_force_apple_intelligence = summary_force_apple_intelligence
     return s
 
 
@@ -358,6 +359,43 @@ class TestGenerateSummary:
             summary, model = generate_summary(chunks)
             assert model == "extractive"
             assert summary
+
+    def test_force_afm_skips_llm_and_uses_apple_intelligence(self):
+        """When summary_force_apple_intelligence is set, the LLM is never called
+        and the result is attributed to apple-intelligence."""
+        mock_call = MagicMock()
+        with (
+            patch(
+                "harbor_clerk.llm.summarize.get_settings",
+                return_value=_mock_settings(summary_force_apple_intelligence=True),
+            ),
+            patch("harbor_clerk.llm.summarize._call_llm", mock_call),
+            patch(
+                "harbor_clerk.llm.summarize._apple_intelligence_summary",
+                return_value="AFM-generated summary.",
+            ),
+        ):
+            summary, model = generate_summary(["A" * 100])
+            assert summary == "AFM-generated summary."
+            assert model == "apple-intelligence"
+            mock_call.assert_not_called()
+
+    def test_force_afm_falls_back_to_extractive_when_afm_unavailable(self):
+        """If AFM is unavailable while forced, fall through to extractive — not the LLM."""
+        mock_call = MagicMock()
+        with (
+            patch(
+                "harbor_clerk.llm.summarize.get_settings",
+                return_value=_mock_settings(summary_force_apple_intelligence=True),
+            ),
+            patch("harbor_clerk.llm.summarize._call_llm", mock_call),
+            patch("harbor_clerk.llm.summarize._apple_intelligence_summary", return_value=None),
+        ):
+            chunks = ["A" * 100]
+            summary, model = generate_summary(chunks)
+            assert model == "extractive"
+            assert summary
+            mock_call.assert_not_called()
 
 
 class TestTruncateAtSentence:


### PR DESCRIPTION
## Summary

User-requested switch on the Models preferences page: **"Always use Apple Intelligence for summaries"**. When enabled, the summarize pipeline stage skips the local LLM entirely and goes straight to AFM (or extractive fallback if AFM is unavailable). Chat, research, and document-type classification still use the active LLM model.

## Why

The earlier conversation established that the heavy MoE Qwen models (35B-A3B, 30B-A3B) and Gemma 4 26B-A4B all run at ~3-4B-effective inference cost — same as the small dense models. So users get no speed benefit from picking "small" over "big" for summaries; the bottleneck is the LLM call itself. Apple Intelligence on Apple Silicon is dramatically faster than any of them and matches or exceeds quality on most documents.

This switch lets users keep an LLM loaded for the use cases that actually need it (chat, research, doc type) while bypassing it for the bulk-throughput summarize work.

## Changes

| File | Change |
|---|---|
| `src/harbor_clerk/config.py` | New `summary_force_apple_intelligence: bool` setting; picked up by `refresh_llm_settings()` from config.json so workers see the flip without restart. |
| `src/harbor_clerk/llm/summarize.py` | `generate_summary()` short-circuits to AFM at the top when the flag is set. Falls through to extractive if AFM returns nothing. **Doesn't fall back to the LLM** when forced — the user explicitly asked us to skip it. |
| `src/harbor_clerk/api/routes/chat.py` | New `PUT /api/chat/models/summary-afm?enabled=…` (admin) + `GET /api/chat/models/summary-afm` (user). Mirrors the YaRN endpoint pattern exactly. Persisted via `sync_native_config`. |
| `frontend/src/pages/ModelsPage.tsx` | New toggle directly under the YaRN section, same visual treatment, same handler shape. |
| `tests/test_summarize.py` | Two new tests: flag-set + AFM-available → uses AFM, never calls LLM; flag-set + AFM-unavailable → uses extractive, still never calls LLM. |

## Test plan

- [x] `uv run pytest tests/test_summarize.py -v` → 54 passed (+2 new)
- [x] `uv run pytest tests/` → 386 passed, 6 skipped
- [x] `uv run ruff check . && ruff format --check .` — clean
- [x] `npm run lint` (13 pre-existing warnings, 0 errors), `tsc --noEmit`, `format:check`, `build` — clean
- [ ] Manual: enable toggle, queue some docs, watch worker-llm.log for "Summarize forced to Apple Intelligence by setting" rather than the usual "Map-reduce summarization" / per-call timing lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
