### PR TITLE
feat(frontend): four small UI tweaks (search-to-chunk, ingestion order, research nudge, entity colors)

### DIFF
--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -561,9 +561,7 @@ export default function DocumentDetailPage() {
             // pagination + the page DOM commit before we measure positions.
             requestAnimationFrame(() => {
               requestAnimationFrame(() => {
-                document
-                  .getElementById(`page-${urlTargetPage}`)
-                  ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                document.getElementById(`page-${urlTargetPage}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
               })
             })
             // Clear highlight after animation

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
-import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'react-router-dom'
 import { get, post, del } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents, type JobEvent } from '../hooks/useJobEvents'
@@ -227,16 +227,61 @@ interface DocStats {
   ocr_confidence: { avg: number; min: number; max: number } | null
 }
 
+// Color palette covering all spaCy entity types we might see. Grouped by
+// semantic kind so related types share a hue family:
+//   blue/indigo:  people + groups (PERSON, NORP)
+//   green/teal:   organizations + products (ORG, PRODUCT, WORK_OF_ART)
+//   amber/orange: places (GPE, LOC, FAC)
+//   cyan/sky:     time (DATE, TIME)
+//   pink/rose:    events + law (EVENT, LAW)
+//   violet/fuchsia: language + culture (LANGUAGE)
+//   emerald:      money/percent (MONEY, PERCENT)
+//   stone:        numbers (CARDINAL, ORDINAL, QUANTITY)
 const ENTITY_TYPE_COLORS: Record<string, string> = {
   PERSON: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  NORP: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
   ORG: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  PRODUCT: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
+  WORK_OF_ART: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
   GPE: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  LOC: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  LOC: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  FAC: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
   DATE: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
+  TIME: 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400',
   EVENT: 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400',
+  LAW: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400',
+  LANGUAGE: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
+  MONEY: 'bg-lime-100 text-lime-700 dark:bg-lime-900/30 dark:text-lime-400',
+  PERCENT: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  CARDINAL: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
+  ORDINAL: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
+  QUANTITY: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
 }
 
 const DEFAULT_HIDDEN_ENTITY_TYPES = new Set(['CARDINAL', 'ORDINAL', 'QUANTITY'])
+
+/**
+ * Wrap the chunk-text substring inside a page's text with a `<mark>` tag so
+ * the user lands on the exact span that matched their search. Falls back to
+ * the unmodified text when:
+ *   - no highlight target was passed (normal navigation, not from search)
+ *   - the chunk text spans multiple pages and doesn't fully appear in any
+ *     single page (partial-match fallback isn't worth the complexity)
+ */
+function renderPageWithHighlight(text: string, highlight: string | null): ReactNode {
+  if (!highlight) return text
+  const trimmed = highlight.trim()
+  if (!trimmed) return text
+  const idx = text.indexOf(trimmed)
+  if (idx === -1) return text
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="rounded-sm bg-yellow-200 px-0.5 dark:bg-yellow-700/50 dark:text-yellow-100">{trimmed}</mark>
+      {text.slice(idx + trimmed.length)}
+    </>
+  )
+}
 
 function DocumentStatsDisclosure({ docId }: { docId: string }) {
   const [stats, setStats] = useState<DocStats | null>(null)
@@ -384,7 +429,13 @@ export default function DocumentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
+  const location = useLocation()
   const { isAdmin, user } = useAuth()
+
+  // Optional inline highlight target — populated when the user arrives from a
+  // search result. The chunk text is passed via React Router state (not URL)
+  // because chunk bodies can be long and noisy in the address bar.
+  const highlightChunkText = (location.state as { highlightChunkText?: string } | null)?.highlightChunkText ?? null
   const [doc, setDoc] = useState<DocumentDetail | null>(null)
   const [content, setContent] = useState<ContentResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -506,6 +557,15 @@ export default function DocumentDetailPage() {
             const paginationPage = Math.floor(pageIdx / pageSize) + 1
             setContentPage(paginationPage)
             setHighlightPage(urlTargetPage)
+            // Scroll to the page anchor once it's rendered. Two RAFs let
+            // pagination + the page DOM commit before we measure positions.
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                document
+                  .getElementById(`page-${urlTargetPage}`)
+                  ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+              })
+            })
             // Clear highlight after animation
             setTimeout(() => setHighlightPage(null), 2000)
           }
@@ -612,6 +672,45 @@ export default function DocumentDetailPage() {
 
       <DocStatusBanner doc={doc} />
 
+      {doc.jobs.length > 0 && (
+        <div className="mb-4">
+          <Disclosure label="Ingestion Jobs" defaultOpen={!isReady}>
+            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-5">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200 dark:border-gray-700 text-left text-xs text-gray-500 dark:text-gray-400">
+                    <th className="pb-1 pr-3">Stage</th>
+                    <th className="pb-1 pr-3">Status</th>
+                    <th className="pb-1 pr-3">Progress</th>
+                    <th className="pb-1">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {doc.jobs.map((j) => (
+                    <tr key={j.job_id || j.stage} className="border-b border-gray-100 dark:border-gray-700">
+                      <td className="py-1 pr-3 font-medium">{j.stage}</td>
+                      <td className="py-1 pr-3">
+                        <JobStatusBadge status={j.status} />
+                      </td>
+                      <td className="py-1 pr-3 text-gray-500 dark:text-gray-400">
+                        {j.progress_total ? `${j.progress_current || 0}/${j.progress_total}` : '—'}
+                      </td>
+                      <td className="py-1 text-xs text-gray-400">
+                        {j.finished_at
+                          ? new Date(j.finished_at).toLocaleTimeString()
+                          : j.started_at
+                            ? 'running...'
+                            : 'queued'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Disclosure>
+        </div>
+      )}
+
       {/* File metadata line */}
       <div className="mb-2 flex items-center justify-between">
         <div className="text-sm">
@@ -659,45 +758,6 @@ export default function DocumentDetailPage() {
             ))}
           </div>
         </details>
-      )}
-
-      {doc.jobs.length > 0 && (
-        <div className="mt-6 mb-6">
-          <Disclosure label="Ingestion Jobs" defaultOpen={!isReady}>
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-5">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-gray-200 dark:border-gray-700 text-left text-xs text-gray-500 dark:text-gray-400">
-                    <th className="pb-1 pr-3">Stage</th>
-                    <th className="pb-1 pr-3">Status</th>
-                    <th className="pb-1 pr-3">Progress</th>
-                    <th className="pb-1">Time</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {doc.jobs.map((j) => (
-                    <tr key={j.job_id || j.stage} className="border-b border-gray-100 dark:border-gray-700">
-                      <td className="py-1 pr-3 font-medium">{j.stage}</td>
-                      <td className="py-1 pr-3">
-                        <JobStatusBadge status={j.status} />
-                      </td>
-                      <td className="py-1 pr-3 text-gray-500 dark:text-gray-400">
-                        {j.progress_total ? `${j.progress_current || 0}/${j.progress_total}` : '—'}
-                      </td>
-                      <td className="py-1 text-xs text-gray-400">
-                        {j.finished_at
-                          ? new Date(j.finished_at).toLocaleTimeString()
-                          : j.started_at
-                            ? 'running...'
-                            : 'queued'}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </Disclosure>
-        </div>
       )}
 
       <h2 className="mb-2 mt-6 text-lg font-semibold">Content</h2>
@@ -757,6 +817,7 @@ export default function DocumentDetailPage() {
               {visiblePages.map((page) => (
                 <div
                   key={page.page_num}
+                  id={`page-${page.page_num}`}
                   className={`rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-4 transition-all duration-500 ${
                     highlightPage === page.page_num ? 'ring-2 ring-(--color-accent)/40' : ''
                   }`}
@@ -769,7 +830,9 @@ export default function DocumentDetailPage() {
                       </span>
                     )}
                   </div>
-                  <pre className="whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200">{page.text}</pre>
+                  <pre className="whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200">
+                    {renderPageWithHighlight(page.text, highlightChunkText)}
+                  </pre>
                 </div>
               ))}
 

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -1,10 +1,11 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
 import ToolResultDisplay from '../components/ToolResultDisplay'
 import { del, get } from '../api'
 import { useChat } from '../contexts/ChatContext'
 import { useResearch, type ToolCallEntry } from '../contexts/ResearchContext'
+import { useLLMStatus } from '../hooks/useLLMStatus'
 import { formatRelativeDate } from '../utils/dates'
 
 interface ResearchSummary {
@@ -99,6 +100,8 @@ export default function ResearchPage() {
   const navigate = useNavigate()
 
   const { isStreaming: chatStreaming } = useChat()
+  const { status: llmStatus } = useLLMStatus()
+  const hasActiveModel = llmStatus.state === 'ready' && llmStatus.model_id !== null
   const [history, setHistory] = useState<ResearchSummary[]>([])
   const [selectedTask, setSelectedTask] = useState<ResearchDetail | null>(null)
   const [question, setQuestionRaw] = useState(() => sessionStorage.getItem('research_draft') ?? '')
@@ -461,7 +464,9 @@ export default function ResearchPage() {
                   comprehensive report. This may take several minutes.
                 </p>
 
-                {isRunning || chatStreaming ? (
+                {!hasActiveModel ? (
+                  <ModelNudge />
+                ) : isRunning || chatStreaming ? (
                   <div className="max-w-md mx-auto rounded-xl border border-amber-200 dark:border-amber-800/40 bg-amber-50/50 dark:bg-amber-900/10 px-4 py-3 text-center">
                     <p className="text-[13px] text-amber-700 dark:text-amber-400">
                       {chatStreaming
@@ -924,6 +929,47 @@ function RoundLabel({ round }: { round: number }) {
       <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
         Round {round}
       </span>
+    </div>
+  )
+}
+
+/* ---- Model onboarding nudge (mirrors ChatPage.ModelNudge tone, retargeted) ---- */
+
+function ModelNudge() {
+  return (
+    <div className="max-w-md mx-auto text-center empty-state-appear">
+      <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-50 dark:bg-amber-900/30 ring-1 ring-amber-200/60 dark:ring-amber-700/40">
+        <svg
+          className="h-7 w-7 text-amber-500 dark:text-amber-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
+          />
+        </svg>
+      </div>
+      <h3 className="text-[15px] font-semibold text-gray-800 dark:text-gray-200 mb-2">Choose a model to research with</h3>
+      <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-5">
+        Deep Research drives a local LLM through many tool calls — pick a model first.
+      </p>
+      <Link
+        to="/admin/models"
+        className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2 text-[13px] font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+          />
+        </svg>
+        Choose a model
+      </Link>
     </div>
   )
 }

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -953,7 +953,9 @@ function ModelNudge() {
           />
         </svg>
       </div>
-      <h3 className="text-[15px] font-semibold text-gray-800 dark:text-gray-200 mb-2">Choose a model to research with</h3>
+      <h3 className="text-[15px] font-semibold text-gray-800 dark:text-gray-200 mb-2">
+        Choose a model to research with
+      </h3>
       <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-5">
         Deep Research drives a local LLM through many tool calls — pick a model first.
       </p>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -327,6 +327,11 @@ export default function SearchPage() {
                   hit.page_start != null
                     ? `/docs/${hit.doc_id}?showContent=true&page=${hit.page_start}`
                     : `/docs/${hit.doc_id}?showContent=true`
+                // Pass the chunk text via React Router state so the doc detail
+                // page can scroll to and inline-highlight the matching span
+                // within the page text. Avoids URL pollution since chunk
+                // bodies can be long.
+                const linkState = { highlightChunkText: hit.chunk_text, highlightChunkId: hit.chunk_id }
 
                 return (
                   <div
@@ -334,7 +339,11 @@ export default function SearchPage() {
                     className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4"
                   >
                     <div className="mb-2 flex items-center justify-between">
-                      <Link to={linkTo} className="font-medium text-blue-600 dark:text-blue-400 hover:underline">
+                      <Link
+                        to={linkTo}
+                        state={linkState}
+                        className="font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                      >
                         {hit.doc_title || 'Untitled'}
                       </Link>
                       <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary

Four small frontend tweaks per request. No backend changes.

1. **Search results link directly to the matching chunk** — page divs get `id="page-N"` anchors; doc detail page scrolls smoothly to the target page after pagination commits; the matching chunk text is wrapped in a `<mark>` for inline highlight (passed via React Router `state` to keep URLs clean).
2. **Ingestion Jobs disclosure moved up** — now sits right under the "Ingestion complete" status banner instead of below file metadata, related docs, and DocumentStatsDisclosure.
3. **Research page gets the "Choose a model" nudge** — mirrors ChatPage's pattern via `useLLMStatus()`. When no model is loaded (idle state), shows a Research-specific nudge with a link to `/admin/models` instead of letting users submit research that would fail downstream.
4. **Entity badges color-coded for all 18 spaCy types** — extended the palette from 6 → 18 types, grouped by semantic kind (people/groups blue, orgs/products green, places amber/orange, time cyan, events/law pink/rose, money green, numbers stone). Colors are shared between the type-filter badges and top-entities chips.

## Implementation notes

For #1, the chunk text rides on `<Link state={...}>` rather than the URL because chunk bodies are long and noisy in the address bar. The doc detail page reads `useLocation().state?.highlightChunkText`, finds the substring inside any visible page text, and wraps it. Falls back gracefully when the chunk spans multiple pages and doesn't fully appear in any one page.

For #1's scroll, two RAFs let pagination + page DOM commit before `scrollIntoView` measures positions — without that, the scroll sometimes fires against the old layout.

## Out of scope (separate brainstorm)

- Linking from doc detail to the original file (Reveal in Finder for the macOS native app, download / path display for Docker / web). Tracked separately — needs a brief design discussion before code.

Files changed:
- `frontend/src/pages/SearchPage.tsx` (+9 / −2)
- `frontend/src/pages/DocumentDetailPage.tsx` (+103 / −41)
- `frontend/src/pages/ResearchPage.tsx` (+51 / −2)

Frontend type-check + lint clean (no new warnings); no Python changes so backend test suite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)