### PR TITLE
fix(auth): persist onboardingComplete so the wizard can actually be dismissed

### DIFF
--- a/src/harbor_clerk/api/routes/auth.py
+++ b/src/harbor_clerk/api/routes/auth.py
@@ -208,6 +208,8 @@ async def update_preferences(
         prefs["theme"] = body.theme
     if body.page_size is not None:
         prefs["page_size"] = body.page_size
+    if body.onboardingComplete is not None:
+        prefs["onboardingComplete"] = body.onboardingComplete
 
     await session.execute(update(User).where(User.user_id == principal.id).values(preferences=prefs))
     await session.commit()

--- a/src/harbor_clerk/api/schemas/auth.py
+++ b/src/harbor_clerk/api/schemas/auth.py
@@ -26,6 +26,12 @@ class UserInfo(BaseModel):
 class PreferencesUpdate(BaseModel):
     theme: str | None = None
     page_size: int | None = None
+    # JSONB-stored boolean set when the user completes (or dismisses) the
+    # first-run onboarding wizard. Frontend reads `preferences.onboardingComplete`
+    # in Layout.tsx to decide whether to render <OnboardingWizard />.
+    # Naming is camelCase to match the existing frontend type and the JSONB
+    # key the wizard reads — mixing snake/camel here is intentional, not a bug.
+    onboardingComplete: bool | None = None
 
 
 class PasswordChangeRequest(BaseModel):

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -55,3 +55,50 @@ async def test_get_me_without_token(client):
 async def test_logout(client):
     resp = await client.post("/api/auth/logout")
     assert resp.status_code == 200
+
+
+async def test_update_preferences_persists_onboarding_complete(client, admin_user, admin_token):
+    """PATCH /api/me/preferences must store onboardingComplete in JSONB.
+
+    Regression for the wizard-can't-be-dismissed bug: PreferencesUpdate's
+    Pydantic model previously only declared `theme` and `page_size`, so
+    Pydantic silently stripped `onboardingComplete` from the request body.
+    The wizard's onComplete handler succeeded but the flag never reached the
+    database, so Layout.tsx kept rendering the wizard.
+    """
+    # Initial PATCH writes the flag
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"onboardingComplete": True},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["preferences"].get("onboardingComplete") is True
+
+    # GET /api/me confirms persistence (catches the case where the response
+    # is correct but the database write was a no-op).
+    resp = await client.get("/api/me", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["preferences"].get("onboardingComplete") is True
+
+
+async def test_update_preferences_partial_does_not_clobber_existing(client, admin_user, admin_token):
+    """A subsequent PATCH that only sends `theme` must preserve onboardingComplete."""
+    # First, set onboardingComplete = true
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"onboardingComplete": True},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+
+    # Then, update only theme — onboardingComplete should remain
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"theme": "dark"},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    prefs = resp.json()["preferences"]
+    assert prefs.get("theme") == "dark"
+    assert prefs.get("onboardingComplete") is True


### PR DESCRIPTION
## Summary

Stage 2 (PR #253) shipped the OnboardingWizard wired to dismiss via `Layout.tsx`'s `handleOnboardingComplete` → `updatePreferences({ onboardingComplete: true })` → `PATCH /api/me/preferences`. The wizard never closed because the backend silently dropped the new key.

## How it failed

`PreferencesUpdate` (`src/harbor_clerk/api/schemas/auth.py:26-28`) only declared `theme` and `page_size`. Pydantic's default behaviour is to silently strip undeclared keys — so `{ onboardingComplete: true }` arrived as `PreferencesUpdate(theme=None, page_size=None)`, the route's `if body.theme is not None / if body.page_size is not None` branches both no-op'd, the PATCH succeeded with a clean 200, the backend wrote nothing, the frontend re-rendered `Layout`, and `showWizard` stayed `true` because `user.preferences.onboardingComplete` was still `undefined`. Wizard re-mounted in the same state. Dismissal felt like clicking into the void.

## Fix

- Add `onboardingComplete: bool | None = None` to `PreferencesUpdate`.
- Write it through to the JSONB `prefs` dict in `update_preferences`.
- Naming is camelCase to match the existing frontend type and the JSONB key the wizard reads — mixing snake/camel here is intentional (consistent with the frontend), not a style miss.

## Tests

Two regression tests in `tests/test_api_auth.py`:

- `test_update_preferences_persists_onboarding_complete` — PATCH writes the flag, GET `/api/me` confirms persistence (catches the case where the response looks correct but the database write was a no-op).
- `test_update_preferences_partial_does_not_clobber_existing` — a follow-up PATCH that only touches `theme` keeps `onboardingComplete` in place. Belt-and-suspenders for the `is not None` branching pattern.

391 passed (+2 new), ruff clean, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
