### PR TITLE
chore(migration): rename Postgres enum type version_status -> pipeline_status

### DIFF
--- a/alembic/versions/0018_rename_version_status_enum.py
+++ b/alembic/versions/0018_rename_version_status_enum.py
@@ -1,0 +1,32 @@
+"""Rename Postgres enum type version_status -> pipeline_status.
+
+The Python class was renamed VersionStatus -> PipelineStatus in PR #255
+(Stage 3 flatten), but the underlying Postgres enum type kept its old
+name for the duration of the refactor to avoid coupling the Python rename
+with a schema migration. This migration brings the DB type name in line
+with the Python name so future readers of pg_dump aren't confused.
+
+The Python alias VersionStatus = PipelineStatus is kept for back-compat
+with any external tooling that still imports it; that's a separate
+concern from the DB type name.
+
+Revision ID: 0018
+Revises: 0017
+"""
+
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... RENAME TO ... is a metadata-only operation in Postgres
+    # (no table rewrite), so this is fast even on large databases.
+    op.execute("ALTER TYPE version_status RENAME TO pipeline_status")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE pipeline_status RENAME TO version_status")

--- a/src/harbor_clerk/models/document.py
+++ b/src/harbor_clerk/models/document.py
@@ -19,7 +19,7 @@ class Document(Base):
     # Per-content state (pulled up from former DocumentVersion in 0017 migration)
     sha256: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     pipeline_status: Mapped[PipelineStatus] = mapped_column(
-        Enum(PipelineStatus, name="version_status", create_type=False),
+        Enum(PipelineStatus, name="pipeline_status", create_type=False),
         nullable=False,
     )
     pipeline_seq: Mapped[int] = mapped_column(

--- a/tests/test_alembic_0018_enum_rename.py
+++ b/tests/test_alembic_0018_enum_rename.py
@@ -1,0 +1,117 @@
+"""Test the 0018 enum rename: version_status -> pipeline_status."""
+
+import os
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from alembic import command
+
+_SYNC_URL = os.environ["DATABASE_URL"].replace("+asyncpg", "+psycopg2")
+
+
+@pytest.fixture(scope="module")
+def alembic_cfg():
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def sync_engine():
+    engine = create_engine(_SYNC_URL)
+    yield engine
+    engine.dispose()
+
+
+def _enum_typename_exists(conn, typename: str) -> bool:
+    """True if a Postgres enum type with this name exists."""
+    return bool(
+        conn.execute(
+            text("SELECT 1 FROM pg_type WHERE typname = :name"),
+            {"name": typename},
+        ).scalar()
+    )
+
+
+def test_0018_renames_version_status_to_pipeline_status(alembic_cfg, sync_engine):
+    """At revision 0017 the enum is named version_status; after 0018 it is
+    pipeline_status. Round-tripping back to 0017 restores the original name."""
+    # Establish a clean baseline at 0017
+    command.downgrade(alembic_cfg, "base")
+    command.upgrade(alembic_cfg, "0017")
+
+    with sync_engine.connect() as conn:
+        assert _enum_typename_exists(conn, "version_status"), "Expected version_status enum to exist at revision 0017"
+        assert not _enum_typename_exists(conn, "pipeline_status"), (
+            "Expected pipeline_status enum to NOT exist at revision 0017"
+        )
+
+    # Apply the rename
+    command.upgrade(alembic_cfg, "0018")
+
+    with sync_engine.connect() as conn:
+        assert _enum_typename_exists(conn, "pipeline_status"), (
+            "Expected pipeline_status enum to exist after 0018 upgrade"
+        )
+        assert not _enum_typename_exists(conn, "version_status"), (
+            "Expected version_status enum to be gone after 0018 upgrade"
+        )
+
+    # Roll back the rename
+    command.downgrade(alembic_cfg, "0017")
+
+    with sync_engine.connect() as conn:
+        assert _enum_typename_exists(conn, "version_status"), (
+            "Expected version_status enum to be restored after 0018 downgrade"
+        )
+        assert not _enum_typename_exists(conn, "pipeline_status"), (
+            "Expected pipeline_status enum to be gone after 0018 downgrade"
+        )
+
+
+def test_0018_preserves_documents_pipeline_status_column_values(alembic_cfg, sync_engine):
+    """Renaming the type must not affect existing rows that use it. Insert a
+    document at 0017 with pipeline_status='ready', upgrade to 0018, verify
+    the row still reads back correctly."""
+    import hashlib
+    import uuid
+
+    command.downgrade(alembic_cfg, "base")
+    command.upgrade(alembic_cfg, "0017")
+
+    doc_id = uuid.uuid4()
+    sha = hashlib.sha256(b"enum-rename-fixture").digest()
+
+    with sync_engine.begin() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO documents (doc_id, title, status, sha256, pipeline_status, created_at, updated_at)
+                VALUES (:did, 'Enum rename fixture', 'active', :sha, 'ready', now(), now())
+            """),
+            {"did": doc_id, "sha": sha},
+        )
+
+    command.upgrade(alembic_cfg, "0018")
+
+    with sync_engine.connect() as conn:
+        row = conn.execute(
+            text("SELECT pipeline_status FROM documents WHERE doc_id = :did"),
+            {"did": doc_id},
+        ).first()
+        assert row is not None
+        # Cast to text for the assertion since the column type changed names
+        assert str(row.pipeline_status) == "ready"
+
+        # Verify the column type is the renamed one
+        type_name = conn.execute(
+            text("""
+                SELECT t.typname
+                FROM pg_attribute a
+                JOIN pg_class c ON c.oid = a.attrelid
+                JOIN pg_type t ON t.oid = a.atttypid
+                WHERE c.relname = 'documents' AND a.attname = 'pipeline_status'
+            """)
+        ).scalar()
+        assert type_name == "pipeline_status"


### PR DESCRIPTION
## Summary

Renames the Postgres enum type `version_status` → `pipeline_status` to match the Python class name (renamed `VersionStatus` → `PipelineStatus` in PR #255). Was deferred at the time to avoid coupling the Python rename with a schema migration; flagged in the Stage 3 caller-changes release notes (PR #260) as scheduled follow-up.

## Migration

`ALTER TYPE ... RENAME TO ...` is a metadata-only operation in Postgres (no table rewrite), so this is fast even on large databases.

```sql
-- upgrade
ALTER TYPE version_status RENAME TO pipeline_status;
-- downgrade
ALTER TYPE pipeline_status RENAME TO version_status;
```

The downgrade chain still works correctly: `0018` down restores `version_status`, which `0017` down then references in its `document_versions` recreation.

## Caller impact

- **ORM column declaration** in `models/document.py` updated to `name="pipeline_status"` to match the new DB type name. **Pulling 0018 without applying the migration will fail at startup or on first query.** Standard `alembic upgrade head` before launching the new app version.
- The Python alias `VersionStatus = PipelineStatus` is kept for back-compat with any external tooling that still imports it; that's a separate concern from the DB type name.

## Tests

`tests/test_alembic_0018_enum_rename.py`:

- `test_0018_renames_version_status_to_pipeline_status` — verifies the rename in both directions (upgrade then downgrade) by checking `pg_type`
- `test_0018_preserves_documents_pipeline_status_column_values` — inserts a row with `pipeline_status='ready'` at 0017, upgrades to 0018, reads back to confirm the value survives the type rename and the column is bound to the new type name

424 passed (+2 new), ruff clean, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)