### PR TITLE
refactor(api): replace _EXPECTED_SCHEMA_VERSION with dynamic alembic head detection

### DIFF
--- a/src/harbor_clerk/api/app.py
+++ b/src/harbor_clerk/api/app.py
@@ -29,6 +29,51 @@ from harbor_clerk.storage import get_storage
 
 logger = logging.getLogger(__name__)
 
+
+def _find_alembic_dir() -> Path | None:
+    """Walk parents of this file looking for an `alembic/` directory next to
+    an `alembic.ini`. Works in dev (src layout: repo root has both) and in
+    the bundled macOS app (bundle resource dir has both). Returns None if
+    no candidate is found.
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "alembic"
+        if candidate.is_dir() and (parent / "alembic.ini").exists():
+            return candidate
+    return None
+
+
+def _get_expected_schema_version() -> str | None:
+    """Discover the head migration revision via alembic's ScriptDirectory.
+
+    Returns the revision id string (e.g. "0018") or None if alembic isn't
+    importable or the migrations directory can't be located. Called once at
+    startup; the result is logged for the schema-version sanity check.
+
+    This replaces the previous pattern of hardcoding `_EXPECTED_SCHEMA_VERSION`
+    inside the lifespan function — that constant had to be bumped on every
+    new migration, which was easy to forget and produced misleading
+    "schema mismatch" log lines after every release. Reading the head
+    dynamically keeps the check in sync automatically.
+    """
+    try:
+        from alembic.script import ScriptDirectory
+    except ImportError:
+        return None
+
+    alembic_dir = _find_alembic_dir()
+    if alembic_dir is None:
+        return None
+
+    try:
+        script = ScriptDirectory(str(alembic_dir))
+        return script.get_current_head()
+    except Exception:
+        logger.exception("Found alembic dir at %s but could not read head", alembic_dir)
+        return None
+
+
 # Create MCP app + session manager at module level so we can wire lifespan
 from harbor_clerk.mcp_server import create_mcp_app  # noqa: E402
 
@@ -203,8 +248,10 @@ async def lifespan(app: FastAPI):
 
     logger.info("Starting Harbor Clerk API")
 
-    # Verify database schema is up to date
-    _EXPECTED_SCHEMA_VERSION = "0018"
+    # Verify database schema is up to date. The expected head is read from
+    # the alembic migrations directory at startup, so this stays correct
+    # automatically as new migrations land — no manual constant bumps.
+    expected = _get_expected_schema_version()
     try:
         from harbor_clerk.db import async_session_factory
 
@@ -215,11 +262,16 @@ async def lifespan(app: FastAPI):
             row = result.first()
             if row is None:
                 logger.error("No alembic_version found — database may not be initialized")
-            elif row[0] != _EXPECTED_SCHEMA_VERSION:
+            elif expected is None:
+                logger.info(
+                    "Database schema version: %s (could not auto-detect expected head; check skipped)",
+                    row[0],
+                )
+            elif row[0] != expected:
                 logger.error(
                     "Database schema version mismatch: have %s, expected %s. Run migrations.",
                     row[0],
-                    _EXPECTED_SCHEMA_VERSION,
+                    expected,
                 )
             else:
                 logger.info("Database schema version: %s (current)", row[0])

--- a/src/harbor_clerk/api/app.py
+++ b/src/harbor_clerk/api/app.py
@@ -204,7 +204,7 @@ async def lifespan(app: FastAPI):
     logger.info("Starting Harbor Clerk API")
 
     # Verify database schema is up to date
-    _EXPECTED_SCHEMA_VERSION = "0017"
+    _EXPECTED_SCHEMA_VERSION = "0018"
     try:
         from harbor_clerk.db import async_session_factory
 

--- a/tests/test_schema_version_check.py
+++ b/tests/test_schema_version_check.py
@@ -1,0 +1,36 @@
+"""Tests for the dynamic schema-version detection at API startup."""
+
+from harbor_clerk.api.app import _find_alembic_dir, _get_expected_schema_version
+
+
+def test_find_alembic_dir_returns_existing_directory():
+    """The walk-up should find the project's alembic dir."""
+    result = _find_alembic_dir()
+    assert result is not None
+    assert result.is_dir()
+    assert (result.parent / "alembic.ini").exists()
+
+
+def test_get_expected_schema_version_returns_alembic_head():
+    """The function should return the highest migration revision in the
+    alembic versions directory.
+
+    This test asserts the function returns *something* numeric and that it
+    matches the highest-numbered revision file. We don't hardcode "0018"
+    here because the whole point of this change is to stop hardcoding
+    revision numbers — the test would defeat itself if it did.
+    """
+    result = _get_expected_schema_version()
+    assert result is not None, "Expected a head revision; got None"
+
+    # Cross-check against the highest-numbered migration file (filename
+    # convention: NNNN_description.py).
+    alembic_dir = _find_alembic_dir()
+    assert alembic_dir is not None
+    versions = sorted(p.name for p in (alembic_dir / "versions").glob("[0-9]*.py"))
+    assert versions, "No numbered migration files found"
+    highest_filename_revision = versions[-1].split("_", 1)[0]
+    assert result == highest_filename_revision, (
+        f"_get_expected_schema_version returned {result}, but the highest "
+        f"migration file is {versions[-1]} (revision {highest_filename_revision})"
+    )


### PR DESCRIPTION
## Summary

Replaces `_EXPECTED_SCHEMA_VERSION` with dynamic alembic-head detection at startup so the schema-version sanity check stays in sync automatically as new migrations land. No more "forgot to bump the constant" misleading-mismatch logs after every release.

(Started as a one-line bump from `0017` to `0018` to fix the misleading log line after PR #261. Per @alex, moving to the dynamic approach now since "the next time someone touches this, it's because they had a bad time.")

## How it works

Two new helpers in `app.py`:

- **`_find_alembic_dir()`** walks parents of `app.py` looking for an `alembic/` directory next to an `alembic.ini`. Works in dev (src layout: repo root has both) and in the bundled macOS app (bundle resource dir has both). The path depths differ between layouts — walking instead of hardcoding handles both.
- **`_get_expected_schema_version()`** uses `alembic.script.ScriptDirectory` to discover the head, returning `None` if alembic isn't importable or the migrations directory can't be located. The lifespan check then logs a "could not auto-detect" message and skips the comparison rather than crashing.

The lifespan check itself is now version-agnostic: it compares whatever the DB says with whatever alembic says.

## Tests

`tests/test_schema_version_check.py`:

- `test_find_alembic_dir_returns_existing_directory` — confirms the walk-up resolves to the project's actual alembic dir and `alembic.ini` is present alongside
- `test_get_expected_schema_version_returns_alembic_head` — asserts the return value matches the highest-numbered migration filename (without hardcoding `"0018"`, which would defeat the whole point)

426 passed (+2 new), ruff clean, format clean.

## Commits

- `44448fc` — initial one-line bump `0017` → `0018` (now superseded by the next commit)
- `278b8bc` — replace the constant entirely with dynamic detection

Both commits get squash-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)