### PR TITLE
fix(languages): post-merge code review fixes (NER extraction self-heal, onboarding partial install)

### DIFF
--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -73,30 +73,61 @@ export default function OnboardingWizard({ onComplete }: Props) {
       return
     }
     setInstallingLangs(true)
-    try {
-      // Install each selected language's tools (OCR + NER for now).
-      // We do these sequentially to avoid hammering the upstream
-      // host-name (~15-20 MB each) and to give the user honest progress
-      // feedback if anything fails.
-      for (const code of selectedLangs) {
-        const lang = languages.find((l) => l.code === code)
-        if (!lang) continue
-        const tools = Object.keys(lang.tools)
-        if (tools.length > 0) {
-          await post(`/api/languages/${code}/install`, { tools })
-        }
+
+    // Track which selections actually installed; partial failures must
+    // not strand on-disk packs without a corresponding preference. If
+    // German fails but French succeeds, we still want the operator's
+    // enabled_languages to include French — otherwise the pack is on
+    // disk but never used, and the operator has to discover the gap
+    // themselves.
+    const installed: string[] = []
+    const failures: string[] = []
+
+    // Install each selected language's tools sequentially. Sequential
+    // (rather than parallel) avoids hammering the upstream host-name on
+    // small networks and lets a single failure not abort the rest of
+    // the batch.
+    for (const code of selectedLangs) {
+      const lang = languages.find((l) => l.code === code)
+      if (!lang) continue
+      const tools = Object.keys(lang.tools)
+      if (tools.length === 0) {
+        installed.push(code)
+        continue
       }
-      // Persist the operator's enabled-languages preference. Backend
-      // normalises (always inserts 'en' first, dedupes, validates).
-      await patch('/api/me/preferences', {
-        enabled_languages: Array.from(selectedLangs),
-      })
-      setPage(3)
-    } catch (e) {
-      setError(e instanceof ApiError || e instanceof Error ? e.message : 'Failed to install languages')
-    } finally {
-      setInstallingLangs(false)
+      try {
+        await post(`/api/languages/${code}/install`, { tools })
+        installed.push(code)
+      } catch (e) {
+        const msg = e instanceof ApiError || e instanceof Error ? e.message : 'install failed'
+        failures.push(`${code} (${msg})`)
+      }
     }
+
+    if (installed.length > 0) {
+      try {
+        // Backend normalises (always inserts 'en' first, dedupes, validates).
+        await patch('/api/me/preferences', { enabled_languages: installed })
+      } catch (e) {
+        // Pref-save failed but packs are on disk. Surface so the
+        // operator can flip the toggle in System Settings → Languages.
+        failures.push(`preferences save (${e instanceof Error ? e.message : 'unknown'})`)
+      }
+    }
+
+    setInstallingLangs(false)
+
+    if (failures.length > 0) {
+      setError(
+        `Some languages failed to install: ${failures.join(', ')}. ` +
+          `Successfully installed languages are still available — manage them under System Settings → Languages.`,
+      )
+      // Stay on this page so the user sees the error; they can click
+      // Skip to advance once they've read it.
+      return
+    }
+
+    setPage(3)
   }, [selectedLangs, languages])
 
   async function handlePickFolder() {

--- a/src/harbor_clerk/lang_packs/manager.py
+++ b/src/harbor_clerk/lang_packs/manager.py
@@ -106,6 +106,24 @@ def download_artifact(lang_code: str, tool: Tool) -> DownloadResult:
     target = artifact_path(lang_code, tool)
 
     if target.exists() and verify_artifact(lang_code, tool):
+        # Wheel passed SHA verification, but a NER wheel also needs its
+        # extracted package dir. If the dir is missing (e.g. a previous
+        # _extract_ner_wheel raised due to a transient I/O issue or
+        # permissions error), the model can't be loaded and the install
+        # is silently broken. Re-extract here so a normal retry
+        # (`POST /api/languages/{code}/install` again) self-heals
+        # rather than requiring a remove + reinstall cycle.
+        if tool == Tool.NER and target.suffix == ".whl":
+            extracted = extracted_spacy_dir(target)
+            if not extracted.is_dir():
+                try:
+                    _extract_ner_wheel(target)
+                except Exception:
+                    logger.exception(
+                        "Re-extraction failed for %s/%s; remove + reinstall to recover",
+                        lang_code,
+                        tool.value,
+                    )
         return DownloadResult(status="already_installed")
 
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/lang_packs/test_manager.py
+++ b/tests/lang_packs/test_manager.py
@@ -355,3 +355,38 @@ def test_ner_wheel_re_install_replaces_extracted_dir(monkeypatch, httpserver, tm
     assert not stale_file.exists()
     # Real extracted contents are present
     assert (extracted / "__init__.py").is_file()
+
+
+def test_ner_install_self_heals_when_extraction_was_lost(monkeypatch, httpserver, tmp_path):
+    """Recovery scenario: a previous install completed (wheel verified,
+    SHA matches), but the extracted package directory was wiped (manual
+    cleanup, disk pressure cron, prior failed extraction, etc.). A
+    second `download_artifact()` call should detect the missing extracted
+    dir and re-extract on the spot — without requiring a remove +
+    reinstall cycle the operator might not know to perform.
+
+    Caught by review of PR #266 — the original code returned
+    ``already_installed`` based purely on wheel SHA and never re-extracted.
+    """
+    _patch_french_with_real_wheel_shape(monkeypatch, httpserver, tmp_path)
+
+    # First install — both wheel and extracted dir end up on disk.
+    download_artifact("fr", Tool.NER)
+    extracted = tmp_path / "fr" / "ner" / "fr_core_news_sm"
+    assert extracted.is_dir()
+
+    # Simulate a lost extraction (extracted dir removed, wheel intact).
+    import shutil
+
+    shutil.rmtree(extracted)
+    assert not extracted.exists()
+    wheel = tmp_path / "fr" / "ner" / "fr_core_news_sm-3.8.0-py3-none-any.whl"
+    assert wheel.exists()  # wheel is still verified-by-SHA
+
+    # Re-running install should self-heal: detect the missing dir and
+    # re-extract. Status is still `already_installed` because the wheel
+    # itself was already on disk — the extraction is a quiet repair.
+    result = download_artifact("fr", Tool.NER)
+    assert result.status == "already_installed"
+    assert extracted.is_dir(), "extracted dir should have been re-created"
+    assert (extracted / "__init__.py").is_file()


### PR DESCRIPTION
## Summary

Two bugs caught by post-merge code review of PR #266 (language-packs completion). Both have a clean recovery story but weren't behaving correctly under failure.

## 1. NER wheel install self-heals when extraction was lost

**Confidence: 92, severity: critical** (per the review).

`download_artifact` short-circuits to `already_installed` when the wheel passes SHA verification. For NER wheels, the wheel is only half the install — the extracted spaCy package directory next to it is what `spacy.load(<path>)` actually reads.

Before this fix, if `_extract_ner_wheel()` failed (transient I/O, permissions, disk pressure cron, manual cleanup) the wheel SHA still verified on the next install attempt. The early return fired without re-extracting, so the system stayed broken: the wheel passed verification, the package dir didn't exist, every NER call silently fell back to no-entities for that language.

**The only recovery path was `remove_artifact()` followed by reinstall** — which the operator had no signal to perform, since both `installed_tools_for()` and the API listing said "installed". A "retry" via the install endpoint did nothing.

**Fix:** in the early-return guard, for NER wheels, check whether the extracted dir exists. If not, re-extract before returning `already_installed`. The status stays `already_installed` because the wheel itself was on disk; the re-extraction is a quiet repair.

New regression test: `test_ner_install_self_heals_when_extraction_was_lost` — install, wipe extracted dir, re-install, assert dir is back.

## 2. Onboarding wizard partial install now persists the working subset

**Confidence: 85, severity: important.**

The wizard's install loop was wrapped in a single try/catch. A failure on the third of five selected languages aborted the entire batch, AND skipped the `PATCH /api/me/preferences` that would have recorded the two languages that did install. Result: packs on disk, no preference entry to enable them at OCR time. The user's only recourse was to discover the gap themselves and toggle the languages on under System Settings → Languages.

**Fix:** track `installed`/`failures` in arrays; never let a per-language failure abort the batch. After the loop, PATCH preferences for the working subset (backend always inserts `'en'` at index 0). Surface the failures with a message that points the operator at System Settings → Languages.

If everything fails, the wizard stays on page 2 so the user sees the error rather than silently advancing. Skip remains available.

Frontend-only — no test added since the project doesn't have a JS unit-test setup. The logic is small enough to review by reading.

## Out of scope

The following items from the same review were intentionally NOT addressed (all confirmed as acceptable tradeoffs or non-issues):

- Zip-slip in `_extract_ner_wheel`: confirmed safe (Python stdlib protections + SHA pinning + member-prefix filter).
- Refresh-on-demand cost: review re-confirmed it's once per document, not once per page. Cheap.
- NER threading lock: correctly needed for the worker pool's double-checked locking pattern.
- Legacy vs non-OCR'd doc conflation in the reprocess banner: known acceptable tradeoff (top-level Reprocess button still available to admins).
- `_CHUNK_LANGUAGE_TO_ISO` 5 dead entries: documented in the static map.
- Onboarding install UX freeze on slow networks: real but low-severity; Skip remains available.

## Validation

- 516 passed (+1 new), ruff clean, format clean
- Frontend type-check + lint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)