### PR TITLE
fix(worker): finalize.py passes doc_id both positionally and as kwarg

### DIFF
--- a/src/harbor_clerk/worker/stages/finalize.py
+++ b/src/harbor_clerk/worker/stages/finalize.py
@@ -56,7 +56,6 @@ def run_finalize(doc_id: uuid.UUID) -> None:
     mark_stage_done(
         doc_id,
         JobStage.finalize,
-        doc_id=doc_id,
         page_count=page_count,
         chunk_count=chunk_count,
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,9 +3,10 @@
 import pytest
 
 from harbor_clerk.db_sync import get_sync_session
-from harbor_clerk.models import Document
-from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models import Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
 from harbor_clerk.worker.pipeline import check_pipeline_seq
+from harbor_clerk.worker.stages.finalize import run_finalize
 
 
 @pytest.mark.asyncio
@@ -90,5 +91,49 @@ async def test_check_pipeline_seq_passes_at_higher_seq(db_session):
         assert check_pipeline_seq(sync_session, doc.doc_id, 2) is True
         # Old worker that started with seq=1: mismatch → False
         assert check_pipeline_seq(sync_session, doc.doc_id, 1) is False
+    finally:
+        sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_run_finalize_completes_without_typeerror(db_session):
+    """Regression: finalize.py was passing doc_id both positionally AND as a kwarg
+    to mark_stage_done(), which raises `TypeError: got multiple values for argument 'doc_id'`.
+    Asserting that run_finalize completes without exception covers the regression."""
+    doc = Document(
+        title="Finalize regression",
+        canonical_filename="finalize.pdf",
+        status="active",
+        sha256=b"f" * 32,
+        pipeline_status=PipelineStatus.summarized,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+
+    # The finalize stage requires a queued IngestionJob row to claim
+    job = IngestionJob(doc_id=doc.doc_id, stage=JobStage.finalize, status=JobStatus.queued)
+    db_session.add(job)
+    await db_session.commit()
+
+    # run_finalize is sync; call it directly. If it raises TypeError, this test fails.
+    run_finalize(doc.doc_id)
+
+    # Verify side effects: pipeline_status flipped to ready, job marked done
+    sync_session = get_sync_session()
+    try:
+        from sqlalchemy import select
+
+        refreshed_doc = sync_session.execute(
+            select(Document).where(Document.doc_id == doc.doc_id)
+        ).scalar_one()
+        assert refreshed_doc.pipeline_status == PipelineStatus.ready
+
+        refreshed_job = sync_session.execute(
+            select(IngestionJob).where(
+                IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.finalize
+            )
+        ).scalar_one()
+        assert refreshed_job.status == JobStatus.done
     finally:
         sync_session.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -124,15 +124,11 @@ async def test_run_finalize_completes_without_typeerror(db_session):
     try:
         from sqlalchemy import select
 
-        refreshed_doc = sync_session.execute(
-            select(Document).where(Document.doc_id == doc.doc_id)
-        ).scalar_one()
+        refreshed_doc = sync_session.execute(select(Document).where(Document.doc_id == doc.doc_id)).scalar_one()
         assert refreshed_doc.pipeline_status == PipelineStatus.ready
 
         refreshed_job = sync_session.execute(
-            select(IngestionJob).where(
-                IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.finalize
-            )
+            select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.finalize)
         ).scalar_one()
         assert refreshed_job.status == JobStatus.done
     finally:


### PR DESCRIPTION
## Summary

Stage 3 (PR #255) shipped a typo in `finalize.py` that broke every ingestion's last stage:

```
ERROR harbor_clerk.worker.entry Job <doc_id>/finalize failed:
TypeError: mark_stage_done() got multiple values for argument 'doc_id'
```

`mark_stage_done`'s signature is `(doc_id, stage, **extra_event_fields)`. The Stage 3 refactor in `finalize.py` was calling it with `doc_id` BOTH positionally AND as a keyword:

```python
mark_stage_done(
    doc_id,
    JobStage.finalize,
    doc_id=doc_id,           # ← TypeError: duplicate
    page_count=page_count,
    chunk_count=chunk_count,
)
```

Likely a leftover from when the function was `(version_id, stage, **extra)` and `doc_id` was a separate event kwarg. After the version → doc rekey, both became `doc_id` and nothing in the test suite exercised the full finalize call path, so the dup was missed.

## Fix

Drop the redundant `doc_id=doc_id` kwarg.

## Regression test

New `test_run_finalize_completes_without_typeerror` in `tests/test_pipeline.py`. Builds a Document at `pipeline_status=summarized` with a queued finalize IngestionJob, calls `run_finalize(doc_id)`, asserts the doc flips to `pipeline_status=ready` and the job to `done`. The TypeError reproduction case is the test's primary purpose.

The pattern (call the stage's `run()` directly with a fixture doc + queued job) is cheap to extend to the other six stages if any of them turn out to have similarly fragile caller shapes.

## Verification

- `pytest tests/`: **398 passed (+1 new)**, 6 skipped
- `ruff check src/harbor_clerk/worker/stages/finalize.py tests/test_pipeline.py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
