### PR TITLE
feat: source-file access — Reveal in Finder (macOS) + gated Download (Docker)

### DIFF
--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -7,11 +7,8 @@ interface SystemInfo {
   watch_root: string | null
 }
 
-declare global {
-  interface Window {
-    harborclerk?: { pickFolder: () => Promise<string | null> }
-  }
-}
+// window.harborclerk typing lives in src/types/harborclerk.d.ts (shared
+// across pages/components that touch the native bridge).
 
 interface Props {
   onComplete: () => void

--- a/frontend/src/hooks/useSystemConfig.ts
+++ b/frontend/src/hooks/useSystemConfig.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+
+export interface SystemConfig {
+  /**
+   * True when the backend is configured to serve original document bytes
+   * over /api/docs/{doc_id}/download. Defaults to false on every deployment;
+   * macOS native does not expose any toggle to flip this on (use Reveal in
+   * Finder instead). On Docker, an admin can opt in via ALLOW_SOURCE_DOWNLOAD.
+   */
+  allowSourceDownload: boolean
+  /**
+   * True once the system config has been fetched at least once. While false
+   * the UI should treat capability flags conservatively (e.g. hide buttons
+   * rather than show them only to have them flicker off when the response
+   * arrives).
+   */
+  loaded: boolean
+}
+
+const FALLBACK: SystemConfig = { allowSourceDownload: false, loaded: false }
+
+/**
+ * Fetches /api/system/health once on mount to read deployment-wide
+ * capabilities. Used by DocumentDetailPage to decide whether to render the
+ * Download button.
+ *
+ * Not a global context — the page-level cost is one fetch on mount,
+ * negligible. If a future page needs the config too and we end up making
+ * the same call from multiple components, lifting this into a context is
+ * the obvious refactor.
+ */
+export function useSystemConfig(): SystemConfig {
+  const [config, setConfig] = useState<SystemConfig>(FALLBACK)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/system/health')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return
+        setConfig({
+          allowSourceDownload: Boolean(data.allow_source_download),
+          loaded: true,
+        })
+      })
+      .catch(() => {
+        // Health endpoint is unauthenticated and very rarely fails. If it
+        // does, leave the conservative default in place — a failure to
+        // fetch capability shouldn't be interpreted as "everything is
+        // available". The user just sees a slightly less complete UI.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return config
+}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'reac
 import { get, post, del } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents, type JobEvent } from '../hooks/useJobEvents'
+import { useSystemConfig, type SystemConfig } from '../hooks/useSystemConfig'
 import { ENTITY_TYPE_LABELS } from '../components/stats/CorpusCharts'
 
 interface JobInfo {
@@ -261,6 +262,74 @@ const ENTITY_TYPE_COLORS: Record<string, string> = {
 const DEFAULT_HIDDEN_ENTITY_TYPES = new Set(['CARDINAL', 'ORDINAL', 'QUANTITY'])
 
 /**
+ * Source file row: shows the path and exposes whichever of "Reveal in Finder"
+ * and "Download" the deployment supports.
+ *
+ * Reveal: only available when running inside the macOS WKWebView client (the
+ * native bridge `window.harborclerk.revealInFinder` is detected synchronously
+ * — absent in regular browsers and in the Docker web UI). Doesn't go through
+ * the HTTP server at all; calls NSWorkspace directly via the WKScriptMessage
+ * channel registered in macos/HarborClerk/.../ContentView.swift.
+ *
+ * Download: gated by the server-side `allow_source_download` setting. Default
+ * off everywhere — see hooks/useSystemConfig.ts and the backend setting
+ * docstring for the rationale.
+ *
+ * If neither action is available, we still show the path because operators
+ * frequently want to confirm "this is the right file".
+ */
+function SourceFileSection({ doc, sysConfig }: { doc: DocumentDetail; sysConfig: SystemConfig }) {
+  // Anything to display? Watched-folder docs always have source_path; uploaded
+  // docs may have only original_object_key (which is internal storage and not
+  // particularly useful to the user — we don't surface it as a "source path").
+  if (!doc.source_path) return null
+
+  const canReveal = typeof window !== 'undefined' && Boolean(window.harborclerk?.revealInFinder)
+  const canDownload = sysConfig.allowSourceDownload && sysConfig.loaded
+
+  async function handleReveal() {
+    try {
+      await window.harborclerk?.revealInFinder?.(doc.source_path!)
+    } catch {
+      // Swift handler logs its own errors; nothing actionable in the UI.
+    }
+  }
+
+  return (
+    <div className="mb-2 flex items-start justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="text-xs text-gray-500 dark:text-gray-400">Source</div>
+        <div className="text-xs text-gray-400 break-all font-mono">{doc.source_path}</div>
+      </div>
+      {(canReveal || canDownload) && (
+        <div className="flex shrink-0 items-center gap-2">
+          {canReveal && (
+            <button
+              type="button"
+              onClick={handleReveal}
+              className="rounded-md bg-(--color-bg-tertiary) px-2.5 py-1 text-xs font-medium text-(--color-text-secondary) hover:opacity-80"
+              title="Reveal this file in Finder"
+            >
+              Reveal in Finder
+            </button>
+          )}
+          {canDownload && (
+            <a
+              href={`/api/docs/${doc.doc_id}/download`}
+              download
+              className="rounded-md bg-(--color-bg-tertiary) px-2.5 py-1 text-xs font-medium text-(--color-text-secondary) hover:opacity-80"
+              title="Download the original file"
+            >
+              Download
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
  * Wrap the chunk-text substring inside a page's text with a `<mark>` tag so
  * the user lands on the exact span that matched their search. Falls back to
  * the unmodified text when:
@@ -431,6 +500,7 @@ export default function DocumentDetailPage() {
   const [searchParams] = useSearchParams()
   const location = useLocation()
   const { isAdmin, user } = useAuth()
+  const sysConfig = useSystemConfig()
 
   // Optional inline highlight target — populated when the user arrives from a
   // search result. The chunk text is passed via React Router state (not URL)
@@ -727,7 +797,7 @@ export default function DocumentDetailPage() {
         OCR: {doc.needs_ocr ? 'yes' : 'no'} | Text layer: {doc.has_text_layer ? 'yes' : 'no'}
       </div>
 
-      {doc.source_path && <div className="mb-2 text-xs text-gray-400 break-all">Source: {doc.source_path}</div>}
+      <SourceFileSection doc={doc} sysConfig={sysConfig} />
 
       <DocumentStatsDisclosure docId={doc.doc_id} />
 

--- a/frontend/src/pages/FoldersPage.tsx
+++ b/frontend/src/pages/FoldersPage.tsx
@@ -32,11 +32,8 @@ interface SystemInfo {
   watch_root: string | null
 }
 
-declare global {
-  interface Window {
-    harborclerk?: { pickFolder: () => Promise<string | null> }
-  }
-}
+// window.harborclerk typing lives in src/types/harborclerk.d.ts (shared
+// across pages/components that touch the native bridge).
 
 function errorMessage(e: unknown, fallback: string): string {
   if (e instanceof ApiError || e instanceof Error) return e.message

--- a/frontend/src/types/harborclerk.d.ts
+++ b/frontend/src/types/harborclerk.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Native bridge surface exposed by the macOS WKWebView app via
+ * window.harborclerk. Callable from any page that runs inside the bundled
+ * Mac client; absent in any other browser (regular Chrome/Safari, the
+ * Docker web UI, etc.). Always feature-detect before calling, e.g.:
+ *
+ *     if (window.harborclerk?.revealInFinder) { ... }
+ *
+ * The Swift side registers each handler in macos/HarborClerk/HarborClerk/
+ * ContentView.swift and injects the JS shim that maps these calls onto
+ * window.webkit.messageHandlers.<channel>.postMessage(...).
+ */
+declare global {
+  interface Window {
+    harborclerk?: {
+      /**
+       * Open a native NSOpenPanel and resolve to the chosen absolute path,
+       * or null if the user cancelled. Used by the watched-folder picker.
+       *
+       * Required when `harborclerk` is present — every shipped Mac client
+       * registers this handler; absence of `pickFolder` would mean we're
+       * not really running in the bridge environment.
+       */
+      pickFolder: () => Promise<string | null>
+      /**
+       * Reveal the file at the given absolute host path in Finder. Returns
+       * a Promise that resolves once the message has been delivered to the
+       * Swift side.
+       *
+       * Optional because older Mac clients (pre-revealInFinder bridge) may
+       * have `harborclerk.pickFolder` but not this method. Always
+       * feature-detect: `if (window.harborclerk?.revealInFinder) { ... }`.
+       */
+      revealInFinder?: (path: string) => Promise<void>
+    }
+  }
+}
+
+export {}

--- a/macos/HarborClerk/HarborClerk/ContentView.swift
+++ b/macos/HarborClerk/HarborClerk/ContentView.swift
@@ -112,11 +112,33 @@ struct WebView: NSViewRepresentable {
             contentWorld: .page,
             name: "pickFolder"
         )
+
+        // Reveal-in-Finder bridge: window.harborclerk.revealInFinder(path) opens
+        // Finder with the given file selected. Fire-and-forget — the JS Promise
+        // resolves once the message lands on the Swift side, regardless of
+        // whether the file actually exists. NSWorkspace handles missing files
+        // gracefully (shows the parent dir).
+        //
+        // This is the *only* way macOS users can access source files through
+        // Harbor Clerk — the HTTP download endpoint is disabled by default
+        // and the menu app intentionally exposes no toggle to enable it. By
+        // routing reveal through NSWorkspace instead of through the API
+        // server, we keep the file-access path off the network entirely.
+        let revealHandler = RevealInFinderHandler()
+        config.userContentController.addScriptMessageHandler(
+            revealHandler,
+            contentWorld: .page,
+            name: "revealInFinder"
+        )
+
         let bridgeScript = WKUserScript(
             source: """
             window.harborclerk = window.harborclerk || {};
             window.harborclerk.pickFolder = function() {
                 return window.webkit.messageHandlers.pickFolder.postMessage({});
+            };
+            window.harborclerk.revealInFinder = function(path) {
+                return window.webkit.messageHandlers.revealInFinder.postMessage({path: path});
             };
             """,
             injectionTime: .atDocumentStart,
@@ -292,6 +314,45 @@ final class FolderPickerHandler: NSObject, WKScriptMessageHandlerWithReply {
             } else {
                 replyHandler(nil, nil)
             }
+        }
+    }
+}
+
+// MARK: - Reveal in Finder bridge
+
+/// Bridges window.harborclerk.revealInFinder(path) (called from the doc
+/// detail page) to NSWorkspace.activateFileViewerSelecting. Fire-and-forget;
+/// the JS Promise resolves as soon as the message is delivered.
+///
+/// We use WKScriptMessageHandlerWithReply (not the older
+/// WKScriptMessageHandler) so the JS side gets a real Promise to await on,
+/// matching the existing pickFolder pattern. The reply value is always
+/// nil — there's no useful "did NSWorkspace succeed" signal worth surfacing.
+final class RevealInFinderHandler: NSObject, WKScriptMessageHandlerWithReply {
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage,
+        replyHandler: @escaping (Any?, String?) -> Void
+    ) {
+        // Best-effort path extraction. JS shim wraps the path in {path: "..."}.
+        guard let body = message.body as? [String: Any],
+              let path = body["path"] as? String,
+              !path.isEmpty
+        else {
+            replyHandler(nil, "revealInFinder: missing or empty path")
+            return
+        }
+
+        DispatchQueue.main.async {
+            let url = URL(fileURLWithPath: path)
+            // activateFileViewerSelecting handles missing files gracefully —
+            // it falls back to revealing the parent directory if the file
+            // itself doesn't exist (e.g. user moved/deleted it after
+            // ingestion). Doesn't open the file's contents, just shows it
+            // in Finder, so it's a benign action even if the path turned
+            // out to be unexpected.
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+            replyHandler(nil, nil)
         }
     }
 }

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -27,6 +27,7 @@ from harbor_clerk.api.schemas.documents import (
 )
 from harbor_clerk.api.scope import apply_key_scope
 from harbor_clerk.audit import log_audit
+from harbor_clerk.config import get_settings
 from harbor_clerk.db import get_session
 from harbor_clerk.models import (
     Chunk,
@@ -710,7 +711,25 @@ async def download_document(
     principal: Principal = Depends(require_read_access),
     session: AsyncSession = Depends(get_session),
 ):
-    """Download the original file for a document."""
+    """Download the original file for a document.
+
+    Gated by the ``allow_source_download`` setting (env: ALLOW_SOURCE_DOWNLOAD).
+    Disabled by default everywhere because the response exposes the raw bytes
+    of the original document — meaningfully more data than the chunk excerpts
+    that read-only API keys were designed to surface. On macOS native, the menu
+    app intentionally does NOT expose a way to enable this; use Reveal in
+    Finder instead. On Docker, an admin can opt in by setting the env var.
+    """
+    if not get_settings().allow_source_download:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Source-file download is disabled on this deployment. "
+                "On macOS, use Reveal in Finder. "
+                "On Docker, an admin can enable downloads by setting ALLOW_SOURCE_DOWNLOAD=true."
+            ),
+        )
+
     query = select(Document).where(Document.doc_id == doc_id, Document.status == "active")
     query = apply_key_scope(query, principal)
     result = await session.execute(query)

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -85,6 +85,10 @@ async def health_check(
         "status": "healthy" if overall else "degraded",
         "build": BUILD_HASH,
         "checks": checks,
+        # Deployment-wide capabilities the frontend needs to know about. Kept
+        # in the health response so it's fetched on app boot without a
+        # separate round-trip — see frontend/src/hooks/useSystemConfig.ts.
+        "allow_source_download": get_settings().allow_source_download,
     }
 
 

--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -106,6 +106,16 @@ class Settings(BaseSettings):
     oauth_refresh_token_days: int = Field(default=90)
     oauth_access_token_minutes: int = Field(default=60)
 
+    # Source-file download via the API. Defaults to OFF on every deployment
+    # because the download endpoint exposes the raw bytes of any document the
+    # caller can already see in search — that's a meaningful escalation over
+    # the chunk-excerpt access read-only API keys are designed for. On macOS
+    # native, the menu app does NOT expose a way to flip this on, so the only
+    # way to access source files there is Reveal in Finder (which doesn't go
+    # through the HTTP server). On Docker, an admin can opt in by setting
+    # ALLOW_SOURCE_DOWNLOAD=true in the compose file.
+    allow_source_download: bool = Field(default=False)
+
     @field_validator("public_url")
     @classmethod
     def _strip_trailing_slash(cls, v: str) -> str:

--- a/tests/test_api_documents.py
+++ b/tests/test_api_documents.py
@@ -294,3 +294,56 @@ async def test_get_document_entities_empty(client, admin_user, admin_token, db_s
     assert data["total"] == 0
     assert data["entities"] == []
     assert data["entity_types"] == []
+
+
+async def test_download_returns_403_when_disabled_by_default(client, admin_user, admin_token, db_session, tmp_path):
+    """allow_source_download defaults to False; download must 403 with a clear
+    message instead of silently serving the bytes."""
+    src = tmp_path / "secret.pdf"
+    src.write_bytes(b"%PDF-1.4 secret content")
+    doc = Document(title="Secret", status="active", source_path=str(src), **_DOC_DEFAULTS)
+    db_session.add(doc)
+    await db_session.flush()
+
+    resp = await client.get(f"/api/docs/{doc.doc_id}/download", headers=auth_header(admin_token))
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "disabled" in body["detail"].lower()
+    # The error message should point at both the macOS and Docker remediations
+    # so the user knows where to look.
+    assert "ALLOW_SOURCE_DOWNLOAD" in body["detail"]
+    assert "Reveal in Finder" in body["detail"]
+
+
+async def test_download_returns_bytes_when_enabled(client, admin_user, admin_token, db_session, tmp_path):
+    """When the operator explicitly enables source download, the endpoint
+    serves the original bytes."""
+    from harbor_clerk.config import get_settings
+
+    src = tmp_path / "doc.pdf"
+    payload = b"%PDF-1.4 hello world"
+    src.write_bytes(payload)
+    doc = Document(title="Permitted", status="active", source_path=str(src), **_DOC_DEFAULTS)
+    db_session.add(doc)
+    await db_session.flush()
+
+    s = get_settings()
+    original = s.allow_source_download
+    s.allow_source_download = True
+    try:
+        resp = await client.get(f"/api/docs/{doc.doc_id}/download", headers=auth_header(admin_token))
+    finally:
+        s.allow_source_download = original
+
+    assert resp.status_code == 200
+    assert resp.content == payload
+    # Content-Disposition uses RFC 8187 encoding with the filename
+    assert "doc.pdf" in resp.headers["content-disposition"]
+
+
+async def test_download_403_fires_before_doc_existence_check(client, admin_user, admin_token):
+    """Verify the 403 short-circuits before the DB query — i.e. an attacker
+    can't probe doc_id existence via differential 403 vs 404 responses."""
+    fake_id = uuid.uuid4()
+    resp = await client.get(f"/api/docs/{fake_id}/download", headers=auth_header(admin_token))
+    assert resp.status_code == 403

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -18,3 +18,32 @@ async def test_health_check(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["checks"]["postgres"] == "ok"
+
+
+async def test_health_check_exposes_allow_source_download_default_false(client):
+    """The health endpoint surfaces the allow_source_download capability so the
+    frontend can decide whether to render the Download button. Default must be
+    False on every deployment — see the setting docstring for why."""
+    resp = await client.get("/api/system/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "allow_source_download" in data
+    assert data["allow_source_download"] is False
+
+
+async def test_health_check_reflects_allow_source_download_when_set(client):
+    """Toggling the setting at runtime should be visible immediately on the
+    next health fetch. Tests use the same Settings singleton; mutating it on
+    the fly is the production-equivalent of an admin flipping the env var
+    and restarting (the singleton is read fresh on each request)."""
+    from harbor_clerk.config import get_settings
+
+    s = get_settings()
+    original = s.allow_source_download
+    s.allow_source_download = True
+    try:
+        resp = await client.get("/api/system/health")
+        assert resp.status_code == 200
+        assert resp.json()["allow_source_download"] is True
+    finally:
+        s.allow_source_download = original


### PR DESCRIPTION
## Summary

Adds Reveal-in-Finder (macOS) and gated Download (Docker) for source files, with deployment-aware safety defaults per [the design discussion](https://github.com/r0shi/harborclerk/pull/263#issuecomment-...). Defaults to **fully conservative on every deployment**:

- **macOS native**: download is **disabled with no toggle**. Reveal in Finder is the only file-access path. Routes through NSWorkspace via the WKScriptMessage bridge — never traverses the HTTP server.
- **Docker / Linux**: download is **disabled by default**. Admin can opt in via `ALLOW_SOURCE_DOWNLOAD=true`.

## Why this default

The download endpoint exposes the raw bytes of any document the caller can already see in search. That's a meaningful escalation over the chunk-excerpt access read-only API keys are designed for — embedded images, signed PDFs, form data, OCR-skipped content all become extractable in full fidelity. On macOS native specifically, the API runs as the user with full FS access; routing file delivery through the HTTP server would effectively make it a "read any file the user can read" endpoint behind nothing but auth.

Reveal in Finder is a fundamentally safer alternative on macOS — it hits NSWorkspace directly via a WKScriptMessage channel, in-process to the bundled WKWebView app. No HTTP exposure at all.

## Backend changes

- **`config.py`**: new `allow_source_download: bool = False` setting (env: `ALLOW_SOURCE_DOWNLOAD`). Setting docstring documents the rationale and the macOS no-toggle policy.
- **`api/routes/documents.py`**: download endpoint returns 403 with a clear message pointing at both remediations (Reveal in Finder for macOS, env var for Docker). The 403 short-circuits before the doc-existence check so attackers can't probe doc IDs via differential 403 vs 404.
- **`api/routes/system.py`**: `/api/system/health` response gains `allow_source_download` so the frontend can render conditionally without a separate fetch.

## Frontend changes

- **`hooks/useSystemConfig.ts`** (new): one-shot fetch of `/api/system/health` on mount, exposes `allowSourceDownload` + a `loaded` flag (so we hide buttons until the response arrives rather than flicker them off).
- **`types/harborclerk.d.ts`** (new): shared `window.harborclerk` typing replacing duplicate `declare global` blocks in `OnboardingWizard.tsx` and `FoldersPage.tsx`. `revealInFinder` is optional in the type — older Mac clients without the new bridge won't have it.
- **`pages/DocumentDetailPage.tsx`**: new `SourceFileSection` component renders the path + conditional buttons. Uses synchronous client-side detection (`window.harborclerk?.revealInFinder`) for Reveal availability and the system-config hook for Download availability.

## Swift changes

- **`macos/HarborClerk/HarborClerk/ContentView.swift`**: new `RevealInFinderHandler` (`WKScriptMessageHandlerWithReply`) registered on a `"revealInFinder"` channel; JS shim injected as `window.harborclerk.revealInFinder(path)`. Calls `NSWorkspace.shared.activateFileViewerSelecting(URL(fileURLWithPath: path))`.

`activateFileViewerSelecting` handles missing files gracefully — it shows the parent directory if the file itself doesn't exist (e.g. user moved it after ingestion). And it doesn't open the file's contents, just reveals it, so it's a benign action even if a bug ever caused an unexpected path to land in `source_path`.

## Tests

`tests/test_api_system.py`:
- `test_health_check_exposes_allow_source_download_default_false`
- `test_health_check_reflects_allow_source_download_when_set`

`tests/test_api_documents.py`:
- `test_download_returns_403_when_disabled_by_default` — verifies both status code and that the error message points at both remediations
- `test_download_returns_bytes_when_enabled` — flips setting on, confirms file content + Content-Disposition header
- `test_download_403_fires_before_doc_existence_check` — ensures no doc-ID enumeration via differential 403 vs 404

431 passed (+5 new), ruff clean, format clean, frontend type-check + lint + prettier clean.

## Caller-facing change

This PR removes a default capability (download was previously enabled). Anyone running an existing deployment who relied on download will need to set `ALLOW_SOURCE_DOWNLOAD=true` in their compose file after updating. Will note in the next release-notes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)