### PR TITLE
feat(languages): on-demand language packs phases 1-4 (closes silent French OCR regression)

### DIFF
--- a/alembic/versions/0019_documents_ocr_languages_used.py
+++ b/alembic/versions/0019_documents_ocr_languages_used.py
@@ -1,0 +1,30 @@
+"""Add documents.ocr_languages_used to record which languages a doc was OCR'd with.
+
+Population happens in worker/stages/ocr.py after a successful OCR pass.
+NULL is used to mean "we don't know" — that covers legacy docs OCR'd
+before this column existed, plus docs whose OCR is yet to run.
+
+Revision ID: 0019
+Revises: 0018
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY
+
+from alembic import op
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column("ocr_languages_used", ARRAY(sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("documents", "ocr_languages_used")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import SystemMaintenancePage from './pages/SystemMaintenancePage'
 import ServiceLogsPage from './pages/ServiceLogsPage'
 import ChatPage from './pages/ChatPage'
 import HomePage from './pages/HomePage'
+import LanguagesPage from './pages/LanguagesPage'
 import ModelsPage from './pages/ModelsPage'
 import PreferencesPage from './pages/PreferencesPage'
 import RateLimitSettingsPage from './pages/RateLimitSettingsPage'
@@ -61,6 +62,7 @@ export default function App() {
             <Route path="/admin/system/logs" element={<ServiceLogsPage />} />
             <Route path="/admin/system/maintenance" element={<SystemMaintenancePage />} />
             <Route path="/admin/models" element={<ModelsPage />} />
+            <Route path="/admin/languages" element={<LanguagesPage />} />
             <Route path="/admin/retrieval" element={<RetrievalSettingsPage />} />
             <Route path="/admin/rate-limits" element={<RateLimitSettingsPage />} />
           </Route>

--- a/frontend/src/pages/LanguagesPage.tsx
+++ b/frontend/src/pages/LanguagesPage.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import { del, get, patch, post } from '../api'
+
+interface ToolStatus {
+  status: 'not_installed' | 'installed' | 'failed'
+  size_bytes?: number | null
+}
+
+interface LanguageSummary {
+  code: string
+  display_name: string
+  built_in: boolean
+  enabled: boolean
+  tools: Record<string, ToolStatus>
+}
+
+interface ApiResponse {
+  languages: LanguageSummary[]
+}
+
+interface InstallResultItem {
+  tool: string
+  status: string
+  error: string | null
+}
+
+interface InstallResponse {
+  results: InstallResultItem[]
+}
+
+function markBusy(setBusy: Dispatch<SetStateAction<Set<string>>>, code: string, busy: boolean) {
+  setBusy((prev) => {
+    const next = new Set(prev)
+    if (busy) next.add(code)
+    else next.delete(code)
+    return next
+  })
+}
+
+function formatBytes(n: number | null | undefined): string {
+  if (n == null) return ''
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function totalDownloadSize(lang: LanguageSummary): number {
+  return Object.values(lang.tools).reduce((acc, t) => acc + (t.size_bytes ?? 0), 0)
+}
+
+export default function LanguagesPage() {
+  const [languages, setLanguages] = useState<LanguageSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState<Set<string>>(new Set()) // language codes currently mid-action
+
+  const reload = useCallback(async () => {
+    try {
+      const data = await get<ApiResponse>('/api/languages')
+      setLanguages(data.languages)
+      setError('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load languages')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    // ESLint's react-hooks/set-state-in-effect can't see through useCallback,
+    // so it flags any direct call here even though setState only runs after
+    // the awaited fetch resolves. Wrapping in an inline async fn (the
+    // documented codebase pattern — see MEMORY.md "ESLint react-hooks/
+    // set-state-in-effect") sidesteps the false positive.
+    let cancelled = false
+    async function loadInitial() {
+      try {
+        const data = await get<ApiResponse>('/api/languages')
+        if (cancelled) return
+        setLanguages(data.languages)
+        setError('')
+      } catch (e) {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : 'Failed to load languages')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    loadInitial()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Persist enabled_languages whenever the user toggles a language. The
+  // backend normalises (always inserts 'en' first, dedupes, validates),
+  // so we just send the new desired set.
+  const setEnabled = useCallback(
+    async (code: string, enable: boolean) => {
+      const next = enable
+        ? Array.from(new Set([...languages.filter((l) => l.enabled).map((l) => l.code), code]))
+        : languages.filter((l) => l.enabled && l.code !== code).map((l) => l.code)
+      try {
+        await patch('/api/me/preferences', { enabled_languages: next })
+        await reload()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to update enabled languages')
+      }
+    },
+    [languages, reload],
+  )
+
+  const installTools = useCallback(
+    async (code: string, tools: string[]) => {
+      markBusy(setBusy, code, true)
+      try {
+        const result = await post<InstallResponse>(`/api/languages/${code}/install`, { tools })
+        const failures = result.results.filter((r) => r.status === 'failed')
+        if (failures.length > 0) {
+          setError(`Install failed for ${failures.map((f) => `${code}/${f.tool}: ${f.error ?? 'unknown'}`).join(', ')}`)
+        }
+        await reload()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to install language pack')
+      } finally {
+        markBusy(setBusy, code, false)
+      }
+    },
+    [reload],
+  )
+
+  const removeTool = useCallback(
+    async (code: string, tool: string) => {
+      markBusy(setBusy, code, true)
+      try {
+        await del(`/api/languages/${code}/install/${tool}`)
+        await reload()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to remove language pack')
+      } finally {
+        markBusy(setBusy, code, false)
+      }
+    },
+    [reload],
+  )
+
+  const installAndEnable = useCallback(
+    async (lang: LanguageSummary) => {
+      const tools = Object.entries(lang.tools)
+        .filter(([, t]) => t.status !== 'installed')
+        .map(([name]) => name)
+      if (tools.length > 0) {
+        await installTools(lang.code, tools)
+      }
+      if (!lang.enabled) {
+        await setEnabled(lang.code, true)
+      }
+    },
+    [installTools, setEnabled],
+  )
+
+  if (loading) return <div className="text-gray-500 dark:text-gray-400">Loading languages...</div>
+
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Languages</h1>
+      <p className="mb-4 text-sm text-(--color-text-secondary)">
+        Choose which languages Harbor Clerk should process. English is built-in. Other languages download per-tool model
+        files (Tesseract OCR, spaCy entities) on demand.
+      </p>
+
+      {error && (
+        <div className="mb-3 rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden divide-y divide-(--color-border)">
+        {languages.map((lang) => {
+          const isBusy = busy.has(lang.code)
+          const installedToolCount = Object.values(lang.tools).filter((t) => t.status === 'installed').length
+          const totalToolCount = Object.keys(lang.tools).length
+          const allInstalled = totalToolCount > 0 && installedToolCount === totalToolCount
+
+          return (
+            <div key={lang.code} className="px-4 py-3.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[14px] font-medium text-(--color-text-primary)">{lang.display_name}</span>
+                    <span className="text-[11px] font-mono text-gray-400">{lang.code}</span>
+                    {lang.built_in && (
+                      <span className="rounded-md bg-blue-100 dark:bg-blue-900/30 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-400">
+                        built-in
+                      </span>
+                    )}
+                    {lang.enabled && (
+                      <span className="rounded-md bg-green-100 dark:bg-green-900/30 px-1.5 py-0.5 text-[10px] font-medium text-green-700 dark:text-green-400">
+                        enabled
+                      </span>
+                    )}
+                  </div>
+
+                  {!lang.built_in && (
+                    <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px] text-(--color-text-secondary)">
+                      {Object.entries(lang.tools).map(([toolName, status]) => (
+                        <ToolStatusBadge
+                          key={toolName}
+                          tool={toolName}
+                          status={status}
+                          onRemove={isBusy ? undefined : () => removeTool(lang.code, toolName)}
+                          onInstall={
+                            isBusy || status.status === 'installed'
+                              ? undefined
+                              : () => installTools(lang.code, [toolName])
+                          }
+                        />
+                      ))}
+                      {totalToolCount > 0 && (
+                        <span className="text-gray-400">total {formatBytes(totalDownloadSize(lang))}</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex shrink-0 items-center gap-2">
+                  {lang.built_in ? (
+                    <span className="text-[11px] text-gray-400">always on</span>
+                  ) : !allInstalled && !lang.enabled ? (
+                    <button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => installAndEnable(lang)}
+                      className="rounded-md bg-blue-600 px-3 py-1.5 text-[12px] font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {isBusy ? 'Working...' : 'Install & enable'}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => setEnabled(lang.code, !lang.enabled)}
+                      className={`rounded-md px-3 py-1.5 text-[12px] font-medium shadow-xs disabled:opacity-50 ${
+                        lang.enabled
+                          ? 'bg-(--color-bg-tertiary) text-(--color-text-secondary) hover:opacity-80'
+                          : 'bg-blue-600 text-white hover:bg-blue-700'
+                      }`}
+                    >
+                      {isBusy ? 'Working...' : lang.enabled ? 'Disable' : 'Enable'}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <p className="mt-4 text-[11px] text-gray-400">
+        Worker restart required to pick up newly-installed packs. Disabling a language stops new documents from using it
+        for OCR; existing documents keep their previously-extracted text.
+      </p>
+    </div>
+  )
+}
+
+function ToolStatusBadge({
+  tool,
+  status,
+  onInstall,
+  onRemove,
+}: {
+  tool: string
+  status: ToolStatus
+  onInstall?: () => void
+  onRemove?: () => void
+}) {
+  const installed = status.status === 'installed'
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="font-mono uppercase text-[10px] text-gray-500">{tool}</span>
+      <span
+        className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium ${
+          installed
+            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+            : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+        }`}
+      >
+        {installed ? 'installed' : `download ${formatBytes(status.size_bytes)}`}
+      </span>
+      {installed && onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-[10px] text-gray-400 hover:text-red-500 underline-offset-2 hover:underline"
+          title={`Remove ${tool} pack`}
+        >
+          remove
+        </button>
+      )}
+      {!installed && onInstall && (
+        <button
+          type="button"
+          onClick={onInstall}
+          className="text-[10px] text-gray-400 hover:text-blue-600 underline-offset-2 hover:underline"
+          title={`Install ${tool} pack`}
+        >
+          install
+        </button>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -4,6 +4,7 @@ const ITEMS = [
   { to: '/admin/users', label: 'Users', description: 'Manage user accounts and roles' },
   { to: '/admin/keys', label: 'API Keys', description: 'Create and revoke API keys' },
   { to: '/admin/models', label: 'Models', description: 'Download and manage LLM models' },
+  { to: '/admin/languages', label: 'Languages', description: 'Enable additional languages for OCR and entities' },
   { to: '/admin/retrieval', label: 'Retrieval', description: 'Chat and MCP search behavior' },
   { to: '/admin/rate-limits', label: 'Rate Limits', description: 'Default API key rate limits' },
   { to: '/admin/system/status', label: 'System Status', description: 'Health checks and statistics' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 test = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24",
+    "pytest-httpserver>=1.1",
     "ruff>=0.11",
     "pip-audit>=2.7",
 ]

--- a/src/harbor_clerk/api/app.py
+++ b/src/harbor_clerk/api/app.py
@@ -15,6 +15,7 @@ from harbor_clerk.api.routes.auth import router as auth_router
 from harbor_clerk.api.routes.chat import router as chat_router
 from harbor_clerk.api.routes.documents import router as documents_router
 from harbor_clerk.api.routes.jobs import router as jobs_router
+from harbor_clerk.api.routes.languages import router as languages_router
 from harbor_clerk.api.routes.oauth import router as oauth_router
 from harbor_clerk.api.routes.research import router as research_router
 from harbor_clerk.api.routes.search import router as search_router
@@ -383,6 +384,7 @@ def create_app() -> FastAPI:
     app.include_router(chat_router, prefix="/api")
     app.include_router(research_router, prefix="/api")
     app.include_router(watch_router, prefix="/api")
+    app.include_router(languages_router, prefix="/api")
 
     # OAuth 2.1 endpoints (no /api prefix — /.well-known must be at root)
     app.include_router(oauth_router)

--- a/src/harbor_clerk/api/routes/auth.py
+++ b/src/harbor_clerk/api/routes/auth.py
@@ -197,6 +197,15 @@ async def update_preferences(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="page_size must be 10, 25, 50, or 100",
         )
+    if body.enabled_languages is not None:
+        from harbor_clerk.languages import LANGUAGES
+
+        unknown = [c for c in body.enabled_languages if c not in LANGUAGES]
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown language codes: {unknown}",
+            )
 
     result = await session.execute(select(User).where(User.user_id == principal.id))
     user = result.scalar_one_or_none()
@@ -210,6 +219,17 @@ async def update_preferences(
         prefs["page_size"] = body.page_size
     if body.onboardingComplete is not None:
         prefs["onboardingComplete"] = body.onboardingComplete
+    if body.enabled_languages is not None:
+        # Normalise: dedupe, preserve order, always include English (the
+        # bundled fallback). Letting a user accidentally turn off English
+        # would silently disable OCR for every doc — make that impossible.
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for code in ["en", *body.enabled_languages]:
+            if code not in seen:
+                seen.add(code)
+                ordered.append(code)
+        prefs["enabled_languages"] = ordered
 
     await session.execute(update(User).where(User.user_id == principal.id).values(preferences=prefs))
     await session.commit()

--- a/src/harbor_clerk/api/routes/languages.py
+++ b/src/harbor_clerk/api/routes/languages.py
@@ -1,0 +1,199 @@
+"""REST endpoints for managing language packs.
+
+Read-only ``GET /api/languages`` is available to any authenticated user
+(the Languages page lives under System Settings but the read view is
+useful from elsewhere too — e.g. a future "doc was OCR'd as English but
+French is enabled, want to reprocess?" affordance). Mutations (install,
+remove) are admin-only.
+"""
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.api.deps import Principal, require_admin, require_human_user
+from harbor_clerk.api.schemas.languages import (
+    InstallRequest,
+    InstallResponse,
+    InstallToolResult,
+    LanguagesListResponse,
+    LanguageSummary,
+    RemoveResponse,
+    ToolStatus,
+)
+from harbor_clerk.db import get_session
+from harbor_clerk.lang_packs.manager import (
+    download_artifact,
+    installed_tools_for,
+    remove_artifact,
+    remove_language,
+)
+from harbor_clerk.languages import LANGUAGES, Tool
+from harbor_clerk.models import User
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/languages", tags=["languages"])
+
+
+async def _get_enabled_languages(principal: Principal, session: AsyncSession) -> set[str]:
+    """Read the operator's enabled_languages preference from their user record.
+
+    Single-tenant appliance, so any human user's preference is effectively
+    the global setting for that user. API-key callers don't have a
+    preferences blob; they see English-only enabled. Falls back to
+    {'en'} if the preference isn't set yet (fresh install).
+    """
+    if principal.type != "user":
+        return {"en"}
+    user = await session.get(User, principal.id)
+    if user is None:
+        return {"en"}
+    prefs = user.preferences or {}
+    enabled = prefs.get("enabled_languages")
+    if isinstance(enabled, list) and enabled:
+        return {str(c) for c in enabled if isinstance(c, str)}
+    return {"en"}
+
+
+def _summarize_language(code: str, enabled: set[str]) -> LanguageSummary:
+    spec = LANGUAGES[code]
+    installed = installed_tools_for(code)
+    tools_dict: dict[str, ToolStatus] = {}
+    for tool, artifact in spec.artifacts.items():
+        tools_dict[tool.value] = ToolStatus(
+            status="installed" if tool in installed else "not_installed",
+            size_bytes=artifact.size_bytes,
+        )
+    return LanguageSummary(
+        code=code,
+        display_name=spec.display_name,
+        built_in=not spec.artifacts,
+        enabled=code in enabled,
+        tools=tools_dict,
+    )
+
+
+@router.get("", response_model=LanguagesListResponse)
+async def list_languages(
+    principal: Principal = Depends(require_human_user),
+    session: AsyncSession = Depends(get_session),
+) -> LanguagesListResponse:
+    """Return the curated language list with per-tool install state and the
+    operator's current enabled-set."""
+    enabled = await _get_enabled_languages(principal, session)
+    return LanguagesListResponse(
+        languages=[_summarize_language(code, enabled) for code in LANGUAGES],
+    )
+
+
+@router.post("/{lang_code}/install", response_model=InstallResponse)
+async def install_language_tools(
+    lang_code: str,
+    body: InstallRequest,
+    principal: Principal = Depends(require_admin),
+) -> InstallResponse:
+    """Download and install one or more tool artifacts for a language.
+
+    Synchronous from the API's perspective — the call returns when every
+    requested artifact has been fetched and verified, or failed. Per-call
+    runtime is bounded by the artifact size; French OCR (~1 MB) and NER
+    (~16 MB) finish in seconds on residential broadband. If we ever need
+    to install much larger artifacts, switch to a background-task pattern
+    with SSE progress.
+
+    Each artifact is installed independently; one failure doesn't roll
+    back the others.
+    """
+    if lang_code not in LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown language: {lang_code!r}",
+        )
+    spec = LANGUAGES[lang_code]
+
+    requested: list[Tool] = []
+    for t in body.tools:
+        try:
+            requested.append(Tool(t))
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown tool: {t!r}",
+            )
+    for tool in requested:
+        if tool not in spec.artifacts:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Language {lang_code!r} has no {tool.value} artifact",
+            )
+
+    # download_artifact uses synchronous httpx.stream; run in a worker
+    # thread so the event loop stays responsive for other requests.
+    loop = asyncio.get_running_loop()
+    results: list[InstallToolResult] = []
+    for tool in requested:
+        result = await loop.run_in_executor(None, download_artifact, lang_code, tool)
+        results.append(
+            InstallToolResult(
+                tool=tool.value,
+                status=result.status,
+                error=result.error,
+            )
+        )
+        if result.status == "failed":
+            logger.warning(
+                "Language pack install failed: %s/%s — %s",
+                lang_code,
+                tool.value,
+                result.error,
+            )
+    return InstallResponse(results=results)
+
+
+@router.delete("/{lang_code}/install/{tool_name}", response_model=RemoveResponse)
+async def remove_language_tool(
+    lang_code: str,
+    tool_name: str,
+    principal: Principal = Depends(require_admin),
+) -> RemoveResponse:
+    """Remove a single tool artifact for a language. Idempotent."""
+    if lang_code not in LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown language: {lang_code!r}",
+        )
+    try:
+        tool = Tool(tool_name)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown tool: {tool_name!r}",
+        )
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, remove_artifact, lang_code, tool)
+    return RemoveResponse(status="removed")
+
+
+@router.delete("/{lang_code}", response_model=RemoveResponse)
+async def remove_language_completely(
+    lang_code: str,
+    principal: Principal = Depends(require_admin),
+) -> RemoveResponse:
+    """Remove every installed artifact for a language. Idempotent.
+
+    Convenience for the "Disable French entirely" UI affordance — saves
+    the client from looping over Tool variants and gracefully handles
+    partial installs.
+    """
+    if lang_code not in LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown language: {lang_code!r}",
+        )
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, remove_language, lang_code)
+    return RemoveResponse(status="removed")

--- a/src/harbor_clerk/api/schemas/auth.py
+++ b/src/harbor_clerk/api/schemas/auth.py
@@ -32,6 +32,13 @@ class PreferencesUpdate(BaseModel):
     # Naming is camelCase to match the existing frontend type and the JSONB
     # key the wizard reads — mixing snake/camel here is intentional, not a bug.
     onboardingComplete: bool | None = None
+    # ISO 639-1 codes of languages the operator has opted in to. Drives
+    # OCR/NER tool selection at job time. English is always implicitly
+    # enabled (it's bundled and is the fallback) — the API normalises by
+    # always inserting "en" if it's missing rather than rejecting the
+    # update, so a user who flips off French doesn't accidentally turn
+    # off OCR entirely.
+    enabled_languages: list[str] | None = None
 
 
 class PasswordChangeRequest(BaseModel):

--- a/src/harbor_clerk/api/schemas/languages.py
+++ b/src/harbor_clerk/api/schemas/languages.py
@@ -1,0 +1,46 @@
+"""Pydantic models for the /api/languages endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+class ToolStatus(BaseModel):
+    """Per-tool installation status for one language."""
+
+    status: str = Field(description="not_installed | installed | failed")
+    size_bytes: int | None = Field(default=None, description="Approximate download size from the static map")
+
+
+class LanguageSummary(BaseModel):
+    """One row in the /api/languages response — what the UI renders per language."""
+
+    code: str = Field(description="ISO 639-1 code (e.g. 'fr')")
+    display_name: str
+    built_in: bool = Field(description="True for languages bundled with the app (English)")
+    enabled: bool = Field(description="True if this language is in the user's enabled_languages preference")
+    tools: dict[str, ToolStatus] = Field(
+        description="Per-tool status keyed by Tool.value (e.g. 'ocr', 'ner')",
+    )
+
+
+class LanguagesListResponse(BaseModel):
+    languages: list[LanguageSummary]
+
+
+class InstallRequest(BaseModel):
+    """Body for POST /api/languages/{code}/install."""
+
+    tools: list[str] = Field(description="Tool.value names to install (e.g. ['ocr', 'ner'])")
+
+
+class InstallToolResult(BaseModel):
+    tool: str
+    status: str = Field(description="installed | already_installed | failed")
+    error: str | None = None
+
+
+class InstallResponse(BaseModel):
+    results: list[InstallToolResult]
+
+
+class RemoveResponse(BaseModel):
+    status: str = Field(description="removed")

--- a/src/harbor_clerk/lang_packs/__init__.py
+++ b/src/harbor_clerk/lang_packs/__init__.py
@@ -1,0 +1,9 @@
+"""On-demand language pack management.
+
+See docs/superpowers/specs/2026-05-02-language-packs-on-demand-design.md
+for the full design and rationale.
+
+Submodules:
+  storage  -- disk layout helpers (where artifacts live on disk)
+  manager  -- download / verify / remove / status operations
+"""

--- a/src/harbor_clerk/lang_packs/manager.py
+++ b/src/harbor_clerk/lang_packs/manager.py
@@ -1,0 +1,179 @@
+"""Download / verify / remove language pack artifacts.
+
+Synchronous for the initial cut. The REST endpoints wrap calls in
+``run_in_executor`` to keep the event loop responsive. A future
+enhancement could stream progress over SSE for the Languages UI;
+that's not needed yet because per-language artifacts are small (1-50 MB
+each, tens of seconds at most on residential broadband).
+
+Each operation is idempotent and safe to retry. Partial downloads are
+written to a ``.tmp`` sibling file and atomic-renamed only after the
+SHA256 verifies; an interrupted download leaves a ``.tmp`` file but
+not a corrupt artifact.
+"""
+
+import hashlib
+import logging
+import shutil
+from dataclasses import dataclass
+from typing import Literal
+
+import httpx
+
+from harbor_clerk.lang_packs.storage import artifact_path, lang_dir
+from harbor_clerk.languages import LANGUAGES, Tool
+
+logger = logging.getLogger(__name__)
+
+DownloadStatus = Literal["installed", "already_installed", "failed"]
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    """Outcome of a download_artifact() call."""
+
+    status: DownloadStatus
+    error: str | None = None
+    bytes_downloaded: int = 0
+
+
+def download_artifact(lang_code: str, tool: Tool) -> DownloadResult:
+    """Fetch + SHA-verify + install one (lang, tool) artifact.
+
+    Idempotent: if the artifact is already on disk and verifies, returns
+    ``already_installed`` without re-fetching.
+    """
+    if lang_code not in LANGUAGES:
+        return DownloadResult(status="failed", error=f"unknown language: {lang_code!r}")
+    spec = LANGUAGES[lang_code].artifacts.get(tool)
+    if spec is None:
+        return DownloadResult(
+            status="failed",
+            error=f"language {lang_code!r} has no {tool.value} artifact",
+        )
+
+    target = artifact_path(lang_code, tool)
+
+    if target.exists() and verify_artifact(lang_code, tool):
+        return DownloadResult(status="already_installed")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_target = target.with_suffix(target.suffix + ".tmp")
+
+    try:
+        with httpx.stream("GET", spec.url, timeout=300.0, follow_redirects=True) as resp:
+            resp.raise_for_status()
+            sha = hashlib.sha256()
+            bytes_written = 0
+            with open(tmp_target, "wb") as f:
+                for chunk in resp.iter_bytes(chunk_size=64 * 1024):
+                    f.write(chunk)
+                    sha.update(chunk)
+                    bytes_written += len(chunk)
+
+        actual_sha = sha.hexdigest()
+        if actual_sha != spec.sha256:
+            tmp_target.unlink(missing_ok=True)
+            return DownloadResult(
+                status="failed",
+                error=f"sha256 mismatch for {lang_code}/{tool.value}: "
+                f"expected {spec.sha256[:8]}..., got {actual_sha[:8]}...",
+            )
+
+        tmp_target.replace(target)
+        logger.info(
+            "Installed lang pack %s/%s (%d bytes) at %s",
+            lang_code,
+            tool.value,
+            bytes_written,
+            target,
+        )
+        return DownloadResult(status="installed", bytes_downloaded=bytes_written)
+    except Exception as e:
+        tmp_target.unlink(missing_ok=True)
+        return DownloadResult(status="failed", error=f"{type(e).__name__}: {e}")
+
+
+def verify_artifact(lang_code: str, tool: Tool) -> bool:
+    """Re-check the SHA256 of an on-disk artifact.
+
+    Used by the REST endpoint to detect tampering or bit-rot, and by
+    download_artifact() to short-circuit when the artifact already
+    matches.
+    """
+    if lang_code not in LANGUAGES:
+        return False
+    spec = LANGUAGES[lang_code].artifacts.get(tool)
+    if spec is None:
+        return False
+    target = artifact_path(lang_code, tool)
+    if not target.exists():
+        return False
+    sha = hashlib.sha256()
+    with open(target, "rb") as f:
+        while chunk := f.read(64 * 1024):
+            sha.update(chunk)
+    return sha.hexdigest() == spec.sha256
+
+
+def remove_artifact(lang_code: str, tool: Tool) -> None:
+    """Delete a single artifact from disk. Idempotent.
+
+    Cleans up empty parent directories up to (but not including) the
+    per-language root, so a fully-removed language leaves only an empty
+    ``<lang_packs>/<lang>/`` directory rather than orphaned subdirs.
+    """
+    if lang_code not in LANGUAGES:
+        return
+    spec = LANGUAGES[lang_code].artifacts.get(tool)
+    if spec is None:
+        return
+    target = artifact_path(lang_code, tool)
+    target.unlink(missing_ok=True)
+
+    # Walk up removing empty intermediate dirs, stopping at the
+    # per-language root (we leave that in place even when empty so the
+    # UI's "is this language installed at all" check is consistent).
+    lang_root = lang_dir(lang_code)
+    parent = target.parent
+    while parent != lang_root and parent != parent.parent:
+        try:
+            parent.rmdir()
+            parent = parent.parent
+        except OSError:
+            break  # not empty, stop
+
+
+def remove_language(lang_code: str) -> None:
+    """Remove every installed artifact for one language. Idempotent.
+
+    Convenience for the "Disable French entirely" UI affordance — saves
+    callers from looping over Tool variants themselves and gracefully
+    handles partial installs.
+    """
+    if lang_code not in LANGUAGES:
+        return
+    root = lang_dir(lang_code)
+    if root.exists():
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def installed_tools_for(lang_code: str) -> set[Tool]:
+    """Which of this language's artifacts are installed and verified."""
+    if lang_code not in LANGUAGES:
+        return set()
+    spec = LANGUAGES[lang_code]
+    return {tool for tool in spec.artifacts if verify_artifact(lang_code, tool)}
+
+
+def installed_languages() -> list[str]:
+    """ISO codes of languages with at least one installed-and-verified
+    artifact. English is always included (it's bundled, not installed)."""
+    out = []
+    for code, spec in LANGUAGES.items():
+        if not spec.artifacts:
+            # Bundled language — always considered "installed"
+            out.append(code)
+        elif installed_tools_for(code):
+            out.append(code)
+    return out

--- a/src/harbor_clerk/lang_packs/storage.py
+++ b/src/harbor_clerk/lang_packs/storage.py
@@ -1,0 +1,63 @@
+"""Disk layout for downloaded language artifacts.
+
+Layout::
+
+    <lang_packs_dir>/<lang_code>/<install_subpath>
+
+Configurable via the ``LANG_PACKS_DIR`` env var. Defaults to a platform-
+appropriate Application Support directory on macOS, ``~/.local/share/...``
+on Linux. Same convention as the LLM ``models_dir``.
+
+Tesseract is wired to look at this directory by setting the
+``TESSDATA_PREFIX`` env var to include the per-language tesseract subdirs
+(future work — phase 4 of the language-packs implementation plan).
+spaCy models load by extracting their wheel into the per-language ner
+subdir and pointing ``spacy.util.load_model_from_path`` at the result.
+"""
+
+import os
+import platform
+from pathlib import Path
+
+from harbor_clerk.languages import LANGUAGES, Tool
+
+
+def lang_packs_dir() -> Path:
+    """Root directory for downloaded language artifacts.
+
+    Override with the ``LANG_PACKS_DIR`` env var (used by tests to point
+    at a temp directory; production users should rely on the default).
+    """
+    env_dir = os.environ.get("LANG_PACKS_DIR")
+    if env_dir:
+        return Path(env_dir)
+    if platform.system() == "Darwin":
+        return Path.home() / "Library" / "Application Support" / "Harbor Clerk" / "lang-packs"
+    return Path.home() / ".local" / "share" / "harbor-clerk" / "lang-packs"
+
+
+def lang_dir(lang_code: str) -> Path:
+    """Per-language root, where all of that language's tool artifacts live."""
+    return lang_packs_dir() / lang_code
+
+
+def artifact_path(lang_code: str, tool: Tool) -> Path:
+    """Where this artifact lives on disk after download.
+
+    Raises KeyError if the language doesn't exist or the language doesn't
+    have an artifact for the requested tool — caller is responsible for
+    feature-detecting before calling.
+    """
+    spec = LANGUAGES[lang_code]
+    artifact = spec.artifacts[tool]
+    return lang_dir(lang_code) / artifact.install_subpath
+
+
+def tesseract_data_dir(lang_code: str) -> Path:
+    """The directory Tesseract should add to TESSDATA_PREFIX for this lang.
+
+    Tesseract reads .traineddata files from each path in TESSDATA_PREFIX
+    (colon-separated). We give it one entry per enabled language so it
+    finds e.g. ``fra.traineddata`` under ``<lang_packs>/fr/tesseract/``.
+    """
+    return lang_dir(lang_code) / "tesseract"

--- a/src/harbor_clerk/lang_packs/tesseract_setup.py
+++ b/src/harbor_clerk/lang_packs/tesseract_setup.py
@@ -1,0 +1,113 @@
+"""Wire Tesseract to find both bundled and per-language-pack .traineddata files.
+
+Tesseract's ``--tessdata-dir`` flag and ``TESSDATA_PREFIX`` env var only
+accept a single path, not colon-separated. To make both bundled languages
+(English, OSD) and per-language packs (French, etc.) findable, we
+maintain a unified directory of symlinks at
+``<lang_packs_dir>/_tessdata/`` and point Tesseract at it.
+
+Called once at worker startup. Re-running is safe (idempotent).
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from harbor_clerk.lang_packs.manager import installed_languages, installed_tools_for
+from harbor_clerk.lang_packs.storage import lang_packs_dir, tesseract_data_dir
+from harbor_clerk.languages import Tool
+
+logger = logging.getLogger(__name__)
+
+# Common bundled-tessdata locations to probe when TESSDATA_PREFIX is unset
+# or already points at our unified dir (e.g. on a worker restart). First
+# match wins.
+_BUNDLED_FALLBACK_PATHS = [
+    "/usr/share/tesseract-ocr/4.00/tessdata",  # Debian/Ubuntu
+    "/usr/share/tesseract-ocr/5/tessdata",
+    "/usr/share/tessdata",
+    "/opt/homebrew/share/tessdata",  # macOS Homebrew (Apple Silicon)
+    "/usr/local/share/tessdata",  # macOS Homebrew (Intel)
+]
+
+
+def unified_tessdata_dir() -> Path:
+    """The single directory Tesseract sees as its tessdata path."""
+    return lang_packs_dir() / "_tessdata"
+
+
+def _find_bundled_tessdata_dir(unified: Path) -> Path | None:
+    """Locate the bundled tessdata directory.
+
+    Honors the existing ``TESSDATA_PREFIX`` env var (set by the macOS
+    bundle launcher or by Docker compose) unless it already points at
+    our unified dir — in which case we probe the platform fallbacks
+    instead, since the unified dir is downstream of the bundled one.
+    """
+    env = os.environ.get("TESSDATA_PREFIX")
+    if env:
+        env_path = Path(env)
+        if env_path.is_dir() and env_path.resolve() != unified.resolve():
+            return env_path
+    for candidate in _BUNDLED_FALLBACK_PATHS:
+        if Path(candidate).is_dir():
+            return Path(candidate)
+    return None
+
+
+def _symlink_traineddata_files(src_dir: Path, unified: Path) -> int:
+    """Symlink every .traineddata in src_dir into unified. Skips files
+    already present (preserves whatever's there). Returns symlinks added.
+    """
+    if not src_dir.is_dir():
+        return 0
+    if src_dir.resolve() == unified.resolve():
+        return 0  # don't symlink a dir into itself
+    added = 0
+    for src in src_dir.glob("*.traineddata"):
+        link = unified / src.name
+        if link.exists() or link.is_symlink():
+            continue
+        try:
+            link.symlink_to(src.resolve())
+            added += 1
+        except OSError:
+            logger.exception("Failed to symlink %s -> %s", link, src)
+    return added
+
+
+def setup_unified_tessdata_dir() -> Path:
+    """Create the unified tessdata dir, populate it from bundled + installed
+    packs, and override TESSDATA_PREFIX to point at it.
+
+    Idempotent. Returns the unified dir path.
+
+    Limitation: per-language packs installed AFTER worker startup are not
+    visible until the next worker restart. Future improvement: refresh
+    on-demand at OCR time, or have the manager call this function when
+    a new pack is installed.
+    """
+    unified = unified_tessdata_dir()
+    unified.mkdir(parents=True, exist_ok=True)
+
+    bundled = _find_bundled_tessdata_dir(unified)
+    if bundled is not None:
+        added = _symlink_traineddata_files(bundled, unified)
+        if added:
+            logger.info("tessdata: symlinked %d bundled file(s) from %s", added, bundled)
+    else:
+        logger.warning(
+            "tessdata: could not locate bundled tessdata dir; OCR may fall back to "
+            "tesseract's compile-time default. Set TESSDATA_PREFIX to point at it."
+        )
+
+    pack_added = 0
+    for lang_code in installed_languages():
+        if Tool.OCR not in installed_tools_for(lang_code):
+            continue
+        pack_added += _symlink_traineddata_files(tesseract_data_dir(lang_code), unified)
+    if pack_added:
+        logger.info("tessdata: symlinked %d language-pack file(s) into %s", pack_added, unified)
+
+    os.environ["TESSDATA_PREFIX"] = str(unified)
+    return unified

--- a/src/harbor_clerk/languages.py
+++ b/src/harbor_clerk/languages.py
@@ -1,0 +1,85 @@
+"""Static map of (language, tool) -> downloadable artifact spec.
+
+Single source of truth for what we know how to install per-language. The
+download manager (lang_packs/manager.py) consults this map; the System
+Settings UI renders it; the worker reads the user preferences and picks
+the right artifacts at job time.
+
+Adding a new language: pin the upstream URL + SHA256 + approximate size
+and the on-disk install subpath. SHAs are real values from the upstream
+artifacts; ``download_artifact`` will refuse to install anything whose
+content hash doesn't match. To refresh a SHA after an upstream republish,
+fetch and verify the new artifact, then update both the SHA and the
+install subpath (e.g. bump the version segment in the wheel filename).
+
+English ships in the bundle and has no per-language download. Embedder
+is intentionally absent — multilingual-e5-small handles 100+ languages
+out of the box, so there's no per-language artifact for it.
+
+See docs/superpowers/specs/2026-05-02-language-packs-on-demand-design.md
+for the full design and rationale.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Tool(Enum):
+    """Tools that have per-language artifacts. Extension point — add new
+    tools here as Harbor Clerk grows (e.g. a per-language LLM stylist).
+    """
+
+    OCR = "ocr"  # Tesseract traineddata
+    NER = "ner"  # spaCy *_core_news_sm or *_core_web_sm
+
+
+@dataclass(frozen=True)
+class ArtifactSpec:
+    """One downloadable artifact for one (language, tool) pair."""
+
+    url: str  # https URL to fetch from
+    sha256: str  # hex digest, exactly 64 chars
+    size_bytes: int  # approximate, for UI download-size display
+    install_subpath: str  # relative to lang_packs/<lang>/
+
+
+@dataclass(frozen=True)
+class LanguageSpec:
+    """Everything we know about a single language."""
+
+    code: str  # ISO 639-1, e.g. "fr"
+    display_name: str  # e.g. "French"
+    artifacts: dict[Tool, ArtifactSpec] = field(default_factory=dict)
+
+
+# Curated default list. English is bundled; French is the headline use
+# case (currently silently OCR'd as English — see PR #258 release notes).
+# Additional languages will land in a follow-up PR once the foundation
+# is shipped — adding entries here is purely additive.
+LANGUAGES: dict[str, LanguageSpec] = {
+    "en": LanguageSpec(
+        code="en",
+        display_name="English",
+        # Bundled in the app — no per-language download. The empty
+        # artifacts map is the signal "this language is built-in."
+        artifacts={},
+    ),
+    "fr": LanguageSpec(
+        code="fr",
+        display_name="French",
+        artifacts={
+            Tool.OCR: ArtifactSpec(
+                url="https://github.com/tesseract-ocr/tessdata_fast/raw/main/fra.traineddata",
+                sha256="ced037562e8c80c13122dece28dd477d399af80911a28791a66a63ac1e3445ca",
+                size_bytes=1_130_365,  # ~1.1 MB
+                install_subpath="tesseract/fra.traineddata",
+            ),
+            Tool.NER: ArtifactSpec(
+                url="https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.8.0/fr_core_news_sm-3.8.0-py3-none-any.whl",
+                sha256="7d6ad14cd5078e53147bfbf70fb9d433c6a3865b695fda2657140bbc59a27e29",
+                size_bytes=16_271_721,  # ~16 MB
+                install_subpath="ner/fr_core_news_sm-3.8.0-py3-none-any.whl",
+            ),
+        },
+    ),
+}

--- a/src/harbor_clerk/models/document.py
+++ b/src/harbor_clerk/models/document.py
@@ -1,4 +1,5 @@
 from sqlalchemy import BigInteger, Boolean, Enum, ForeignKey, Integer, LargeBinary, Text, text
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 
 from harbor_clerk.models.base import Base, created_at, updated_at, uuid_pk
@@ -39,6 +40,14 @@ class Document(Base):
     size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     original_bucket: Mapped[str | None] = mapped_column(Text, nullable=True)
     original_object_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # ISO 639-1 codes of the languages this doc was OCR'd with. NULL for
+    # non-OCR'd docs and for legacy pre-language-packs docs (we can't
+    # retroactively know what was used). Populated by worker/stages/ocr.py
+    # after a successful OCR pass.
+    ocr_languages_used: Mapped[list[str] | None] = mapped_column(
+        ARRAY(Text),
+        nullable=True,
+    )
 
     created_at: Mapped[created_at]
     updated_at: Mapped[updated_at]

--- a/src/harbor_clerk/worker/entry.py
+++ b/src/harbor_clerk/worker/entry.py
@@ -279,6 +279,21 @@ def main():
 
     _resolve_tmpdir_symlinks()
 
+    # Set up the unified Tesseract data dir so per-language pack
+    # .traineddata files are findable alongside bundled ones. Idempotent
+    # — re-running on worker restart picks up packs installed since the
+    # previous launch. Only relevant for the cpu queue (which runs OCR);
+    # cheap enough to do unconditionally.
+    try:
+        from harbor_clerk.lang_packs.tesseract_setup import setup_unified_tessdata_dir
+
+        setup_unified_tessdata_dir()
+    except Exception:
+        # Don't block worker startup on lang-pack setup failures — OCR
+        # will fall back to whatever TESSDATA_PREFIX was originally set
+        # to (bundled English-only).
+        logger.exception("Failed to set up unified tessdata dir; OCR may not see language packs")
+
     stages: list[JobStage] = []
     for q in args.queues:
         stages.extend(QUEUE_STAGES[q])

--- a/src/harbor_clerk/worker/ocr_languages.py
+++ b/src/harbor_clerk/worker/ocr_languages.py
@@ -1,0 +1,118 @@
+"""OCR language resolution: preferences -> Tesseract `-l` arg.
+
+Reads the operator's ``enabled_languages`` preference, intersects it with
+languages whose Tesseract artifact is actually installed, and produces
+the ``-l eng+fra+...`` argument that pytesseract expects.
+
+English is always included (it's bundled and is the safe fallback);
+turning it off in preferences is impossible by API design.
+"""
+
+import logging
+
+from sqlalchemy import select
+
+from harbor_clerk.lang_packs.manager import installed_tools_for
+from harbor_clerk.languages import LANGUAGES, Tool
+from harbor_clerk.models import User
+from harbor_clerk.models.enums import UserRole
+
+logger = logging.getLogger(__name__)
+
+# ISO 639-1 -> Tesseract's 3-letter language code (only differences from
+# the ISO code; languages where they match can be derived). Add entries
+# as new languages land in LANGUAGES.
+_ISO_TO_TESSERACT = {
+    "en": "eng",
+    "fr": "fra",
+    "de": "deu",
+    "es": "spa",
+    "it": "ita",
+    "pt": "por",
+    "nl": "nld",
+}
+
+
+def iso_to_tesseract(iso_code: str) -> str:
+    """ISO 639-1 -> Tesseract's 3-letter code. Falls back to the ISO code
+    if no mapping is registered (most languages happen to use 3-letter
+    codes already)."""
+    return _ISO_TO_TESSERACT.get(iso_code, iso_code)
+
+
+def get_enabled_languages_from_preferences(session) -> list[str]:
+    """Read the global enabled_languages preference (single-tenant app, so
+    we use any admin user's setting). Returns ISO 639-1 codes.
+
+    Returns ``["en"]`` on a fresh install (no admin yet, no preference
+    set yet) — English is always implicitly enabled.
+    """
+    user = session.execute(
+        select(User).where(User.role == UserRole.admin).order_by(User.created_at).limit(1)
+    ).scalar_one_or_none()
+    if user is None:
+        return ["en"]
+    prefs = user.preferences or {}
+    enabled = prefs.get("enabled_languages")
+    if isinstance(enabled, list) and enabled:
+        codes = [c for c in enabled if isinstance(c, str) and c in LANGUAGES]
+        if "en" not in codes:
+            codes.insert(0, "en")
+        return codes
+    return ["en"]
+
+
+def resolve_ocr_languages(enabled_iso: list[str]) -> list[str]:
+    """Filter the enabled list to ISO codes whose Tesseract pack is
+    installed (or built-in). English is always included.
+
+    Returns the ISO codes — the caller maps to Tesseract's 3-letter
+    codes via ``iso_to_tesseract`` when building the ``-l`` arg.
+    """
+    out = ["en"]
+    seen = {"en"}
+    for code in enabled_iso:
+        if code in seen:
+            continue
+        if code == "en":
+            continue
+        spec = LANGUAGES.get(code)
+        if spec is None:
+            continue
+        if Tool.OCR not in spec.artifacts:
+            # Language exists in our map but doesn't ship an OCR pack
+            # (rare; future-proofing for a NER-only language entry).
+            continue
+        if Tool.OCR not in installed_tools_for(code):
+            logger.warning(
+                "OCR: language %r is enabled but the Tesseract pack isn't installed; "
+                "OCR will skip it. Install via /api/languages/%s/install.",
+                code,
+                code,
+            )
+            continue
+        out.append(code)
+        seen.add(code)
+    return out
+
+
+def tesseract_lang_arg(iso_codes: list[str]) -> str:
+    """Build the Tesseract ``-l`` argument from ISO codes.
+
+    >>> tesseract_lang_arg(["en", "fr"])
+    'eng+fra'
+    """
+    return "+".join(iso_to_tesseract(c) for c in iso_codes)
+
+
+def get_ocr_languages_for_doc(session) -> tuple[list[str], str]:
+    """One-stop: read preferences, filter to installed packs, return both
+    the ISO list (for ``ocr_languages_used``) and the Tesseract arg
+    (for pytesseract).
+
+    Returns ``(["en", "fr"], "eng+fra")`` for the typical post-install
+    French case.
+    """
+    enabled = get_enabled_languages_from_preferences(session)
+    iso_codes = resolve_ocr_languages(enabled)
+    return iso_codes, tesseract_lang_arg(iso_codes)

--- a/src/harbor_clerk/worker/stages/ocr.py
+++ b/src/harbor_clerk/worker/stages/ocr.py
@@ -16,20 +16,25 @@ from harbor_clerk.events import publish_job_event
 from harbor_clerk.models import Document, DocumentPage, IngestionJob
 from harbor_clerk.models.enums import JobStage
 from harbor_clerk.storage import get_storage
+from harbor_clerk.worker.ocr_languages import get_ocr_languages_for_doc
 from harbor_clerk.worker.pipeline import check_pipeline_seq, mark_stage_done, mark_stage_running
 
 logger = logging.getLogger(__name__)
 
-TESSERACT_LANG = "eng+fra"
 DPI = 300
 
 
-def _ocr_image_bytes(image_data: bytes) -> tuple[str, float]:
-    """OCR a single image, return (text, confidence)."""
+def _ocr_image_bytes(image_data: bytes, lang: str) -> tuple[str, float]:
+    """OCR a single image with the given Tesseract ``-l`` argument.
+
+    Returns ``(text, average_word_confidence)``. The confidence is the
+    mean of non-empty Tesseract word confidences in [0, 100]; 0.0 when
+    no words were extracted.
+    """
     img = Image.open(_io.BytesIO(image_data))
     # Get detailed data for confidence
-    data = pytesseract.image_to_data(img, lang=TESSERACT_LANG, output_type=pytesseract.Output.DICT)
-    text = pytesseract.image_to_string(img, lang=TESSERACT_LANG)
+    data = pytesseract.image_to_data(img, lang=lang, output_type=pytesseract.Output.DICT)
+    text = pytesseract.image_to_string(img, lang=lang)
 
     # Compute average confidence from non-empty words
     confs = [int(c) for c, t in zip(data["conf"], data["text"]) if t.strip() and int(c) >= 0]
@@ -80,6 +85,14 @@ def run_ocr(doc_id: uuid.UUID) -> None:
 
         mime = (doc.mime_type or "").lower()
 
+        # Resolve which Tesseract languages to use for this doc.
+        # Honors the operator's enabled_languages preference, filtered to
+        # those with installed packs. English is always included as the
+        # safe fallback. See harbor_clerk/worker/ocr_languages.py for
+        # the resolution rules.
+        ocr_iso, ocr_lang = get_ocr_languages_for_doc(session)
+        logger.info("OCR for doc %s: using languages %s (-l %s)", doc_id, ocr_iso, ocr_lang)
+
         # Update job progress total
         job = session.execute(
             select(IngestionJob).where(
@@ -93,7 +106,7 @@ def run_ocr(doc_id: uuid.UUID) -> None:
             job.progress_total = 1
             session.commit()
 
-            text, confidence = _ocr_image_bytes(data)
+            text, confidence = _ocr_image_bytes(data, lang=ocr_lang)
 
             # Race check before writing results
             if not check_pipeline_seq(session, doc_id, worker_seq):
@@ -110,6 +123,7 @@ def run_ocr(doc_id: uuid.UUID) -> None:
             page.ocr_used = True
             page.ocr_confidence = confidence
             doc.extracted_chars = len(text)
+            doc.ocr_languages_used = ocr_iso
 
             job.progress_current = 1
             session.commit()
@@ -138,7 +152,7 @@ def run_ocr(doc_id: uuid.UUID) -> None:
                 img.save(buf, format="PNG")
                 img_bytes = buf.getvalue()
 
-                text, confidence = _ocr_image_bytes(img_bytes)
+                text, confidence = _ocr_image_bytes(img_bytes, lang=ocr_lang)
                 ocr_results.append((page_num, text, confidence))
 
             # Race check before writing results
@@ -177,6 +191,7 @@ def run_ocr(doc_id: uuid.UUID) -> None:
                 publish_job_event(doc_id, "ocr", "running", progress=i + 1, total=len(images))
 
             doc.extracted_chars = total_chars
+            doc.ocr_languages_used = ocr_iso
             session.commit()
         else:
             logger.warning("OCR requested for unsupported mime type: %s", mime)

--- a/tests/api/test_languages_endpoints.py
+++ b/tests/api/test_languages_endpoints.py
@@ -1,0 +1,245 @@
+"""Tests for /api/languages endpoints.
+
+Mocks the actual download by patching the LANGUAGES static map to point
+at httpserver fixtures, so install/remove paths exercise real code
+without hitting upstream servers.
+"""
+
+import hashlib
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from harbor_clerk.lang_packs import manager as lp_manager
+from harbor_clerk.languages import LANGUAGES, ArtifactSpec, LanguageSpec, Tool
+from tests.conftest import auth_header
+
+
+@pytest.fixture(autouse=True)
+def _isolated_lang_packs_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+
+
+@pytest.fixture
+def patched_french(monkeypatch, httpserver: HTTPServer):
+    """Replace LANGUAGES['fr'] with a spec whose URLs point at httpserver."""
+    payload = b"FAKE-TRAINEDDATA-CONTENT-FOR-API-TESTS"
+    sha = hashlib.sha256(payload).hexdigest()
+    httpserver.expect_request("/fra.traineddata").respond_with_data(payload)
+    fake = LanguageSpec(
+        code="fr",
+        display_name="French",
+        artifacts={
+            Tool.OCR: ArtifactSpec(
+                url=httpserver.url_for("/fra.traineddata"),
+                sha256=sha,
+                size_bytes=len(payload),
+                install_subpath="tesseract/fra.traineddata",
+            ),
+        },
+    )
+    monkeypatch.setitem(LANGUAGES, "fr", fake)
+    return fake
+
+
+# --- list_languages ---
+
+
+async def test_list_languages_returns_curated_set(client, admin_user, admin_token):
+    resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    codes = {lang["code"] for lang in resp.json()["languages"]}
+    assert "en" in codes
+    assert "fr" in codes
+
+
+async def test_list_languages_marks_english_as_built_in(client, admin_user, admin_token):
+    resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    en = next(lang for lang in resp.json()["languages"] if lang["code"] == "en")
+    assert en["built_in"] is True
+    assert en["tools"] == {}
+    # English is always considered "enabled" — it's bundled
+    assert en["enabled"] is True
+
+
+async def test_list_languages_marks_french_not_installed_initially(client, admin_user, admin_token):
+    resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    fr = next(lang for lang in resp.json()["languages"] if lang["code"] == "fr")
+    assert fr["built_in"] is False
+    for tool_status in fr["tools"].values():
+        assert tool_status["status"] == "not_installed"
+
+
+async def test_list_languages_reflects_user_enabled_languages_preference(client, admin_user, admin_token, db_session):
+    """When the operator's preference includes 'fr', the listing reports
+    French as enabled. Mirrors what the UI uses to render the toggle state."""
+    admin_user.preferences = {"enabled_languages": ["en", "fr"]}
+    await db_session.flush()
+    await db_session.commit()
+
+    resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    fr = next(lang for lang in resp.json()["languages"] if lang["code"] == "fr")
+    assert fr["enabled"] is True
+
+
+async def test_list_languages_defaults_to_english_only_enabled(client, admin_user, admin_token):
+    """Fresh install: no enabled_languages preference → English only."""
+    resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    payload = resp.json()
+    en = next(lang for lang in payload["languages"] if lang["code"] == "en")
+    fr = next(lang for lang in payload["languages"] if lang["code"] == "fr")
+    assert en["enabled"] is True
+    assert fr["enabled"] is False
+
+
+async def test_list_languages_requires_auth(client):
+    resp = await client.get("/api/languages")
+    assert resp.status_code == 401
+
+
+# --- install ---
+
+
+async def test_install_french_ocr_succeeds_with_admin(client, admin_user, admin_token, patched_french):
+    resp = await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["results"][0]["tool"] == "ocr"
+    assert body["results"][0]["status"] == "installed"
+    assert body["results"][0]["error"] is None
+    # After install, list should reflect installed state
+    list_resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    fr = next(lang for lang in list_resp.json()["languages"] if lang["code"] == "fr")
+    assert fr["tools"]["ocr"]["status"] == "installed"
+
+
+async def test_install_is_idempotent(client, admin_user, admin_token, patched_french):
+    first = await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    assert first.json()["results"][0]["status"] == "installed"
+
+    second = await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    assert second.json()["results"][0]["status"] == "already_installed"
+
+
+async def test_install_requires_admin(client, regular_user, user_token, patched_french):
+    resp = await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(user_token),
+    )
+    assert resp.status_code == 403
+
+
+async def test_install_unknown_language_returns_404(client, admin_user, admin_token):
+    resp = await client.post(
+        "/api/languages/xx/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 404
+
+
+async def test_install_unknown_tool_returns_422(client, admin_user, admin_token):
+    resp = await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["bogus"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 422
+
+
+async def test_install_tool_with_no_artifact_returns_422(client, admin_user, admin_token):
+    """English has no artifacts — asking to install English/OCR is invalid."""
+    resp = await client.post(
+        "/api/languages/en/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 422
+
+
+async def test_install_failure_is_reported_per_tool_not_thrown(client, admin_user, admin_token, monkeypatch):
+    """If download_artifact fails (server down, SHA mismatch, etc.), the
+    response is 200 with a per-tool failure entry — callers shouldn't have
+    to thread try/except around install requests."""
+
+    def _fail(*args, **kwargs):
+        return lp_manager.DownloadResult(status="failed", error="simulated network error")
+
+    monkeypatch.setattr(lp_manager, "download_artifact", _fail)
+    # languages.py imports the function by name into its module namespace
+    from harbor_clerk.api.routes import languages as lang_routes
+
+    monkeypatch.setattr(lang_routes, "download_artifact", _fail)
+
+    resp = await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    result = resp.json()["results"][0]
+    assert result["status"] == "failed"
+    assert "simulated network error" in result["error"]
+
+
+# --- remove ---
+
+
+async def test_remove_single_tool(client, admin_user, admin_token, patched_french):
+    # Install first so there's something to remove
+    await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    resp = await client.delete(
+        "/api/languages/fr/install/ocr",
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "removed"
+    list_resp = await client.get("/api/languages", headers=auth_header(admin_token))
+    fr = next(lang for lang in list_resp.json()["languages"] if lang["code"] == "fr")
+    assert fr["tools"]["ocr"]["status"] == "not_installed"
+
+
+async def test_remove_is_idempotent(client, admin_user, admin_token):
+    """Removing a tool that isn't installed is fine."""
+    resp = await client.delete(
+        "/api/languages/fr/install/ocr",
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+
+
+async def test_remove_language_completely(client, admin_user, admin_token, patched_french):
+    await client.post(
+        "/api/languages/fr/install",
+        json={"tools": ["ocr"]},
+        headers=auth_header(admin_token),
+    )
+    resp = await client.delete("/api/languages/fr", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+
+
+async def test_remove_requires_admin(client, regular_user, user_token):
+    resp = await client.delete(
+        "/api/languages/fr/install/ocr",
+        headers=auth_header(user_token),
+    )
+    assert resp.status_code == 403

--- a/tests/lang_packs/test_manager.py
+++ b/tests/lang_packs/test_manager.py
@@ -1,0 +1,242 @@
+"""Download manager tests against pytest-httpserver fixtures.
+
+Real upstream URLs would make tests flaky and slow; we patch the
+LANGUAGES map to point at a local fixture server instead. This exercises
+the full download → verify → install flow against artifacts whose SHAs
+we control at test time.
+"""
+
+import hashlib
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from harbor_clerk.lang_packs.manager import (
+    DownloadResult,
+    download_artifact,
+    installed_languages,
+    installed_tools_for,
+    remove_artifact,
+    remove_language,
+    verify_artifact,
+)
+from harbor_clerk.lang_packs.storage import artifact_path, lang_dir
+from harbor_clerk.languages import LANGUAGES, ArtifactSpec, LanguageSpec, Tool
+
+
+@pytest.fixture(autouse=True)
+def _isolated_lang_packs_dir(monkeypatch, tmp_path):
+    """Every test gets a fresh lang_packs_dir under tmp_path."""
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+
+
+def _patch_french_to_local_server(monkeypatch, httpserver: HTTPServer, payload: bytes, with_ner: bool = False):
+    """Replace the LANGUAGES['fr'] entry with one whose URLs point at
+    httpserver and whose SHAs match the supplied payload(s).
+
+    Returns the patched LanguageSpec for assertion access.
+    """
+    sha = hashlib.sha256(payload).hexdigest()
+    httpserver.expect_request("/fra.traineddata").respond_with_data(payload)
+    artifacts = {
+        Tool.OCR: ArtifactSpec(
+            url=httpserver.url_for("/fra.traineddata"),
+            sha256=sha,
+            size_bytes=len(payload),
+            install_subpath="tesseract/fra.traineddata",
+        ),
+    }
+    if with_ner:
+        ner_payload = b"FAKE-WHEEL-CONTENT-FOR-NER-TESTS"
+        ner_sha = hashlib.sha256(ner_payload).hexdigest()
+        httpserver.expect_request("/fr_core_news_sm-3.8.0-py3-none-any.whl").respond_with_data(ner_payload)
+        artifacts[Tool.NER] = ArtifactSpec(
+            url=httpserver.url_for("/fr_core_news_sm-3.8.0-py3-none-any.whl"),
+            sha256=ner_sha,
+            size_bytes=len(ner_payload),
+            install_subpath="ner/fr_core_news_sm-3.8.0-py3-none-any.whl",
+        )
+    fake = LanguageSpec(code="fr", display_name="French (test)", artifacts=artifacts)
+    monkeypatch.setitem(LANGUAGES, "fr", fake)
+    return fake
+
+
+def test_download_writes_file_and_verifies(monkeypatch, httpserver, tmp_path):
+    payload = b"FAKE-TRAINEDDATA-CONTENT-WITH-KNOWN-HASH"
+    _patch_french_to_local_server(monkeypatch, httpserver, payload)
+
+    result = download_artifact("fr", Tool.OCR)
+
+    assert isinstance(result, DownloadResult)
+    assert result.status == "installed"
+    assert result.bytes_downloaded == len(payload)
+    target = tmp_path / "fr" / "tesseract" / "fra.traineddata"
+    assert target.read_bytes() == payload
+    assert verify_artifact("fr", Tool.OCR) is True
+
+
+def test_download_is_idempotent(monkeypatch, httpserver, tmp_path):
+    """Second call against an already-installed artifact returns
+    already_installed without re-fetching."""
+    payload = b"IDEMPOTENT-CONTENT"
+    _patch_french_to_local_server(monkeypatch, httpserver, payload)
+
+    first = download_artifact("fr", Tool.OCR)
+    assert first.status == "installed"
+
+    second = download_artifact("fr", Tool.OCR)
+    assert second.status == "already_installed"
+    assert second.bytes_downloaded == 0
+
+
+def test_download_fails_on_sha_mismatch(monkeypatch, httpserver, tmp_path):
+    """Server returns content whose SHA doesn't match what the static
+    map promises. The download must fail AND must not leave a
+    half-installed artifact on disk for a future verify_artifact() to
+    misinterpret."""
+    httpserver.expect_request("/fra.traineddata").respond_with_data(b"WRONG-CONTENT")
+    fake = LanguageSpec(
+        code="fr",
+        display_name="French (test)",
+        artifacts={
+            Tool.OCR: ArtifactSpec(
+                url=httpserver.url_for("/fra.traineddata"),
+                sha256="0" * 64,  # never matches
+                size_bytes=10,
+                install_subpath="tesseract/fra.traineddata",
+            ),
+        },
+    )
+    monkeypatch.setitem(LANGUAGES, "fr", fake)
+
+    result = download_artifact("fr", Tool.OCR)
+
+    assert result.status == "failed"
+    assert "sha256" in result.error.lower()
+    target = tmp_path / "fr" / "tesseract" / "fra.traineddata"
+    assert not target.exists(), "Failed downloads must not leave a partial file"
+    # Sibling .tmp file should also be cleaned up
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_download_fails_on_http_error(monkeypatch, httpserver, tmp_path):
+    """A 404 / 500 from upstream should produce a failed result, not
+    raise — callers don't want to thread try/except around every call."""
+    httpserver.expect_request("/fra.traineddata").respond_with_data(b"missing", status=404)
+    fake = LanguageSpec(
+        code="fr",
+        display_name="French (test)",
+        artifacts={
+            Tool.OCR: ArtifactSpec(
+                url=httpserver.url_for("/fra.traineddata"),
+                sha256="0" * 64,
+                size_bytes=1,
+                install_subpath="tesseract/fra.traineddata",
+            ),
+        },
+    )
+    monkeypatch.setitem(LANGUAGES, "fr", fake)
+
+    result = download_artifact("fr", Tool.OCR)
+
+    assert result.status == "failed"
+    assert result.error
+    target = tmp_path / "fr" / "tesseract" / "fra.traineddata"
+    assert not target.exists()
+
+
+def test_download_unknown_language_returns_failed_not_raises():
+    result = download_artifact("xx", Tool.OCR)
+    assert result.status == "failed"
+    assert "unknown language" in result.error
+
+
+def test_download_language_without_tool_artifact_returns_failed():
+    """English has no artifacts — asking for English/OCR is an error."""
+    result = download_artifact("en", Tool.OCR)
+    assert result.status == "failed"
+    assert "no ocr artifact" in result.error.lower()
+
+
+def test_verify_artifact_false_when_missing(monkeypatch, httpserver, tmp_path):
+    _patch_french_to_local_server(monkeypatch, httpserver, b"x")
+    assert verify_artifact("fr", Tool.OCR) is False
+
+
+def test_verify_artifact_false_when_corrupted(monkeypatch, httpserver, tmp_path):
+    payload = b"ORIGINAL"
+    _patch_french_to_local_server(monkeypatch, httpserver, payload)
+    download_artifact("fr", Tool.OCR)
+
+    # Tamper with the on-disk file
+    target = tmp_path / "fr" / "tesseract" / "fra.traineddata"
+    target.write_bytes(b"TAMPERED")
+
+    assert verify_artifact("fr", Tool.OCR) is False
+
+
+def test_remove_artifact_deletes_file(monkeypatch, httpserver, tmp_path):
+    _patch_french_to_local_server(monkeypatch, httpserver, b"removable")
+    download_artifact("fr", Tool.OCR)
+    target = artifact_path("fr", Tool.OCR)
+    assert target.exists()
+
+    remove_artifact("fr", Tool.OCR)
+
+    assert not target.exists()
+
+
+def test_remove_artifact_cleans_empty_intermediate_dirs(monkeypatch, httpserver, tmp_path):
+    """The empty ``tesseract/`` subdir should go away after the only
+    artifact in it is removed. The per-language root (``fr/``) stays."""
+    _patch_french_to_local_server(monkeypatch, httpserver, b"removable")
+    download_artifact("fr", Tool.OCR)
+
+    remove_artifact("fr", Tool.OCR)
+
+    # The tesseract subdir should be cleaned up
+    assert not (tmp_path / "fr" / "tesseract").exists()
+    # But the lang root stays (may host other tools)
+    assert lang_dir("fr").exists()
+
+
+def test_remove_artifact_idempotent(monkeypatch, httpserver, tmp_path):
+    """Removing twice doesn't raise."""
+    _patch_french_to_local_server(monkeypatch, httpserver, b"x")
+    remove_artifact("fr", Tool.OCR)  # not installed yet
+    remove_artifact("fr", Tool.OCR)  # still not installed
+
+
+def test_remove_language_clears_everything(monkeypatch, httpserver, tmp_path):
+    """Disabling French should wipe the entire fr/ tree, not just one tool."""
+    _patch_french_to_local_server(monkeypatch, httpserver, b"x", with_ner=True)
+    download_artifact("fr", Tool.OCR)
+    download_artifact("fr", Tool.NER)
+    assert lang_dir("fr").exists()
+
+    remove_language("fr")
+
+    assert not lang_dir("fr").exists()
+
+
+def test_installed_tools_for_returns_only_verified(monkeypatch, httpserver, tmp_path):
+    _patch_french_to_local_server(monkeypatch, httpserver, b"x", with_ner=True)
+    assert installed_tools_for("fr") == set()
+
+    download_artifact("fr", Tool.OCR)
+    assert installed_tools_for("fr") == {Tool.OCR}
+
+    download_artifact("fr", Tool.NER)
+    assert installed_tools_for("fr") == {Tool.OCR, Tool.NER}
+
+
+def test_installed_languages_includes_english_always():
+    """English is bundled, not downloaded — should always show up."""
+    assert "en" in installed_languages()
+
+
+def test_installed_languages_includes_french_after_install(monkeypatch, httpserver, tmp_path):
+    _patch_french_to_local_server(monkeypatch, httpserver, b"x")
+    assert "fr" not in installed_languages()
+    download_artifact("fr", Tool.OCR)
+    assert "fr" in installed_languages()

--- a/tests/lang_packs/test_storage.py
+++ b/tests/lang_packs/test_storage.py
@@ -1,0 +1,75 @@
+"""Disk layout helpers (lang_packs_dir, lang_dir, artifact_path)."""
+
+from pathlib import Path
+
+import pytest
+
+from harbor_clerk.lang_packs.storage import (
+    artifact_path,
+    lang_dir,
+    lang_packs_dir,
+    tesseract_data_dir,
+)
+from harbor_clerk.languages import LANGUAGES, Tool
+
+
+def test_lang_packs_dir_uses_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    assert lang_packs_dir() == tmp_path
+
+
+def test_lang_packs_dir_falls_back_to_platform_default(monkeypatch):
+    """When the env var is unset we use a platform-appropriate path.
+    Don't assert exact path (varies between macOS and Linux), just that
+    it's an absolute Path under the user's home."""
+    monkeypatch.delenv("LANG_PACKS_DIR", raising=False)
+    result = lang_packs_dir()
+    assert result.is_absolute()
+    assert str(result).startswith(str(Path.home()))
+    assert "lang-packs" in str(result) or "lang_packs" in str(result)
+
+
+def test_lang_dir_combines_root_and_lang_code(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    assert lang_dir("fr") == tmp_path / "fr"
+    assert lang_dir("de") == tmp_path / "de"
+
+
+def test_artifact_path_combines_lang_dir_and_install_subpath(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    fr_ocr_path = artifact_path("fr", Tool.OCR)
+    expected = tmp_path / "fr" / "tesseract" / "fra.traineddata"
+    assert fr_ocr_path == expected
+
+
+def test_artifact_path_raises_for_unknown_language(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    with pytest.raises(KeyError):
+        artifact_path("xx", Tool.OCR)
+
+
+def test_artifact_path_raises_for_missing_tool(monkeypatch, tmp_path):
+    """English has no artifacts. Asking for one is a programming error."""
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    with pytest.raises(KeyError):
+        artifact_path("en", Tool.OCR)
+
+
+def test_tesseract_data_dir_is_per_language(monkeypatch, tmp_path):
+    """Tesseract takes a colon-separated TESSDATA_PREFIX; we give it one
+    entry per enabled language. The dir must exist under the per-language
+    root so tessdata lookups don't cross-pollinate."""
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    assert tesseract_data_dir("fr") == tmp_path / "fr" / "tesseract"
+    assert tesseract_data_dir("de") == tmp_path / "de" / "tesseract"
+
+
+def test_artifact_path_matches_real_french_specs(monkeypatch, tmp_path):
+    """Sanity check that the static map and the storage helpers agree on
+    where French artifacts land."""
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+    fr = LANGUAGES["fr"]
+    for tool, artifact in fr.artifacts.items():
+        path = artifact_path("fr", tool)
+        assert str(path).startswith(str(tmp_path))
+        assert path.name == artifact.install_subpath.rsplit("/", 1)[-1]

--- a/tests/lang_packs/test_tesseract_setup.py
+++ b/tests/lang_packs/test_tesseract_setup.py
@@ -1,0 +1,118 @@
+"""Tests for the unified tessdata dir setup."""
+
+import hashlib
+import os
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from harbor_clerk.lang_packs.manager import download_artifact
+from harbor_clerk.lang_packs.tesseract_setup import (
+    setup_unified_tessdata_dir,
+    unified_tessdata_dir,
+)
+from harbor_clerk.languages import LANGUAGES, ArtifactSpec, LanguageSpec, Tool
+
+
+@pytest.fixture(autouse=True)
+def _isolated_lang_packs_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path / "lang-packs"))
+
+
+def test_setup_creates_unified_dir_and_sets_env(monkeypatch, tmp_path):
+    """Even with no bundled tessdata + no packs installed, calling setup
+    creates the dir and sets TESSDATA_PREFIX. Worker startup is a no-op
+    in that case (just an empty unified dir)."""
+    monkeypatch.delenv("TESSDATA_PREFIX", raising=False)
+    setup_unified_tessdata_dir()
+    assert unified_tessdata_dir().is_dir()
+    assert os.environ["TESSDATA_PREFIX"] == str(unified_tessdata_dir())
+
+
+def test_setup_symlinks_bundled_tessdata(monkeypatch, tmp_path):
+    """When TESSDATA_PREFIX points at a real bundled dir, every
+    .traineddata file in it gets a symlink in the unified dir."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "eng.traineddata").write_bytes(b"english data")
+    (bundled / "osd.traineddata").write_bytes(b"osd data")
+    (bundled / "README.md").write_text("not a traineddata")
+    monkeypatch.setenv("TESSDATA_PREFIX", str(bundled))
+
+    setup_unified_tessdata_dir()
+    unified = unified_tessdata_dir()
+
+    assert (unified / "eng.traineddata").is_symlink()
+    assert (unified / "osd.traineddata").is_symlink()
+    # Symlinks resolve to the bundled originals
+    assert (unified / "eng.traineddata").read_bytes() == b"english data"
+    # Non-traineddata files are skipped
+    assert not (unified / "README.md").exists()
+    # TESSDATA_PREFIX is overridden to the unified dir
+    assert os.environ["TESSDATA_PREFIX"] == str(unified)
+
+
+def test_setup_symlinks_installed_language_packs(monkeypatch, tmp_path, httpserver: HTTPServer):
+    """After a pack is installed via the manager, setup picks up its
+    .traineddata file."""
+    monkeypatch.delenv("TESSDATA_PREFIX", raising=False)
+
+    payload = b"FRENCH-TRAINEDDATA"
+    sha = hashlib.sha256(payload).hexdigest()
+    httpserver.expect_request("/fra.traineddata").respond_with_data(payload)
+    fake = LanguageSpec(
+        code="fr",
+        display_name="French",
+        artifacts={
+            Tool.OCR: ArtifactSpec(
+                url=httpserver.url_for("/fra.traineddata"),
+                sha256=sha,
+                size_bytes=len(payload),
+                install_subpath="tesseract/fra.traineddata",
+            ),
+        },
+    )
+    monkeypatch.setitem(LANGUAGES, "fr", fake)
+    download_artifact("fr", Tool.OCR)
+
+    setup_unified_tessdata_dir()
+    unified = unified_tessdata_dir()
+
+    assert (unified / "fra.traineddata").is_symlink()
+    assert (unified / "fra.traineddata").read_bytes() == payload
+
+
+def test_setup_is_idempotent(monkeypatch, tmp_path):
+    """Calling setup twice is a no-op the second time — symlinks
+    already exist."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "eng.traineddata").write_bytes(b"english")
+    monkeypatch.setenv("TESSDATA_PREFIX", str(bundled))
+
+    setup_unified_tessdata_dir()
+    setup_unified_tessdata_dir()  # second call shouldn't raise
+
+    unified = unified_tessdata_dir()
+    assert (unified / "eng.traineddata").is_symlink()
+
+
+def test_setup_handles_tessdata_prefix_already_pointing_at_unified_dir(monkeypatch, tmp_path):
+    """Worker restart scenario: TESSDATA_PREFIX is the unified dir from
+    the previous run. We mustn't symlink the unified dir into itself
+    (that would create a loop or fail). Setup should detect this and
+    skip the bundled-symlink step."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "eng.traineddata").write_bytes(b"english")
+
+    # First run: TESSDATA_PREFIX points at bundled
+    monkeypatch.setenv("TESSDATA_PREFIX", str(bundled))
+    setup_unified_tessdata_dir()
+    unified = unified_tessdata_dir()
+    assert (unified / "eng.traineddata").exists()
+
+    # Second run: TESSDATA_PREFIX now points at unified (set by previous call)
+    # Setup should not loop or fail. The existing symlink survives.
+    setup_unified_tessdata_dir()  # no exception
+    assert (unified / "eng.traineddata").is_symlink()

--- a/tests/test_alembic_0017_flatten.py
+++ b/tests/test_alembic_0017_flatten.py
@@ -29,6 +29,15 @@ def sync_engine():
     engine.dispose()
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _restore_head_after_module(alembic_cfg):
+    """Migration tests leave the DB at the revision they exercised. Restore
+    head when the module finishes so subsequent test files (which expect
+    the current ORM schema) don't see "column does not exist" errors."""
+    yield
+    command.upgrade(alembic_cfg, "head")
+
+
 def test_0017_flattens_two_version_doc(alembic_cfg, sync_engine):
     """A doc with two versions: latest content survives, prior is pruned."""
     # Ensure we are exactly at revision 0016 before inserting test data.

--- a/tests/test_alembic_0018_enum_rename.py
+++ b/tests/test_alembic_0018_enum_rename.py
@@ -25,6 +25,15 @@ def sync_engine():
     engine.dispose()
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _restore_head_after_module(alembic_cfg):
+    """Migration tests leave the DB at the revision they exercised. Restore
+    head when the module finishes so subsequent test files (which expect
+    the current ORM schema) don't see "column does not exist" errors."""
+    yield
+    command.upgrade(alembic_cfg, "head")
+
+
 def _enum_typename_exists(conn, typename: str) -> bool:
     """True if a Postgres enum type with this name exists."""
     return bool(

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -102,3 +102,48 @@ async def test_update_preferences_partial_does_not_clobber_existing(client, admi
     prefs = resp.json()["preferences"]
     assert prefs.get("theme") == "dark"
     assert prefs.get("onboardingComplete") is True
+
+
+async def test_update_preferences_enabled_languages_persists(client, admin_user, admin_token):
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"enabled_languages": ["en", "fr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["preferences"]["enabled_languages"] == ["en", "fr"]
+
+
+async def test_update_preferences_enabled_languages_always_includes_english(client, admin_user, admin_token):
+    """Operator who tries to set ['fr'] (without en) gets ['en', 'fr'] back —
+    English is the bundled fallback and turning it off would silently
+    disable OCR for every doc."""
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"enabled_languages": ["fr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    enabled = resp.json()["preferences"]["enabled_languages"]
+    assert enabled[0] == "en"
+    assert "fr" in enabled
+
+
+async def test_update_preferences_enabled_languages_dedupes(client, admin_user, admin_token):
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"enabled_languages": ["en", "fr", "en", "fr"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["preferences"]["enabled_languages"] == ["en", "fr"]
+
+
+async def test_update_preferences_enabled_languages_rejects_unknown_codes(client, admin_user, admin_token):
+    resp = await client.patch(
+        "/api/me/preferences",
+        json={"enabled_languages": ["en", "xx"]},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 422
+    assert "xx" in resp.json()["detail"]

--- a/tests/test_languages_static_map.py
+++ b/tests/test_languages_static_map.py
@@ -1,0 +1,74 @@
+"""Schema validation for the static (language, tool) -> ArtifactSpec map."""
+
+import pytest
+
+from harbor_clerk.languages import LANGUAGES, Tool
+
+
+def test_english_is_present_with_no_artifacts():
+    """English ships in the bundle. Empty artifacts map is the
+    'this language is built-in' signal that the rest of the code uses
+    to skip download flows."""
+    assert "en" in LANGUAGES
+    assert LANGUAGES["en"].artifacts == {}
+
+
+def test_every_language_spec_has_iso_code_matching_key():
+    """Belt-and-suspenders: the dict key and the spec.code field can
+    drift apart silently if someone copy-pastes an entry. Catch that."""
+    for code, spec in LANGUAGES.items():
+        assert spec.code == code, f"key {code!r} != spec.code {spec.code!r}"
+
+
+def test_every_language_spec_has_non_empty_display_name():
+    for code, spec in LANGUAGES.items():
+        assert spec.display_name, f"{code} has empty display_name"
+
+
+def test_every_artifact_has_https_url_and_64_char_sha256():
+    """Real SHAs only — no placeholders. The download manager refuses
+    to install anything whose content hash doesn't match, so a placeholder
+    SHA would just produce confusing 'sha256 mismatch' errors at install
+    time. Catch the mistake at test time instead."""
+    for code, spec in LANGUAGES.items():
+        for tool, artifact in spec.artifacts.items():
+            assert artifact.url.startswith("https://"), f"{code}/{tool.value} url not https"
+            assert len(artifact.sha256) == 64, (
+                f"{code}/{tool.value} sha256 wrong length: {len(artifact.sha256)} (expected 64)"
+            )
+            assert all(c in "0123456789abcdef" for c in artifact.sha256), (
+                f"{code}/{tool.value} sha256 contains non-hex characters"
+            )
+            assert artifact.size_bytes > 0, f"{code}/{tool.value} size_bytes must be positive"
+            assert artifact.install_subpath, f"{code}/{tool.value} install_subpath empty"
+
+
+def test_french_has_both_ocr_and_ner_artifacts():
+    """French is the headline use case (silently OCR'd as English today).
+    Both Tesseract and spaCy artifacts must be present."""
+    fr = LANGUAGES["fr"]
+    assert Tool.OCR in fr.artifacts
+    assert Tool.NER in fr.artifacts
+    # Sanity-check the install paths reflect the right tool naming
+    assert "fra.traineddata" in fr.artifacts[Tool.OCR].install_subpath
+    assert "fr_core_news_sm" in fr.artifacts[Tool.NER].install_subpath
+
+
+def test_install_subpaths_are_relative_not_absolute():
+    """install_subpath joins under lang_packs_dir/<lang>/. An absolute
+    path would escape that directory at storage.artifact_path() time."""
+    for code, spec in LANGUAGES.items():
+        for tool, artifact in spec.artifacts.items():
+            assert not artifact.install_subpath.startswith("/"), (
+                f"{code}/{tool.value} install_subpath is absolute: {artifact.install_subpath}"
+            )
+            assert ".." not in artifact.install_subpath.split("/"), (
+                f"{code}/{tool.value} install_subpath contains parent traversal"
+            )
+
+
+@pytest.mark.parametrize("tool", list(Tool))
+def test_tool_enum_has_string_value(tool):
+    """The REST API uses tool.value as the URL segment ('/api/languages/{code}/install/{tool}')."""
+    assert isinstance(tool.value, str)
+    assert tool.value.islower()

--- a/tests/worker/test_ocr_languages.py
+++ b/tests/worker/test_ocr_languages.py
@@ -1,0 +1,268 @@
+"""Tests for OCR language resolution: preferences -> Tesseract -l arg.
+
+These exercise the pure logic (no Tesseract subprocess invocation). The
+end-to-end OCR path is intentionally not unit-tested here — it's
+exercised manually via the macOS bundle and would require a tesseract
+binary + traineddata fixtures.
+"""
+
+import hashlib
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from harbor_clerk.languages import LANGUAGES, ArtifactSpec, LanguageSpec, Tool
+from harbor_clerk.models import User
+from harbor_clerk.models.enums import UserRole
+from harbor_clerk.worker.ocr_languages import (
+    get_enabled_languages_from_preferences,
+    get_ocr_languages_for_doc,
+    iso_to_tesseract,
+    resolve_ocr_languages,
+    tesseract_lang_arg,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_lang_packs_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANG_PACKS_DIR", str(tmp_path))
+
+
+def _install_french_pack(monkeypatch, httpserver: HTTPServer):
+    """Patch LANGUAGES['fr'] to a fixture spec and install the OCR pack."""
+    from harbor_clerk.lang_packs.manager import download_artifact
+
+    payload = b"FRENCH-TRAINEDDATA-FIXTURE"
+    sha = hashlib.sha256(payload).hexdigest()
+    httpserver.expect_request("/fra.traineddata").respond_with_data(payload)
+    fake = LanguageSpec(
+        code="fr",
+        display_name="French",
+        artifacts={
+            Tool.OCR: ArtifactSpec(
+                url=httpserver.url_for("/fra.traineddata"),
+                sha256=sha,
+                size_bytes=len(payload),
+                install_subpath="tesseract/fra.traineddata",
+            ),
+        },
+    )
+    monkeypatch.setitem(LANGUAGES, "fr", fake)
+    result = download_artifact("fr", Tool.OCR)
+    assert result.status == "installed"
+
+
+# --- iso_to_tesseract ---
+
+
+def test_iso_to_tesseract_known_mappings():
+    assert iso_to_tesseract("en") == "eng"
+    assert iso_to_tesseract("fr") == "fra"
+    assert iso_to_tesseract("de") == "deu"
+
+
+def test_iso_to_tesseract_falls_back_to_iso_code():
+    """Unknown languages return the ISO code unchanged — many languages
+    use the same code in both schemes."""
+    assert iso_to_tesseract("xx") == "xx"
+
+
+# --- tesseract_lang_arg ---
+
+
+def test_tesseract_lang_arg_single():
+    assert tesseract_lang_arg(["en"]) == "eng"
+
+
+def test_tesseract_lang_arg_multiple():
+    assert tesseract_lang_arg(["en", "fr"]) == "eng+fra"
+
+
+# --- resolve_ocr_languages ---
+
+
+def test_resolve_returns_english_only_when_no_packs_installed():
+    """No French pack on disk → French is dropped from the list."""
+    assert resolve_ocr_languages(["en", "fr"]) == ["en"]
+
+
+def test_resolve_includes_french_when_pack_installed(monkeypatch, httpserver):
+    _install_french_pack(monkeypatch, httpserver)
+    result = resolve_ocr_languages(["en", "fr"])
+    assert result == ["en", "fr"]
+
+
+def test_resolve_always_includes_english_first():
+    """Even if the caller passes only ['fr'], English is included as
+    the safe fallback."""
+    result = resolve_ocr_languages(["fr"])
+    assert result == ["en"]
+    # And won't include French because the pack isn't installed
+    # (test_resolve_includes_french_when_pack_installed covers the
+    # other direction)
+
+
+def test_resolve_skips_unknown_codes():
+    """Codes not in LANGUAGES are dropped (e.g. a stale prefs entry)."""
+    assert resolve_ocr_languages(["en", "xx", "yy"]) == ["en"]
+
+
+def test_resolve_dedupes():
+    assert resolve_ocr_languages(["en", "en"]) == ["en"]
+
+
+# --- get_enabled_languages_from_preferences ---
+
+
+@pytest.mark.asyncio
+async def test_get_enabled_languages_returns_default_when_no_admin(db_session):
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        assert get_enabled_languages_from_preferences(sync_session) == ["en"]
+    finally:
+        sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_get_enabled_languages_reads_admin_preference(db_session, admin_user):
+    """The OCR worker is single-tenant and reads any admin user's preference
+    as the global setting."""
+    admin_user.preferences = {"enabled_languages": ["en", "fr"]}
+    await db_session.flush()
+    await db_session.commit()
+
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        result = get_enabled_languages_from_preferences(sync_session)
+    finally:
+        sync_session.close()
+
+    assert result == ["en", "fr"]
+
+
+@pytest.mark.asyncio
+async def test_get_enabled_languages_filters_unknown_codes(db_session):
+    """If the prefs blob contains stale codes (e.g. a removed language)
+    we silently drop them rather than passing them through to Tesseract."""
+    from harbor_clerk.auth import hash_password
+
+    admin = User(
+        email="admin2@test.com",
+        password_hash=hash_password("TestPassword123"),
+        role=UserRole.admin,
+        is_active=True,
+        preferences={"enabled_languages": ["en", "fr", "xx", "yy"]},
+    )
+    db_session.add(admin)
+    await db_session.flush()
+    await db_session.commit()
+
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        result = get_enabled_languages_from_preferences(sync_session)
+    finally:
+        sync_session.close()
+
+    assert "xx" not in result
+    assert "yy" not in result
+    assert "en" in result
+    assert "fr" in result
+
+
+@pytest.mark.asyncio
+async def test_get_enabled_languages_inserts_english_if_missing(db_session):
+    """Defense in depth: if somehow the prefs blob ended up without
+    English, we put it back at index 0. The API normaliser does this
+    too, but the OCR side guards against any path that bypassed it."""
+    from harbor_clerk.auth import hash_password
+
+    admin = User(
+        email="admin3@test.com",
+        password_hash=hash_password("TestPassword123"),
+        role=UserRole.admin,
+        is_active=True,
+        preferences={"enabled_languages": ["fr"]},  # no en — shouldn't happen via API
+    )
+    db_session.add(admin)
+    await db_session.flush()
+    await db_session.commit()
+
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        result = get_enabled_languages_from_preferences(sync_session)
+    finally:
+        sync_session.close()
+
+    assert result[0] == "en"
+    assert "fr" in result
+
+
+# --- get_ocr_languages_for_doc (the integration helper) ---
+
+
+@pytest.mark.asyncio
+async def test_get_ocr_languages_for_doc_default_install(db_session):
+    """Fresh install: no admin, no packs. Returns English only."""
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        iso, lang_arg = get_ocr_languages_for_doc(sync_session)
+    finally:
+        sync_session.close()
+
+    assert iso == ["en"]
+    assert lang_arg == "eng"
+
+
+@pytest.mark.asyncio
+async def test_get_ocr_languages_for_doc_with_french_enabled_and_installed(
+    db_session, admin_user, monkeypatch, httpserver
+):
+    """The headline use case: admin enabled French and the pack is
+    installed. Worker should pass `-l eng+fra` to Tesseract."""
+    admin_user.preferences = {"enabled_languages": ["en", "fr"]}
+    await db_session.flush()
+    await db_session.commit()
+    _install_french_pack(monkeypatch, httpserver)
+
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        iso, lang_arg = get_ocr_languages_for_doc(sync_session)
+    finally:
+        sync_session.close()
+
+    assert iso == ["en", "fr"]
+    assert lang_arg == "eng+fra"
+
+
+@pytest.mark.asyncio
+async def test_get_ocr_languages_for_doc_french_enabled_but_not_installed(db_session, admin_user):
+    """Operator enabled French but never installed the pack. Tesseract
+    can't do anything with it, so we silently drop French and OCR with
+    English only — better than passing -l eng+fra and getting a
+    'Failed loading language fra' warning every job."""
+    admin_user.preferences = {"enabled_languages": ["en", "fr"]}
+    await db_session.flush()
+    await db_session.commit()
+
+    from harbor_clerk.db_sync import get_sync_session
+
+    sync_session = get_sync_session()
+    try:
+        iso, lang_arg = get_ocr_languages_for_doc(sync_session)
+    finally:
+        sync_session.close()
+
+    assert iso == ["en"]
+    assert lang_arg == "eng"

--- a/uv.lock
+++ b/uv.lock
@@ -762,6 +762,7 @@ test = [
     { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-httpserver" },
     { name = "ruff" },
 ]
 
@@ -790,6 +791,7 @@ requires-dist = [
     { name = "pytesseract", specifier = ">=0.3.13" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
+    { name = "pytest-httpserver", marker = "extra == 'test'", specifier = ">=1.1" },
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11" },
     { name = "smolagents", extras = ["openai"], specifier = ">=1.22.0" },
@@ -2197,6 +2199,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", hash = "sha256:dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1", size = 70974, upload-time = "2026-02-14T13:27:23.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", hash = "sha256:ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a", size = 23330, upload-time = "2026-02-14T13:27:22.119Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3494,6 +3508,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phases 1–4 of the language-packs design — closes the silent French OCR recall regression that's been latent since PR #258.

**Headline:** French content can now actually be OCR'd as French. Today the worker passes `tesseract -l eng+fra` despite the bundle shipping only `eng + osd`, so French docs silently fall back to English-only OCR. With this PR, an operator enables French at `/admin/languages`, the download manager fetches `fra.traineddata` + `fr_core_news_sm`, and the OCR stage reads the preference + uses the right `-l` arg per doc.

| Phase | What | Status |
|---|---|---|
| **1** | Static `(lang, tool) → ArtifactSpec` map (real upstream SHA256s for French) + disk layout helpers | ✅ |
| **2** | Synchronous download manager (httpx.stream + atomic SHA-verified install) + `/api/languages` REST endpoints | ✅ |
| **3a** | `enabled_languages` preference plumbing on `PATCH /api/me/preferences` (validates, dedupes, always inserts `en` first) | ✅ |
| **3b** | `/admin/languages` System Settings page with per-tool install state + Enable/Disable toggle | ✅ |
| **4** | OCR stage reads enabled_languages + intersects with installed packs + builds `-l eng+fra` dynamically; new `documents.ocr_languages_used` column persists what was used | ✅ |

## Architecture highlights

- **Real SHAs only.** `download_artifact` refuses to install anything whose content hash doesn't match the static map. Placeholder SHAs would just produce confusing install-time errors, so the schema-validation test rejects them at test time.
- **Atomic installs.** Each download writes to a `.tmp` sibling and atomic-renames after SHA verification. Interrupted downloads leave a `.tmp` file but never a corrupt `.traineddata` for the next call to misinterpret.
- **English is always implicit.** The API normalises `enabled_languages` to always include `en` at index 0 — the backend, the OCR resolver, and the frontend Disable button all agree turning off English would silently disable OCR for every doc and refuse to do it.
- **Unified tessdata dir.** Tesseract's `--tessdata-dir` / `TESSDATA_PREFIX` only accept ONE path. The worker maintains `<lang_packs>/_tessdata/` with symlinks to both bundled (`eng`, `osd`) and per-language pack (`fra`) `.traineddata` files. Setup is idempotent and runs at worker startup.
- **Doc-ID enumeration mitigation** (carried over from #264): admin-required endpoints 403 before resource lookup so a non-admin can't enumerate language codes via 404 vs 403 differentials.

## Caller note

Existing English-OCR'd docs do NOT auto-reprocess when a new language is enabled — by design (multi-thousand-doc corpora make auto-reprocess prohibitively expensive). `doc.ocr_languages_used` is written from this PR forward; legacy docs have NULL, which the future "reprocess with new language" UI will use to detect candidates.

**Worker restart** is required to pick up newly-installed packs (the unified tessdata symlinks are populated once at startup). Documented in the UI and in the worker startup hook docstring.

## Tests

68 new tests:

- `test_languages_static_map.py` (8) — schema validation
- `tests/lang_packs/test_storage.py` (8) — disk layout
- `tests/lang_packs/test_manager.py` (16) — download/verify/remove against pytest-httpserver fixtures (no real network)
- `tests/lang_packs/test_tesseract_setup.py` (5) — unified dir + symlinks
- `tests/api/test_languages_endpoints.py` (17) — full REST surface incl. auth gates, idempotency, per-tool failure handling
- `tests/test_api_auth.py` (4) — `enabled_languages` validation/normalisation
- `tests/worker/test_ocr_languages.py` (16) — preference resolution + Tesseract arg generation + integration helper

Plus two existing migration test files got module-scoped teardown fixtures (they previously left the DB at their tested revision, which was fine when that WAS head — now there's a newer head and subsequent tests need it restored).

**504 passed total (+68 new), ruff clean, format clean, frontend type-check + lint + prettier clean.**

## Out of scope (in the spec, future PRs)

- spaCy NER per-language model loading (the download manager already pulls `fr_core_news_sm`; the worker side that loads on demand is the next PR)
- Per-doc reprocess affordance ("doc was OCR'd English-only, reprocess with French now?")
- Onboarding wizard "Languages" step
- Curated default-list expansion to ~25 languages (currently English + French; pattern is purely additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)