### PR TITLE
feat(extract): surface Tika container_exception on 422 instead of bare HTTPStatusError

### DIFF
--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -67,7 +67,13 @@ def _extract_txt(data: bytes) -> list[tuple[int, str]]:
 
 
 def _extract_via_tika(data: bytes, mime_type: str, is_pdf: bool = False) -> list[tuple[int, str]]:
-    """Extract text via Apache Tika. For PDFs, splits on form feed characters."""
+    """Extract text via Apache Tika. For PDFs, splits on form feed characters.
+
+    On 422 (Unprocessable Entity), Tika has refused to parse the file but doesn't
+    say why in the response body. Refetch via `/rmeta/text` to surface the
+    underlying parser exception (POI/PDFBox bug, malformed file, etc.) in the
+    raised error so it shows up in the doc's pipeline_status=error message.
+    """
     settings = get_settings()
     if not settings.tika_url:
         raise RuntimeError(
@@ -79,6 +85,9 @@ def _extract_via_tika(data: bytes, mime_type: str, is_pdf: bool = False) -> list
         headers={"Content-Type": mime_type, "Accept": "text/plain"},
         timeout=120,
     )
+    if resp.status_code == 422:
+        detail = _fetch_tika_exception_detail(data, mime_type)
+        raise RuntimeError(f"Tika rejected file (422): {detail}")
     resp.raise_for_status()
     text = resp.text.strip()
 
@@ -88,6 +97,38 @@ def _extract_via_tika(data: bytes, mime_type: str, is_pdf: bool = False) -> list
         return [(i + 1, p.strip()) for i, p in enumerate(raw_pages) if p.strip()]
 
     return _paginate_text(text, settings.synthetic_page_chars)
+
+
+def _fetch_tika_exception_detail(data: bytes, mime_type: str) -> str:
+    """Refetch via /rmeta/text to extract X-TIKA:EXCEPTION:container_exception.
+
+    Best-effort diagnostic — failures here just produce a generic message.
+    Truncates the stacktrace to the first line so the error column stays usable.
+    """
+    settings = get_settings()
+    try:
+        resp = httpx.put(
+            f"{settings.tika_url}/rmeta/text",
+            content=data,
+            headers={"Content-Type": mime_type, "Accept": "application/json"},
+            timeout=60,
+        )
+        if resp.status_code != 200:
+            return f"rmeta returned {resp.status_code}"
+        meta_list = resp.json()
+        if not isinstance(meta_list, list) or not meta_list:
+            return "rmeta returned empty list"
+        meta = meta_list[0]
+        # Tika exposes container parser failures under this key
+        exc = meta.get("X-TIKA:EXCEPTION:container_exception", "")
+        if not exc:
+            return "no container_exception in rmeta response"
+        # First line carries the exception type + message; rest is a Java stacktrace
+        first_line = exc.split("\n", 1)[0].strip()
+        # Cap to keep the DB error column compact
+        return first_line[:300]
+    except Exception as e:  # noqa: BLE001 — best-effort diagnostic
+        return f"rmeta refetch failed: {type(e).__name__}: {e}"
 
 
 def _alpha_ratio(text: str) -> float:

--- a/tests/test_extract_helpers.py
+++ b/tests/test_extract_helpers.py
@@ -1,6 +1,11 @@
-"""Tests for extract stage helpers: _paginate_text, _alpha_ratio."""
+"""Tests for extract stage helpers: _paginate_text, _alpha_ratio, Tika 422 diagnostics."""
 
-from harbor_clerk.worker.stages.extract import _alpha_ratio, _paginate_text
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from harbor_clerk.worker.stages.extract import _alpha_ratio, _extract_via_tika, _paginate_text
 
 # --- _paginate_text ---
 
@@ -63,3 +68,80 @@ def test_alpha_ratio_all_digits():
 def test_alpha_ratio_mixed():
     ratio = _alpha_ratio("abc123")
     assert 0.4 < ratio < 0.6  # 3/6 = 0.5
+
+
+# --- Tika 422 diagnostics ---
+
+
+def _mock_response(status_code: int, text: str = "", json_data=None) -> httpx.Response:
+    """Build a minimal httpx.Response for mocking."""
+    request = httpx.Request("PUT", "http://test/tika")
+    if json_data is not None:
+        import json
+
+        return httpx.Response(status_code, content=json.dumps(json_data).encode(), request=request)
+    return httpx.Response(status_code, text=text, request=request)
+
+
+def test_tika_422_surfaces_pdfbox_container_exception():
+    """Real failure mode from production: PDFBox 'Page tree root must be a dictionary'.
+    The 422 from /tika has no body; we refetch via /rmeta/text and surface the
+    container exception in the raised RuntimeError so it lands in the doc's
+    pipeline_status=error message instead of just 'HTTPStatusError 422'.
+    """
+    rmeta_payload = [
+        {
+            "X-TIKA:Parsed-By": ["org.apache.tika.parser.pdf.PDFParser"],
+            "X-TIKA:EXCEPTION:container_exception": (
+                "java.io.IOException: Page tree root must be a dictionary\n"
+                "\tat org.apache.pdfbox.pdfparser.COSParser.checkPages(COSParser.java:1416)\n"
+                "\tat org.apache.pdfbox.pdfparser.PDFParser.initialParse(PDFParser.java:120)"
+            ),
+        }
+    ]
+    responses = [_mock_response(422), _mock_response(200, json_data=rmeta_payload)]
+
+    with (
+        patch("httpx.put", side_effect=responses),
+        pytest.raises(RuntimeError, match="Page tree root must be a dictionary"),
+    ):
+        _extract_via_tika(b"%PDF-1.4 ...corrupted...", "application/pdf", is_pdf=True)
+
+
+def test_tika_422_surfaces_poi_container_exception():
+    """Real failure mode from production: POI HWPF 'Index 10 out of bounds for length 7'."""
+    rmeta_payload = [
+        {
+            "X-TIKA:Parsed-By": ["org.apache.tika.parser.microsoft.OfficeParser"],
+            "X-TIKA:EXCEPTION:container_exception": (
+                "java.lang.IndexOutOfBoundsException: Index 10 out of bounds for length 7\n"
+                "\tat java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)"
+            ),
+        }
+    ]
+    responses = [_mock_response(422), _mock_response(200, json_data=rmeta_payload)]
+
+    with (
+        patch("httpx.put", side_effect=responses),
+        pytest.raises(RuntimeError, match="Index 10 out of bounds for length 7"),
+    ):
+        _extract_via_tika(b"\xd0\xcf\x11\xe0...", "application/msword")
+
+
+def test_tika_422_with_no_rmeta_detail_still_raises_with_generic_message():
+    """If the rmeta refetch also fails or returns no exception, we still raise
+    a RuntimeError mentioning Tika rejected the file — the operator at least
+    knows it was a 422, not a network error."""
+    responses = [_mock_response(422), _mock_response(500, text="rmeta crashed")]
+
+    with patch("httpx.put", side_effect=responses), pytest.raises(RuntimeError, match="Tika rejected file \\(422\\)"):
+        _extract_via_tika(b"garbage", "application/pdf")
+
+
+def test_tika_non_422_failures_still_raise_via_raise_for_status():
+    """Make sure we didn't accidentally swallow other status codes — 500 etc.
+    should still come through httpx's HTTPStatusError, not get rerouted to rmeta."""
+    responses = [_mock_response(500, text="tika crashed")]
+
+    with patch("httpx.put", side_effect=responses), pytest.raises(httpx.HTTPStatusError):
+        _extract_via_tika(b"any data", "application/pdf")


### PR DESCRIPTION
## Summary

When Tika's `/tika` endpoint returns 422 (Unprocessable Entity) it sends no body explaining why. extract.py was raising the bare `HTTPStatusError`, which lands in the doc's `pipeline_status=error` column as just "HTTPStatusError 422" — useless for diagnosis.

The actual cause lives in the `X-TIKA:EXCEPTION:container_exception` field of the JSON returned by Tika's `/rmeta/text` endpoint. Three real failure modes seen in production all surface there:

- **PDFBox:** `java.io.IOException: Page tree root must be a dictionary` — malformed PDF page tree
- **POI HWPF:** `java.lang.IndexOutOfBoundsException: Index 10 out of bounds for length 7` — Word `.doc` with header structure POI's HWPF parser can't handle
- **Misnamed file:** Tika detects a content-type mismatch with the request's `Content-Type` and rejects with the actual parser exception

## Fix

On 422 from `/tika`, refetch via `/rmeta/text`, pull the first line of `container_exception` (typically `<class>: <message>`), and raise a `RuntimeError` with that detail. Other status codes still come through `httpx.HTTPStatusError` unchanged.

The rmeta refetch is best-effort — failures there fall back to a generic `Tika rejected file (422)` message so the operator at least knows it was a 422, not a network error.

## Tests

`tests/test_extract_helpers.py`:
- `test_tika_422_surfaces_pdfbox_container_exception` — fixture matches the production Chomsky.pdf failure
- `test_tika_422_surfaces_poi_container_exception` — fixture matches the production gombo.doc failure
- `test_tika_422_with_no_rmeta_detail_still_raises_with_generic_message` — rmeta refetch failure path
- `test_tika_non_422_failures_still_raise_via_raise_for_status` — guards against accidentally swallowing 500s

402 passed (+4 new), ruff clean, format clean.

## Out of scope

- The 3 production docs that hit these errors are still in `pipeline_status=error`; this PR doesn't auto-retry them. Once it lands, re-enqueueing one will produce a useful error message instead of just "HTTPStatusError 422".
- Misnamed file (Excel saved as `.pdf`) still fails — fixing that needs a separate magic-bytes-detection pass before sending to Tika.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
