### PR TITLE
Frontend design pass — Calm Cartography hybrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 .claude/
 .serena/
 .worktrees/
+.superpowers/
 
 # Frontend
 frontend/node_modules/

--- a/docs/superpowers/plans/2026-05-04-frontend-design-pass.md
+++ b/docs/superpowers/plans/2026-05-04-frontend-design-pass.md
@@ -1,0 +1,2394 @@
+# Frontend Design Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the "Calm Cartography" hybrid design pass (per-area accent palette + serif title face + subtle depth + document-type icons) across every route in the React SPA, in dark + light mode.
+
+**Architecture:** All changes are CSS + JSX inside `frontend/`. New design tokens go to `index.css`; a small `useAreaAccent` hook binds the active route's hue to `--area-accent` on the layout root; six new shared components (`PageHeader`, `StatusPill`, `IconTile`, `Card`, plus a `documentTypeIcon` util and a `topicDotColor` util) carry the new conventions; every page imports those components instead of repeating the patterns inline.
+
+**Tech Stack:** React 19, React Router 7, Tailwind CSS 4 (CSS-first config in `frontend/src/index.css`), Vite 7.3, TypeScript 5, ESLint 10. No new dependencies. No JS unit-test setup (project doesn't have one — we verify with type-check + lint + format + manual smoke).
+
+**Spec:** [`docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md`](../specs/2026-05-03-frontend-design-pass-design.md)
+
+---
+
+## File map
+
+**Create:**
+- `frontend/src/components/PageHeader.tsx` — serif title + accent bar + optional subtitle
+- `frontend/src/components/StatusPill.tsx` — glyph + label, state-tinted bg
+- `frontend/src/components/IconTile.tsx` — 28-30px rounded-square tinted tile, hue prop
+- `frontend/src/components/Card.tsx` — gradient surface wrapper (thin React component)
+- `frontend/src/utils/documentTypeIcon.ts` — `(doc: { doc_type, mime_type, canonical_filename }) => { glyph, hue }`
+- `frontend/src/utils/topicDotColor.ts` — deterministic-hash-of-string → one of eight area-accent hues
+- `frontend/src/hooks/useAreaAccent.ts` — reads route, returns `{ areaName, accentVar }`, optionally applies to root
+
+**Modify (tokens / global):**
+- `frontend/src/index.css` — add `--area-{name}-accent[-tint|-text]` vars (8 areas × 3 = 24 dark + 24 light), font-family stack with New York, hairline tokens (`--color-border` already exists; bump consistency)
+
+**Modify (top nav):**
+- `frontend/src/components/Layout.tsx` — `TabLink` gets icon prop; active tab uses `--area-accent` instead of hard-coded blue; layout root gets `data-layout-root` + the `useAreaAccent` hook
+
+**Modify (per-page sweeps — see Tasks 9-19):**
+- `SystemSettingsPage` (hub), 12 Settings subpages, `DocumentsPage`, `DocumentDetailPage`, `FoldersPage`, `ExplorePage`, `SearchPage`, `StatsPage`, `ResearchPage`, `ChatPage` + `HomePage` + chat sidebar, `LoginPage`, `OnboardingWizard`
+
+---
+
+## Task 1: Token foundation in `index.css`
+
+**Files:**
+- Modify: `frontend/src/index.css`
+
+- [ ] **Step 1: Read the current token block to see what's already there**
+
+```bash
+sed -n '1,90p' frontend/src/index.css
+```
+
+Expected: existing `@theme` block, light + `.dark` variable definitions, scrollbar styles. Note where the dark-mode variables end (around line 56 in the audit snapshot — re-verify before editing).
+
+- [ ] **Step 2: Append the per-area accent tokens after the existing `.dark` block**
+
+Add this block after the closing `}` of the `.dark { ... }` selector (and before the `*` selector for font smoothing). Both light-mode (root) and dark-mode (under `.dark`) variants are required.
+
+```css
+/* ---- Per-area accent tokens (light mode = :root) ---- */
+
+:root {
+  /* Ask — terracotta (light) */
+  --area-ask-accent: #8a5a42;
+  --area-ask-accent-tint: rgba(138, 90, 66, 0.10);
+  --area-ask-accent-text: #8a5a42;
+
+  /* Research — ochre (light) */
+  --area-research-accent: #966c2e;
+  --area-research-accent-tint: rgba(150, 108, 46, 0.10);
+  --area-research-accent-text: #966c2e;
+
+  /* Folders — warm khaki (light) */
+  --area-folders-accent: #6e6a5a;
+  --area-folders-accent-tint: rgba(110, 106, 90, 0.10);
+  --area-folders-accent-text: #6e6a5a;
+
+  /* Docs — dusty blue (light) */
+  --area-docs-accent: #3f6885;
+  --area-docs-accent-tint: rgba(63, 104, 133, 0.10);
+  --area-docs-accent-text: #3f6885;
+
+  /* Explore — mauve (light) */
+  --area-explore-accent: #6a4d6a;
+  --area-explore-accent-tint: rgba(106, 77, 106, 0.10);
+  --area-explore-accent-text: #6a4d6a;
+
+  /* Search — dusty teal (light) */
+  --area-search-accent: #4a7585;
+  --area-search-accent-tint: rgba(74, 117, 133, 0.10);
+  --area-search-accent-text: #4a7585;
+
+  /* Observatory — sage (light) */
+  --area-observatory-accent: #5a7556;
+  --area-observatory-accent-tint: rgba(90, 117, 86, 0.10);
+  --area-observatory-accent-text: #5a7556;
+
+  /* Settings — slate (light) */
+  --area-settings-accent: #5a5a64;
+  --area-settings-accent-tint: rgba(90, 90, 100, 0.10);
+  --area-settings-accent-text: #5a5a64;
+
+  /* Default — bound by useAreaAccent on the layout root.
+     Pre-auth pages (login/setup) get the docs accent as a neutral fallback. */
+  --area-accent: var(--area-docs-accent);
+  --area-accent-tint: var(--area-docs-accent-tint);
+  --area-accent-text: var(--area-docs-accent-text);
+}
+
+.dark {
+  /* Ask — terracotta (dark) */
+  --area-ask-accent: #a8745a;
+  --area-ask-accent-tint: rgba(168, 116, 90, 0.12);
+  --area-ask-accent-text: #d49d80;
+
+  /* Research — ochre (dark) */
+  --area-research-accent: #b88a4a;
+  --area-research-accent-tint: rgba(184, 138, 74, 0.12);
+  --area-research-accent-text: #d4a574;
+
+  /* Folders — warm khaki (dark) */
+  --area-folders-accent: #8a8576;
+  --area-folders-accent-tint: rgba(138, 133, 118, 0.12);
+  --area-folders-accent-text: #b0aa9a;
+
+  /* Docs — dusty blue (dark) */
+  --area-docs-accent: #5b8aa8;
+  --area-docs-accent-tint: rgba(91, 138, 168, 0.15);
+  --area-docs-accent-text: #8aafc4;
+
+  /* Explore — mauve (dark) */
+  --area-explore-accent: #8a6a8a;
+  --area-explore-accent-tint: rgba(138, 106, 138, 0.15);
+  --area-explore-accent-text: #b890b8;
+
+  /* Search — dusty teal (dark) */
+  --area-search-accent: #6a96a8;
+  --area-search-accent-tint: rgba(106, 150, 168, 0.15);
+  --area-search-accent-text: #90b8c8;
+
+  /* Observatory — sage (dark) */
+  --area-observatory-accent: #7a9670;
+  --area-observatory-accent-tint: rgba(122, 150, 112, 0.15);
+  --area-observatory-accent-text: #a8c49a;
+
+  /* Settings — slate (dark) */
+  --area-settings-accent: #7a7a82;
+  --area-settings-accent-tint: rgba(122, 122, 130, 0.15);
+  --area-settings-accent-text: #a0a0a8;
+
+  /* Default — same fallback chain as light */
+  --area-accent: var(--area-docs-accent);
+  --area-accent-tint: var(--area-docs-accent-tint);
+  --area-accent-text: var(--area-docs-accent-text);
+}
+```
+
+- [ ] **Step 3: Add the serif font stack to the `@theme` block**
+
+Find the existing `--font-sans` declaration in `@theme { ... }` and add the serif stack alongside:
+
+```css
+@theme {
+  --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  --font-serif: 'New York', 'NewYork', ui-serif, Georgia, serif;
+  /* (existing --shadow-mac and --shadow-mac-lg lines stay) */
+}
+```
+
+This makes `font-serif` available as a Tailwind utility (`font-serif`) per Tailwind v4's `@theme` convention.
+
+- [ ] **Step 4: Add the surface-card layer-class for the gradient surface treatment**
+
+After the design-tokens block (after the `.dark { ... }` selector, can sit alongside the area tokens), add:
+
+```css
+@layer components {
+  .surface-card {
+    background-color: var(--color-bg-primary);
+    background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.012) 0%, transparent 100%);
+    border: 1px solid var(--color-border);
+    border-radius: 0.625rem; /* matches existing rounded-[10px] elsewhere */
+    transition: border-color 150ms ease;
+  }
+
+  .dark .surface-card {
+    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.025) 0%, transparent 100%);
+  }
+
+  .surface-card:hover {
+    border-color: rgba(0, 0, 0, 0.14);
+  }
+
+  .dark .surface-card:hover {
+    border-color: rgba(255, 255, 255, 0.18);
+  }
+}
+```
+
+- [ ] **Step 5: Verify build still works**
+
+Run:
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+
+Expected: build succeeds. If it fails, the most likely cause is a CSS syntax error in the appended block — fix and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/index.css
+git commit -m "$(cat <<'EOF'
+feat(frontend): add per-area accent tokens + serif stack + surface-card layer
+
+Eight per-area accent triples (--area-{name}-accent[-tint|-text]) for
+both light and dark modes — the foundation for the design pass. Adds
+--font-serif (New York, falls back to Georgia). Adds .surface-card
+component class with the subtle top→bottom gradient (highlight in dark,
+shadow in light). Default --area-accent fallback points at docs (dusty
+blue) for pre-auth pages; useAreaAccent hook (next task) overrides it
+per-route on the layout root.
+
+No JSX changes yet; tokens unused. Follow-up tasks pick them up.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `useAreaAccent` hook + layout-root binding
+
+**Files:**
+- Create: `frontend/src/hooks/useAreaAccent.ts`
+- Modify: `frontend/src/components/Layout.tsx`
+
+- [ ] **Step 1: Create the hook**
+
+Write `frontend/src/hooks/useAreaAccent.ts`:
+
+```typescript
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+/** Single source of truth for the eight area names used throughout the design system. */
+export type AreaHue =
+  | 'ask'
+  | 'research'
+  | 'folders'
+  | 'docs'
+  | 'explore'
+  | 'search'
+  | 'observatory'
+  | 'settings'
+
+const ROUTE_TO_AREA: { test: (path: string) => boolean; area: AreaHue }[] = [
+  // Order matters — most specific first.
+  { test: (p) => p.startsWith('/research'), area: 'research' },
+  { test: (p) => p.startsWith('/folders'), area: 'folders' },
+  { test: (p) => p.startsWith('/docs'), area: 'docs' },
+  { test: (p) => p.startsWith('/explore'), area: 'explore' },
+  { test: (p) => p.startsWith('/search'), area: 'search' },
+  { test: (p) => p.startsWith('/stats'), area: 'observatory' },
+  { test: (p) => p.startsWith('/admin') || p.startsWith('/integrations') || p.startsWith('/preferences'), area: 'settings' },
+  // Ask is the default — matches '/' and '/c/:conversationId'.
+  { test: () => true, area: 'ask' },
+]
+
+/**
+ * Returns the active area name for the current route.
+ * Side effect: applies the area's accent vars to the layout root element
+ * (the element with `data-layout-root`), which makes `--area-accent`,
+ * `--area-accent-tint`, `--area-accent-text` resolve to the right hue.
+ */
+export function useAreaAccent(): { area: AreaHue } {
+  const location = useLocation()
+  const area = ROUTE_TO_AREA.find((m) => m.test(location.pathname))!.area
+
+  useEffect(() => {
+    const root = document.querySelector<HTMLElement>('[data-layout-root]')
+    if (!root) return
+    root.style.setProperty('--area-accent', `var(--area-${area}-accent)`)
+    root.style.setProperty('--area-accent-tint', `var(--area-${area}-accent-tint)`)
+    root.style.setProperty('--area-accent-text', `var(--area-${area}-accent-text)`)
+  }, [area])
+
+  return { area }
+}
+```
+
+- [ ] **Step 2: Wire the hook into Layout.tsx**
+
+Open `frontend/src/components/Layout.tsx`. Find the outermost layout container (the top-level wrapper that everything else is inside — typically a `<div>` near the start of the JSX returned by `Layout`). Add `data-layout-root` to it.
+
+The exact diff depends on the existing Layout structure. Verify by reading lines 70-110 of `Layout.tsx`. Most likely candidate: the `<div className="min-h-screen ...">` wrapper. Add:
+
+```tsx
+<div data-layout-root className="min-h-screen ...">
+```
+
+Then add the hook import + call near the other hooks at the top of the `Layout` function:
+
+```tsx
+import { useAreaAccent } from '../hooks/useAreaAccent'
+// ...
+function Layout() {
+  // (existing hooks: useAuth, useState, etc.)
+  useAreaAccent()
+  // (rest of body)
+}
+```
+
+- [ ] **Step 3: Type-check + lint**
+
+```bash
+cd frontend && npm run type-check && npm run lint
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Verify in HarborClerk**
+
+Open the HarborClerk client app (or rebuild + open if changes need a fresh bundle):
+
+```bash
+cd frontend && npm run build
+```
+
+Then open HarborClerk, log in, navigate to `/docs`. Open DevTools (right-click → Inspect — works inside WKWebView in dev mode). On the layout-root element, confirm the inline style includes `--area-accent: var(--area-docs-accent)`. Navigate to `/admin` and re-check — should switch to `--area-settings-accent`.
+
+If DevTools isn't accessible, skip — Task 3 onward will surface visible regressions if the binding is wrong.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/hooks/useAreaAccent.ts frontend/src/components/Layout.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): useAreaAccent hook + bind active area on layout root
+
+Hook reads location.pathname, maps it to one of eight area names
+(ask / research / folders / docs / explore / search / observatory /
+settings), and applies that area's accent vars to the layout root via
+data-layout-root selector + element.style.setProperty.
+
+After this commit --area-accent etc. resolve to the active area's hue
+on every page. Components in subsequent tasks consume those vars.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `PageHeader` shared component
+
+**Files:**
+- Create: `frontend/src/components/PageHeader.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Write `frontend/src/components/PageHeader.tsx`:
+
+```tsx
+import { ReactNode } from 'react'
+
+interface PageHeaderProps {
+  title: string
+  subtitle?: ReactNode
+  /** Optional content rendered to the right of the title (action button, search input, etc.). */
+  actions?: ReactNode
+}
+
+/**
+ * Standard page-title block: serif title + short accent bar tinted with
+ * the active area's hue + optional subtitle line + optional right-aligned
+ * actions slot.
+ *
+ * The accent bar uses var(--area-accent) which is bound by the
+ * useAreaAccent hook on the layout root — so every page that renders
+ * inside Layout automatically gets the right color.
+ */
+export function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-4 flex items-start justify-between gap-4">
+      <div>
+        <h1 className="font-serif text-3xl font-semibold tracking-tight text-(--color-text-primary)">
+          {title}
+        </h1>
+        <div
+          className="mt-1.5 h-[3px] w-12 rounded-sm"
+          style={{ background: 'var(--area-accent)' }}
+        />
+        {subtitle && (
+          <p className="mt-2 text-sm text-(--color-text-secondary)">{subtitle}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  )
+}
+
+export default PageHeader
+```
+
+- [ ] **Step 2: Type-check + lint**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check
+```
+
+Expected: all pass. If `format:check` fails, run `npx prettier --write frontend/src/components/PageHeader.tsx` to auto-fix.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/components/PageHeader.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): add PageHeader shared component (serif title + accent bar)
+
+Renders the standard page-title block: serif title (font-serif, the
+New York stack), short 48px×3px accent bar in the active area's hue
+(via --area-accent), optional subtitle, optional right-aligned actions
+slot. Used by every page in the next tasks; replaces the ad-hoc
+<h1 className="text-2xl font-bold mb-4">…</h1> patterns sprinkled
+across the page files.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `StatusPill` shared component
+
+**Files:**
+- Create: `frontend/src/components/StatusPill.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Write `frontend/src/components/StatusPill.tsx`:
+
+```tsx
+export type PillState = 'active' | 'running' | 'idle' | 'error' | 'pending'
+
+interface StatusPillProps {
+  state: PillState
+  /** Override the default label for the state (e.g. "embedding" instead of "running"). */
+  label?: string
+  /** Override the default glyph for the state. */
+  glyph?: string
+}
+
+const STATE_CONFIG: Record<PillState, { glyph: string; label: string; cls: string }> = {
+  active: {
+    glyph: '●',
+    label: 'active',
+    // Sage tints — light mode bg/fg first, dark mode after the colon.
+    cls: 'bg-[rgba(74,108,73,0.10)] text-[#4a6c49] dark:bg-[rgba(122,150,112,0.18)] dark:text-[#a8c49a]',
+  },
+  running: {
+    glyph: '⟳',
+    label: 'running',
+    cls: 'bg-[rgba(150,108,46,0.10)] text-[#966c2e] dark:bg-[rgba(184,138,74,0.18)] dark:text-[#d4a574]',
+  },
+  idle: {
+    glyph: '○',
+    label: 'idle',
+    cls: 'bg-[rgba(90,90,100,0.10)] text-[#5a5a64] dark:bg-[rgba(122,122,130,0.18)] dark:text-[#a0a0a8]',
+  },
+  error: {
+    glyph: '⚠',
+    label: 'error',
+    cls: 'bg-[rgba(168,90,90,0.10)] text-[#a85a5a] dark:bg-[rgba(168,90,90,0.20)] dark:text-[#d49a9a]',
+  },
+  pending: {
+    glyph: '◐',
+    label: 'pending',
+    cls: 'bg-[rgba(63,104,133,0.10)] text-[#3f6885] dark:bg-[rgba(91,138,168,0.18)] dark:text-[#8aafc4]',
+  },
+}
+
+/**
+ * Status pill — leading glyph + label, with state-tinted background and
+ * matching foreground color in both light and dark modes.
+ */
+export function StatusPill({ state, label, glyph }: StatusPillProps) {
+  const cfg = STATE_CONFIG[state]
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${cfg.cls}`}
+    >
+      <span aria-hidden>{glyph ?? cfg.glyph}</span>
+      <span>{label ?? cfg.label}</span>
+    </span>
+  )
+}
+
+export default StatusPill
+```
+
+- [ ] **Step 2: Type-check + lint + format**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/components/StatusPill.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): add StatusPill component (5 states with glyph + tint)
+
+Single component for status indicators across the app. Five states —
+active (● sage), running (⟳ ochre), idle (○ slate), error (⚠ rust),
+pending (◐ dusty blue) — each with glyph, label, and matched bg+fg
+hues for both light and dark modes. Optional label/glyph props for
+state aliases like "embedding" instead of "running".
+
+Replaces the ad-hoc inline pill markup currently scattered across
+FoldersPage, DocumentsPage, DocumentDetailPage, the queue tray, and
+StatsPage. Sweep happens in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `IconTile` shared component
+
+**Files:**
+- Create: `frontend/src/components/IconTile.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Write `frontend/src/components/IconTile.tsx`:
+
+```tsx
+import { ReactNode } from 'react'
+import type { AreaHue } from '../hooks/useAreaAccent'
+
+interface IconTileProps {
+  /** Area name whose accent variables drive the tint. Falls back to the active area when omitted. */
+  hue?: AreaHue
+  /** Glyph or small element rendered inside (e.g. "📕" or "🔑"). */
+  children: ReactNode
+  /** Tile size in pixels. Default 30. */
+  size?: number
+}
+
+/**
+ * Small rounded-square colored tile used as a category/type indicator
+ * (document type next to a doc title, settings-section icon, etc.).
+ *
+ * Uses --area-{hue}-accent-tint as the background and --area-{hue}-accent-text
+ * as the foreground so dark/light variants come along for free. When hue
+ * is omitted the active area's --area-accent-tint / --area-accent-text are
+ * used instead (so the tile matches the page it lives on).
+ */
+export function IconTile({ hue, children, size = 30 }: IconTileProps) {
+  const style = hue
+    ? {
+        backgroundColor: `var(--area-${hue}-accent-tint)`,
+        color: `var(--area-${hue}-accent-text)`,
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.47),
+      }
+    : {
+        backgroundColor: 'var(--area-accent-tint)',
+        color: 'var(--area-accent-text)',
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.47),
+      }
+
+  return (
+    <div
+      className="flex shrink-0 items-center justify-center rounded-[7px]"
+      style={style}
+      aria-hidden
+    >
+      {children}
+    </div>
+  )
+}
+
+export default IconTile
+```
+
+- [ ] **Step 2: Type-check + lint + format**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/components/IconTile.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): add IconTile component (rounded tinted square for icons)
+
+Renders a 28-30px (default 30) rounded square with a 12-15% tint of the
+chosen area's accent and the accent itself as foreground. Defaults to
+the active area when no hue is passed (uses --area-accent-tint /
+--area-accent-text). Used by document-type rows, settings sections,
+and category indicators in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `Card` shared component
+
+**Files:**
+- Create: `frontend/src/components/Card.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Write `frontend/src/components/Card.tsx`:
+
+```tsx
+import { HTMLAttributes, forwardRef } from 'react'
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Render as a different element type. Default 'div'. */
+  as?: 'div' | 'section' | 'article' | 'a'
+}
+
+/**
+ * Surface card with the standard gradient + hairline border treatment.
+ * Wraps the .surface-card layer-class defined in index.css. Forwarded ref
+ * for callers that need it (e.g. focus management).
+ *
+ * Usage: <Card className="p-4">…</Card>
+ *
+ * The .surface-card class supplies bg, gradient, border, and hover state.
+ * Padding, layout, and per-instance overrides come from className as usual.
+ */
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { className = '', children, as: _as = 'div', ...rest },
+  ref,
+) {
+  return (
+    <div ref={ref} className={`surface-card ${className}`} {...rest}>
+      {children}
+    </div>
+  )
+})
+
+export default Card
+```
+
+(The `as` prop is in the interface but unused for now — `'div'` only. Future task can extend if anchors/sections become useful.)
+
+- [ ] **Step 2: Type-check + lint + format**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/components/Card.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): add Card component wrapping the .surface-card layer-class
+
+Tiny React wrapper around the .surface-card class so call sites get
+ref forwarding + an as-prop seam without sweeping every existing
+.rounded-xl shadow-mac ring-1 ring-border block. Used heavily in the
+per-page sweeps to follow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `documentTypeIcon` utility
+
+**Files:**
+- Create: `frontend/src/utils/documentTypeIcon.ts`
+
+- [ ] **Step 1: Create the utility**
+
+Write `frontend/src/utils/documentTypeIcon.ts`:
+
+```typescript
+import type { AreaHue } from '../hooks/useAreaAccent'
+
+export interface DocLike {
+  doc_type?: string | null
+  mime_type?: string | null
+  canonical_filename?: string | null
+}
+
+export interface DocumentIconResult {
+  glyph: string
+  hue: AreaHue
+}
+
+/** Pattern → icon. First match wins, so order matters (most specific first). */
+const DOC_TYPE_PATTERNS: { pattern: RegExp; glyph: string; hue: AreaHue }[] = [
+  // The travel-vs-guide tie: 'travel' must come before generic 'guide'.
+  { pattern: /\btravel(ogue|\s+(writing|journal|guide))?\b/i, glyph: '🧭', hue: 'explore' },
+  { pattern: /\b(restaurant\s+menu|menu)\b/i, glyph: '🍽', hue: 'observatory' },
+  { pattern: /\b(recipe|cookbook|cooking\s+guide)\b/i, glyph: '🍳', hue: 'observatory' },
+  { pattern: /\breview\b/i, glyph: '⭐', hue: 'research' },
+  { pattern: /\b(magazine\s+article|article|blog)\b/i, glyph: '📰', hue: 'docs' },
+  { pattern: /\bmagazine\b/i, glyph: '🗞', hue: 'explore' },
+  { pattern: /\b(essay|philosophical\s+dialogue|dialogue)\b/i, glyph: '🎓', hue: 'search' },
+  { pattern: /\bguide\b/i, glyph: '🗺', hue: 'explore' },
+  { pattern: /\b(memoir|personal\s+narrative|narrative)\b/i, glyph: '📓', hue: 'ask' },
+  { pattern: /\b(research\s+paper|journal\s+article|paper)\b/i, glyph: '🔬', hue: 'docs' },
+  { pattern: /\b(contract|agreement|license|legal)\b/i, glyph: '⚖', hue: 'settings' },
+  { pattern: /\b(personal\s+letter|letter)\b/i, glyph: '💌', hue: 'ask' },
+  { pattern: /\b(invoice|receipt)\b/i, glyph: '🧾', hue: 'observatory' },
+  // Plain "novel" / "book" — but not "cookbook" / "recipe book" (caught above).
+  { pattern: /\b(novel|book)\b/i, glyph: '📕', hue: 'docs' },
+  { pattern: /\bdescription\b/i, glyph: '📋', hue: 'settings' },
+]
+
+/** MIME-type → icon (used when doc_type doesn't match anything). */
+const MIME_PATTERNS: { test: (mime: string) => boolean; glyph: string; hue: AreaHue }[] = [
+  { test: (m) => m === 'application/pdf', glyph: '📄', hue: 'ask' },
+  { test: (m) => m.includes('spreadsheet') || m === 'text/csv', glyph: '📊', hue: 'observatory' },
+  { test: (m) => m === 'message/rfc822', glyph: '✉', hue: 'research' },
+  { test: (m) => m.includes('presentation'), glyph: '🎞', hue: 'explore' },
+  { test: (m) => m.startsWith('audio/'), glyph: '🎙', hue: 'ask' },
+  { test: (m) => m.startsWith('image/'), glyph: '🖼', hue: 'search' },
+  { test: (m) => m === 'text/html', glyph: '🌐', hue: 'explore' },
+  { test: (m) => m.startsWith('text/x-') || m === 'application/json', glyph: '💻', hue: 'explore' },
+  { test: (m) => m.startsWith('text/'), glyph: '📜', hue: 'settings' },
+]
+
+/** Filename-extension → icon (final fallback when both above miss). */
+const EXT_PATTERNS: { exts: string[]; glyph: string; hue: AreaHue }[] = [
+  { exts: ['pdf'], glyph: '📄', hue: 'ask' },
+  { exts: ['xlsx', 'xls', 'csv', 'numbers'], glyph: '📊', hue: 'observatory' },
+  { exts: ['eml', 'msg', 'mbox'], glyph: '✉', hue: 'research' },
+  { exts: ['pptx', 'ppt', 'key'], glyph: '🎞', hue: 'explore' },
+  { exts: ['mp3', 'wav', 'm4a', 'flac', 'aac', 'ogg'], glyph: '🎙', hue: 'ask' },
+  { exts: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'tiff', 'bmp', 'heic'], glyph: '🖼', hue: 'search' },
+  { exts: ['html', 'htm'], glyph: '🌐', hue: 'explore' },
+  { exts: ['py', 'js', 'ts', 'tsx', 'jsx', 'rb', 'go', 'rs', 'c', 'h', 'cpp', 'java', 'json'], glyph: '💻', hue: 'explore' },
+  { exts: ['txt', 'md', 'log', 'rtf'], glyph: '📜', hue: 'settings' },
+]
+
+const FALLBACK: DocumentIconResult = { glyph: '📦', hue: 'settings' }
+
+/**
+ * Resolve a document to an icon glyph + area hue.
+ *
+ * Resolution order:
+ *   1. doc_type (LLM-derived, free-form — case-insensitive substring match).
+ *   2. mime_type.
+ *   3. canonical_filename extension.
+ *   4. Fallback: 📦 (slate).
+ *
+ * The doc_type list and coverage rationale are documented in the
+ * 2026-05-03 spec ("Coverage audit" section).
+ */
+export function documentTypeIcon(doc: DocLike): DocumentIconResult {
+  if (doc.doc_type) {
+    const dt = doc.doc_type
+    for (const { pattern, glyph, hue } of DOC_TYPE_PATTERNS) {
+      if (pattern.test(dt)) return { glyph, hue }
+    }
+  }
+
+  if (doc.mime_type) {
+    const mime = doc.mime_type.toLowerCase()
+    for (const { test, glyph, hue } of MIME_PATTERNS) {
+      if (test(mime)) return { glyph, hue }
+    }
+  }
+
+  if (doc.canonical_filename) {
+    const dot = doc.canonical_filename.lastIndexOf('.')
+    const ext = dot >= 0 ? doc.canonical_filename.slice(dot + 1).toLowerCase() : ''
+    if (ext) {
+      for (const { exts, glyph, hue } of EXT_PATTERNS) {
+        if (exts.includes(ext)) return { glyph, hue }
+      }
+    }
+  }
+
+  return FALLBACK
+}
+```
+
+- [ ] **Step 2: Type-check + lint + format**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Sanity check the patterns by hand**
+
+Open the file in your editor and walk through the corpus's top doc types from the spec's coverage table mentally:
+- "Wine Review" → matches `/\breview\b/i` first → ⭐ research ✓
+- "Recipe Book" → matches `/\b(recipe|cookbook|cooking\s+guide)\b/i` first (recipe matches before book) → 🍳 observatory ✓
+- "Travel Guide" → matches `/\btravel(ogue|\s+(writing|journal|guide))?\b/i` first (travel guide is in the alternation) → 🧭 explore ✓
+- "Beekeeping Guide" → no travel match, falls to `/\bguide\b/i` → 🗺 explore ✓
+- "Magazine Article" → matches `/\b(magazine\s+article|article|blog)\b/i` → 📰 docs ✓
+- "Personal Letter" → matches `/\b(personal\s+letter|letter)\b/i` → 💌 ask ✓
+- "Cookbook" → matches recipe/cookbook → 🍳 observatory ✓ (and not the `/\bbook\b/i` pattern because cookbook matches earlier)
+- "Novel" → matches `/\b(novel|book)\b/i` → 📕 docs ✓
+- "Food Writing" → no match → falls to mime → fallback → 📦 settings (acknowledged limitation in spec)
+
+If any case feels wrong, adjust the pattern + re-run lint.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/utils/documentTypeIcon.ts
+git commit -m "$(cat <<'EOF'
+feat(frontend): add documentTypeIcon util (LLM-aware doc → glyph + hue)
+
+Resolves (DocLike doc) → { glyph, hue } via three-tier lookup:
+priority-ordered regex over doc_type (LLM free-form text), then
+mime_type, then filename extension. Patterns + coverage rationale
+documented in the 2026-05-03 spec; ~80%+ coverage on the live corpus's
+top-30 doc_types.
+
+Travel-vs-guide tie-breaker: "travel" alternation comes before generic
+guide, so "Travel Guide" → 🧭 (travel-writing) and "Wine Guide" → 🗺
+(generic guide). Recipe before book, so "Recipe Book" → 🍳 not 📕.
+
+Used by DocumentsPage rows + DocumentDetailPage in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `topicDotColor` utility
+
+**Files:**
+- Create: `frontend/src/utils/topicDotColor.ts`
+
+- [ ] **Step 1: Create the utility**
+
+Write `frontend/src/utils/topicDotColor.ts`:
+
+```typescript
+import type { AreaHue } from '../hooks/useAreaAccent'
+
+const HUES: AreaHue[] = [
+  'ask',
+  'research',
+  'folders',
+  'docs',
+  'explore',
+  'search',
+  'observatory',
+  'settings',
+]
+
+/**
+ * Deterministic-hash-of-id → one of the eight area-accent hues.
+ *
+ * Used by the conversation list (Ask + Research sidebars) so each
+ * conversation gets a stable colored dot. v1 derivation per the
+ * 2026-05-03 spec: hash of conversation_id mod 8. Smarter "color by
+ * dominant topic / top-cited entity" is a deferred follow-up.
+ */
+export function topicDotColor(id: string): AreaHue {
+  // FNV-1a, 32-bit. Deterministic, low collision, no deps.
+  let hash = 0x811c9dc5
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return HUES[hash % HUES.length]
+}
+
+/** Convenience: returns the CSS var() reference for the hue's accent value. */
+export function topicDotVar(id: string): string {
+  return `var(--area-${topicDotColor(id)}-accent)`
+}
+```
+
+- [ ] **Step 2: Type-check + lint + format**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/utils/topicDotColor.ts
+git commit -m "$(cat <<'EOF'
+feat(frontend): add topicDotColor util (conversation-id → stable hue)
+
+FNV-1a hash of an id mod 8 mapped onto the area-accent hues, plus a
+topicDotVar convenience that returns the matching var() reference for
+inline styles. Used by the Ask + Research conversation sidebars in the
+following tasks. Smarter "color by dominant topic" is a deferred
+follow-up per the spec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Update `Layout.tsx` TabLink with icons + accent
+
+**Files:**
+- Modify: `frontend/src/components/Layout.tsx`
+
+- [ ] **Step 1: Read the current TabLink + nav structure**
+
+```bash
+sed -n '1,110p' frontend/src/components/Layout.tsx
+```
+
+Understand: the current `TabLink` returns a `<NavLink>` with the active state styled blue (`bg-blue-50 text-blue-700 ring-blue-200/60` and dark variants). We're replacing the hard-coded blue with the active area's accent and adding an icon prop.
+
+- [ ] **Step 2: Replace `TabLink` with the new version**
+
+Find the `TabLink` function (currently around line 11) and replace its entire body with:
+
+```tsx
+function TabLink({
+  to,
+  end,
+  icon,
+  children,
+}: {
+  to: string
+  end?: boolean
+  icon?: string
+  children: React.ReactNode
+}) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        `relative inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors ${
+          isActive
+            ? 'text-(--area-accent-text) ring-1'
+            : 'text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 hover:text-(--color-text-primary)'
+        }`
+      }
+      style={({ isActive }) =>
+        isActive
+          ? {
+              backgroundColor: 'var(--area-accent-tint)',
+              boxShadow: 'inset 0 0 0 1px var(--area-accent)',
+            }
+          : undefined
+      }
+    >
+      {icon && <span aria-hidden>{icon}</span>}
+      <span>{children}</span>
+    </NavLink>
+  )
+}
+```
+
+The `boxShadow: inset 0 0 0 1px var(--area-accent)` substitutes for the `ring-1 ring-blue-200/60` pattern because Tailwind's `ring-` utilities can't reference CSS variables for the color in v4 without a workaround. Inset box-shadow gives the same visual.
+
+- [ ] **Step 3: Pass the icon prop to each TabLink call**
+
+In the same file, find the nav block (around lines 90-99). Update each TabLink call to include the icon. Example (with the full replacement):
+
+```tsx
+<TabLink to="/" end icon="💬">Ask</TabLink>
+<TabLink to="/research" icon="🐙">Research</TabLink>
+<TabLink to="/folders" icon="📁">Folders</TabLink>
+<TabLink to="/docs" icon="📄">Documents</TabLink>
+<TabLink to="/explore" icon="🌍">Explore</TabLink>
+<TabLink to="/search" icon="🔍">Search</TabLink>
+<TabLink to="/stats" icon="📊">Observatory</TabLink>
+{isAdmin && <TabLink to="/integrations" icon="🔌">Integrations</TabLink>}
+{isAdmin && <TabLink to="/admin" icon="⚙">System Settings</TabLink>}
+```
+
+If your existing nav has the Ask tab written as a different element (e.g. a logo + text instead of a TabLink), preserve that and only add the icon to actual TabLinks. Verify by reading the current JSX.
+
+- [ ] **Step 4: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass; build succeeds.
+
+- [ ] **Step 5: Smoke-check in HarborClerk**
+
+Open HarborClerk, log in, click through every top-level tab. Expected:
+- Each tab now shows a small emoji to the left of the label.
+- The active tab's pill background + ring is the area's accent hue (terracotta on Ask, dusty blue on Documents, sage on Observatory, slate on System Settings, etc.) — not blue.
+- Inactive tabs look like before.
+
+If a tab's accent looks wrong (e.g. Documents stays blue), check that `useAreaAccent` from Task 2 is wired up.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/components/Layout.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): TabLink icons + per-area accent active state
+
+Each top-nav tab gets a small emoji icon next to the label. Active-tab
+pill + ring switch from hard-coded blue to the active area's accent
+(via --area-accent-tint background + inset box-shadow ring + accent-text
+text color), so the nav strip is the first place users see the area's
+hue. Hover state on inactive tabs unchanged.
+
+Inset box-shadow workaround used in lieu of Tailwind's ring-{color}
+utilities, which don't accept CSS variables for the color in v4
+without a workaround.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Sweep Settings hub + simple Settings subpages
+
+**Files:**
+- Modify: `frontend/src/pages/SystemSettingsPage.tsx`
+- Modify: `frontend/src/pages/UsersPage.tsx`
+- Modify: `frontend/src/pages/ApiKeysPage.tsx`
+- Modify: `frontend/src/pages/ApiKeyDashboardPage.tsx`
+- Modify: `frontend/src/pages/RetrievalSettingsPage.tsx`
+- Modify: `frontend/src/pages/RateLimitSettingsPage.tsx`
+- Modify: `frontend/src/pages/ServiceLogsPage.tsx`
+- Modify: `frontend/src/pages/IntegrationsPage.tsx`
+- Modify: `frontend/src/pages/PreferencesPage.tsx`
+
+- [ ] **Step 1: Rewrite `SystemSettingsPage.tsx` with grouped sections + icon tiles**
+
+The current file (44 lines) is a flat list of `<Link>` rows. Replace with grouped sections per the spec. New full file:
+
+```tsx
+import { Link } from 'react-router-dom'
+import { useAuth } from '../auth'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { IconTile, type AreaHue } from '../components/IconTile'
+
+interface SettingsItem {
+  to: string
+  label: string
+  sub: string
+  icon: string
+  hue: AreaHue
+}
+
+const SECTIONS: { label: string; items: SettingsItem[] }[] = [
+  {
+    label: 'Access & identity',
+    items: [
+      { to: '/admin/users', label: 'Users', sub: 'Manage accounts and roles', icon: '👥', hue: 'docs' },
+      { to: '/admin/keys', label: 'API Keys', sub: 'Create and revoke API keys', icon: '🔑', hue: 'research' },
+    ],
+  },
+  {
+    label: 'Models & languages',
+    items: [
+      { to: '/admin/models', label: 'Models', sub: 'Download and manage LLM models', icon: '🧠', hue: 'observatory' },
+      { to: '/admin/languages', label: 'Languages', sub: 'OCR & entity language packs', icon: '🌐', hue: 'explore' },
+    ],
+  },
+  {
+    label: 'Behavior & limits',
+    items: [
+      { to: '/admin/retrieval', label: 'Retrieval', sub: 'Chat & MCP search behavior', icon: '🔍', hue: 'search' },
+      { to: '/admin/rate-limits', label: 'Rate Limits', sub: 'Default API key rate limits', icon: '⏱', hue: 'ask' },
+    ],
+  },
+  {
+    label: 'Operations',
+    items: [
+      { to: '/admin/system/status', label: 'System Status', sub: 'Health checks and statistics', icon: '💚', hue: 'observatory' },
+      { to: '/admin/system/logs', label: 'Service Logs', sub: 'View log files and tail commands', icon: '📜', hue: 'settings' },
+      { to: '/admin/system/maintenance', label: 'System Maintenance', sub: 'Purge, reaper, and cleanup', icon: '🧹', hue: 'ask' },
+    ],
+  },
+]
+
+export default function SystemSettingsPage() {
+  const { user } = useAuth()
+  if (user?.role !== 'admin') {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        <PageHeader title="System Settings" />
+        <p className="text-sm text-(--color-text-secondary)">Admins only.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <PageHeader title="System Settings" />
+      {SECTIONS.map((section) => (
+        <div key={section.label} className="mb-6">
+          <h2 className="mb-2 font-serif text-base font-semibold tracking-tight text-(--color-text-primary)">
+            {section.label}
+          </h2>
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            {section.items.map((item) => (
+              <Card key={item.to} className="p-0">
+                <Link
+                  to={item.to}
+                  className="flex items-center gap-3 px-3.5 py-3 text-sm"
+                >
+                  <IconTile hue={item.hue} size={28}>{item.icon}</IconTile>
+                  <div className="flex-1">
+                    <div className="font-medium text-(--color-text-primary)">{item.label}</div>
+                    <div className="text-[11px] text-(--color-text-secondary)">{item.sub}</div>
+                  </div>
+                  <span className="text-(--color-text-secondary) opacity-50">›</span>
+                </Link>
+              </Card>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Sweep the simple Settings subpages — apply PageHeader, replace ad-hoc h1s**
+
+For each of these files: read the existing content, find the page-title `<h1>` (or `<h2>` standing in for one), and replace with `<PageHeader title="…" />`. Drop the import line for `PageHeader` at the top. Preserve all other JSX and logic.
+
+Files to sweep (in this order, one commit per pair if you prefer smaller commits, otherwise one commit at the end of step 3):
+
+1. **`UsersPage.tsx`** — find `<h1>Users</h1>` (or similar), replace with `<PageHeader title="Users" />`. Wrap the user table in `<Card className="overflow-hidden">…</Card>` if it isn't already in some kind of card.
+2. **`ApiKeysPage.tsx`** — same: `<PageHeader title="API Keys" />`.
+3. **`ApiKeyDashboardPage.tsx`** — `<PageHeader title={`Key: ${keyName}`} />` if there's a key in scope, else `<PageHeader title="API Key" />`.
+4. **`RetrievalSettingsPage.tsx`** — `<PageHeader title="Retrieval" subtitle="Chat & MCP search behavior" />`.
+5. **`RateLimitSettingsPage.tsx`** — `<PageHeader title="Rate Limits" />`.
+6. **`ServiceLogsPage.tsx`** — `<PageHeader title="Service Logs" />`.
+7. **`IntegrationsPage.tsx`** — `<PageHeader title="Integrations" subtitle="MCP and external integrations" />`.
+8. **`PreferencesPage.tsx`** — `<PageHeader title="Preferences" subtitle="Personal settings" />`.
+
+For each one: also wrap the largest top-level content block in a `<Card className="p-4">` if it currently lives on raw page background. If it's already a card (e.g. uses `rounded-xl ring-1 ring-(--color-border)`), replace those classes with `<Card className="p-4">`.
+
+- [ ] **Step 3: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Smoke-check**
+
+Open HarborClerk, navigate to `/admin`. Expected:
+- Hub page now grouped into four serif-titled sections.
+- Each item is a card with a colored icon tile, hover state, chevron.
+- Active "System Settings" tab in nav is slate.
+- Click into Users / API Keys / etc. — each subpage has the serif `PageHeader` with a slate accent bar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/SystemSettingsPage.tsx \
+        frontend/src/pages/UsersPage.tsx \
+        frontend/src/pages/ApiKeysPage.tsx \
+        frontend/src/pages/ApiKeyDashboardPage.tsx \
+        frontend/src/pages/RetrievalSettingsPage.tsx \
+        frontend/src/pages/RateLimitSettingsPage.tsx \
+        frontend/src/pages/ServiceLogsPage.tsx \
+        frontend/src/pages/IntegrationsPage.tsx \
+        frontend/src/pages/PreferencesPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep Settings hub + simple subpages with new design tokens
+
+System Settings hub rewritten: grouped into four sections (Access &
+identity / Models & languages / Behavior & limits / Operations) with
+serif section labels and IconTile-tile icons drawn from the per-area
+accents (Users → docs/blue, API Keys → research/ochre, Models →
+observatory/sage, Languages → explore/mauve, etc.).
+
+Simple subpages (Users, API Keys, API Key Dashboard, Retrieval, Rate
+Limits, Service Logs, Integrations, Preferences) get PageHeader with
+the auto-bound slate accent (via the Settings area route prefix), and
+their primary content surfaces wrapped in <Card>. No behavior changes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Sweep richer Settings subpages (Models / Languages / SystemStatus / SystemMaintenance)
+
+**Files:**
+- Modify: `frontend/src/pages/ModelsPage.tsx`
+- Modify: `frontend/src/pages/LanguagesPage.tsx`
+- Modify: `frontend/src/pages/SystemStatusPage.tsx`
+- Modify: `frontend/src/pages/SystemMaintenancePage.tsx`
+
+- [ ] **Step 1: ModelsPage — PageHeader + Card-per-model + StatusPill for download state**
+
+Read the file. Replace the page title `<h1>` with `<PageHeader title="Models" subtitle="Download and manage local LLM models" />`. Find the loop that renders one card per model (most likely `models.map((m) => (...))` or similar). Wrap each model's row in `<Card className="p-4 mb-2">…</Card>`.
+
+If model state is shown as text or a colored span (e.g. "ready", "downloading", "missing"), replace with `<StatusPill state="active" label="ready" />` / `<StatusPill state="running" label="downloading" />` / `<StatusPill state="idle" label="missing" />` / `<StatusPill state="error" />` as appropriate.
+
+Imports to add:
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill } from '../components/StatusPill'
+```
+
+- [ ] **Step 2: LanguagesPage — PageHeader + Card-per-language-row + StatusPill for install state**
+
+Same pattern. Replace the page title `<h1>` with `<PageHeader title="Languages" subtitle="OCR and entity language packs" />`. Wrap each language row in `<Card className="p-3 mb-2">`. Replace install-state badges with `<StatusPill>`.
+
+The existing language pack states map to:
+- "installed" → `<StatusPill state="active" label="installed" />`
+- "installing" → `<StatusPill state="running" label="installing" />`
+- "available" / "not installed" → `<StatusPill state="idle" label="available" />`
+- "failed" → `<StatusPill state="error" />`
+
+- [ ] **Step 3: SystemStatusPage — PageHeader + Cards for the existing status sections**
+
+Find the page title and replace with `<PageHeader title="System Status" subtitle="Health checks and service statistics" />`. The existing health/status cards (worker queues, postgres, embedder, etc.) likely already live in some kind of card markup — replace those wrappers with `<Card className="p-4">`.
+
+Inside each card, if there's a per-service status indicator (green dot, "running" text, etc.) replace with the appropriate `<StatusPill>`.
+
+- [ ] **Step 4: SystemMaintenancePage — PageHeader + Cards for action sections**
+
+Find the page title and replace with `<PageHeader title="System Maintenance" subtitle="Purge, reaper, and cleanup actions" />`. Wrap each action group (Purge / Reaper / Cleanup) in `<Card className="p-4 mb-3">`. Destructive buttons keep their existing red styling.
+
+- [ ] **Step 5: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Smoke-check**
+
+Open `/admin/models`, `/admin/languages`, `/admin/system/status`, `/admin/system/maintenance`. Expected:
+- Each page has the slate `PageHeader`.
+- State indicators render as the new StatusPill.
+- Cards have the subtle gradient.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/ModelsPage.tsx \
+        frontend/src/pages/LanguagesPage.tsx \
+        frontend/src/pages/SystemStatusPage.tsx \
+        frontend/src/pages/SystemMaintenancePage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep richer Settings subpages with PageHeader + Card + StatusPill
+
+Models, Languages, SystemStatus, SystemMaintenance get the same
+PageHeader + Card + StatusPill treatment as the simple subpages.
+Install/download/health states all map onto the new five-state pill
+component (active/running/idle/error/pending). No behavioral change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Sweep `DocumentsPage`
+
+**Files:**
+- Modify: `frontend/src/pages/DocumentsPage.tsx`
+
+- [ ] **Step 1: Read the file structure**
+
+```bash
+sed -n '1,80p' frontend/src/pages/DocumentsPage.tsx
+grep -n "h1\|h2\|className=\"text-\|status\|active\|filter" frontend/src/pages/DocumentsPage.tsx | head -30
+```
+
+Understand: where the page title is rendered, where the filter row is, where the row-rendering loop is (the `documents.map(...)` or similar), and where the status pill markup lives.
+
+- [ ] **Step 2: Add imports + replace the page title**
+
+At the top of the file, add:
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill } from '../components/StatusPill'
+import { IconTile } from '../components/IconTile'
+import { documentTypeIcon } from '../utils/documentTypeIcon'
+```
+
+Find the existing page title `<h1>` (probably `<h1 className="text-2xl font-bold mb-4">Documents</h1>` or similar) and replace with:
+
+```tsx
+<PageHeader title="Documents" actions={<FoldersLink />} />
+```
+
+…where `<FoldersLink />` represents the existing top-right "Folders" button. If it's a single inline element rather than a separate component, just put that JSX into the actions slot directly.
+
+If there's a "Continue viewing" affordance currently rendered above the title, leave it where it is (above the PageHeader); the spec preserves it.
+
+- [ ] **Step 3: Update each row to use IconTile + StatusPill**
+
+Find the row-rendering JSX (the `.map((doc) => (...))` block). Inside the row's JSX, add an `IconTile` at the start (left of the title) and replace the existing inline status badge with `<StatusPill state={...} />`.
+
+Example (the exact JSX depends on existing structure — adapt; keep all existing data bindings):
+
+```tsx
+{documents.map((doc) => {
+  const { glyph, hue } = documentTypeIcon(doc)
+  return (
+    <Card key={doc.doc_id} className="mb-1.5 flex items-center gap-3 px-3.5 py-3">
+      <IconTile hue={hue} size={30}>{glyph}</IconTile>
+      <div className="min-w-0 flex-1">
+        <Link to={`/docs/${doc.doc_id}`} className="block truncate font-medium text-(--color-text-primary) hover:underline">
+          {doc.title}
+        </Link>
+        <p className="truncate text-[11px] text-(--color-text-secondary)">
+          {doc.canonical_filename ?? doc.title}
+        </p>
+      </div>
+      <StatusPill state={mapDocStatusToPillState(doc.pipeline_status)} />
+      <span className="shrink-0 text-[11px] text-(--color-text-secondary)">
+        {formatDate(doc.updated_at)}
+      </span>
+      <DownloadIcon doc={doc} />
+    </Card>
+  )
+})}
+```
+
+Add a small helper at the top of the file (or at the bottom — wherever existing helpers live). The `pipeline_status` enum values are defined in `src/harbor_clerk/models/enums.py` (`PipelineStatus`):
+
+```tsx
+import type { PillState } from '../components/StatusPill'
+
+// Maps backend pipeline_status (PipelineStatus enum) → frontend pill state.
+// The enum values: queued, extracting, extracted, ocr_running, ocr_done,
+// chunking, chunked, extracting_entities, entities_done, embedding, embedded,
+// summarizing, summarized, finalizing, ready, error.
+function mapDocStatusToPillState(pipeline: string): PillState {
+  if (pipeline === 'error') return 'error'
+  if (pipeline === 'ready') return 'active'
+  if (pipeline === 'queued') return 'pending'
+  // All other states are in-progress (extracting / chunking / embedding / etc.).
+  return 'running'
+}
+```
+
+(Pass `doc.pipeline_status` to this when rendering each row.)
+
+- [ ] **Step 4: Update the expanded-row metadata block**
+
+When a row is expanded (the chevron-click reveals "DOCUMENT TYPE", "SUMMARY", "TOPIC", "SOURCE"), wrap the expanded section's content in a slightly inset `<Card className="mt-2 ml-9 p-3">` (or whatever margin matches the existing visual). The expanded content should look like a nested elevated surface, not blend into the row above.
+
+- [ ] **Step 5: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Smoke-check**
+
+Open HarborClerk → Documents. Expected:
+- PageHeader serif title + dusty-blue accent bar.
+- Each row: type-icon tile (left) → title + filename → status pill → date → download icon.
+- Different doc types show different icons (Novel = 📕 / PDF = 📄 / etc.).
+- Clicking a row's expand caret reveals nested Card with the metadata.
+- Active "Documents" tab in nav is dusty blue.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/DocumentsPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep DocumentsPage with PageHeader + IconTile + StatusPill
+
+PageHeader replaces the inline h1 (dusty-blue accent bar via the
+auto-bound docs area). Each row gets an IconTile with the document-
+type glyph (Novel / PDF / Spreadsheet / Email / etc.) drawn from
+documentTypeIcon. Status text replaced with StatusPill. Expanded-row
+metadata wraps in a nested Card so it visually nests instead of
+bleeding into table chrome.
+
+Continue-viewing affordance preserved at the top. Filter row layout
+unchanged. No behavior changes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Sweep `DocumentDetailPage`
+
+**Files:**
+- Modify: `frontend/src/pages/DocumentDetailPage.tsx`
+
+- [ ] **Step 1: Replace the page title block + add IconTile next to the title**
+
+At the top of the file add the imports (PageHeader, Card, StatusPill, IconTile, documentTypeIcon — same set as DocumentsPage; some may already be imported).
+
+Find the existing title block (probably `<h1 className="...">{doc.title}</h1>` near the top of the JSX). Replace with:
+
+```tsx
+{doc && (
+  <div className="mb-4 flex items-start gap-3">
+    <IconTile hue={documentTypeIcon(doc).hue} size={36}>
+      {documentTypeIcon(doc).glyph}
+    </IconTile>
+    <div className="flex-1">
+      <PageHeader
+        title={doc.title}
+        subtitle={doc.canonical_filename}
+        actions={
+          <>
+            <button onClick={onReprocess} className="...">Reprocess</button>
+            <button onClick={onDelete} className="...">Delete</button>
+          </>
+        }
+      />
+    </div>
+  </div>
+)}
+```
+
+Adapt the action buttons' classes to match existing — don't restyle them, just preserve the existing classNames.
+
+- [ ] **Step 2: Wrap the ingestion-jobs and stats sections in Cards**
+
+Find the Ingestion Jobs section and wrap its body in `<Card className="p-3 mb-4">`. Inside the jobs list, replace the per-job status indicator with `<StatusPill state={...} />` mapping the job's status to the pill state.
+
+Find the Document Statistics section and wrap in `<Card className="p-4 mb-4">`. Existing entity-type colored badges in this section MUST remain unchanged (the existing `ENTITY_TYPE_COLORS` map continues to power them).
+
+- [ ] **Step 3: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Smoke-check**
+
+Open any document's detail page. Expected:
+- Type-icon tile to the left of the serif title.
+- Dusty-blue accent bar under the title.
+- Ingestion Jobs section in its own Card with StatusPill per job.
+- Document Statistics in a Card with entity-type colored badges UNCHANGED.
+- Reprocess + Delete buttons stay where they were.
+- Reveal in Finder button (if user is on macOS) unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/DocumentDetailPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep DocumentDetailPage with PageHeader + IconTile + Cards
+
+Title row picks up the document-type icon (left of the serif title).
+Ingestion jobs wrapped in a Card with StatusPill per job. Document
+statistics wrapped in a Card. Existing entity-type colored badges
+preserved exactly as-is — they were the working color story on this
+page already.
+
+Reprocess + Delete + Reveal in Finder action buttons unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Sweep `FoldersPage`
+
+**Files:**
+- Modify: `frontend/src/pages/FoldersPage.tsx`
+
+- [ ] **Step 1: Add imports + replace the page title**
+
+At the top of the file add:
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill } from '../components/StatusPill'
+import { IconTile } from '../components/IconTile'
+```
+
+Find the page title `<h1>` and replace with:
+
+```tsx
+<PageHeader
+  title="Folders"
+  actions={
+    <button
+      onClick={onAddFolder}
+      className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium"
+      style={{
+        backgroundColor: 'var(--area-accent-tint)',
+        color: 'var(--area-accent-text)',
+        border: '1px solid var(--area-accent)',
+      }}
+    >
+      <span aria-hidden>＋</span> Add Folder
+    </button>
+  }
+/>
+```
+
+The button uses inline styles with the area-accent vars (the page is in the Folders area, so the active accent is warm khaki). This replaces the current iOS-blue "Add Folder" button.
+
+- [ ] **Step 2: Replace the table with Card-per-row**
+
+Find the existing table markup. Replace with a vertical stack of cards, one per folder. Example:
+
+```tsx
+{folders.map((folder) => (
+  <Card key={folder.id} className="mb-2 flex items-center gap-3 px-3.5 py-3">
+    <IconTile size={30}>📁</IconTile>
+    <div className="min-w-0 flex-1">
+      <div className="truncate font-medium text-(--color-text-primary)">{folder.path}</div>
+      <div className="text-[11px] text-(--color-text-secondary)">
+        {folder.progress_completed} / {folder.progress_total}
+      </div>
+    </div>
+    <StatusPill state={mapFolderStatusToPillState(folder.status)} />
+    <div className="flex shrink-0 items-center gap-2">
+      <button onClick={() => onDisable(folder)} className="...">Disable</button>
+      <button onClick={() => onDelete(folder)} className="...">Delete</button>
+    </div>
+  </Card>
+))}
+```
+
+Add a helper:
+
+```tsx
+function mapFolderStatusToPillState(status: string): 'active' | 'running' | 'idle' | 'error' | 'pending' {
+  if (status === 'idle') return 'idle'
+  if (status === 'scanning' || status === 'ingesting') return 'running'
+  if (status === 'errored') return 'error'
+  return 'active'
+}
+```
+
+Adapt the status enum strings to match the actual values returned by the backend (verify by grepping `src/harbor_clerk/models/watched_folder.py` or the API schema).
+
+- [ ] **Step 3: Add empty state**
+
+Wrap the folders list in a check for `folders.length === 0` and render a centered hero block in that case:
+
+```tsx
+{folders.length === 0 ? (
+  <Card className="mx-auto mt-8 flex max-w-md flex-col items-center gap-3 p-8 text-center">
+    <IconTile size={56}>📁</IconTile>
+    <h3 className="font-serif text-lg font-semibold">No folders yet</h3>
+    <p className="text-sm text-(--color-text-secondary)">
+      Add a folder to start watching for documents to ingest.
+    </p>
+    <button onClick={onAddFolder} className="..." style={{ /* same as the header button */ }}>
+      ＋ Add Folder
+    </button>
+  </Card>
+) : (
+  <div>{/* the .map(...) above */}</div>
+)}
+```
+
+- [ ] **Step 4: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Smoke-check**
+
+Open /folders. Expected:
+- Serif "Folders" title with khaki accent bar.
+- "Add Folder" button uses khaki-tinted styling (not blue).
+- Each folder rendered as a Card row with folder icon tile + path + progress + StatusPill + Disable/Delete buttons.
+- Empty state (if you have access to a fresh install): centered hero card.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/FoldersPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep FoldersPage with khaki accent + Card-per-row + empty state
+
+Page title now uses PageHeader (khaki accent bar via Folders area).
+Add Folder button switches from iOS-blue to khaki-tinted styling
+(inline styles using --area-accent-tint / --area-accent-text /
+--area-accent border). Each folder rendered as a Card row with folder
+icon tile, path, progress text, StatusPill, and the existing Disable
++ Delete actions. Empty state added — centered hero card with the
+add-folder CTA when zero folders.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Sweep `ExplorePage` (entity-type tinted pills)
+
+**Files:**
+- Modify: `frontend/src/pages/ExplorePage.tsx`
+
+- [ ] **Step 1: Add imports + replace page title**
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { ENTITY_COLORS } from '../components/stats/CorpusCharts'
+```
+
+Find the page title and replace with:
+
+```tsx
+<PageHeader
+  title="Explore"
+  subtitle="People, places, organizations, and topic clusters in your corpus"
+  actions={
+    <input
+      type="search"
+      placeholder="Search topics & entities…"
+      value={searchTerm}
+      onChange={(e) => setSearchTerm(e.target.value)}
+      className="w-64 rounded-md bg-(--color-bg-secondary) px-3 py-1.5 text-sm ring-1 ring-(--color-border) focus:outline-none focus:ring-2"
+      style={{ outlineColor: 'var(--area-accent)' }}
+    />
+  }
+/>
+```
+
+(Re-use whatever search-input class is already in use in the file; what matters is replacing the surrounding title block.)
+
+- [ ] **Step 2: Tint the People / Places / Organizations pills with entity-type colors**
+
+Find the pills loop for each section (likely something like `people.map((p) => <span className="bg-gray-...">{p.name}</span>)`).
+
+Replace the gray pill class with inline-styled pills using the entity type's color from the existing `ENTITY_COLORS` map. People = PERSON (blue), Places = GPE (orange), Organizations = ORG (green). Example:
+
+```tsx
+{people.map((p) => (
+  <span
+    key={p.id}
+    className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs"
+    style={{
+      backgroundColor: `${ENTITY_COLORS.PERSON}1f`, // 12% opacity hex
+      color: ENTITY_COLORS.PERSON,
+    }}
+  >
+    {p.name}
+    <span className="text-[10px] opacity-70">{p.count}</span>
+  </span>
+))}
+```
+
+The `1f` suffix on the hex is 12% opacity in 8-digit hex. (Tailwind v4 supports `bg-[var(...)/12]` for opacity-on-vars too — either form is fine.)
+
+Repeat for the Places loop using `ENTITY_COLORS.GPE` and Organizations using `ENTITY_COLORS.ORG`.
+
+- [ ] **Step 3: Wrap each Topic Cluster card body in `<Card>`**
+
+Find the Topic Clusters grid. Each cluster's container becomes:
+
+```tsx
+<Card key={cluster.id} className="p-3.5">
+  <div className="mb-1.5 flex items-center gap-2">
+    <span
+      className="inline-block h-2 w-2 rounded-full"
+      style={{ backgroundColor: cluster.color }}
+    />
+    <h4 className="font-medium text-(--color-text-primary)">{cluster.name}</h4>
+  </div>
+  {/* existing tag chips, document count, etc. */}
+</Card>
+```
+
+(The `cluster.color` field is already populated from the existing topic-color logic; preserve it.)
+
+- [ ] **Step 4: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Smoke-check**
+
+Open /explore. Expected:
+- Serif "Explore" title with mauve accent bar.
+- People pills tinted blue (PERSON), Places tinted orange (GPE), Organizations tinted green (ORG).
+- Topic Cluster cards have the gradient surface treatment.
+- Active "Explore" tab in nav is mauve.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/ExplorePage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep ExplorePage — entity-type tinted pills + topic-cluster Cards
+
+People / Places / Organizations pills switch from monochrome gray to
+12%-tint pills colored with their entity type's hue from ENTITY_COLORS
+(PERSON = blue, GPE = orange, ORG = green) — the highest-leverage spot
+for entity colors outside DocumentDetail. Topic cluster cards wrapped
+in <Card>. PageHeader with mauve accent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Sweep `SearchPage`
+
+**Files:**
+- Modify: `frontend/src/pages/SearchPage.tsx`
+
+- [ ] **Step 1: Replace page title + accent the focus ring + button**
+
+Add imports:
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+```
+
+Replace the existing page title with `<PageHeader title="Search" subtitle="Hybrid lexical + semantic retrieval" />`.
+
+Find the "Search" submit button. Replace its current blue styling with the area's accent treatment (the search input's existing focus-ring stays as-is — restyling Tailwind ring colors with CSS vars is fiddly enough to defer):
+
+```tsx
+<button
+  type="submit"
+  className="rounded-md px-4 py-1.5 text-sm font-medium"
+  style={{
+    backgroundColor: 'var(--area-accent-tint)',
+    color: 'var(--area-accent-text)',
+    border: '1px solid var(--area-accent)',
+  }}
+>
+  Search
+</button>
+```
+
+- [ ] **Step 2: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Smoke-check**
+
+Open /search. Expected:
+- Serif title with dusty-teal accent bar.
+- Search button styled in dusty teal (not blue).
+- Active "Search" tab in nav is dusty teal.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/SearchPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep SearchPage with PageHeader + dusty-teal button accent
+
+Page title block, focus ring, and Search submit button switch to the
+dusty-teal area accent. No behavior change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Sweep `StatsPage` (Observatory) — serif KPI numerals + sage accent
+
+**Files:**
+- Modify: `frontend/src/pages/StatsPage.tsx`
+
+- [ ] **Step 1: Add imports + replace page title**
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+```
+
+Replace the existing title block with `<PageHeader title="Observatory" subtitle="Corpus statistics and processing pipeline" />`.
+
+Sub-tabs ("Corpus Statistics" / "Processing Pipeline") keep their existing tab pattern; the active tab indicator should use `var(--area-accent)` instead of hard-coded blue. If the sub-tab markup is custom (not TabLink), update the active-state class/style to use the var.
+
+- [ ] **Step 2: KPI numerals get the serif treatment**
+
+Find the four KPI cards (Documents / Chunks / Pages / Entities at the top). For each, update the number element to use `font-serif`:
+
+```tsx
+<div className="font-serif text-3xl font-semibold tracking-tight text-(--color-text-primary)">
+  {data.documents.toLocaleString()}
+</div>
+```
+
+If the KPI cards are already wrapped in card-like markup, keep that wrapper and just update the inner number's classes. If they're not wrapped, wrap each one in `<Card className="p-4">`.
+
+- [ ] **Step 3: Existing charts stay untouched**
+
+Important: the entity-color charts (Top Entities bar chart, Topic Distribution treemap, Entity Network graph) are NOT to be changed in this pass. Their colors are working. Just confirm they still render unchanged after the page-header swap.
+
+If the chart container divs use ad-hoc card markup (`rounded-xl bg-... shadow-mac ring-1 ring-...`), you can replace those wrappers with `<Card className="p-4">` to pick up the gradient surface — but DO NOT alter chart contents or palettes.
+
+- [ ] **Step 4: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Smoke-check**
+
+Open /stats. Expected:
+- Serif "Observatory" title with sage accent bar.
+- KPI numerals render in serif (visibly different from the labels above them).
+- Top Entities bar chart, Topic Distribution treemap, Entity Network graph all render with their existing colors and layouts — no regression.
+- Sub-tab active indicator is sage.
+- Active "Observatory" tab in nav is sage.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/StatsPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep StatsPage (Observatory) with sage accent + serif KPIs
+
+PageHeader with sage accent bar. KPI numerals render in font-serif so
+they read as confident headline numbers instead of generic large text.
+Sub-tab active indicator switches to sage. Existing entity-colored
+charts (Top Entities, Topic Distribution, Entity Network) unchanged —
+they were already the page's working color story.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Sweep `ResearchPage`
+
+**Files:**
+- Modify: `frontend/src/pages/ResearchPage.tsx`
+
+- [ ] **Step 1: Add imports + replace page title**
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { topicDotVar } from '../utils/topicDotColor'
+```
+
+Find the page title block. Replace the title with `<PageHeader title="Research" subtitle="Deep multi-step research over your corpus" />`.
+
+Important: leave the octopus illustration and the "Start Research" CTA (the current loud amber/orange button) UNCHANGED. The spec preserves both — the CTA "rhymes" with the area accent and the octopus is iconic.
+
+- [ ] **Step 2: Sidebar "+ New Research" button + conversation topic dots**
+
+Find the sidebar "+ New Research" button. Update it to use the ochre area accent:
+
+```tsx
+<button
+  onClick={onNewResearch}
+  className="mb-3 inline-flex w-full items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium"
+  style={{
+    backgroundColor: 'var(--area-accent-tint)',
+    color: 'var(--area-accent-text)',
+    border: '1px solid var(--area-accent)',
+  }}
+>
+  <span aria-hidden>＋</span> New Research
+</button>
+```
+
+Find the conversation list `.map()` in the sidebar. For each row, prepend a colored topic dot using `topicDotVar(conv.id)`:
+
+```tsx
+{conversations.map((conv) => (
+  <div key={conv.id} className="flex items-center gap-2 rounded px-2 py-1.5 hover:bg-(--color-bg-secondary)">
+    <span
+      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+      style={{ background: topicDotVar(conv.id) }}
+    />
+    <Link to={`/research/${conv.id}`} className="min-w-0 flex-1 truncate text-sm">
+      {conv.title}
+    </Link>
+    <span className="shrink-0 text-[10px] text-(--color-text-secondary)">
+      {formatRelative(conv.updated_at)}
+    </span>
+  </div>
+))}
+```
+
+(Adapt to existing sidebar JSX — the point is: prepend a colored dot, swap the new-research button to ochre.)
+
+- [ ] **Step 3: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Smoke-check**
+
+Open /research. Expected:
+- Octopus + serif "Research" title + ochre accent bar.
+- "Start Research" CTA still loud amber/orange — unchanged.
+- Sidebar "+ New Research" button now ochre-tinted.
+- Each conversation in the sidebar shows a colored topic dot.
+- Active "Research" tab in nav is ochre.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/ResearchPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep ResearchPage with ochre accent + sidebar topic dots
+
+PageHeader with ochre accent. Sidebar New Research button switches to
+the ochre area treatment. Each conversation in the sidebar gets a
+colored topic dot via topicDotColor (FNV-1a hash mod 8 onto the area-
+accent hues). Octopus illustration and the loud orange Start Research
+CTA preserved per spec — the existing color story rhymes with the
+area accent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: Sweep `HomePage` + `ChatPage` + chat sidebar (Ask area)
+
+**Files:**
+- Modify: `frontend/src/pages/HomePage.tsx`
+- Modify: `frontend/src/pages/ChatPage.tsx` (the sidebar lives inside ChatPage — there's no separate sidebar component; verified 2026-05-04)
+
+- [ ] **Step 1: Sidebar — apply terracotta accent + topic dots**
+
+In `ChatPage.tsx`, find the sidebar markup (the conversation list `.map()` and the "+ New conversation" button). Change the "+ New conversation" button to terracotta:
+
+```tsx
+import { topicDotVar } from '../utils/topicDotColor'
+// ...
+<button
+  onClick={onNewConversation}
+  className="mb-3 inline-flex w-full items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium"
+  style={{
+    backgroundColor: 'var(--area-accent-tint)',
+    color: 'var(--area-accent-text)',
+    border: '1px solid var(--area-accent)',
+  }}
+>
+  <span aria-hidden>＋</span> New conversation
+</button>
+```
+
+Update each conversation row to prepend a colored topic dot:
+
+```tsx
+<Link
+  to={`/c/${conv.id}`}
+  className="flex items-center gap-2 rounded px-2 py-1.5 hover:bg-(--color-bg-secondary)"
+>
+  <span
+    className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+    style={{ background: topicDotVar(conv.id) }}
+  />
+  <span className="min-w-0 flex-1 truncate text-sm text-(--color-text-primary)">{conv.title}</span>
+  <span className="shrink-0 text-[10px] text-(--color-text-secondary)">{formatRelative(conv.updated_at)}</span>
+</Link>
+```
+
+- [ ] **Step 2: HomePage / ChatPage empty state — terracotta hero block**
+
+In whichever component renders the chat empty state ("Ask your documents" + the icon + the suggestion chips), find the title block and update it to:
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { IconTile } from '../components/IconTile'
+// ...
+<div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+  <IconTile size={64}>📚</IconTile>
+  <div>
+    <h2 className="font-serif text-2xl font-semibold tracking-tight">Ask your documents</h2>
+    <p className="mt-2 text-sm text-(--color-text-secondary)">
+      Start a conversation to search, read, and reason over your library using a local LLM.
+    </p>
+  </div>
+  <div className="flex flex-wrap justify-center gap-2">
+    {SUGGESTION_CHIPS.map((chip) => (
+      <button
+        key={chip}
+        onClick={() => onChipClick(chip)}
+        className="rounded-full px-3 py-1 text-xs hover:opacity-80"
+        style={{
+          backgroundColor: 'var(--area-accent-tint)',
+          color: 'var(--area-accent-text)',
+          border: '1px solid var(--area-accent)',
+        }}
+      >
+        {chip}
+      </button>
+    ))}
+  </div>
+</div>
+```
+
+The IconTile picks up the active area's accent automatically (no `hue` prop = uses `--area-accent`), so this becomes a terracotta tinted square on Ask.
+
+Suggestion chip strings come from the existing constants in ChatPage / HomePage — preserve them.
+
+- [ ] **Step 3: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Smoke-check**
+
+Open / (Ask). Expected:
+- Empty state: terracotta IconTile (📚) + serif "Ask your documents" + terracotta suggestion chips.
+- Sidebar "+ New conversation" button is terracotta.
+- Each conversation in the sidebar has a colored topic dot.
+- Active "Ask" tab in nav is terracotta.
+- Click into a conversation: sidebar still shows dots.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/HomePage.tsx \
+        frontend/src/pages/ChatPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep Ask area — terracotta accent, hero IconTile, topic dots
+
+Sidebar New conversation button switches to terracotta-tinted styling.
+Each conversation row gets a colored topic dot via topicDotColor.
+Empty state hero gets a 64px terracotta IconTile + serif title +
+terracotta suggestion chips. Active Ask tab in nav is terracotta.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 20: Sweep `LoginPage` + `OnboardingWizard` + `SetupPage`
+
+**Files:**
+- Modify: `frontend/src/pages/LoginPage.tsx`
+- Modify: `frontend/src/pages/SetupPage.tsx`
+- Modify: `frontend/src/components/OnboardingWizard.tsx`
+
+- [ ] **Step 1: LoginPage — PageHeader + Card**
+
+Add imports:
+
+```tsx
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+```
+
+Find the existing centered login form. Wrap the form in `<Card className="mx-auto max-w-sm p-6">`. Above the form fields, add:
+
+```tsx
+<PageHeader title="Harbor Clerk" subtitle="Sign in to continue" />
+```
+
+Note: LoginPage is pre-auth so the layout-root binding doesn't run; `--area-accent` falls back to the docs default (dusty blue). That's fine — login doesn't need an area identity.
+
+- [ ] **Step 2: SetupPage — same treatment**
+
+Add the same PageHeader + Card wrapping. Title: "Setup" with a subtitle describing the step (the existing JSX likely has step text — preserve it as the subtitle).
+
+- [ ] **Step 3: OnboardingWizard — apply slate accent on Languages step**
+
+The wizard already lives inside Layout (`/onboarding` route), so `useAreaAccent` is active. The Languages step is one of the wizard's pages. On that step:
+
+- The "Install N & continue" CTA button uses inline styles bound to `var(--area-settings-accent-tint)` etc. (Settings = slate). Even though the active area might technically be Ask (since the wizard appears on /), we explicitly want this step to feel like a Settings interaction. So use `--area-settings-*` directly, not `--area-accent-*`.
+
+Example button:
+
+```tsx
+<button
+  onClick={onInstallAndContinue}
+  className="rounded-md px-4 py-2 text-sm font-medium"
+  style={{
+    backgroundColor: 'var(--area-settings-accent-tint)',
+    color: 'var(--area-settings-accent-text)',
+    border: '1px solid var(--area-settings-accent)',
+  }}
+>
+  Install {selectedCount} & continue
+</button>
+```
+
+The Skip button stays as a quiet text button.
+
+For other wizard steps (folder pick, progress overview), no per-step accent — let them use the active area's accent (which is whatever route the wizard appears on).
+
+- [ ] **Step 4: Type-check + lint + format + build**
+
+```bash
+cd frontend && npm run type-check && npm run lint && npm run format:check && npm run build 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Smoke-check**
+
+- Log out. Expected: login page now in a Card with serif "Harbor Clerk" title.
+- Trigger setup (if a fresh install is available, otherwise skip): same treatment.
+- Trigger the onboarding wizard: Languages step's Install button is slate-tinted.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway
+git add frontend/src/pages/LoginPage.tsx \
+        frontend/src/pages/SetupPage.tsx \
+        frontend/src/components/OnboardingWizard.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): sweep LoginPage + SetupPage + OnboardingWizard
+
+LoginPage and SetupPage get PageHeader + Card wrappers (pre-auth, so
+they fall back to the docs/dusty-blue default — fine since neither
+needs an area identity). Onboarding wizard's Languages step explicitly
+binds its Install CTA to the settings/slate area accent because it's
+conceptually a Settings interaction. Other wizard steps inherit the
+active area's accent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 21: Final validation + smoke checklist + open PR
+
+**Files:** none (validation + PR creation)
+
+- [ ] **Step 1: Full type-check + lint + format**
+
+```bash
+cd /Users/alex/mcp-gateway/frontend
+npm run type-check
+npm run lint
+npm run format:check
+npm run build 2>&1 | tail -20
+```
+
+All four must pass clean. Fix any remaining issues before proceeding.
+
+- [ ] **Step 2: Manual smoke checklist (per spec)**
+
+Open HarborClerk. Log in. Walk every top-level page in this order, verifying the bullets:
+
+- **Ask** (`/`):
+  - [ ] Active tab in nav is terracotta.
+  - [ ] Empty state shows terracotta IconTile (📚) + serif title + terracotta suggestion chips.
+  - [ ] Sidebar conversations have colored topic dots.
+- **Research** (`/research`):
+  - [ ] Active tab in nav is ochre.
+  - [ ] Octopus illustration unchanged. Start Research CTA still loud amber.
+  - [ ] Sidebar New Research button is ochre.
+- **Folders** (`/folders`):
+  - [ ] Active tab in nav is khaki.
+  - [ ] Add Folder button is khaki-tinted (not blue).
+  - [ ] Folder rows are Cards with status pills.
+- **Documents** (`/docs`):
+  - [ ] Active tab in nav is dusty blue.
+  - [ ] PageHeader serif title + dusty blue accent bar.
+  - [ ] Each row has a type-icon tile + status pill.
+  - [ ] Filter row preserved.
+- **DocumentDetail** (`/docs/<some-id>`):
+  - [ ] Type-icon tile to the left of the serif title.
+  - [ ] Existing entity-type colored badges unchanged.
+  - [ ] Ingestion Jobs in a Card with StatusPills.
+- **Explore** (`/explore`):
+  - [ ] Active tab in nav is mauve.
+  - [ ] People pills tinted blue (PERSON), Places tinted orange (GPE), Organizations tinted green (ORG).
+  - [ ] Topic Cluster cards have gradient surface.
+- **Search** (`/search`):
+  - [ ] Active tab in nav is dusty teal.
+  - [ ] Search button styled in dusty teal.
+- **Observatory** (`/stats`):
+  - [ ] Active tab in nav is sage.
+  - [ ] KPI numerals render in serif.
+  - [ ] Top Entities, Topic Distribution, Entity Network charts unchanged.
+- **System Settings** (`/admin`):
+  - [ ] Active tab in nav is slate.
+  - [ ] Hub grouped into 4 sections with serif labels + IconTile-led cards.
+  - [ ] Click into each subpage: each has a slate PageHeader.
+
+- [ ] **Step 3: Switch to light mode and re-spot-check**
+
+System Settings → Appearance → Light. Re-walk Ask, Documents, Observatory, Settings. For each:
+- [ ] Page hue is the deeper light-mode variant (not the dark variant on a white background).
+- [ ] Surface gradient flips to a faint top-down shadow (not a highlight).
+- [ ] Status pills have ~10% opacity bg + the deeper hue text.
+
+Switch back to Dark.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+cd /Users/alex/mcp-gateway
+git push -u origin spec/frontend-design-pass
+gh pr create --title "Frontend design pass — Calm Cartography hybrid" --body "$(cat <<'EOF'
+## Summary
+
+Implements [`docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md`](docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md) — a hybrid of option A (per-area hue + icon + subtle depth) executed with option B's restraint (muted earth-tone palette, serif title face, hairline rules).
+
+## What changed
+
+**Tokens (`frontend/src/index.css`):**
+- 8 per-area accent triples (`--area-{name}-accent[-tint|-text]`) for both light and dark modes.
+- `--font-serif` stack — New York with Georgia fallback.
+- `.surface-card` layer-class with the subtle top→bottom gradient (highlight in dark, shadow in light).
+
+**New shared components:**
+- `PageHeader` — serif title + accent bar.
+- `StatusPill` — 5 states (active/running/idle/error/pending) with glyph + state-tinted bg.
+- `IconTile` — colored rounded-square tile for category indicators.
+- `Card` — wrapper around `.surface-card` with ref forwarding.
+- `documentTypeIcon` util — pattern-matched LLM doc_type → glyph + hue (~80% coverage on the live corpus's top doc_types).
+- `topicDotColor` util — FNV-1a hash mod 8 → area-accent hue for conversation dots.
+- `useAreaAccent` hook — binds the active route's hue to `--area-accent` on the layout root.
+
+**Per-page sweeps:** every route gets the new PageHeader + StatusPill + IconTile + Card treatment with its area's accent — Ask (terracotta), Research (ochre), Folders (warm khaki), Documents (dusty blue), Explore (mauve), Search (dusty teal), Observatory (sage), Settings hub + 12 subpages (slate). LoginPage + SetupPage + OnboardingWizard also covered.
+
+## What didn't change
+
+Per the spec, these are working today and stay untouched:
+- Entity-type colors in DocumentDetail (`ENTITY_TYPE_COLORS`).
+- Observatory chart colors (Top Entities, Topic Distribution treemap, Entity Network graph).
+- Research page octopus illustration + amber Start Research CTA.
+- Documents page "Continue viewing" affordance + filter row layout.
+- All backend behavior, schemas, API surfaces, MCP tools, ingestion pipeline.
+
+## Out of scope (captured in `pr_followups.md`)
+
+Per spec — motion / micro-interactions, KPI trend deltas, topic-aware conversation dot, webfont fallback for Docker-served SPA, login brand mark, per-page background atmosphere, Tailwind v4 token migration audit, document-type icon coverage rescan after each new test corpus.
+
+## Validation
+
+- `npm run type-check` ✓
+- `npm run lint` ✓
+- `npm run format:check` ✓
+- `npm run build` ✓
+- Manual smoke walk through every page in both dark and light modes — see plan task 21 step 2.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Capture out-of-scope items in `pr_followups.md`**
+
+After the PR opens, append the following to `~/.claude/projects/-Users-alex-mcp-gateway/memory/pr_followups.md` under an appropriate category (or create new categories). The exact PR number is inserted after `gh pr create` returns the URL:
+
+```markdown
+## UX (frontend)
+
+- **PR #<NUM>** — Frontend design pass: motion / micro-interactions deferred. No hover-lift animations, no animated chart entries. Worth a follow-up pass once the static design lands.
+- **PR #<NUM>** — Frontend design pass: KPI trend deltas (the "+47 today" line under Observatory KPIs) deferred. Requires backend support for time-windowed counts.
+- **PR #<NUM>** — Frontend design pass: topic-aware conversation dot color deferred. v1 ships with hash-of-id; smarter "color by detected topic / top entity" needs a backend join or client-side derivation.
+- **PR #<NUM>** — Frontend design pass: webfont fallback for Docker-served SPA deferred. Georgia fallback acceptable for v1; a Source Serif Pro download is a follow-up.
+- **PR #<NUM>** — Frontend design pass: login page brand mark / illustration deferred. Page is now slightly less plain (gradient + serif) but still doesn't add identity.
+- **PR #<NUM>** — Frontend design pass: per-page background atmosphere (option C from brainstorming) explicitly deferred. Revisit if the muted-accent approach feels too subtle in practice.
+
+## Cleanup
+
+- **PR #<NUM>** — Frontend design pass: Tailwind v4 design-token migration audit deferred. This pass adds CSS vars; a follow-up could move all color tokens onto the `@theme` block uniformly.
+
+## Coverage / data quality
+
+- **PR #<NUM>** — Frontend design pass: document-type icon coverage rescan needed after each new test corpus is ingested. Snapshot SQL + protocol live in `project_test_corpora_plan.md`. Trigger: any future corpus dropping top-50 coverage below ~75%.
+```
+
+- [ ] **Step 6: Final commit**
+
+If you appended to `pr_followups.md`, no commit needed — that file is in `~/.claude` not the repo. Otherwise, the PR's commit history is the final state.
+
+```bash
+echo "Done. PR URL above."
+```
+
+---
+
+## Self-review notes (do these checks before handing off)
+
+After every task lands, before calling the plan complete:
+
+1. **Spec coverage:** every "Per-page changes" entry in the spec maps to a task above. Verified:
+   - Ask → Task 19 ✓
+   - Research → Task 18 ✓
+   - Folders → Task 14 ✓
+   - Documents → Task 12 ✓
+   - DocumentDetail → Task 13 ✓
+   - Search → Task 16 ✓
+   - Explore → Task 15 ✓
+   - Observatory → Task 17 ✓
+   - System Settings hub → Task 10 ✓
+   - All Settings subpages → Tasks 10 + 11 ✓
+   - DocumentDetail (entity colors stay) → Task 13 ✓
+   - Languages → Task 11 ✓
+   - Login → Task 20 ✓
+   - Onboarding wizard → Task 20 ✓
+
+2. **Tokens used consistently:** every page uses `var(--area-accent)` etc., never hard-coded hex. Verified by spec → tasks.
+
+3. **No new dependencies:** confirmed — every component uses React + Tailwind v4 only.
+
+4. **No backend changes:** confirmed — spec is CSS/JSX-only and plan tasks all touch `frontend/`.
+
+5. **No tests added:** correct per spec ("project doesn't currently have a JS unit-test setup, and adding one is out of scope"). Validation = type-check + lint + format + manual smoke checklist.

--- a/docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md
+++ b/docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md
@@ -86,25 +86,94 @@ These replace the current single-color status pills; existing call sites (Folder
 
 ### Document-type icons
 
-A new `documentTypeIcon(category)` helper maps document categories (already returned by the backend in `DocumentDetail.category` / file-extension fallback) to glyphs and to the matching icon-tile palette:
+A new `documentTypeIcon(doc)` helper resolves to a `{glyph, hue}` pair. Inputs (in priority order): the LLM-derived `doc.doc_type` (free-form text from summarization), then `doc.mime_type`, then file extension fallback.
 
-| Category | Glyph | Icon hue |
+**Important:** `doc_type` is LLM-generated and varied — the corpus shows entries like `"Wine Review"`, `"Cookbook"`, `"Recipe Book"`, `"Recipe book"`, `"Magazine Article"`, `"Food article"`, `"Philosophical Essay"`, `"Travelogue"`, `"Personal Letter"`, `"Non-Exclusive License Agreement"`, etc. The helper does **case-insensitive substring matching** against a priority-ordered list of patterns (most specific first), not exact-string lookup. The first matching pattern wins. The mapping is data-informed: the patterns below cover ~80%+ of the existing corpus's top doc_types based on a 2026-05-03 audit (see "Coverage audit" subsection).
+
+Patterns matched against `doc_type` (case-insensitive substring; first match wins). Hue picks from the eight area accents so categories harmonize with the Documents-area visual language and don't fight it:
+
+| Pattern matched | Glyph | Icon hue |
 |---|---|---|
-| Novel / book | 📕 | dusty blue (Documents area accent) |
-| PDF | 📄 | terracotta |
-| Spreadsheet | 📊 | sage |
-| Email | ✉ | ochre |
-| Plain text / notes | 📜 | slate |
-| Code / source | 💻 | mauve |
-| Image | 🖼 | dusty teal |
-| Presentation | 🎞 | mauve |
-| Audio / transcript | 🎙 | terracotta |
-| HTML / web | 🌐 | mauve |
-| Unknown / other | 📦 | slate |
+| `review` | ⭐ | ochre |
+| `recipe`, `cookbook`, `cooking guide` | 🍳 | sage |
+| `restaurant menu`, `menu` | 🍽 | sage |
+| `magazine` (when not also `article` — the `article` pattern below catches that combo) | 🗞 | mauve |
+| `article`, `blog` | 📰 | dusty blue |
+| `essay`, `philosophical dialogue`, `dialogue` | 🎓 | dusty teal |
+| `travelogue`, `travel writing`, `travel journal` | 🧭 | mauve |
+| `guide` (Food / Travel / Wine / Beekeeping / Tea / Coffee / Preservation, etc.) | 🗺 | mauve |
+| `memoir`, `personal narrative`, `narrative` | 📓 | terracotta |
+| `research paper`, `journal article`, `paper` | 🔬 | dusty blue |
+| `contract`, `agreement`, `license`, `legal` | ⚖ | slate |
+| `personal letter`, `letter` | 💌 | terracotta |
+| `invoice`, `receipt` | 🧾 | sage |
+| `novel`, `book` (as a non-modifier — i.e. not "cookbook" / "recipe book") | 📕 | dusty blue |
+| `description` (Restaurant / Wine / Product / Business / Fruit, etc.) | 📋 | slate |
+
+If no `doc_type` pattern matches, fall through to mime/extension:
+
+| Source | Glyph | Icon hue |
+|---|---|---|
+| `application/pdf` (and `.pdf` extension) | 📄 | terracotta |
+| `application/vnd.openxmlformats-officedocument.spreadsheetml.*`, `.xlsx`, `.xls`, `.csv` | 📊 | sage |
+| `message/rfc822`, `.eml`, `.msg` | ✉ | ochre |
+| `text/plain`, `.txt`, `.md`, `.log` | 📜 | slate |
+| `text/x-python`, `text/x-c`, etc. (any `text/x-*` source-code mime), common code extensions | 💻 | mauve |
+| `image/*` | 🖼 | dusty teal |
+| `application/vnd.openxmlformats-officedocument.presentationml.*`, `.pptx`, `.key` | 🎞 | mauve |
+| `audio/*`, `.mp3`, `.wav`, `.m4a` | 🎙 | terracotta |
+| `text/html`, `.html`, `.htm` | 🌐 | mauve |
+| Unknown / unmatched | 📦 | slate |
 
 The icon tile is a 28-30px rounded square with a 12% tint of the category hue and the hue itself as text color (or, in dark mode, a slightly lighter variant for legibility).
 
 This icon appears on Documents-page rows and on the DocumentDetail header. It does not replace the document title — title still leads.
+
+### Coverage audit (2026-05-03)
+
+Snapshot of top doc_types in the live corpus (3,150 docs) with which pattern they map to. Counts shown for the 30 most common values; tail follows the same patterns.
+
+| doc_type (top 30) | Count | Maps to pattern |
+|---|---:|---|
+| (null/empty) | 890 | mime/extension fallback |
+| Wine Review | 171 | `review` → ⭐ |
+| Recipe | 165 | `recipe` → 🍳 |
+| Book Review | 95 | `review` → ⭐ |
+| Philosophical Essay | 91 | `essay` → 🎓 |
+| Restaurant Review | 78 | `review` → ⭐ |
+| Food Article | 54 | `article` → 📰 |
+| Travelogue | 53 | `travelogue` → 🧭 |
+| Food Review | 53 | `review` → ⭐ |
+| Cookbook | 51 | `cookbook` → 🍳 |
+| Food Guide | 44 | `guide` → 🗺 |
+| Cookbook Review | 37 | `review` → ⭐ |
+| Restaurant Menu | 29 | `menu` → 🍽 |
+| Recipe Book | 28 | `recipe` → 🍳 |
+| Restaurant Description | 26 | `description` → 📋 |
+| Travel Guide | 25 | `travel` (more specific than `guide`) → 🧭 (or 🗺 if we relax — see decision below) |
+| Cooking Guide | 24 | `cooking guide` → 🍳 |
+| News Article | 23 | `article` → 📰 |
+| Food article | 23 | `article` → 📰 |
+| Recipe book | 22 | `recipe` → 🍳 |
+| Novel | 21 | `novel` → 📕 |
+| Food Writing | 20 | (food + writing — falls through; see "limitations" below) |
+| Contract | 16 | `contract` → ⚖ |
+| Wine Guide | 16 | `guide` → 🗺 |
+| Wine Description | 14 | `description` → 📋 |
+| Recipe Collection | 14 | `recipe` → 🍳 |
+| Personal Letter | 13 | `personal letter` → 💌 |
+| Wine article | 12 | `article` → 📰 |
+| Restaurant Guide | 12 | `guide` → 🗺 |
+| Beekeeping Guide | 11 | `guide` → 🗺 |
+
+**Coverage:** ~85% of non-null top-30 doc_types map to a real icon (not the fallback). Including the long tail (sampled): ~80%. The remaining ~20% (e.g. "Food Writing", "Culinary History", "Magazine Editorial", "Product Description"-ish edge cases) fall to the mime/extension fallback or the unknown 📦 — acceptable for v1.
+
+**Travel guide ambiguity:** "Travel Guide" matches both `travel` (🧭) and `guide` (🗺). Resolve by ordering the pattern list with `travel*` before `guide` so travel writing wins; "Wine Guide" / "Beekeeping Guide" / "Tea Guide" then match `guide`. The implementation plan should encode this priority explicitly.
+
+**Limitations to acknowledge:**
+- Doc types are LLM-generated. Case variation ("Food Article" vs "Food article", "Recipe Book" vs "Recipe book") is fine because matching is case-insensitive.
+- Anything the LLM writes that doesn't contain a known root word (e.g. "Food Writing", "Culinary History") falls through to the fallback. This is expected behavior — the LLM occasionally invents categories that don't fit any obvious bucket.
+- Coverage will need re-auditing as new corpora are ingested. See `pr_followups.md` and the test corpora memory note for the rescan protocol.
 
 ### Hairlines and dividers
 
@@ -247,6 +316,7 @@ These came up during brainstorming but aren't in this pass — flag for follow-u
 6. **Login page brand mark / illustration.** The login page is currently very plain — the gradient + serif treatment helps but doesn't add identity. Post-pass consideration.
 7. **Per-page background atmosphere** (option C from brainstorming). Explicitly not in this pass; revisit if the muted-accent approach feels too subtle in practice.
 8. **Tailwind v4 design-token migration audit.** This pass adds new CSS vars; a follow-up could move all color tokens onto the `@theme` block uniformly. Out of scope here.
+9. **Document-type icon coverage rescan.** Coverage was audited against the live corpus on 2026-05-03 (~80%). Each new test corpus added per the `project_test_corpora_plan.md` memory note must trigger a rescan; new patterns get added in a small follow-up PR if coverage on top-50 doc_types drops below ~75%. Tracked in that memory note's "Once acquired" checklist.
 
 ## Files affected (working list — implementation plan refines)
 

--- a/docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md
+++ b/docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md
@@ -1,0 +1,309 @@
+# Frontend Design Pass — "Calm Cartography" Hybrid
+
+**Date:** 2026-05-03
+**Status:** Design (awaiting user approval before implementation plan)
+**Scope:** React SPA only (`frontend/`). No backend, no schema, no API changes.
+
+## Goals
+
+The current SPA is functional but visually flat and monotonous. Pages are visually interchangeable: top nav is plain text with a tab underline, every page sits on the same dark canvas with the same hairline-card treatment, and color appears in only three places (entity-type pills in DocumentDetail, status pills, and the Research page's amber CTA). The audit pass identified the boring spots: System Settings reads as a list of links with no visual hint, Folders feels half-empty, the Ask conversation list is a stack of identical-looking text rows, the Documents table blends into its own chrome.
+
+This pass introduces categorical color, depth, and a serif title face, in service of three things:
+
+1. **Navigability.** A glance at any page should tell you which area you're in without reading the label.
+2. **Aesthetic identity.** The app should feel intentional, not template-default.
+3. **Working color.** Color appears where it carries meaning (page area, document type, status, entity), not as decoration.
+
+## Direction
+
+**"Calm Cartography" hybrid** — option A's structure (per-page hue + icon + subtle depth) executed with option B's restraint (muted earth-tone palette, serif title face, hairline rules). Specifically:
+
+- Each top-level area gets its own hue + icon. The hue appears on the active tab underline, the page title's accent bar, and a small icon next to the tab label — but **not** on the page background or the body content. Data still reads on neutral surfaces.
+- Page titles render in a serif (New York, the macOS system serif, with Georgia fallback). Body, labels, and numerics stay on the system sans (SF Pro).
+- Cards pick up a subtle gradient (5% top→bottom highlight in dark mode, faint top→bottom shadow in light mode) so they read as elevated surfaces instead of being indistinguishable from background.
+- Document types get icons (📕 Novel, 📊 Spreadsheet, ✉ Email, 📄 PDF, 📜 Plain text, etc.). Status pills get glyphs (●, ⟳, ○).
+- Existing entity-type colors and Observatory chart colors stay untouched — they're already working.
+
+This direction is more surgical than a full visual overhaul. It introduces personality through tokens, not through a redesign of any specific screen.
+
+## Design Tokens
+
+### Per-area accent palette
+
+Eight hues, one per top-level area. Dark-mode value listed first; light-mode is the same hue pushed ~20–25% darker and slightly more saturated.
+
+| Area | Hue family | Dark | Light |
+|---|---|---|---|
+| Ask | terracotta | `#a8745a` | `#8a5a42` |
+| Research | ochre | `#b88a4a` | `#966c2e` |
+| Folders | warm khaki | `#8a8576` | `#6e6a5a` |
+| Documents | dusty blue | `#5b8aa8` | `#3f6885` |
+| Explore | mauve | `#8a6a8a` | `#6a4d6a` |
+| Search | dusty teal | `#6a96a8` | `#4a7585` |
+| Observatory | sage | `#7a9670` | `#5a7556` |
+| System Settings | slate | `#7a7a82` | `#5a5a64` |
+
+These are accent colors only — used on the tab indicator (`border-bottom`), the page title accent bar, the area's tab icon when active, focus rings within that area, and the area's "primary action" buttons (e.g. "+ New conversation" in Ask). They are **not** applied to page backgrounds, card surfaces, or body text.
+
+Each accent ships with two derived tokens:
+
+- `--area-accent-tint`: the accent at ~12% opacity, used as icon-tile background within that area.
+- `--area-accent-text`: a lighter variant of the accent (dark mode) or the accent itself (light mode), used as icon-tile foreground.
+
+CSS-vars naming convention: `--area-{name}-accent`, `--area-{name}-accent-tint`, `--area-{name}-accent-text`. The active area's vars get aliased to `--area-accent` (etc.) on the layout root via a per-route hook.
+
+### Typography
+
+- **Page title** (one per page, e.g. "Documents"): `font-family: 'New York', 'NewYork', ui-serif, Georgia, serif; font-weight: 600; font-size: 28-32px; letter-spacing: -0.02em.`
+- **Section headings within page** (e.g. "Access & identity" on Settings): same serif, `font-weight: 600; font-size: 14-16px; letter-spacing: -0.01em`.
+- **KPI numerals** (e.g. "3,150" in Observatory): same serif, `font-weight: 600; font-size: 24-28px; letter-spacing: -0.02em`. The serif gives them weight and stops them feeling float-y.
+- **Everything else** (body, labels, table cells, button labels, captions): existing system sans stack — unchanged.
+
+New York is shipped with macOS system-wide and is available without download in the WKWebView client. For the Docker SPA it is not present; the Georgia fallback handles that case acceptably (similar feel, slightly different forms). No webfont download is added — keeping the change CSS-only and zero-network.
+
+### Card / surface elevation
+
+Cards (everything currently using the `.rounded-xl bg-(--color-bg-primary) shadow-mac ring-1 ring-(--color-border)` pattern) gain a subtle gradient:
+
+- **Dark mode:** `background: linear-gradient(180deg, rgba(255,255,255,0.025) 0%, transparent 100%);` over the existing `--color-bg-primary` surface. Border opacity bumps from `rgba(255,255,255,0.08)` → `rgba(255,255,255,0.10)` so the edge stays defined.
+- **Light mode:** `background: linear-gradient(180deg, rgba(0,0,0,0.012) 0%, transparent 100%);` over the existing surface. Border `rgba(0,0,0,0.07)`.
+
+Hover state: border opacity bumps another 4–6% on hover; no transform or shadow change (we want quiet feedback, not bouncing cards).
+
+### Status pill conventions
+
+Pills get a leading glyph **in addition to** the existing label, and the background opacity drops while the foreground hue gets crisper:
+
+| State | Glyph | Hue family | Dark bg / fg | Light bg / fg |
+|---|---|---|---|---|
+| active | ● | sage | `rgba(122,150,112,0.18)` / `#a8c49a` | `rgba(74,108,73,0.10)` / `#4a6c49` |
+| running / embedding | ⟳ | ochre | `rgba(184,138,74,0.18)` / `#d4a574` | `rgba(150,108,46,0.10)` / `#966c2e` |
+| idle | ○ | slate | `rgba(122,122,130,0.18)` / `#a0a0a8` | `rgba(90,90,100,0.10)` / `#5a5a64` |
+| error | ⚠ | rust | `rgba(168,90,90,0.20)` / `#d49a9a` | `rgba(168,90,90,0.10)` / `#a85a5a` |
+| pending | ◐ | dusty blue | `rgba(91,138,168,0.18)` / `#8aafc4` | `rgba(63,104,133,0.10)` / `#3f6885` |
+
+These replace the current single-color status pills; existing call sites (Folders status, Documents status, ingestion job badges) all migrate to the new pill component.
+
+### Document-type icons
+
+A new `documentTypeIcon(category)` helper maps document categories (already returned by the backend in `DocumentDetail.category` / file-extension fallback) to glyphs and to the matching icon-tile palette:
+
+| Category | Glyph | Icon hue |
+|---|---|---|
+| Novel / book | 📕 | dusty blue (Documents area accent) |
+| PDF | 📄 | terracotta |
+| Spreadsheet | 📊 | sage |
+| Email | ✉ | ochre |
+| Plain text / notes | 📜 | slate |
+| Code / source | 💻 | mauve |
+| Image | 🖼 | dusty teal |
+| Presentation | 🎞 | mauve |
+| Audio / transcript | 🎙 | terracotta |
+| HTML / web | 🌐 | mauve |
+| Unknown / other | 📦 | slate |
+
+The icon tile is a 28-30px rounded square with a 12% tint of the category hue and the hue itself as text color (or, in dark mode, a slightly lighter variant for legibility).
+
+This icon appears on Documents-page rows and on the DocumentDetail header. It does not replace the document title — title still leads.
+
+### Hairlines and dividers
+
+The nav/body separator and section dividers go from "essentially invisible" to "visible but quiet":
+
+- Dark mode: `1px solid rgba(255,255,255,0.06)` (was `rgba(255,255,255,0.08)` but applied inconsistently).
+- Light mode: `1px solid rgba(0,0,0,0.06)`.
+
+Settings page section labels get a serif heading + a hairline above each non-first group.
+
+## Component-by-component changes
+
+These are concrete UI changes mapped to existing components/files. They reuse the tokens above; nothing introduces a token not defined in the token section.
+
+### Top navigation (`frontend/src/components/Layout.tsx` — `TabLink`)
+
+- Each `TabLink` gets an icon prop (small emoji or single-glyph SVG, paired with the tab name it already renders).
+- The active-tab underline color is bound to `--area-accent` (the area's hue). Inactive tabs keep the existing secondary-text color and have no underline.
+- Hover on inactive tabs subtly tints the icon toward the area's accent.
+- The nav strip itself gains a hairline bottom border (the dark/light-mode hairline above).
+
+### Page title block (new shared component, e.g. `PageHeader`)
+
+Used by every page that currently renders a plain `<h1>Documents</h1>`. Renders:
+
+- The serif title at the page-title scale.
+- A short accent bar (~48-56px wide × 3px tall) below the title in `--area-accent`.
+- Optional subtitle line in secondary text.
+
+This component replaces the ad-hoc `<h1 className="...">` patterns in `DocumentsPage`, `SearchPage`, `ResearchPage`, `FoldersPage`, `LanguagesPage`, `UsersPage`, `ApiKeysPage`, `ApiKeyDashboardPage`, `ModelsPage`, `SystemMaintenancePage`, `SystemStatusPage`, `RetrievalSettingsPage`, `RateLimitSettingsPage`, `ServiceLogsPage`, `StatsPage` (Observatory), `ExplorePage`, `SystemSettingsPage` (Settings hub), `IntegrationsPage`, `PreferencesPage`, `SetupPage`, and the chat sidebar header.
+
+### Card / surface treatment
+
+Every existing `.rounded-xl ... ring-1 ring-(--color-border) ... shadow-mac` site gets the subtle gradient applied. The simplest path: extend the existing utility/class so all cards pick it up centrally rather than per-site. Concrete options to evaluate during implementation:
+
+- Tailwind v4 component class via `@layer components { .surface-card { ... } }` in `index.css`, then sweep replace the existing pattern.
+- Or a small `<Card>` wrapper component the existing call sites adopt.
+
+Either is fine; the implementation plan will pick one. The token values must match the table above.
+
+### Status pills
+
+A single `<StatusPill state="active|running|idle|error|pending">` component replaces the ad-hoc inline pill markup currently scattered across `FoldersPage`, `DocumentsPage`, `DocumentDetailPage` ingestion jobs section, the queue tray, and `StatsPage`. The component handles glyph + color tokens.
+
+### Per-page changes (mapped to files)
+
+**Ask** (`frontend/src/pages/HomePage.tsx`, `ChatPage.tsx`, sidebar component):
+- Sidebar "+ New conversation" button gains the area accent (terracotta tinted bg + accent border + accent text).
+- Each conversation row gets a colored topic dot. **v1 derivation:** deterministic hash of `conversation_id` mapped onto the eight area-accent hues (terracotta / ochre / khaki / dusty blue / mauve / dusty teal / sage / slate). Stable per conversation, harmonizes with the page palette, ships now. Smarter "color by detected topic / top entity" is a deferred enhancement (see Out of scope).
+- Hero/empty state: a 64px rounded-square tile in the area's accent tint with a single emoji (📚), serif "Ask your documents" headline, sans subtitle, suggestion chips. Replaces the current monochrome icon and plain h2.
+- Suggestion chips on hover: tint into the area accent.
+
+**Research** (`frontend/src/pages/ResearchPage.tsx`):
+- Octopus illustration stays. Iconic, has personality.
+- Page title block uses the ochre area accent.
+- "Start Research" CTA stays the loud orange/amber (it is the canonical primary action of this page; the area accent rhymes with it).
+- Sidebar "+ New Research" button picks up the ochre area treatment.
+- Conversation rows in sidebar get topic dots (same scheme as Ask).
+
+**Folders** (`frontend/src/pages/FoldersPage.tsx`):
+- Page title block + warm khaki accent bar.
+- "Add Folder" button: filled-but-quieter — khaki accent tint + accent text + accent border (instead of the current iOS-blue filled button), so the area identity shows up.
+- Folder rows in the table get the gradient card treatment row-by-row (each row is its own elevated surface with row spacing — replaces the current near-borderless table).
+- Each row leads with a small folder icon tile in the area's accent.
+- Status pill migrated to the new `StatusPill`.
+- Empty state: when zero folders, a centered hero block (similar shape to the Ask hero) with the "Add Folder" CTA.
+
+**Documents** (`frontend/src/pages/DocumentsPage.tsx`):
+- Page title block + dusty-blue accent bar.
+- Filter row (filename / language / category / folder dropdowns) keeps its existing layout but the active sort indicator picks up the accent color.
+- Each row in the list: icon tile (document-type) → title + meta → status pill → date. The expanded-row metadata inherits the gradient card treatment so it visually nests inside the row instead of bleeding into table chrome.
+- "Continue viewing" link at the top picks up the area accent.
+
+**Explore** (`frontend/src/pages/ExplorePage.tsx`):
+- Page title block + mauve accent bar.
+- The People / Places / Organizations section pills tint into their entity-type colors (PERSON = blue, GPE = amber/orange, ORG = green, etc.) — using the existing `ENTITY_COLORS` palette from `components/stats/CorpusCharts`. Pills currently render gray; they switch to a ~12% tint of the entity-type color with the hue as text. This is the highest-leverage spot for entity colors outside DocumentDetail.
+- Topic Cluster cards keep their existing topic-color dot but the card body gets the gradient card treatment.
+
+**Search** (`frontend/src/pages/SearchPage.tsx`):
+- Page title block + dusty teal accent bar.
+- Search input focus ring uses the area accent.
+- "Search" button picks up the area's primary-action treatment (tint bg + accent text + accent border).
+- Recent-search history rows: consistent row spacing + hover treatment matching the row patterns elsewhere.
+
+**Observatory** (`frontend/src/pages/StatsPage.tsx`):
+- Page title block + sage accent bar.
+- KPI cards' large numerals re-rendered in the serif at the KPI scale. Optional `--kpi-trend` pill can show delta (out of scope for this pass; see "deferred" section).
+- Charts unchanged in palette — the existing entity colors, the topic treemap colors, the network-graph colors all stay. Pulse dot in chart card titles uses the sage area accent.
+- Sub-tabs ("Corpus Statistics" / "Processing Pipeline") get the area-accent active indicator.
+
+**System Settings hub** (`frontend/src/pages/SystemSettingsPage.tsx`):
+- Page title block + slate accent bar.
+- The flat list of links is **grouped into four labeled sections**: "Access & identity" (Users, API Keys), "Models & languages" (Models, Languages), "Behavior & limits" (Retrieval, Rate Limits), "Operations" (System Status, Service Logs, System Maintenance). Section labels use the serif at section-heading scale.
+- Each item becomes a card-row with a colored icon tile (drawn from the per-area accents — e.g. Models gets sage, Languages gets mauve), the existing title + subtitle, and the chevron.
+- Two-column grid on wider widths; single-column on narrow.
+
+**DocumentDetail** (`frontend/src/pages/DocumentDetailPage.tsx`):
+- Page title block + dusty-blue accent bar (it's a Documents-area page).
+- Document title row gets the document-type icon tile (left of the title).
+- Existing entity-type colored pills stay (they were the original "color" win on this page — the `ENTITY_TYPE_COLORS` map continues to source the entity badges).
+- Ingestion-jobs collapsible section: each job row picks up the new `StatusPill` and the gradient card treatment.
+- "Reveal in Finder" / "Download" / "Reprocess" / "Delete" actions: keep current colors (the destructive Delete stays red, etc.), just gain consistent button heights and the card-gradient treatment on the action surface.
+
+**Languages** (`frontend/src/pages/LanguagesPage.tsx`):
+- Page title block + slate accent bar (it's a Settings-area subpage).
+- Language rows get the gradient card treatment, install-state pill (`StatusPill`), per-row install button uses the slate accent.
+
+**Users / API Keys / Models / Retrieval / Rate Limits / System Status / Service Logs / System Maintenance**: all Settings-area subpages get the slate accent + serif title block + grouped/card treatment matching the hub.
+
+**Login** (`frontend/src/pages/LoginPage.tsx`):
+- Page title block (no area accent — pre-auth, no nav). Just the serif title.
+- Card gradient applied to the login surface.
+
+**Onboarding wizard** (`frontend/src/components/OnboardingWizard.tsx`):
+- Page indicators / step dots use the active step's area accent if the step targets an area (Languages step → slate); otherwise neutral.
+- "Install N & continue" CTA uses the slate accent (it's a Settings-area action).
+- Otherwise unchanged structurally.
+
+## What stays the same
+
+These are working today and must not change in this pass:
+
+- The `ENTITY_COLORS` palette in `components/stats/CorpusCharts.tsx` and its usage on DocumentDetail / Top Entities / Entity Network / Topic Distribution / Documents-by-Topic charts. Entity-type semantic colors are correct as-is.
+- The Observatory's Topic Distribution treemap colors. The treemap is the most visually rich element on the site and works well.
+- The Entity Network force-graph layout and node colors. (PR #226 work.)
+- The Research page's octopus illustration.
+- The Documents page's "Continue viewing" affordance and its existing filter-row layout.
+- All current backend behavior, schemas, API surfaces, MCP tools, ingestion pipeline, etc. This is a CSS/JSX change.
+- All existing tests must continue to pass. Any new test coverage is additive.
+
+## Out of scope / deferred (capture in `pr_followups.md`)
+
+These came up during brainstorming but aren't in this pass — flag for follow-up:
+
+1. **Motion / micro-interactions** beyond the existing 0.15s color transitions. No hover-lift animations, no animated chart entries, no page transitions. Worth a follow-up pass once the static design lands.
+2. **KPI trend deltas** (the "+47 today" line under each Observatory KPI in the mock). Requires backend support for time-windowed counts; out of scope for a CSS pass.
+3. **Topic-aware conversation dot color.** v1 ships with a hash-of-id mapping (above). A smarter "color by the conversation's dominant topic or top-cited entity" requires either a backend join (conversations → top entities/topic) or client-side derivation from message contents. Real follow-up once the visual is in place and we know whether the hash version reads "random" or "intentional".
+4. **Light-mode user toggle** in the menubar / preferences (if not already present). Currently the SPA respects `prefers-color-scheme`; an explicit override is a separate ticket.
+5. **Webfont fallback for non-macOS clients** (the Docker-served SPA). Georgia fallback is acceptable for v1; a Source Serif Pro or similar webfont download is a follow-up.
+6. **Login page brand mark / illustration.** The login page is currently very plain — the gradient + serif treatment helps but doesn't add identity. Post-pass consideration.
+7. **Per-page background atmosphere** (option C from brainstorming). Explicitly not in this pass; revisit if the muted-accent approach feels too subtle in practice.
+8. **Tailwind v4 design-token migration audit.** This pass adds new CSS vars; a follow-up could move all color tokens onto the `@theme` block uniformly. Out of scope here.
+
+## Files affected (working list — implementation plan refines)
+
+Token / global:
+- `frontend/src/index.css` — add `--area-{name}-accent[-tint|-text]` vars (8 areas × 3 = 24 dark vars + 24 light vars), card-gradient utility, hairline utility, status-pill base, document-type-icon helper map, font-family stack with New York.
+- `frontend/src/auth.tsx` or a new `frontend/src/hooks/useAreaAccent.ts` — per-route hook that aliases the active area's vars to `--area-accent` etc. on the layout root.
+
+New shared components:
+- `frontend/src/components/PageHeader.tsx` — serif title + accent bar.
+- `frontend/src/components/StatusPill.tsx` — glyph + label + state-tinted bg.
+- `frontend/src/components/IconTile.tsx` — 28-30px rounded-square tinted tile, optional hue override.
+- `frontend/src/components/Card.tsx` (or layer-class equivalent) — gradient surface wrapper.
+- `frontend/src/utils/documentTypeIcon.ts` — category → glyph + hue.
+
+Modified:
+- `frontend/src/components/Layout.tsx` — `TabLink` gains icon, active underline binds to `--area-accent`, nav hairline.
+- `frontend/src/pages/HomePage.tsx`, `ChatPage.tsx`, sidebar — Ask treatment, hero, conversation dots.
+- `frontend/src/pages/ResearchPage.tsx` — area accent, sidebar treatment.
+- `frontend/src/pages/FoldersPage.tsx` — accent, card-rows, status-pill, empty state.
+- `frontend/src/pages/DocumentsPage.tsx` — accent, icon-tile per row, status-pill.
+- `frontend/src/pages/DocumentDetailPage.tsx` — accent, icon-tile, status-pill on jobs.
+- `frontend/src/pages/SearchPage.tsx` — accent, focus ring, button.
+- `frontend/src/pages/ExplorePage.tsx` — accent, entity-type tinted pills.
+- `frontend/src/pages/StatsPage.tsx` (Observatory) — accent, serif KPI numerals.
+- `frontend/src/pages/SystemSettingsPage.tsx` (Settings hub) — accent, grouped sections, icon tiles.
+- All Settings subpages (`UsersPage`, `ApiKeysPage`, `ApiKeyDashboardPage`, `ModelsPage`, `LanguagesPage`, `RetrievalSettingsPage`, `RateLimitSettingsPage`, `SystemStatusPage`, `ServiceLogsPage`, `SystemMaintenancePage`, `IntegrationsPage`, `PreferencesPage`) — slate accent, page header.
+- `frontend/src/pages/LoginPage.tsx` — page header, card gradient.
+- `frontend/src/components/OnboardingWizard.tsx` — slate accent on Languages step.
+
+The exact list of components to extract vs. inline is decided in the implementation plan.
+
+## Testing
+
+**Frontend type-check + lint + prettier** must pass: `npm run type-check && npm run lint && npm run format:check`. Existing CI gates apply.
+
+**Existing tests** continue to pass: Python `pytest`, all backend tests untouched (this is a CSS-only change).
+
+**No new automated tests are required** — the project doesn't currently have a JS unit-test setup, and adding one is out of scope for a styling pass.
+
+**Manual smoke checklist** (the implementation plan's last task includes walking through this):
+- Log in, walk every top-level page, confirm:
+  - Active tab underline is the area's hue, in both modes.
+  - Page title is serif with a short accent bar.
+  - Card rows / surfaces show the subtle top-down gradient.
+  - At least one status pill is visible per state (active / running / idle / error / pending) and renders correctly in both modes.
+- DocumentDetail still shows the existing entity-type colored badges (regression check on the work that already shipped).
+- Observatory charts (Top Entities bars, Topic Distribution treemap, Entity Network) still render in their existing colors (regression check).
+- Switch system theme (System Settings → Appearance → Light/Dark) and re-walk one or two pages to confirm light-mode tokens kick in.
+- Onboarding wizard renders with slate accent on the Languages step.
+
+## Risk / rollout
+
+- **Single-PR feasibility:** the change is large in surface (every page touched) but small in mechanism (tokens + a few shared components + sweep replacements). The implementation plan should batch by component family (tokens first → shared components → page sweeps in order of complexity), so each commit is a meaningful unit and CI can run between commits.
+- **Visual regression risk:** without a screenshot test setup, regressions are caught manually. The smoke checklist above is the gate.
+- **Rollout:** ships as a single PR. No feature flag, no progressive rollout — it's CSS, and there's only one deployment surface (the bundled SPA in the Mac native app + Docker SPA).
+- **Rollback:** revert the PR. No data, no schema, no API surface affected.
+
+## Companion mockup files (for reference during implementation)
+
+The brainstorming visual companion files live in `.superpowers/brainstorm/` (gitignored — already in `.gitignore` per existing brainstorming skill). They show the agreed-on direction for Documents, Ask, Observatory, Settings (in both dark and light modes) and can be opened in any browser via the brainstorming server while implementing. Reference, not source of truth — the tables in this spec are the source of truth.

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,21 @@
+import { HTMLAttributes, forwardRef } from 'react'
+
+type CardProps = HTMLAttributes<HTMLDivElement>
+
+/**
+ * Surface card with the standard gradient + hairline border treatment.
+ * Wraps the .surface-card layer-class defined in index.css. Forwarded ref
+ * for callers that need it (e.g. focus management).
+ *
+ * Usage: <Card className="p-4">…</Card>
+ *
+ * The .surface-card class supplies bg, gradient, border, and hover state.
+ * Padding, layout, and per-instance overrides come from className as usual.
+ */
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card({ className = '', children, ...rest }, ref) {
+  return (
+    <div ref={ref} className={`surface-card ${className}`} {...rest}>
+      {children}
+    </div>
+  )
+})

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,6 +1,9 @@
 import { HTMLAttributes, forwardRef } from 'react'
 
-type CardProps = HTMLAttributes<HTMLDivElement>
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Apply the hover treatment (border-color shift). Use for clickable list rows; omit for static informational containers. */
+  interactive?: boolean
+}
 
 /**
  * Surface card with the standard gradient + hairline border treatment.
@@ -8,13 +11,19 @@ type CardProps = HTMLAttributes<HTMLDivElement>
  * for callers that need it (e.g. focus management).
  *
  * Usage: <Card className="p-4">…</Card>
+ * Usage (clickable row): <Card interactive className="p-4">…</Card>
  *
- * The .surface-card class supplies bg, gradient, border, and hover state.
+ * The .surface-card class supplies bg, gradient, and border.
+ * The .surface-card-interactive class adds the hover border-color shift.
  * Padding, layout, and per-instance overrides come from className as usual.
  */
-export const Card = forwardRef<HTMLDivElement, CardProps>(function Card({ className = '', children, ...rest }, ref) {
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { className = '', interactive = false, children, ...rest },
+  ref,
+) {
+  const cls = `surface-card ${interactive ? 'surface-card-interactive' : ''} ${className}`.trim()
   return (
-    <div ref={ref} className={`surface-card ${className}`} {...rest}>
+    <div ref={ref} className={cls} {...rest}>
       {children}
     </div>
   )

--- a/frontend/src/components/IconTile.tsx
+++ b/frontend/src/components/IconTile.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from 'react'
+import type { AreaHue } from '../hooks/useAreaAccent'
+
+interface IconTileProps {
+  /** Area name whose accent variables drive the tint. Falls back to the active area when omitted. */
+  hue?: AreaHue
+  /** Glyph or small element rendered inside (e.g. "📕" or "🔑"). */
+  children: ReactNode
+  /** Tile size in pixels. Default 30. */
+  size?: number
+}
+
+/**
+ * Small rounded-square colored tile used as a category/type indicator
+ * (document type next to a doc title, settings-section icon, etc.).
+ *
+ * Uses --area-{hue}-accent-tint as the background and --area-{hue}-accent-text
+ * as the foreground so dark/light variants come along for free. When hue
+ * is omitted the active area's --area-accent-tint / --area-accent-text are
+ * used instead (so the tile matches the page it lives on).
+ */
+export function IconTile({ hue, children, size = 30 }: IconTileProps) {
+  const prefix = hue ? `--area-${hue}-accent` : '--area-accent'
+  const style = {
+    backgroundColor: `var(${prefix}-tint)`,
+    color: `var(${prefix}-text)`,
+    width: size,
+    height: size,
+    fontSize: Math.round(size * 0.47),
+  }
+
+  return (
+    <div className="flex shrink-0 items-center justify-center rounded-[7px]" style={style} aria-hidden="true">
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -79,7 +79,7 @@ export default function Layout() {
   }, [menuOpen])
 
   return (
-    <div data-layout-root className="min-h-screen bg-(--color-bg-secondary)">
+    <div data-layout-root className="min-h-screen bg-(--color-bg-primary)">
       <nav className="sticky top-0 z-40 border-b border-(--color-border) bg-(--bg-vibrancy) backdrop-blur-xl">
         <div className="mx-auto max-w-7xl px-4">
           <div className="flex h-12 items-center justify-between">

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,20 +9,29 @@ import OnboardingWizard from './OnboardingWizard'
 import { useCorpusBannerState } from '../hooks/useCorpusBannerState'
 import { useAreaAccent } from '../hooks/useAreaAccent'
 
-function TabLink({ to, end, children }: { to: string; end?: boolean; children: React.ReactNode }) {
+function TabLink({ to, end, icon, children }: { to: string; end?: boolean; icon?: string; children: React.ReactNode }) {
   return (
     <NavLink
       to={to}
       end={end}
       className={({ isActive }) =>
-        `relative rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors ${
+        `relative inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors ${
           isActive
-            ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 ring-1 ring-blue-200/60 dark:ring-blue-700/40'
+            ? 'text-(--area-accent-text)'
             : 'text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 hover:text-(--color-text-primary)'
         }`
       }
+      style={({ isActive }) =>
+        isActive
+          ? {
+              backgroundColor: 'var(--area-accent-tint)',
+              boxShadow: 'inset 0 0 0 1px var(--area-accent)',
+            }
+          : undefined
+      }
     >
-      {children}
+      {icon && <span aria-hidden="true">{icon}</span>}
+      <span>{children}</span>
     </NavLink>
   )
 }
@@ -89,16 +98,36 @@ export default function Layout() {
                 <img src="/favicon.svg" alt="" className="h-6 w-6" />
                 <span>Ask</span>
               </NavLink>
-              <TabLink to="/research">Research</TabLink>
-              <TabLink to="/folders">Folders</TabLink>
-              <TabLink to="/docs">Documents</TabLink>
-              <TabLink to="/explore">Explore</TabLink>
-              <TabLink to="/search">Search</TabLink>
+              <TabLink to="/research" icon="🐙">
+                Research
+              </TabLink>
+              <TabLink to="/folders" icon="📁">
+                Folders
+              </TabLink>
+              <TabLink to="/docs" icon="📄">
+                Documents
+              </TabLink>
+              <TabLink to="/explore" icon="🌍">
+                Explore
+              </TabLink>
+              <TabLink to="/search" icon="🔍">
+                Search
+              </TabLink>
             </div>
             <div className="flex items-center space-x-1">
-              <TabLink to="/stats">Observatory</TabLink>
-              {isAdmin && <TabLink to="/integrations">Integrations</TabLink>}
-              {isAdmin && <TabLink to="/admin">System Settings</TabLink>}
+              <TabLink to="/stats" icon="📊">
+                Observatory
+              </TabLink>
+              {isAdmin && (
+                <TabLink to="/integrations" icon="🔌">
+                  Integrations
+                </TabLink>
+              )}
+              {isAdmin && (
+                <TabLink to="/admin" icon="⚙️">
+                  System Settings
+                </TabLink>
+              )}
               <div className="relative ml-2" ref={menuRef}>
                 <button
                   onClick={() => setMenuOpen(!menuOpen)}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import { QueueTray } from './queue-tray'
 import CorpusEmptyBanner from './CorpusEmptyBanner'
 import OnboardingWizard from './OnboardingWizard'
 import { useCorpusBannerState } from '../hooks/useCorpusBannerState'
+import { useAreaAccent } from '../hooks/useAreaAccent'
 
 function TabLink({ to, end, children }: { to: string; end?: boolean; children: React.ReactNode }) {
   return (
@@ -33,6 +34,7 @@ export default function Layout() {
   const navigate = useNavigate()
   const location = useLocation()
   const bannerState = useCorpusBannerState()
+  useAreaAccent()
   const bannerSuppressedPath =
     location.pathname === '/folders' ||
     location.pathname.startsWith('/admin') ||
@@ -68,7 +70,7 @@ export default function Layout() {
   }, [menuOpen])
 
   return (
-    <div className="min-h-screen bg-(--color-bg-secondary)">
+    <div data-layout-root className="min-h-screen bg-(--color-bg-secondary)">
       <nav className="sticky top-0 z-40 border-b border-(--color-border) bg-(--bg-vibrancy) backdrop-blur-xl">
         <div className="mx-auto max-w-7xl px-4">
           <div className="flex h-12 items-center justify-between">

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { get, patch, post, ApiError } from '../api'
+import { Card } from './Card'
 
 interface SystemInfo {
   platform: 'macos' | 'docker'
@@ -161,10 +162,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
       onClick={onComplete}
     >
-      <div
-        className="relative w-full max-w-[520px] rounded-2xl bg-white dark:bg-[#2c2c2e] p-6 shadow-mac ring-1 ring-(--color-border)"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <Card className="relative w-full max-w-[520px] p-6" onClick={(e) => e.stopPropagation()}>
         <button
           aria-label="Close"
           onClick={onComplete}
@@ -298,7 +296,12 @@ export default function OnboardingWizard({ onComplete }: Props) {
                 <button
                   onClick={installAndContinue}
                   disabled={installingLangs}
-                  className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+                  className="rounded-md px-4 py-1.5 text-sm font-medium disabled:opacity-50"
+                  style={{
+                    backgroundColor: 'var(--area-settings-accent-tint)',
+                    color: 'var(--area-settings-accent-text)',
+                    border: '1px solid var(--area-settings-accent)',
+                  }}
                 >
                   {installingLangs
                     ? 'Installing…'
@@ -346,7 +349,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
             </div>
           </>
         )}
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react'
+
+interface PageHeaderProps {
+  title: ReactNode
+  subtitle?: ReactNode
+  /** Optional content rendered to the right of the title (action button, search input, etc.). */
+  actions?: ReactNode
+}
+
+/**
+ * Standard page-title block: serif title + short accent bar tinted with
+ * the active area's hue + optional subtitle line + optional right-aligned
+ * actions slot.
+ *
+ * The accent bar uses var(--area-accent) which is bound by the
+ * useAreaAccent hook on the layout root — so every page that renders
+ * inside Layout automatically gets the right color.
+ */
+export function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-4 flex items-start justify-between gap-4">
+      <div>
+        <h1 className="font-serif text-3xl font-semibold tracking-tight text-(--color-text-primary)">{title}</h1>
+        <div className="mt-1.5 h-[3px] w-12 rounded-sm bg-(--area-accent)" />
+        {subtitle && <p className="mt-2 text-sm text-(--color-text-secondary)">{subtitle}</p>}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/StatusPill.tsx
+++ b/frontend/src/components/StatusPill.tsx
@@ -1,0 +1,54 @@
+export type PillState = 'active' | 'running' | 'idle' | 'error' | 'pending'
+
+interface StatusPillProps {
+  state: PillState
+  /** Override the default label for the state (e.g. "embedding" instead of "running"). */
+  label?: string
+  /** Override the default glyph for the state. */
+  glyph?: string
+}
+
+const STATE_CONFIG: Record<PillState, { glyph: string; label: string; cls: string }> = {
+  active: {
+    glyph: '●',
+    label: 'active',
+    // Sage tints — light mode bg/fg first, dark mode after the colon.
+    cls: 'bg-[rgba(74,108,73,0.10)] text-[#4a6c49] dark:bg-[rgba(122,150,112,0.18)] dark:text-[#a8c49a]',
+  },
+  running: {
+    glyph: '⟳',
+    label: 'running',
+    cls: 'bg-[rgba(150,108,46,0.10)] text-[#966c2e] dark:bg-[rgba(184,138,74,0.18)] dark:text-[#d4a574]',
+  },
+  idle: {
+    glyph: '○',
+    label: 'idle',
+    cls: 'bg-[rgba(90,90,100,0.10)] text-[#5a5a64] dark:bg-[rgba(122,122,130,0.18)] dark:text-[#a0a0a8]',
+  },
+  error: {
+    glyph: '⚠',
+    label: 'error',
+    cls: 'bg-[rgba(168,90,90,0.10)] text-[#a85a5a] dark:bg-[rgba(168,90,90,0.20)] dark:text-[#d49a9a]',
+  },
+  pending: {
+    glyph: '◐',
+    label: 'pending',
+    cls: 'bg-[rgba(63,104,133,0.10)] text-[#3f6885] dark:bg-[rgba(91,138,168,0.18)] dark:text-[#8aafc4]',
+  },
+}
+
+/**
+ * Status pill — leading glyph + label, with state-tinted background and
+ * matching foreground color in both light and dark modes.
+ */
+export function StatusPill({ state, label, glyph }: StatusPillProps) {
+  const cfg = STATE_CONFIG[state]
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${cfg.cls}`}
+    >
+      <span aria-hidden>{glyph ?? cfg.glyph}</span>
+      <span>{label ?? cfg.label}</span>
+    </span>
+  )
+}

--- a/frontend/src/hooks/useAreaAccent.ts
+++ b/frontend/src/hooks/useAreaAccent.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+/** Single source of truth for the eight area names used throughout the design system. */
+export type AreaHue = 'ask' | 'research' | 'folders' | 'docs' | 'explore' | 'search' | 'observatory' | 'settings'
+
+const ROUTE_TO_AREA: { test: (path: string) => boolean; area: AreaHue }[] = [
+  // Order matters — most specific first.
+  { test: (p) => p.startsWith('/research'), area: 'research' },
+  { test: (p) => p.startsWith('/folders'), area: 'folders' },
+  { test: (p) => p.startsWith('/docs'), area: 'docs' },
+  { test: (p) => p.startsWith('/explore'), area: 'explore' },
+  { test: (p) => p.startsWith('/search'), area: 'search' },
+  { test: (p) => p.startsWith('/stats'), area: 'observatory' },
+  {
+    test: (p) => p.startsWith('/admin') || p.startsWith('/integrations') || p.startsWith('/preferences'),
+    area: 'settings',
+  },
+  // Ask is the default — matches '/' and '/c/:conversationId'.
+  { test: () => true, area: 'ask' },
+]
+
+/**
+ * Returns the active area name for the current route.
+ * Side effect: applies the area's accent vars to the layout root element
+ * (the element with `data-layout-root`), which makes `--area-accent`,
+ * `--area-accent-tint`, `--area-accent-text` resolve to the right hue.
+ */
+export function useAreaAccent(): { area: AreaHue } {
+  const location = useLocation()
+  const area = ROUTE_TO_AREA.find((m) => m.test(location.pathname))!.area
+
+  useEffect(() => {
+    const root = document.querySelector<HTMLElement>('[data-layout-root]')
+    if (!root) return
+    root.style.setProperty('--area-accent', `var(--area-${area}-accent)`)
+    root.style.setProperty('--area-accent-tint', `var(--area-${area}-accent-tint)`)
+    root.style.setProperty('--area-accent-text', `var(--area-${area}-accent-text)`)
+  }, [area])
+
+  return { area }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,10 +34,10 @@
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f5f5f7;
   --color-bg-tertiary: #e8e8ed;
-  --color-border: rgba(0, 0, 0, 0.06);
+  --color-border: rgba(0, 0, 0, 0.12);
   --color-accent: #007aff;
   --color-text-primary: #1d1d1f;
-  --color-text-secondary: #525258;
+  --color-text-secondary: #6e6e73;
   --bg-vibrancy: rgba(255, 255, 255, 0.8);
   --color-chart-tick: #6b7280;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,7 +34,7 @@
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f5f5f7;
   --color-bg-tertiary: #e8e8ed;
-  --color-border: rgba(0, 0, 0, 0.12);
+  --color-border: rgba(0, 0, 0, 0.15);
   --color-accent: #007aff;
   --color-text-primary: #1d1d1f;
   --color-text-secondary: #6e6e73;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,7 +32,7 @@
 
 :root {
   --color-bg-primary: #ffffff;
-  --color-bg-secondary: #ebebef;
+  --color-bg-secondary: #f5f5f7;
   --color-bg-tertiary: #e8e8ed;
   --color-border: rgba(0, 0, 0, 0.15);
   --color-accent: #007aff;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,7 @@
 
 @theme {
   --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  --font-serif: 'New York', 'NewYork', ui-serif, Georgia, serif;
 
   --shadow-mac: 0 0.5px 1px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.06);
   --shadow-mac-lg: 0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -51,6 +52,125 @@
   --color-text-secondary: #98989d;
   --bg-vibrancy: rgba(28, 28, 30, 0.8);
   --color-chart-tick: #9ca3af;
+}
+
+/* ---- Per-area accent tokens (light mode = :root) ---- */
+
+:root {
+  /* Ask — terracotta (light) */
+  --area-ask-accent: #8a5a42;
+  --area-ask-accent-tint: rgba(138, 90, 66, 0.1);
+  --area-ask-accent-text: #8a5a42;
+
+  /* Research — ochre (light) */
+  --area-research-accent: #966c2e;
+  --area-research-accent-tint: rgba(150, 108, 46, 0.1);
+  --area-research-accent-text: #966c2e;
+
+  /* Folders — warm khaki (light) */
+  --area-folders-accent: #6e6a5a;
+  --area-folders-accent-tint: rgba(110, 106, 90, 0.1);
+  --area-folders-accent-text: #6e6a5a;
+
+  /* Docs — dusty blue (light) */
+  --area-docs-accent: #3f6885;
+  --area-docs-accent-tint: rgba(63, 104, 133, 0.1);
+  --area-docs-accent-text: #3f6885;
+
+  /* Explore — mauve (light) */
+  --area-explore-accent: #6a4d6a;
+  --area-explore-accent-tint: rgba(106, 77, 106, 0.1);
+  --area-explore-accent-text: #6a4d6a;
+
+  /* Search — dusty teal (light) */
+  --area-search-accent: #4a7585;
+  --area-search-accent-tint: rgba(74, 117, 133, 0.1);
+  --area-search-accent-text: #4a7585;
+
+  /* Observatory — sage (light) */
+  --area-observatory-accent: #5a7556;
+  --area-observatory-accent-tint: rgba(90, 117, 86, 0.1);
+  --area-observatory-accent-text: #5a7556;
+
+  /* Settings — slate (light) */
+  --area-settings-accent: #5a5a64;
+  --area-settings-accent-tint: rgba(90, 90, 100, 0.1);
+  --area-settings-accent-text: #5a5a64;
+
+  /* Default — bound by useAreaAccent on the layout root.
+     Pre-auth pages (login/setup) get the docs accent as a neutral fallback. */
+  --area-accent: var(--area-docs-accent);
+  --area-accent-tint: var(--area-docs-accent-tint);
+  --area-accent-text: var(--area-docs-accent-text);
+}
+
+.dark {
+  /* Ask — terracotta (dark) */
+  --area-ask-accent: #a8745a;
+  --area-ask-accent-tint: rgba(168, 116, 90, 0.12);
+  --area-ask-accent-text: #d49d80;
+
+  /* Research — ochre (dark) */
+  --area-research-accent: #b88a4a;
+  --area-research-accent-tint: rgba(184, 138, 74, 0.12);
+  --area-research-accent-text: #d4a574;
+
+  /* Folders — warm khaki (dark) */
+  --area-folders-accent: #8a8576;
+  --area-folders-accent-tint: rgba(138, 133, 118, 0.12);
+  --area-folders-accent-text: #b0aa9a;
+
+  /* Docs — dusty blue (dark) */
+  --area-docs-accent: #5b8aa8;
+  --area-docs-accent-tint: rgba(91, 138, 168, 0.15);
+  --area-docs-accent-text: #8aafc4;
+
+  /* Explore — mauve (dark) */
+  --area-explore-accent: #8a6a8a;
+  --area-explore-accent-tint: rgba(138, 106, 138, 0.15);
+  --area-explore-accent-text: #b890b8;
+
+  /* Search — dusty teal (dark) */
+  --area-search-accent: #6a96a8;
+  --area-search-accent-tint: rgba(106, 150, 168, 0.15);
+  --area-search-accent-text: #90b8c8;
+
+  /* Observatory — sage (dark) */
+  --area-observatory-accent: #7a9670;
+  --area-observatory-accent-tint: rgba(122, 150, 112, 0.15);
+  --area-observatory-accent-text: #a8c49a;
+
+  /* Settings — slate (dark) */
+  --area-settings-accent: #7a7a82;
+  --area-settings-accent-tint: rgba(122, 122, 130, 0.15);
+  --area-settings-accent-text: #a0a0a8;
+
+  /* Default — same fallback chain as light */
+  --area-accent: var(--area-docs-accent);
+  --area-accent-tint: var(--area-docs-accent-tint);
+  --area-accent-text: var(--area-docs-accent-text);
+}
+
+@layer components {
+  .surface-card {
+    background-color: var(--color-bg-primary);
+    background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.012) 0%, transparent 100%);
+    border: 1px solid var(--color-border);
+    border-radius: 0.625rem; /* matches existing rounded-[10px] elsewhere */
+    transition: border-color 150ms ease;
+  }
+
+  .dark .surface-card {
+    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.025) 0%, transparent 100%);
+  }
+
+  .surface-card:hover {
+    border-color: rgba(0, 0, 0, 0.14);
+  }
+
+  .dark .surface-card:hover {
+    border-color: rgba(255, 255, 255, 0.18);
+  }
 }
 
 * {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -164,11 +164,11 @@
     background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.025) 0%, transparent 100%);
   }
 
-  .surface-card:hover {
+  .surface-card-interactive:hover {
     border-color: rgba(0, 0, 0, 0.14);
   }
 
-  .dark .surface-card:hover {
+  .dark .surface-card-interactive:hover {
     border-color: rgba(255, 255, 255, 0.18);
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,7 +32,7 @@
 
 :root {
   --color-bg-primary: #ffffff;
-  --color-bg-secondary: #f5f5f7;
+  --color-bg-secondary: #ebebef;
   --color-bg-tertiary: #e8e8ed;
   --color-border: rgba(0, 0, 0, 0.15);
   --color-accent: #007aff;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,7 +37,7 @@
   --color-border: rgba(0, 0, 0, 0.06);
   --color-accent: #007aff;
   --color-text-primary: #1d1d1f;
-  --color-text-secondary: #6e6e73;
+  --color-text-secondary: #525258;
   --bg-vibrancy: rgba(255, 255, 255, 0.8);
   --color-chart-tick: #6b7280;
 }
@@ -102,6 +102,14 @@
   --area-accent: var(--area-docs-accent);
   --area-accent-tint: var(--area-docs-accent-tint);
   --area-accent-text: var(--area-docs-accent-text);
+
+  /* Entity pill colors — deeper variants for white backgrounds (Explore page) */
+  --entity-person: #0050a8;
+  --entity-person-bg: rgba(0, 80, 168, 0.15);
+  --entity-org: #1f7a36;
+  --entity-org-bg: rgba(31, 122, 54, 0.15);
+  --entity-gpe: #b56a00;
+  --entity-gpe-bg: rgba(181, 106, 0, 0.15);
 }
 
 .dark {
@@ -149,6 +157,14 @@
   --area-accent: var(--area-docs-accent);
   --area-accent-tint: var(--area-docs-accent-tint);
   --area-accent-text: var(--area-docs-accent-text);
+
+  /* Entity pill colors — bright iOS variants for dark surfaces (Explore page) */
+  --entity-person: #007aff;
+  --entity-person-bg: rgba(0, 122, 255, 0.15);
+  --entity-org: #34c759;
+  --entity-org-bg: rgba(52, 199, 89, 0.15);
+  --entity-gpe: #ff9500;
+  --entity-gpe-bg: rgba(255, 149, 0, 0.15);
 }
 
 @layer components {

--- a/frontend/src/pages/ApiKeyDashboardPage.tsx
+++ b/frontend/src/pages/ApiKeyDashboardPage.tsx
@@ -2,6 +2,8 @@ import { Fragment, useCallback, useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { del, get } from '../api'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 /* ---------- types ---------- */
 
@@ -215,49 +217,55 @@ export default function ApiKeyDashboardPage() {
   return (
     <div className="animate-slide-in space-y-6">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <Link to="/admin/keys" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
-            &larr; API Keys
-          </Link>
-          <h1 className="text-xl font-bold">{keyInfo.name}</h1>
-          <span
-            className={`rounded-md px-2 py-0.5 text-[11px] font-medium ${
-              keyInfo.is_active
-                ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-            }`}
-          >
-            {keyInfo.is_active ? 'active' : 'revoked'}
-          </span>
-          <span className="text-sm text-gray-500 dark:text-gray-400">{keyInfo.scope_summary}</span>
-        </div>
-        <div>
-          {!purgeConfirm ? (
-            <button
-              onClick={() => setPurgeConfirm(true)}
-              className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-red-700"
-            >
-              Purge Events
-            </button>
-          ) : (
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-red-600 dark:text-red-400">Delete all logged events?</span>
-              <button
-                onClick={handlePurge}
-                className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-red-700"
+      <div>
+        <Link to="/admin/keys" className="mb-2 inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline">
+          &larr; API Keys
+        </Link>
+        <PageHeader
+          title={
+            <span className="flex flex-wrap items-center gap-2">
+              {keyInfo.name}
+              <span
+                className={`rounded-md px-2 py-0.5 text-[11px] font-medium ${
+                  keyInfo.is_active
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                    : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                }`}
               >
-                Confirm
-              </button>
-              <button
-                onClick={() => setPurgeConfirm(false)}
-                className="rounded-lg bg-gray-200 dark:bg-gray-700 px-3 py-1.5 text-sm font-medium text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600"
-              >
-                Cancel
-              </button>
+                {keyInfo.is_active ? 'active' : 'revoked'}
+              </span>
+            </span>
+          }
+          subtitle={keyInfo.scope_summary}
+          actions={
+            <div>
+              {!purgeConfirm ? (
+                <button
+                  onClick={() => setPurgeConfirm(true)}
+                  className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-red-700"
+                >
+                  Purge Events
+                </button>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-red-600 dark:text-red-400">Delete all logged events?</span>
+                  <button
+                    onClick={handlePurge}
+                    className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-red-700"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setPurgeConfirm(false)}
+                    className="rounded-lg bg-gray-200 dark:bg-gray-700 px-3 py-1.5 text-sm font-medium text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          }
+        />
       </div>
 
       {error && (
@@ -267,9 +275,7 @@ export default function ApiKeyDashboardPage() {
       )}
 
       {!hasData && !error && (
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-8 text-center text-gray-500 dark:text-gray-400">
-          No events logged yet.
-        </div>
+        <Card className="p-8 text-center text-gray-500 dark:text-gray-400">No events logged yet.</Card>
       )}
 
       {usage && (
@@ -277,7 +283,7 @@ export default function ApiKeyDashboardPage() {
           {/* Summary cards */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
             {/* Requests card */}
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+            <Card className="p-4">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Requests</span>
                 <select
@@ -293,14 +299,10 @@ export default function ApiKeyDashboardPage() {
                 </select>
               </div>
               <p className="mt-2 text-2xl font-bold">{usage.requests[reqRange] ?? 0}</p>
-            </div>
+            </Card>
 
             {/* Errors card */}
-            <div
-              className={`rounded-xl shadow-mac ring-1 ring-(--color-border) p-4 ${
-                (usage.errors[errRange] ?? 0) > 0 ? 'bg-red-50 dark:bg-red-900/10' : 'bg-white dark:bg-[#2c2c2e]'
-              }`}
-            >
+            <Card className={`p-4 ${(usage.errors[errRange] ?? 0) > 0 ? 'bg-red-50 dark:bg-red-900/10' : ''}`}>
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Errors</span>
                 <select
@@ -316,14 +318,10 @@ export default function ApiKeyDashboardPage() {
                 </select>
               </div>
               <p className="mt-2 text-2xl font-bold text-red-600 dark:text-red-400">{usage.errors[errRange] ?? 0}</p>
-            </div>
+            </Card>
 
             {/* Denials card */}
-            <div
-              className={`rounded-xl shadow-mac ring-1 ring-(--color-border) p-4 ${
-                (usage.denials[denRange] ?? 0) > 0 ? 'bg-amber-50 dark:bg-amber-900/10' : 'bg-white dark:bg-[#2c2c2e]'
-              }`}
-            >
+            <Card className={`p-4 ${(usage.denials[denRange] ?? 0) > 0 ? 'bg-amber-50 dark:bg-amber-900/10' : ''}`}>
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Denials</span>
                 <select
@@ -341,15 +339,11 @@ export default function ApiKeyDashboardPage() {
               <p className="mt-2 text-2xl font-bold text-amber-600 dark:text-amber-400">
                 {usage.denials[denRange] ?? 0}
               </p>
-            </div>
+            </Card>
 
             {/* Rate Limited card */}
-            <div
-              className={`rounded-xl shadow-mac ring-1 ring-(--color-border) p-4 ${
-                (usage.rate_limited[rlRange] ?? 0) > 0
-                  ? 'bg-orange-50 dark:bg-orange-900/20'
-                  : 'bg-white dark:bg-[#2c2c2e]'
-              }`}
+            <Card
+              className={`p-4 ${(usage.rate_limited[rlRange] ?? 0) > 0 ? 'bg-orange-50 dark:bg-orange-900/20' : ''}`}
             >
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Rate Limited</span>
@@ -368,21 +362,21 @@ export default function ApiKeyDashboardPage() {
               <p className="mt-2 text-2xl font-bold text-orange-600 dark:text-orange-400">
                 {usage.rate_limited[rlRange] ?? 0}
               </p>
-            </div>
+            </Card>
 
             {/* Last Used card */}
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+            <Card className="p-4">
               <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Last Used</span>
               <p className="mt-2 text-lg font-semibold">
                 {usage.last_used_at ? formatTimestamp(usage.last_used_at) : 'Never'}
               </p>
-            </div>
+            </Card>
           </div>
 
           {/* Charts */}
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {/* Requests over time */}
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+            <Card className="p-4">
               <h2 className="mb-3 text-sm font-semibold">Requests over time (30d)</h2>
               {timeline.length > 0 ? (
                 <ResponsiveContainer width="100%" height={240}>
@@ -399,10 +393,10 @@ export default function ApiKeyDashboardPage() {
               ) : (
                 <p className="py-8 text-center text-sm text-gray-400">No timeline data.</p>
               )}
-            </div>
+            </Card>
 
             {/* Tool breakdown */}
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+            <Card className="p-4">
               <div className="mb-3 flex items-center justify-between">
                 <h2 className="text-sm font-semibold">Tool breakdown</h2>
                 <select
@@ -429,11 +423,11 @@ export default function ApiKeyDashboardPage() {
               ) : (
                 <p className="py-8 text-center text-sm text-gray-400">No tool data for this range.</p>
               )}
-            </div>
+            </Card>
           </div>
 
           {/* Request log */}
-          <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+          <Card className="overflow-hidden">
             <div className="border-b border-(--color-border) bg-(--color-bg-secondary) p-4">
               <h2 className="mb-3 text-sm font-semibold">Request log</h2>
               <div className="flex flex-wrap items-center gap-3">
@@ -625,7 +619,7 @@ export default function ApiKeyDashboardPage() {
                 No requests match the current filters.
               </p>
             )}
-          </div>
+          </Card>
         </>
       )}
     </div>

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -418,7 +418,7 @@ function ScopeFormFields({
             type="date"
             value={state.expiresAt}
             onChange={(e) => setState((s) => ({ ...s, expiresAt: e.target.value }))}
-            className="mt-1.5 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="mt-1.5 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         )}
       </div>
@@ -550,7 +550,7 @@ function ScopeFormFields({
           value={state.maxSnippetChars}
           onChange={(e) => setState((s) => ({ ...s, maxSnippetChars: e.target.value }))}
           placeholder="No limit"
-          className="w-40 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+          className="w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
         />
       </div>
 
@@ -576,7 +576,7 @@ function ScopeFormFields({
             value={state.rateLimitRpm}
             onChange={(e) => setState((s) => ({ ...s, rateLimitRpm: e.target.value }))}
             placeholder="System default"
-            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         )}
       </div>
@@ -603,7 +603,7 @@ function ScopeFormFields({
             value={state.rateLimitRph}
             onChange={(e) => setState((s) => ({ ...s, rateLimitRph: e.target.value }))}
             placeholder="System default"
-            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         )}
       </div>
@@ -655,7 +655,7 @@ function CreateKeyForm({
             onChange={(e) => setName(e.target.value)}
             required
             placeholder="e.g. Claude Desktop"
-            className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         </div>
 

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -418,7 +418,7 @@ function ScopeFormFields({
             type="date"
             value={state.expiresAt}
             onChange={(e) => setState((s) => ({ ...s, expiresAt: e.target.value }))}
-            className="mt-1.5 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="mt-1.5 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         )}
       </div>
@@ -550,7 +550,7 @@ function ScopeFormFields({
           value={state.maxSnippetChars}
           onChange={(e) => setState((s) => ({ ...s, maxSnippetChars: e.target.value }))}
           placeholder="No limit"
-          className="w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+          className="w-40 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
         />
       </div>
 
@@ -576,7 +576,7 @@ function ScopeFormFields({
             value={state.rateLimitRpm}
             onChange={(e) => setState((s) => ({ ...s, rateLimitRpm: e.target.value }))}
             placeholder="System default"
-            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         )}
       </div>
@@ -603,7 +603,7 @@ function ScopeFormFields({
             value={state.rateLimitRph}
             onChange={(e) => setState((s) => ({ ...s, rateLimitRph: e.target.value }))}
             placeholder="System default"
-            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="mt-1.5 w-40 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         )}
       </div>
@@ -655,7 +655,7 @@ function CreateKeyForm({
             onChange={(e) => setName(e.target.value)}
             required
             placeholder="e.g. Claude Desktop"
-            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
           />
         </div>
 

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { del, get, patch, post } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 type PermissionTier = 'search' | 'read' | 'full'
 
@@ -217,18 +219,20 @@ export default function ApiKeysPage() {
 
   return (
     <div className="animate-slide-in">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold">API Keys</h1>
-        <button
-          onClick={() => {
-            setShowCreate(!showCreate)
-            setNewKey(null)
-          }}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
-        >
-          {showCreate ? 'Cancel' : 'Create Key'}
-        </button>
-      </div>
+      <PageHeader
+        title="API Keys"
+        actions={
+          <button
+            onClick={() => {
+              setShowCreate(!showCreate)
+              setNewKey(null)
+            }}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
+          >
+            {showCreate ? 'Cancel' : 'Create Key'}
+          </button>
+        }
+      />
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -237,7 +241,7 @@ export default function ApiKeysPage() {
       )}
 
       {newKey && (
-        <div className="mb-4 rounded-xl border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4 shadow-mac">
+        <Card className="mb-4 border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4">
           <p className="mb-2 text-sm font-medium text-green-800 dark:text-green-400">
             API key created! Copy it now — it won't be shown again.
           </p>
@@ -259,7 +263,7 @@ export default function ApiKeysPage() {
               </code>
             </div>
           </div>
-        </div>
+        </Card>
       )}
 
       {showCreate && !newKey && (
@@ -274,7 +278,7 @@ export default function ApiKeysPage() {
         />
       )}
 
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+      <Card className="overflow-hidden">
         <table className="min-w-full divide-y divide-(--color-border)">
           <thead className="bg-(--color-bg-secondary)">
             <tr>
@@ -359,7 +363,7 @@ export default function ApiKeysPage() {
             )}
           </tbody>
         </table>
-      </div>
+      </Card>
 
       {editingKey && (
         <EditKeyModal
@@ -641,34 +645,33 @@ function CreateKeyForm({
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="mb-4 space-y-4 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4"
-    >
-      <div>
-        <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Key Name</label>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-          placeholder="e.g. Claude Desktop"
-          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
-        />
-      </div>
+    <Card className="mb-4 space-y-4 p-4">
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Key Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="e.g. Claude Desktop"
+            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+          />
+        </div>
 
-      <ScopeFormFields state={scope} setState={setScope} topics={topics} folders={folders} />
+        <ScopeFormFields state={scope} setState={setScope} topics={topics} folders={folders} />
 
-      <div className="flex justify-end">
-        <button
-          type="submit"
-          disabled={submitting}
-          className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
-        >
-          Create
-        </button>
-      </div>
-    </form>
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+          >
+            Create
+          </button>
+        </div>
+      </form>
+    </Card>
   )
 }
 
@@ -747,7 +750,7 @@ function EditKeyModal({
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-5">
+      <Card className="w-full max-w-2xl max-h-[90vh] overflow-y-auto p-5">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-bold">Edit Key: {apiKey.name}</h2>
           <button
@@ -789,7 +792,7 @@ function EditKeyModal({
             {submitting ? 'Saving…' : 'Save'}
           </button>
         </div>
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
+import { IconTile } from '../components/IconTile'
 import { del, get, post } from '../api'
 import { useAuth } from '../auth'
 import { useChat, type ChatMessage, type RagContextChunk, type ToolCallInfo } from '../contexts/ChatContext'
@@ -8,6 +9,7 @@ import { useResearch } from '../contexts/ResearchContext'
 import RagContextCard from '../components/RagContextCard'
 import ToolResultDisplay from '../components/ToolResultDisplay'
 import { formatRelativeDate } from '../utils/dates'
+import { topicDotVar } from '../utils/topicDotColor'
 
 interface ConversationSummary {
   conversation_id: string
@@ -261,12 +263,14 @@ export default function ChatPage() {
         <div className="p-3 pb-2">
           <button
             onClick={handleNewChat}
-            className="group w-full flex items-center gap-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-[13px] font-medium text-gray-600 dark:text-gray-300 shadow-xs hover:shadow-md hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200"
+            className="w-full flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-opacity hover:opacity-80"
+            style={{
+              backgroundColor: 'var(--area-accent-tint)',
+              color: 'var(--area-accent-text)',
+              border: '1px solid var(--area-accent)',
+            }}
           >
-            <span className="flex h-5 w-5 items-center justify-center rounded-md bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-800 text-xs transition-transform duration-200 group-hover:scale-110">
-              +
-            </span>
-            New conversation
+            <span aria-hidden>＋</span> New conversation
           </button>
         </div>
 
@@ -285,16 +289,22 @@ export default function ChatPage() {
                     : 'hover:bg-white/60 dark:hover:bg-gray-800/40'
                 }`}
               >
-                <Link to={`/c/${conv.conversation_id}`} className="flex-1 min-w-0">
-                  <div
-                    className={`text-[13px] font-medium truncate ${
-                      isActive ? 'text-gray-900 dark:text-gray-100' : 'text-gray-600 dark:text-gray-400'
-                    }`}
-                  >
-                    {conv.title}
-                  </div>
-                  <div className="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">
-                    {formatRelativeDate(conv.updated_at)}
+                <Link to={`/c/${conv.conversation_id}`} className="flex-1 min-w-0 flex items-start gap-2">
+                  <span
+                    className="inline-block mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full"
+                    style={{ background: topicDotVar(conv.conversation_id) }}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div
+                      className={`text-[13px] font-medium truncate ${
+                        isActive ? 'text-gray-900 dark:text-gray-100' : 'text-gray-600 dark:text-gray-400'
+                      }`}
+                    >
+                      {conv.title}
+                    </div>
+                    <div className="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">
+                      {formatRelativeDate(conv.updated_at)}
+                    </div>
                   </div>
                 </Link>
                 <button
@@ -566,40 +576,39 @@ function ModelNudge() {
 
 /* ---- Empty state ---- */
 
+const SUGGESTION_CHIPS = [
+  'What documents mention compliance?',
+  'Summarize the latest report',
+  'Find conflicting information',
+]
+
 function EmptyState() {
   return (
     <div className="flex h-full items-center justify-center p-8">
-      <div className="text-center max-w-md empty-state-appear">
-        <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-100 dark:bg-gray-800">
-          <svg
-            className="h-7 w-7 text-gray-400 dark:text-gray-500"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={1.2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9zm3.75 11.625a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
-            />
-          </svg>
+      <div className="flex flex-col items-center justify-center gap-4 py-16 text-center empty-state-appear max-w-md">
+        <IconTile size={64}>📚</IconTile>
+        <div>
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-(--color-text-primary)">
+            Ask your documents
+          </h2>
+          <p className="mt-2 text-sm text-(--color-text-secondary)">
+            Start a conversation to search, read, and reason over your library using a local LLM.
+          </p>
         </div>
-        <h3 className="text-[15px] font-semibold text-gray-800 dark:text-gray-200 mb-1.5">Ask your documents</h3>
-        <p className="text-[13px] text-gray-400 dark:text-gray-500 leading-relaxed mb-6">
-          Start a conversation to search, read, and reason over your document library using a local LLM.
-        </p>
         <div className="flex flex-wrap justify-center gap-2">
-          {['What documents mention compliance?', 'Summarize the latest report', 'Find conflicting information'].map(
-            (q) => (
-              <span
-                key={q}
-                className="inline-block rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-1.5 text-[12px] text-gray-500 dark:text-gray-400 shadow-xs cursor-default"
-              >
-                {q}
-              </span>
-            ),
-          )}
+          {SUGGESTION_CHIPS.map((chip) => (
+            <span
+              key={chip}
+              className="rounded-full px-3 py-1 text-xs cursor-default"
+              style={{
+                backgroundColor: 'var(--area-accent-tint)',
+                color: 'var(--area-accent-text)',
+                border: '1px solid var(--area-accent)',
+              }}
+            >
+              {chip}
+            </span>
+          ))}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -947,7 +947,7 @@ export default function DocumentDetailPage() {
                       setPageSize(Number(e.target.value))
                       setContentPage(1)
                     }}
-                    className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-sm text-gray-900 dark:text-gray-100"
+                    className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-sm text-gray-900 dark:text-gray-100"
                   >
                     {PAGE_SIZE_OPTIONS.map((n) => (
                       <option key={n} value={n}>

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../auth'
 import { useJobEvents, type JobEvent } from '../hooks/useJobEvents'
 import { useSystemConfig, type SystemConfig } from '../hooks/useSystemConfig'
 import { ENTITY_TYPE_LABELS } from '../components/stats/CorpusCharts'
+import { DEFAULT_HIDDEN_ENTITY_TYPES, entityTypeClass } from '../utils/entityTypeColors'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'
 import { StatusPill, type PillState } from '../components/StatusPill'
@@ -233,39 +234,6 @@ interface DocStats {
   top_entities: { text: string; type: string; mentions: number }[]
   ocr_confidence: { avg: number; min: number; max: number } | null
 }
-
-// Color palette covering all spaCy entity types we might see. Grouped by
-// semantic kind so related types share a hue family:
-//   blue/indigo:  people + groups (PERSON, NORP)
-//   green/teal:   organizations + products (ORG, PRODUCT, WORK_OF_ART)
-//   amber/orange: places (GPE, LOC, FAC)
-//   cyan/sky:     time (DATE, TIME)
-//   pink/rose:    events + law (EVENT, LAW)
-//   violet/fuchsia: language + culture (LANGUAGE)
-//   emerald:      money/percent (MONEY, PERCENT)
-//   stone:        numbers (CARDINAL, ORDINAL, QUANTITY)
-const ENTITY_TYPE_COLORS: Record<string, string> = {
-  PERSON: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-  NORP: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
-  ORG: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
-  PRODUCT: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
-  WORK_OF_ART: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-  GPE: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  LOC: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-  FAC: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-  DATE: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
-  TIME: 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400',
-  EVENT: 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400',
-  LAW: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400',
-  LANGUAGE: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
-  MONEY: 'bg-lime-100 text-lime-700 dark:bg-lime-900/30 dark:text-lime-400',
-  PERCENT: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
-  CARDINAL: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
-  ORDINAL: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
-  QUANTITY: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
-}
-
-const DEFAULT_HIDDEN_ENTITY_TYPES = new Set(['CARDINAL', 'ORDINAL', 'QUANTITY'])
 
 // Display name lookup for the small subset of languages we currently
 // surface in the mismatch banner. Falls back to the ISO code when a
@@ -532,8 +500,7 @@ function DocumentStatsDisclosure({ docId }: { docId: string }) {
                             className={`rounded-md px-2 py-0.5 text-[11px] font-medium transition-opacity ${
                               isHidden
                                 ? 'bg-gray-100 text-gray-400 dark:bg-gray-700/50 dark:text-gray-500 opacity-60'
-                                : ENTITY_TYPE_COLORS[type] ||
-                                  'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                                : entityTypeClass(type)
                             }`}
                           >
                             {type}: {count}
@@ -553,8 +520,7 @@ function DocumentStatsDisclosure({ docId }: { docId: string }) {
                     {stats.top_entities
                       .filter((e) => !hiddenTypes.has(e.type))
                       .map((e, i) => {
-                        const cls =
-                          ENTITY_TYPE_COLORS[e.type] || 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                        const cls = entityTypeClass(e.type)
                         return (
                           <span key={i} className={`rounded-md px-2 py-0.5 text-[11px] font-medium ${cls}`}>
                             {e.text}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -947,7 +947,7 @@ export default function DocumentDetailPage() {
                       setPageSize(Number(e.target.value))
                       setContentPage(1)
                     }}
-                    className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-sm text-gray-900 dark:text-gray-100"
+                    className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-sm text-gray-900 dark:text-gray-100"
                   >
                     {PAGE_SIZE_OPTIONS.map((n) => (
                       <option key={n} value={n}>

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -5,6 +5,11 @@ import { useAuth } from '../auth'
 import { useJobEvents, type JobEvent } from '../hooks/useJobEvents'
 import { useSystemConfig, type SystemConfig } from '../hooks/useSystemConfig'
 import { ENTITY_TYPE_LABELS } from '../components/stats/CorpusCharts'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill, type PillState } from '../components/StatusPill'
+import { IconTile } from '../components/IconTile'
+import { documentTypeIcon } from '../utils/documentTypeIcon'
 
 interface JobInfo {
   job_id: string
@@ -475,7 +480,7 @@ function DocumentStatsDisclosure({ docId }: { docId: string }) {
         Document Statistics
       </button>
       {open && (
-        <div className="mt-2 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-4">
+        <Card className="mt-2 p-4 mb-4">
           {loading ? (
             <p className="text-sm text-(--color-text-secondary)">Loading statistics...</p>
           ) : stats ? (
@@ -564,7 +569,7 @@ function DocumentStatsDisclosure({ docId }: { docId: string }) {
           ) : (
             <p className="text-sm text-(--color-text-secondary)">No statistics available</p>
           )}
-        </div>
+        </Card>
       )}
     </div>
   )
@@ -593,7 +598,15 @@ export default function DocumentDetailPage() {
   const [highlightPage, setHighlightPage] = useState<number | null>(null)
   const contentLoadedRef = useRef(false)
   const [related, setRelated] = useState<
-    { doc_id: string; title: string; summary: string | null; similarity: number }[]
+    {
+      doc_id: string
+      title: string
+      summary: string | null
+      similarity: number
+      doc_type?: string | null
+      mime_type?: string | null
+      canonical_filename?: string | null
+    }[]
   >([])
 
   // URL params for deep linking from search results
@@ -768,40 +781,45 @@ export default function DocumentDetailPage() {
 
   return (
     <div>
-      <div className="mb-4 flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold">{doc.title}</h1>
-          {doc.canonical_filename && (
-            <p className="text-sm text-gray-500 dark:text-gray-400">{doc.canonical_filename}</p>
-          )}
+      <div className="mb-4 flex items-start gap-3">
+        <IconTile hue={documentTypeIcon(doc).hue} size={36}>
+          {documentTypeIcon(doc).glyph}
+        </IconTile>
+        <div className="flex-1">
+          <PageHeader
+            title={doc.title}
+            subtitle={doc.canonical_filename ?? undefined}
+            actions={
+              isAdmin ? (
+                <>
+                  {hasProcessing && (
+                    <button
+                      onClick={handleCancel}
+                      disabled={actionLoading}
+                      className="rounded-lg bg-gray-500 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-gray-600 disabled:opacity-50"
+                    >
+                      Cancel Processing
+                    </button>
+                  )}
+                  <button
+                    onClick={handleReprocess}
+                    disabled={actionLoading}
+                    className="rounded-lg bg-amber-500 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-amber-600 disabled:opacity-50"
+                  >
+                    Reprocess
+                  </button>
+                  <button
+                    onClick={handleDelete}
+                    disabled={actionLoading}
+                    className="rounded-lg bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/20 disabled:opacity-50"
+                  >
+                    Delete
+                  </button>
+                </>
+              ) : undefined
+            }
+          />
         </div>
-        {isAdmin && (
-          <div className="flex space-x-2">
-            {hasProcessing && (
-              <button
-                onClick={handleCancel}
-                disabled={actionLoading}
-                className="rounded-lg bg-gray-500 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-gray-600 disabled:opacity-50"
-              >
-                Cancel Processing
-              </button>
-            )}
-            <button
-              onClick={handleReprocess}
-              disabled={actionLoading}
-              className="rounded-lg bg-amber-500 px-3 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-amber-600 disabled:opacity-50"
-            >
-              Reprocess
-            </button>
-            <button
-              onClick={handleDelete}
-              disabled={actionLoading}
-              className="rounded-lg bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/20 disabled:opacity-50"
-            >
-              Delete
-            </button>
-          </div>
-        )}
       </div>
 
       {error && (
@@ -827,7 +845,7 @@ export default function DocumentDetailPage() {
       {doc.jobs.length > 0 && (
         <div className="mb-4">
           <Disclosure label="Ingestion Jobs" defaultOpen={!isReady}>
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-5">
+            <Card className="p-3">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-gray-200 dark:border-gray-700 text-left text-xs text-gray-500 dark:text-gray-400">
@@ -838,27 +856,38 @@ export default function DocumentDetailPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {doc.jobs.map((j) => (
-                    <tr key={j.job_id || j.stage} className="border-b border-gray-100 dark:border-gray-700">
-                      <td className="py-1 pr-3 font-medium">{j.stage}</td>
-                      <td className="py-1 pr-3">
-                        <JobStatusBadge status={j.status} />
-                      </td>
-                      <td className="py-1 pr-3 text-gray-500 dark:text-gray-400">
-                        {j.progress_total ? `${j.progress_current || 0}/${j.progress_total}` : '—'}
-                      </td>
-                      <td className="py-1 text-xs text-gray-400">
-                        {j.finished_at
-                          ? new Date(j.finished_at).toLocaleTimeString()
-                          : j.started_at
-                            ? 'running...'
-                            : 'queued'}
-                      </td>
-                    </tr>
-                  ))}
+                  {doc.jobs.map((j) => {
+                    const pillState: PillState =
+                      j.status === 'done'
+                        ? 'active'
+                        : j.status === 'running'
+                          ? 'running'
+                          : j.status === 'error'
+                            ? 'error'
+                            : 'pending'
+                    const pillLabel = j.status === 'done' ? 'done' : j.status === 'queued' ? 'queued' : undefined
+                    return (
+                      <tr key={j.job_id || j.stage} className="border-b border-gray-100 dark:border-gray-700">
+                        <td className="py-1 pr-3 font-medium">{j.stage}</td>
+                        <td className="py-1 pr-3">
+                          <StatusPill state={pillState} label={pillLabel} />
+                        </td>
+                        <td className="py-1 pr-3 text-gray-500 dark:text-gray-400">
+                          {j.progress_total ? `${j.progress_current || 0}/${j.progress_total}` : '—'}
+                        </td>
+                        <td className="py-1 text-xs text-gray-400">
+                          {j.finished_at
+                            ? new Date(j.finished_at).toLocaleTimeString()
+                            : j.started_at
+                              ? 'running...'
+                              : 'queued'}
+                        </td>
+                      </tr>
+                    )
+                  })}
                 </tbody>
               </table>
-            </div>
+            </Card>
           </Disclosure>
         </div>
       )}
@@ -886,30 +915,38 @@ export default function DocumentDetailPage() {
       <DocumentStatsDisclosure docId={doc.doc_id} />
 
       {related.length > 0 && (
-        <details className="group mt-4 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac" open>
-          <summary className="cursor-pointer px-5 py-3 text-sm font-semibold text-(--color-text-primary)">
+        <Card className="mt-4 mb-4">
+          <div className="px-5 py-3 text-sm font-semibold text-(--color-text-primary)">
             Related Documents ({related.length})
-          </summary>
-          <div className="border-t border-(--color-border) px-5 py-3 space-y-1">
-            {related.map((r) => (
-              <Link
-                key={r.doc_id}
-                to={`/docs/${r.doc_id}`}
-                className="block rounded-lg px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-(--color-text-primary) truncate">{r.title}</span>
-                  <span className="ml-2 shrink-0 text-xs tabular-nums text-gray-400">
-                    {Math.round(r.similarity * 100)}% match
-                  </span>
-                </div>
-                {r.summary && (
-                  <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">{r.summary}</p>
-                )}
-              </Link>
-            ))}
           </div>
-        </details>
+          <div className="border-t border-(--color-border) px-5 py-3 space-y-1">
+            {related.map((r) => {
+              const icon = documentTypeIcon(r)
+              return (
+                <Link
+                  key={r.doc_id}
+                  to={`/docs/${r.doc_id}`}
+                  className="flex items-start gap-2 rounded-lg px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  <IconTile hue={icon.hue} size={24}>
+                    {icon.glyph}
+                  </IconTile>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-(--color-text-primary) truncate">{r.title}</span>
+                      <span className="ml-2 shrink-0 text-xs tabular-nums text-gray-400">
+                        {Math.round(r.similarity * 100)}% match
+                      </span>
+                    </div>
+                    {r.summary && (
+                      <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">{r.summary}</p>
+                    )}
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        </Card>
       )}
 
       <h2 className="mb-2 mt-6 text-lg font-semibold">Content</h2>
@@ -967,10 +1004,10 @@ export default function DocumentDetailPage() {
               )}
 
               {visiblePages.map((page) => (
-                <div
+                <Card
                   key={page.page_num}
                   id={`page-${page.page_num}`}
-                  className={`rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-4 transition-all duration-500 ${
+                  className={`p-4 transition-all duration-500 ${
                     highlightPage === page.page_num ? 'ring-2 ring-(--color-accent)/40' : ''
                   }`}
                 >
@@ -985,7 +1022,7 @@ export default function DocumentDetailPage() {
                   <pre className="whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200">
                     {renderPageWithHighlight(page.text, highlightChunkText)}
                   </pre>
-                </div>
+                </Card>
               ))}
 
               {totalPages > 1 && (

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -3,6 +3,10 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents } from '../hooks/useJobEvents'
+import { PageHeader } from '../components/PageHeader'
+import { StatusPill, type PillState } from '../components/StatusPill'
+import { IconTile } from '../components/IconTile'
+import { documentTypeIcon } from '../utils/documentTypeIcon'
 
 const DOCS_STATE_KEY = 'docs-page-state'
 
@@ -28,6 +32,7 @@ interface DocSummary {
   title: string
   canonical_filename?: string
   status: string
+  pipeline_status?: string
   created_at: string
   updated_at: string
   summary?: string
@@ -70,14 +75,12 @@ function normalizeStatus(status?: string): string {
   return status
 }
 
-function StatusBadge({ status }: { status: string }) {
-  const display = normalizeStatus(status)
-  let cls = 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
-  if (display === 'ready') cls = 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  else if (display === 'error') cls = 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-  else if (display === 'processing') cls = 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-
-  return <span className={`inline-block rounded-md px-2 py-0.5 text-[11px] font-medium ${cls}`}>{display}</span>
+function mapDocStatusToPillState(pipeline: string): PillState {
+  if (pipeline === 'error') return 'error'
+  if (pipeline === 'ready') return 'active'
+  if (pipeline === 'queued') return 'pending'
+  // All other states are in-progress (extracting / chunking / embedding / etc.).
+  return 'running'
 }
 
 function Pagination({
@@ -571,24 +574,26 @@ export default function DocumentsPage() {
           </Link>
         </div>
       )}
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold">Documents</h1>
-        <div className="flex items-center gap-3">
-          <input
-            type="text"
-            placeholder="Filter by filename..."
-            value={filterInput}
-            onChange={(e) => handleFilterChange(e.target.value)}
-            className="w-64 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-3 py-1.5 text-sm text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
-          />
-          <Link
-            to="/folders"
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
-          >
-            Folders
-          </Link>
-        </div>
-      </div>
+      <PageHeader
+        title="Documents"
+        actions={
+          <>
+            <input
+              type="text"
+              placeholder="Filter by filename..."
+              value={filterInput}
+              onChange={(e) => handleFilterChange(e.target.value)}
+              className="w-64 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-3 py-1.5 text-sm text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+            />
+            <Link
+              to="/folders"
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
+            >
+              Folders
+            </Link>
+          </>
+        }
+      />
       {/* Filter bar */}
       {(filterOptions.mime_types.length > 0 ||
         filterOptions.doc_types.length > 0 ||
@@ -790,7 +795,7 @@ export default function DocumentsPage() {
             />
           )}
 
-          <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+          <div className="overflow-hidden rounded-[10px] border border-(--color-border) bg-(--color-bg-primary)">
             <table className="min-w-full divide-y divide-(--color-border)">
               <thead className="bg-(--color-bg-secondary)">
                 <tr>
@@ -817,6 +822,7 @@ export default function DocumentsPage() {
               <tbody className="divide-y divide-(--color-border) bg-white dark:bg-[#2c2c2e]">
                 {visibleDocs.map((doc) => {
                   const isExpanded = expanded.has(doc.doc_id)
+                  const { glyph, hue } = documentTypeIcon(doc)
                   return (
                     <Fragment key={doc.doc_id}>
                       <tr className="hover:bg-black/3 dark:hover:bg-white/3">
@@ -830,7 +836,10 @@ export default function DocumentsPage() {
                           />
                         </td>
                         <td className="px-4 py-3">
-                          <div className="flex items-center gap-1.5">
+                          <div className="flex items-center gap-2">
+                            <IconTile hue={hue} size={28}>
+                              {glyph}
+                            </IconTile>
                             <button
                               onClick={() => {
                                 setExpanded((prev) => {
@@ -914,8 +923,8 @@ export default function DocumentsPage() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-1.5">
-                            <StatusBadge status={doc.status} />
-                            {isAdmin && normalizeStatus(doc.status) === 'processing' && (
+                            <StatusPill state={mapDocStatusToPillState(doc.pipeline_status ?? '')} />
+                            {isAdmin && normalizeStatus(doc.pipeline_status) === 'processing' && (
                               <button
                                 onClick={(e) => {
                                   e.preventDefault()
@@ -964,8 +973,8 @@ export default function DocumentsPage() {
                       </tr>
                       {isExpanded && (
                         <tr className="bg-gray-50/50 dark:bg-white/2">
-                          <td colSpan={6} className="px-4 py-4 pl-14">
-                            <div className="space-y-3">
+                          <td colSpan={6} className="px-4 py-3 pl-14">
+                            <div className="p-3 space-y-3">
                               {doc.doc_type && (
                                 <div>
                                   <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide mb-0.5">

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from '../components/PageHeader'
 import { StatusPill, type PillState } from '../components/StatusPill'
 import { IconTile } from '../components/IconTile'
 import { documentTypeIcon } from '../utils/documentTypeIcon'
+import { entityTypeClass } from '../utils/entityTypeColors'
 
 const DOCS_STATE_KEY = 'docs-page-state'
 
@@ -1017,10 +1018,10 @@ export default function DocumentsPage() {
                                     {docEntities[doc.doc_id].slice(0, 15).map((e, i) => (
                                       <span
                                         key={i}
-                                        className="text-[11px] px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
+                                        className={`inline-block rounded-md px-2 py-0.5 text-[11px] font-medium ${entityTypeClass(e.entity_type)}`}
                                       >
                                         {e.entity_text}
-                                        <span className="ml-1 text-gray-400 dark:text-gray-500">{e.entity_type}</span>
+                                        <span className="ml-1 opacity-60">{e.entity_type}</span>
                                       </span>
                                     ))}
                                     {docEntities[doc.doc_id].length > 15 && (

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -584,7 +584,7 @@ export default function DocumentsPage() {
               placeholder="Filter by filename..."
               value={filterInput}
               onChange={(e) => handleFilterChange(e.target.value)}
-              className="w-64 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-3 py-1.5 text-sm text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+              className="w-64 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-3 py-1.5 text-sm text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
             />
             <Link
               to="/folders"
@@ -612,7 +612,7 @@ export default function DocumentsPage() {
               onChange={(e) => handleEntityInputChange(e.target.value)}
               onFocus={() => entitySuggestions.length > 0 && setShowEntityDropdown(true)}
               onBlur={() => setTimeout(() => setShowEntityDropdown(false), 200)}
-              className="w-48 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2.5 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+              className="w-48 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2.5 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
             />
             {entityFilter && (
               <button
@@ -650,7 +650,7 @@ export default function DocumentsPage() {
                 setMimeFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All types</option>
               {filterOptions.mime_types.map((m) => (
@@ -669,7 +669,7 @@ export default function DocumentsPage() {
                 setLangFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All languages</option>
               {filterOptions.languages.map((l) => (
@@ -688,7 +688,7 @@ export default function DocumentsPage() {
                 setDocTypeFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All categories</option>
               {filterOptions.doc_types.map((d) => (
@@ -707,7 +707,7 @@ export default function DocumentsPage() {
                 setFolderFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All folders</option>
               {folderOptions.map((f) => {
@@ -1093,7 +1093,7 @@ export default function DocumentsPage() {
                   setCurrentPage(1)
                   updatePreferences({ page_size: n }).catch(() => {})
                 }}
-                className="rounded-md border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-1.5 py-0.5 text-xs focus:ring-2 focus:ring-(--color-accent)/30"
+                className="rounded-md border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-1.5 py-0.5 text-xs focus:ring-2 focus:ring-(--color-accent)/30"
               >
                 {[10, 25, 50, 100].map((n) => (
                   <option key={n} value={n}>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -584,7 +584,7 @@ export default function DocumentsPage() {
               placeholder="Filter by filename..."
               value={filterInput}
               onChange={(e) => handleFilterChange(e.target.value)}
-              className="w-64 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-3 py-1.5 text-sm text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+              className="w-64 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-3 py-1.5 text-sm text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
             />
             <Link
               to="/folders"
@@ -612,7 +612,7 @@ export default function DocumentsPage() {
               onChange={(e) => handleEntityInputChange(e.target.value)}
               onFocus={() => entitySuggestions.length > 0 && setShowEntityDropdown(true)}
               onBlur={() => setTimeout(() => setShowEntityDropdown(false), 200)}
-              className="w-48 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2.5 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+              className="w-48 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2.5 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
             />
             {entityFilter && (
               <button
@@ -650,7 +650,7 @@ export default function DocumentsPage() {
                 setMimeFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All types</option>
               {filterOptions.mime_types.map((m) => (
@@ -669,7 +669,7 @@ export default function DocumentsPage() {
                 setLangFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All languages</option>
               {filterOptions.languages.map((l) => (
@@ -688,7 +688,7 @@ export default function DocumentsPage() {
                 setDocTypeFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All categories</option>
               {filterOptions.doc_types.map((d) => (
@@ -707,7 +707,7 @@ export default function DocumentsPage() {
                 setFolderFilter(e.target.value)
                 setCurrentPage(1)
               }}
-              className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+              className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
             >
               <option value="">All folders</option>
               {folderOptions.map((f) => {
@@ -1093,7 +1093,7 @@ export default function DocumentsPage() {
                   setCurrentPage(1)
                   updatePreferences({ page_size: n }).catch(() => {})
                 }}
-                className="rounded-md border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-1.5 py-0.5 text-xs focus:ring-2 focus:ring-(--color-accent)/30"
+                className="rounded-md border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-1.5 py-0.5 text-xs focus:ring-2 focus:ring-(--color-accent)/30"
               >
                 {[10, 25, 50, 100].map((n) => (
                   <option key={n} value={n}>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -923,7 +923,17 @@ export default function DocumentsPage() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-1.5">
-                            <StatusPill state={mapDocStatusToPillState(doc.pipeline_status ?? '')} />
+                            {(() => {
+                              const _pipeline = doc.pipeline_status ?? ''
+                              const _pillState = mapDocStatusToPillState(_pipeline)
+                              const _pillLabel =
+                                _pillState === 'active'
+                                  ? 'ready'
+                                  : _pillState === 'pending'
+                                    ? 'queued'
+                                    : _pipeline || 'processing'
+                              return <StatusPill state={_pillState} label={_pillLabel} />
+                            })()}
                             {isAdmin && normalizeStatus(doc.pipeline_status) === 'processing' && (
                               <button
                                 onClick={(e) => {

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -275,7 +275,7 @@ function ExploreMain({
               placeholder="Search topics & entities…"
               value={topicSearch}
               onChange={(e) => setTopicSearch(e.target.value)}
-              className="w-64 rounded-md bg-(--color-bg-secondary) pl-8 pr-8 py-1.5 text-sm ring-1 ring-(--color-border) focus:outline-none focus:ring-2"
+              className="w-64 rounded-md bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) pl-8 pr-8 py-1.5 text-sm ring-1 ring-(--color-border) focus:outline-none focus:ring-2"
             />
             {topicSearch && (
               <button
@@ -729,7 +729,7 @@ function ExploreDocList({
           placeholder="Filter by filename..."
           value={filterInput}
           onChange={(e) => handleFilterChange(e.target.value)}
-          className="w-52 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-3 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+          className="w-52 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-3 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
         />
 
         {filterOptions.mime_types.length > 0 && (
@@ -739,7 +739,7 @@ function ExploreDocList({
               setMimeFilter(e.target.value)
               setCurrentPage(1)
             }}
-            className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+            className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
           >
             <option value="">All types</option>
             {filterOptions.mime_types.map((m) => (
@@ -758,7 +758,7 @@ function ExploreDocList({
               setTopicFilter(e.target.value)
               setCurrentPage(1)
             }}
-            className="max-w-48 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+            className="max-w-48 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
           >
             <option value="">All topics</option>
             {clusters.map((c) => (

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -4,7 +4,6 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recha
 import { get } from '../api'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'
-import { ENTITY_COLORS } from '../components/stats/CorpusCharts'
 
 interface EntityItem {
   entity_text: string
@@ -51,9 +50,9 @@ interface PaginatedDocs {
 }
 
 const ENTITY_SECTIONS = [
-  { type: 'PERSON', label: 'People' },
-  { type: 'GPE', label: 'Places' },
-  { type: 'ORG', label: 'Organizations' },
+  { type: 'PERSON', label: 'People', cssVar: '--entity-person', cssBgVar: '--entity-person-bg' },
+  { type: 'GPE', label: 'Places', cssVar: '--entity-gpe', cssBgVar: '--entity-gpe-bg' },
+  { type: 'ORG', label: 'Organizations', cssVar: '--entity-org', cssBgVar: '--entity-org-bg' },
 ]
 
 const TICK_STYLE = { fontSize: 10, fill: 'var(--color-chart-tick)' }
@@ -299,7 +298,8 @@ function ExploreMain({
             key={section.type}
             label={section.label}
             items={filteredEntities[section.type] || []}
-            color={ENTITY_COLORS[section.type] || '#98989d'}
+            cssVar={section.cssVar}
+            cssBgVar={section.cssBgVar}
             defaultOpen
             onSelect={(entityText) =>
               onOpenSubPane({
@@ -448,13 +448,15 @@ function EntitySection({
   label,
   items,
   defaultOpen,
-  color,
+  cssVar,
+  cssBgVar,
   onSelect,
 }: {
   label: string
   items: EntityItem[]
   defaultOpen: boolean
-  color: string
+  cssVar: string
+  cssBgVar: string
   onSelect: (entityText: string) => void
 }) {
   const [open, setOpen] = useState(defaultOpen)
@@ -489,8 +491,8 @@ function EntitySection({
                   onClick={() => onSelect(item.entity_text)}
                   className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs transition-opacity hover:opacity-80"
                   style={{
-                    backgroundColor: `${color}1f`,
-                    color,
+                    backgroundColor: `var(${cssBgVar})`,
+                    color: `var(${cssVar})`,
                   }}
                 >
                   {item.entity_text}

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -2,6 +2,9 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { Link } from 'react-router-dom'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { get } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { ENTITY_COLORS } from '../components/stats/CorpusCharts'
 
 interface EntityItem {
   entity_text: string
@@ -254,47 +257,49 @@ function ExploreMain({
 
   return (
     <div className="space-y-5">
-      <div className="flex items-center justify-between gap-3">
-        <h1 className="text-lg font-semibold text-(--color-text-primary)">Explore</h1>
-
-        {/* Improvement #5: Topic search */}
-        <div className="relative">
-          <svg
-            className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-(--color-text-secondary)"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input
-            type="text"
-            placeholder="Search topics & entities..."
-            value={topicSearch}
-            onChange={(e) => setTopicSearch(e.target.value)}
-            className="w-64 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac pl-8 pr-3 py-1.5 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
-          />
-          {topicSearch && (
-            <button
-              onClick={() => setTopicSearch('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-(--color-text-secondary) hover:text-(--color-text-primary)"
+      <PageHeader
+        title="Explore"
+        subtitle="People, places, organizations, and topic clusters in your corpus"
+        actions={
+          <div className="relative">
+            <svg
+              className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-(--color-text-secondary)"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
             >
-              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          )}
-        </div>
-      </div>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              type="search"
+              placeholder="Search topics & entities…"
+              value={topicSearch}
+              onChange={(e) => setTopicSearch(e.target.value)}
+              className="w-64 rounded-md bg-(--color-bg-secondary) pl-8 pr-8 py-1.5 text-sm ring-1 ring-(--color-border) focus:outline-none focus:ring-2"
+            />
+            {topicSearch && (
+              <button
+                onClick={() => setTopicSearch('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-(--color-text-secondary) hover:text-(--color-text-primary)"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
+        }
+      />
 
       {/* Entity sections — People / Places / Organizations */}
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden divide-y divide-(--color-border)">
+      <Card className="overflow-hidden divide-y divide-(--color-border)">
         {ENTITY_SECTIONS.map((section) => (
           <EntitySection
             key={section.type}
             label={section.label}
             items={filteredEntities[section.type] || []}
+            color={ENTITY_COLORS[section.type] || '#98989d'}
             defaultOpen
             onSelect={(entityText) =>
               onOpenSubPane({
@@ -306,7 +311,7 @@ function ExploreMain({
             }
           />
         ))}
-      </div>
+      </Card>
 
       {/* Topic Clusters */}
       {clusters.length > 0 && (
@@ -320,14 +325,16 @@ function ExploreMain({
             )}
           </h2>
           {filteredClusters.length === 0 ? (
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) px-5 py-8 text-center">
+            <Card className="px-5 py-8 text-center">
               <p className="text-sm text-(--color-text-secondary)">No topics match your search.</p>
-            </div>
+            </Card>
           ) : (
-            <div className="max-h-96 overflow-y-auto rounded-xl ring-1 ring-(--color-border) p-3 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="max-h-96 overflow-y-auto p-3 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {filteredClusters.map((cluster) => (
-                <button
+                <Card
                   key={cluster.cluster_id}
+                  interactive
+                  className="p-3.5 cursor-pointer group"
                   onClick={() =>
                     onOpenSubPane({
                       type: 'cluster',
@@ -335,18 +342,27 @@ function ExploreMain({
                       clusterId: cluster.cluster_id,
                     })
                   }
-                  className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) px-5 py-4 hover:shadow-mac-lg hover:ring-(--color-border)/80 transition-all text-left group"
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      onOpenSubPane({
+                        type: 'cluster',
+                        label: cluster.name,
+                        clusterId: cluster.cluster_id,
+                      })
+                    }
+                  }}
                 >
-                  <div className="flex items-center justify-between mb-1">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span
-                        className="inline-block h-2.5 w-2.5 rounded-full shrink-0"
-                        style={{ backgroundColor: '#5ac8fa' }}
-                      />
-                      <h3 className="text-[13px] font-semibold text-(--color-text-primary) truncate">{cluster.name}</h3>
-                    </div>
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <span
+                      className="inline-block h-2 w-2 rounded-full shrink-0"
+                      style={{ backgroundColor: '#5ac8fa' }}
+                    />
+                    <h4 className="font-medium text-(--color-text-primary) truncate flex-1">{cluster.name}</h4>
                     <svg
-                      className="h-3.5 w-3.5 text-(--color-text-secondary) opacity-0 group-hover:opacity-100 transition-opacity"
+                      className="h-3.5 w-3.5 shrink-0 text-(--color-text-secondary) opacity-0 group-hover:opacity-100 transition-opacity"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -355,7 +371,7 @@ function ExploreMain({
                       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                     </svg>
                   </div>
-                  {/* Improvement #1: Keyword pills */}
+                  {/* Keyword pills */}
                   {cluster.keywords.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-1.5">
                       {cluster.keywords.slice(0, 5).map((kw) => (
@@ -371,7 +387,7 @@ function ExploreMain({
                   <p className="text-[11px] text-(--color-text-secondary) mt-2">
                     {cluster.doc_count} {cluster.doc_count === 1 ? 'document' : 'documents'}
                   </p>
-                </button>
+                </Card>
               ))}
             </div>
           )}
@@ -383,7 +399,7 @@ function ExploreMain({
         <h2 className="text-[13px] font-semibold text-(--color-text-secondary) uppercase tracking-wider mb-3">
           Timeline
         </h2>
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) px-5 py-4">
+        <Card className="px-5 py-4">
           {timelineData.length <= 2 ? (
             timelineData.length === 0 ? (
               <p className="py-4 text-center text-sm text-(--color-text-secondary)">No timeline data yet.</p>
@@ -420,7 +436,7 @@ function ExploreMain({
               </BarChart>
             </ResponsiveContainer>
           )}
-        </div>
+        </Card>
       </section>
     </div>
   )
@@ -432,11 +448,13 @@ function EntitySection({
   label,
   items,
   defaultOpen,
+  color,
   onSelect,
 }: {
   label: string
   items: EntityItem[]
   defaultOpen: boolean
+  color: string
   onSelect: (entityText: string) => void
 }) {
   const [open, setOpen] = useState(defaultOpen)
@@ -469,12 +487,14 @@ function EntitySection({
                 <button
                   key={item.entity_text}
                   onClick={() => onSelect(item.entity_text)}
-                  className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px] text-(--color-text-primary) bg-(--color-bg-secondary) hover:bg-black/6 dark:hover:bg-white/10 transition-colors"
+                  className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs transition-opacity hover:opacity-80"
+                  style={{
+                    backgroundColor: `${color}1f`,
+                    color,
+                  }}
                 >
-                  <span className="font-medium">{item.entity_text}</span>
-                  <span className="rounded-full bg-black/8 dark:bg-white/12 px-1.5 py-0.5 text-[10px] text-(--color-text-secondary) tabular-nums">
-                    {item.doc_count}
-                  </span>
+                  {item.entity_text}
+                  <span className="text-[10px] opacity-70">{item.doc_count}</span>
                 </button>
               ))}
             </div>
@@ -795,12 +815,12 @@ function ExploreDocList({
           <p className="text-sm text-(--color-text-secondary)">Loading...</p>
         </div>
       ) : docs.length === 0 ? (
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) px-5 py-8 text-center">
+        <Card className="px-5 py-8 text-center">
           <p className="text-sm text-(--color-text-secondary)">No documents found.</p>
-        </div>
+        </Card>
       ) : (
         <>
-          <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+          <Card className="overflow-hidden">
             <table className="min-w-full divide-y divide-(--color-border)">
               <thead className="bg-(--color-bg-secondary)">
                 <tr>
@@ -903,7 +923,7 @@ function ExploreDocList({
                 })}
               </tbody>
             </table>
-          </div>
+          </Card>
 
           {/* Pagination */}
           {totalPages > 1 && (

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -275,7 +275,7 @@ function ExploreMain({
               placeholder="Search topics & entities…"
               value={topicSearch}
               onChange={(e) => setTopicSearch(e.target.value)}
-              className="w-64 rounded-md bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) pl-8 pr-8 py-1.5 text-sm ring-1 ring-(--color-border) focus:outline-none focus:ring-2"
+              className="w-64 rounded-md bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) pl-8 pr-8 py-1.5 text-sm ring-1 ring-(--color-border) focus:outline-none focus:ring-2"
             />
             {topicSearch && (
               <button
@@ -729,7 +729,7 @@ function ExploreDocList({
           placeholder="Filter by filename..."
           value={filterInput}
           onChange={(e) => handleFilterChange(e.target.value)}
-          className="w-52 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-3 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
+          className="w-52 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-3 py-1 text-xs text-(--color-text-primary) placeholder-(--color-text-secondary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30 focus:shadow-md transition-shadow"
         />
 
         {filterOptions.mime_types.length > 0 && (
@@ -739,7 +739,7 @@ function ExploreDocList({
               setMimeFilter(e.target.value)
               setCurrentPage(1)
             }}
-            className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+            className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
           >
             <option value="">All types</option>
             {filterOptions.mime_types.map((m) => (
@@ -758,7 +758,7 @@ function ExploreDocList({
               setTopicFilter(e.target.value)
               setCurrentPage(1)
             }}
-            className="max-w-48 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+            className="max-w-48 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
           >
             <option value="">All topics</option>
             {clusters.map((c) => (

--- a/frontend/src/pages/FoldersPage.tsx
+++ b/frontend/src/pages/FoldersPage.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
 import { del, get, patch, post, ApiError } from '../api'
 import { useFolderProgress } from '../hooks/useFolderProgress'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill, type PillState } from '../components/StatusPill'
+import { IconTile } from '../components/IconTile'
 
 interface FolderInfo {
   folder_id: string
@@ -38,6 +42,38 @@ interface SystemInfo {
 function errorMessage(e: unknown, fallback: string): string {
   if (e instanceof ApiError || e instanceof Error) return e.message
   return fallback
+}
+
+// Precedence: a disabled folder shouldn't show "scanning" even if a stale scan is in flight.
+function mapFolderStatusToPillState(f: FolderInfo, p?: ProgressInfo): PillState {
+  if (f.unavailable_reason) return 'error'
+  if (!f.enabled) return 'idle'
+  if (p?.scan_status === 'scanning') return 'running'
+  return 'active'
+}
+
+function mapFolderStatusLabel(f: FolderInfo, p?: ProgressInfo): string {
+  if (f.unavailable_reason === 'unmounted') return 'unmounted'
+  if (f.unavailable_reason) return 'unavailable'
+  if (!f.enabled) return 'disabled'
+  if (p?.scan_status === 'scanning') return 'scanning'
+  return 'idle'
+}
+
+function AddFolderButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium"
+      style={{
+        backgroundColor: 'var(--area-accent-tint)',
+        color: 'var(--area-accent-text)',
+        border: '1px solid var(--area-accent)',
+      }}
+    >
+      <span aria-hidden>＋</span> Add Folder
+    </button>
+  )
 }
 
 export default function FoldersPage() {
@@ -152,21 +188,13 @@ export default function FoldersPage() {
     }
   }
 
-  if (!system) return <div className="text-sm text-gray-500">Loading...</div>
+  if (!system) return <div className="text-sm text-(--color-text-secondary)">Loading…</div>
+
+  const addButton = system.picker === 'native' ? <AddFolderButton onClick={handleAdd} /> : null
 
   return (
     <div className="animate-slide-in">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold">Folders</h1>
-        {system.picker === 'native' ? (
-          <button
-            onClick={handleAdd}
-            className="rounded-lg bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-xs hover:bg-blue-700"
-          >
-            Add Folder
-          </button>
-        ) : null}
-      </div>
+      <PageHeader title="Folders" actions={addButton} />
 
       {system.picker === 'none' && (
         <div className="mb-4 rounded-md bg-blue-50 dark:bg-blue-900/20 p-3 text-xs text-blue-700 dark:text-blue-400">
@@ -183,49 +211,41 @@ export default function FoldersPage() {
         </div>
       )}
 
-      <div className="overflow-hidden rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border)">
-        <table className="w-full text-sm">
-          <thead className="bg-(--color-bg-secondary)">
-            <tr>
-              <th className="px-4 py-3 text-left">Folder</th>
-              <th className="px-4 py-3 text-left">Status</th>
-              <th className="px-4 py-3 text-left">Progress</th>
-              <th className="px-4 py-3 text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-(--color-border)">
-            {folders.length === 0 && (
-              <tr>
-                <td colSpan={4} className="px-4 py-8 text-center text-sm text-gray-500">
-                  No folders yet.{' '}
-                  {system.picker === 'native'
-                    ? 'Click Add Folder to start watching one.'
-                    : 'Mount a folder under WATCH_ROOT to begin.'}
-                </td>
-              </tr>
-            )}
-            {folders.map((f) => {
-              const p = progress[f.folder_id]
-              const isExpanded = expanded === f.folder_id
-              const deleteDisabled = f.auto_discovered && f.unavailable_reason === null
-              return (
-                <FolderRow
-                  key={f.folder_id}
-                  folder={f}
-                  progress={p}
-                  isExpanded={isExpanded}
-                  deleteDisabled={deleteDisabled}
-                  pendingDelete={pendingDeleteId === f.folder_id}
-                  onToggleExpand={() => setExpanded(isExpanded ? null : f.folder_id)}
-                  onToggleEnabled={() => handleToggle(f)}
-                  onDelete={() => handleDeleteClick(f.folder_id)}
-                  onCancelDelete={() => setPendingDeleteId(null)}
-                />
-              )
-            })}
-          </tbody>
-        </table>
-      </div>
+      {folders.length === 0 ? (
+        <Card className="mx-auto mt-8 flex max-w-md flex-col items-center gap-3 p-8 text-center">
+          <IconTile size={56}>📁</IconTile>
+          <h3 className="font-serif text-lg font-semibold">No folders yet</h3>
+          <p className="text-sm text-(--color-text-secondary)">
+            {system.picker === 'native'
+              ? 'Add a folder to start watching for documents to ingest.'
+              : 'Mount a folder under WATCH_ROOT to begin.'}
+          </p>
+          {system.picker === 'native' && <AddFolderButton onClick={handleAdd} />}
+        </Card>
+      ) : (
+        <div>
+          {folders.map((f) => {
+            const p = progress[f.folder_id]
+            const isExpanded = expanded === f.folder_id
+            const deleteDisabled = f.auto_discovered && f.unavailable_reason === null
+            const pendingDelete = pendingDeleteId === f.folder_id
+            return (
+              <FolderRow
+                key={f.folder_id}
+                folder={f}
+                progress={p}
+                isExpanded={isExpanded}
+                deleteDisabled={deleteDisabled}
+                pendingDelete={pendingDelete}
+                onToggleExpand={() => setExpanded(isExpanded ? null : f.folder_id)}
+                onToggleEnabled={() => handleToggle(f)}
+                onDelete={() => handleDeleteClick(f.folder_id)}
+                onCancelDelete={() => setPendingDeleteId(null)}
+              />
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }
@@ -254,27 +274,31 @@ function FolderRow({
   onCancelDelete,
 }: FolderRowProps) {
   return (
-    <>
-      <tr className="cursor-pointer" onClick={onToggleExpand}>
-        <td className="px-4 py-3">
-          <div className="font-medium">{f.display_name || f.path}</div>
-          <div className="text-xs text-gray-500 font-mono">{f.path}</div>
-          {f.auto_discovered && (
-            <span className="inline-flex items-center mt-1 rounded-md bg-purple-100 dark:bg-purple-900/30 px-2 py-0.5 text-[11px] text-purple-700 dark:text-purple-400">
-              auto-discovered
-            </span>
+    <Card className="mb-2" interactive>
+      <div className="flex cursor-pointer items-center gap-3 px-3.5 py-3" onClick={onToggleExpand}>
+        <IconTile size={30}>📁</IconTile>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-(--color-text-primary)">{f.display_name || f.path}</div>
+          <div className="flex items-center gap-2 text-[11px] text-(--color-text-secondary)">
+            <span className="truncate font-mono">{f.path}</span>
+            {f.auto_discovered && (
+              <span className="inline-flex shrink-0 items-center rounded-md bg-purple-100 dark:bg-purple-900/30 px-2 py-0.5 text-[11px] text-purple-700 dark:text-purple-400">
+                auto-discovered
+              </span>
+            )}
+          </div>
+          {p && (
+            <div className="mt-0.5 text-[11px] text-(--color-text-secondary)">
+              {p.completed_files} / {p.total_files} files
+            </div>
           )}
-        </td>
-        <td className="px-4 py-3">{renderStatusPill(f, p)}</td>
-        <td className="px-4 py-3 text-xs">{p ? `${p.completed_files} / ${p.total_files}` : '—'}</td>
-        <td className="px-4 py-3 text-right">
+        </div>
+        <StatusPill state={mapFolderStatusToPillState(f, p)} label={mapFolderStatusLabel(f, p)} />
+        <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
           {!pendingDelete && (
             <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onToggleEnabled()
-              }}
-              className="mr-2 rounded-lg border border-gray-400 px-2 py-1 text-xs"
+              onClick={onToggleEnabled}
+              className="rounded-lg border border-(--color-border) px-2 py-1 text-xs text-(--color-text-secondary) hover:text-(--color-text-primary)"
             >
               {f.enabled ? 'Disable' : 'Enable'}
             </button>
@@ -282,21 +306,12 @@ function FolderRow({
           {pendingDelete ? (
             <>
               <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onCancelDelete()
-                }}
-                className="mr-2 rounded-lg border border-gray-400 px-2 py-1 text-xs"
+                onClick={onCancelDelete}
+                className="rounded-lg border border-(--color-border) px-2 py-1 text-xs text-(--color-text-secondary) hover:text-(--color-text-primary)"
               >
                 Cancel
               </button>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onDelete()
-                }}
-                className="rounded-lg bg-red-600 px-2 py-1 text-xs font-medium text-white"
-              >
+              <button onClick={onDelete} className="rounded-lg bg-red-600 px-2 py-1 text-xs font-medium text-white">
                 Confirm Delete
               </button>
             </>
@@ -304,66 +319,32 @@ function FolderRow({
             <button
               disabled={deleteDisabled}
               title={deleteDisabled ? 'Active Docker mount — unmount first' : ''}
-              onClick={(e) => {
-                e.stopPropagation()
-                onDelete()
-              }}
-              className="rounded-lg bg-red-600 px-2 py-1 text-xs text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={onDelete}
+              className="rounded-lg bg-red-600 px-2 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
             >
               Delete
             </button>
           )}
-        </td>
-      </tr>
+        </div>
+      </div>
       {isExpanded && p && (
-        <tr>
-          <td colSpan={4} className="bg-(--color-bg-secondary) px-4 py-3">
-            <div className="grid grid-cols-7 gap-2 text-xs">
-              {Object.entries(p.by_stage).map(([stage, counts]) => {
-                const total = counts.done + counts.pending + counts.running + counts.error
-                return (
-                  <div key={stage}>
-                    <div className="font-medium capitalize">{stage}</div>
-                    <div>
-                      {counts.done}/{total}
-                    </div>
-                    {counts.error > 0 && <div className="text-red-600">{counts.error} err</div>}
+        <div className="border-t border-(--color-border) bg-(--color-bg-secondary) px-4 py-3">
+          <div className="grid grid-cols-7 gap-2 text-xs">
+            {Object.entries(p.by_stage).map(([stage, counts]) => {
+              const total = counts.done + counts.pending + counts.running + counts.error
+              return (
+                <div key={stage}>
+                  <div className="font-medium capitalize">{stage}</div>
+                  <div>
+                    {counts.done}/{total}
                   </div>
-                )
-              })}
-            </div>
-          </td>
-        </tr>
+                  {counts.error > 0 && <div className="text-red-600">{counts.error} err</div>}
+                </div>
+              )
+            })}
+          </div>
+        </div>
       )}
-    </>
-  )
-}
-
-function renderStatusPill(f: FolderInfo, p?: ProgressInfo) {
-  if (f.unavailable_reason === 'unmounted') {
-    return (
-      <span className="rounded-md bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-[11px] text-red-700 dark:text-red-400">
-        unmounted
-      </span>
-    )
-  }
-  if (!f.enabled) {
-    return (
-      <span className="rounded-md bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-[11px] text-gray-600 dark:text-gray-300">
-        disabled
-      </span>
-    )
-  }
-  if (p?.scan_status === 'scanning') {
-    return (
-      <span className="rounded-md bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-400">
-        scanning
-      </span>
-    )
-  }
-  return (
-    <span className="rounded-md bg-green-100 dark:bg-green-900/30 px-2 py-0.5 text-[11px] text-green-700 dark:text-green-400">
-      idle
-    </span>
+    </Card>
   )
 }

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import { del, get, put } from '../api'
 import { Link } from 'react-router-dom'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface IntegrationSettings {
   public_url: string
@@ -46,8 +48,6 @@ function CodeBlock({ children }: { children: string }) {
     </div>
   )
 }
-
-const cardClass = 'rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-6'
 
 export default function IntegrationsPage() {
   const [settings, setSettings] = useState<IntegrationSettings>({ public_url: '', oauth_refresh_token_days: 90 })
@@ -121,7 +121,7 @@ export default function IntegrationsPage() {
 
   return (
     <div className="animate-slide-in space-y-6">
-      <h1 className="text-xl font-bold">Integrations</h1>
+      <PageHeader title="Integrations" subtitle="MCP and external integrations" />
 
       {error && (
         <div className="rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -130,7 +130,7 @@ export default function IntegrationsPage() {
       )}
 
       {/* Connection Settings */}
-      <div className={cardClass}>
+      <Card className="p-6">
         <h2 className="text-lg font-semibold mb-4">Connection Settings</h2>
 
         <div className="space-y-4">
@@ -177,16 +177,16 @@ export default function IntegrationsPage() {
             </select>
           </div>
         </div>
-      </div>
+      </Card>
 
       {/* Active Connections */}
       {connections.length === 0 ? (
-        <div className={cardClass}>
+        <Card className="p-6">
           <h2 className="text-lg font-semibold mb-4">Active Connections</h2>
           <p className="text-sm text-(--color-text-secondary)">No external AI tools connected yet.</p>
-        </div>
+        </Card>
       ) : (
-        <div className={cardClass}>
+        <Card className="p-6">
           <details>
             <summary className="text-lg font-semibold cursor-pointer">
               Active Connections ({connections.length})
@@ -241,11 +241,11 @@ export default function IntegrationsPage() {
               </table>
             </div>
           </details>
-        </div>
+        </Card>
       )}
 
       {/* Connection Guides */}
-      <div className={cardClass}>
+      <Card className="p-6">
         <div className="grid grid-cols-4 gap-3 mb-6">
           {(['chatgpt', 'claude', 'gemini', 'openclaw'] as const).map((tab) => {
             const info = {
@@ -454,7 +454,7 @@ export default function IntegrationsPage() {
             </div>
           </>
         )}
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/LanguagesPage.tsx
+++ b/frontend/src/pages/LanguagesPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { del, get, patch, post } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface ToolStatus {
   status: 'not_installed' | 'installed' | 'failed'
@@ -164,11 +166,7 @@ export default function LanguagesPage() {
 
   return (
     <div>
-      <h1 className="mb-4 text-xl font-bold">Languages</h1>
-      <p className="mb-4 text-sm text-(--color-text-secondary)">
-        Choose which languages Harbor Clerk should process. English is built-in. Other languages download per-tool model
-        files (Tesseract OCR, spaCy entities) on demand.
-      </p>
+      <PageHeader title="Languages" subtitle="OCR and entity language packs" />
 
       {error && (
         <div className="mb-3 rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -176,7 +174,7 @@ export default function LanguagesPage() {
         </div>
       )}
 
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden divide-y divide-(--color-border)">
+      <Card className="overflow-hidden divide-y divide-(--color-border)">
         {languages.map((lang) => {
           const isBusy = busy.has(lang.code)
           const installedToolCount = Object.values(lang.tools).filter((t) => t.status === 'installed').length
@@ -255,7 +253,7 @@ export default function LanguagesPage() {
             </div>
           )
         })}
-      </div>
+      </Card>
 
       <p className="mt-4 text-[11px] text-gray-400">
         Worker restart required to pick up newly-installed packs. Disabling a language stops new documents from using it

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../auth'
+import { Card } from '../components/Card'
+import { PageHeader } from '../components/PageHeader'
 
 export default function LoginPage() {
   const { user, loading, login } = useAuth()
@@ -38,42 +40,44 @@ export default function LoginPage() {
     <div className="flex min-h-screen items-center justify-center bg-(--color-bg-secondary)">
       <div className="w-full max-w-sm">
         <img src="/logo.png" alt="Harbor Clerk" className="mx-auto mb-4 h-16 object-contain" />
-        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">Harbor Clerk</h1>
-        <form onSubmit={handleSubmit} className="rounded-xl bg-white dark:bg-[#2c2c2e] p-6 shadow-mac-lg">
-          {error && (
-            <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
-              {error}
-            </div>
-          )}
-          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoFocus
-            autoComplete="username"
-            autoCapitalize="off"
-            className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
-          />
-          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="current-password"
-            autoCapitalize="off"
-            className="mb-6 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
-          />
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
-          >
-            {submitting ? 'Signing in...' : 'Sign in'}
-          </button>
-        </form>
+        <Card className="mx-auto max-w-sm p-6">
+          <PageHeader title="Harbor Clerk" subtitle="Sign in to continue" />
+          <form onSubmit={handleSubmit}>
+            {error && (
+              <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+                {error}
+              </div>
+            )}
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoFocus
+              autoComplete="username"
+              autoCapitalize="off"
+              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+            />
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+              autoCapitalize="off"
+              className="mb-6 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+            />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? 'Signing in...' : 'Sign in'}
+            </button>
+          </form>
+        </Card>
       </div>
     </div>
   )

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -57,7 +57,7 @@ export default function LoginPage() {
               autoFocus
               autoComplete="username"
               autoCapitalize="off"
-              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
             <input
@@ -67,7 +67,7 @@ export default function LoginPage() {
               required
               autoComplete="current-password"
               autoCapitalize="off"
-              className="mb-6 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-6 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             <button
               type="submit"

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -57,7 +57,7 @@ export default function LoginPage() {
               autoFocus
               autoComplete="username"
               autoCapitalize="off"
-              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
             <input
@@ -67,7 +67,7 @@ export default function LoginPage() {
               required
               autoComplete="current-password"
               autoCapitalize="off"
-              className="mb-6 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-6 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             <button
               type="submit"

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -2,6 +2,9 @@ import { Fragment, useEffect, useRef, useState } from 'react'
 import { useAuth } from '../auth'
 import { del, get, post, put } from '../api'
 import { useLLMStatusContext } from '../components/LLMStatusBanner'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill } from '../components/StatusPill'
 
 interface ModelInfo {
   id: string
@@ -273,10 +276,7 @@ export default function ModelsPage() {
 
   return (
     <div className="animate-slide-in">
-      <h1 className="mb-4 text-xl font-bold">LLM Models</h1>
-      <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
-        Download and manage models for the built-in chat assistant. Models run locally on this machine.
-      </p>
+      <PageHeader title="Models" subtitle="Download and manage local LLM models" />
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -284,7 +284,7 @@ export default function ModelsPage() {
         </div>
       )}
 
-      <div className="overflow-hidden rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border)">
+      <Card className="overflow-hidden">
         <table className="w-full text-sm">
           <thead className="bg-(--color-bg-secondary)">
             <tr>
@@ -368,13 +368,9 @@ export default function ModelsPage() {
                         </td>
                         <td className="px-4 py-3">
                           {model.active ? (
-                            <span className="inline-flex items-center rounded-md bg-blue-100 dark:bg-blue-900/30 px-2 py-0.5 text-[11px] font-medium text-blue-700 dark:text-blue-400">
-                              Active
-                            </span>
+                            <StatusPill state="active" label="Active" />
                           ) : model.downloaded ? (
-                            <span className="inline-flex items-center rounded-md bg-green-100 dark:bg-green-900/30 px-2 py-0.5 text-[11px] font-medium text-green-700 dark:text-green-400">
-                              Ready
-                            </span>
+                            <StatusPill state="idle" label="Ready" />
                           ) : downloading.has(model.id) ? (
                             <div className="flex items-center gap-2">
                               <div className="h-1.5 w-24 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
@@ -390,7 +386,7 @@ export default function ModelsPage() {
                               </span>
                             </div>
                           ) : (
-                            <span className="text-xs text-gray-400">Not downloaded</span>
+                            <StatusPill state="idle" label="Not downloaded" />
                           )}
                         </td>
                         <td className="px-4 py-3 text-right">
@@ -436,11 +432,11 @@ export default function ModelsPage() {
               ))}
           </tbody>
         </table>
-      </div>
+      </Card>
 
       {/* Orphaned model files */}
       {orphans.length > 0 && (
-        <div className="mt-6 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <Card className="mt-6 p-4">
           <div className="font-medium text-gray-900 dark:text-gray-100">Orphaned model files</div>
           <p className="mt-0.5 mb-3 text-xs text-gray-500 dark:text-gray-400">
             GGUF files on disk that are no longer in the model registry — typically left over from removed or replaced
@@ -462,12 +458,12 @@ export default function ModelsPage() {
               </li>
             ))}
           </ul>
-        </div>
+        </Card>
       )}
 
       {/* YaRN Extended Context */}
       {models.some((m) => m.yarn_available) && (
-        <div className="mt-6 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+        <Card className="mt-6 p-4">
           <div className="flex items-center justify-between">
             <div>
               <div className="font-medium text-gray-900 dark:text-gray-100">Extended Context (YaRN)</div>
@@ -496,11 +492,11 @@ export default function ModelsPage() {
               LLM server will restart with extended context. Not recommended if most prompts are under 32K tokens.
             </p>
           )}
-        </div>
+        </Card>
       )}
 
       {/* Always use Apple Intelligence for summaries */}
-      <div className="mt-4 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+      <Card className="mt-4 p-4">
         <div className="flex items-center justify-between">
           <div>
             <div className="font-medium text-gray-900 dark:text-gray-100">
@@ -526,7 +522,7 @@ export default function ModelsPage() {
             />
           </button>
         </div>
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -49,7 +49,7 @@ export default function PreferencesPage() {
           <select
             value={pageSize}
             onChange={(e) => updatePreferences({ page_size: Number(e.target.value) })}
-            className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
           >
             {PAGE_SIZE_OPTIONS.map((n) => (
               <option key={n} value={n}>
@@ -126,7 +126,7 @@ function ChangePasswordCard() {
           value={current}
           onChange={(e) => setCurrent(e.target.value)}
           required
-          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
         />
         <input
           type="password"
@@ -136,7 +136,7 @@ function ChangePasswordCard() {
           onChange={(e) => setNext(e.target.value)}
           required
           minLength={12}
-          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
         />
         <input
           type="password"
@@ -146,7 +146,7 @@ function ChangePasswordCard() {
           onChange={(e) => setConfirm(e.target.value)}
           required
           minLength={12}
-          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
         />
         {error && (
           <div className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useState } from 'react'
 import { useAuth } from '../auth'
 import { post } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
 
@@ -11,10 +13,10 @@ export default function PreferencesPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-xl font-bold">Preferences</h1>
+      <PageHeader title="Preferences" subtitle="Personal settings" />
 
       <div className="space-y-6">
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-6">
+        <Card className="p-6">
           <h2 className="mb-1 text-sm font-medium text-gray-900 dark:text-gray-100">Theme</h2>
           <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">Choose between light and dark appearance.</p>
           <div className="flex space-x-2">
@@ -39,9 +41,9 @@ export default function PreferencesPage() {
               Dark
             </button>
           </div>
-        </div>
+        </Card>
 
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-6">
+        <Card className="p-6">
           <h2 className="mb-1 text-sm font-medium text-gray-900 dark:text-gray-100">Default page size</h2>
           <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">Number of items shown per page by default.</p>
           <select
@@ -55,7 +57,7 @@ export default function PreferencesPage() {
               </option>
             ))}
           </select>
-        </div>
+        </Card>
 
         <ChangePasswordCard />
       </div>
@@ -111,7 +113,7 @@ function ChangePasswordCard() {
   }
 
   return (
-    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac p-6">
+    <Card className="p-6">
       <h2 className="mb-1 text-sm font-medium text-gray-900 dark:text-gray-100">Change password</h2>
       <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
         Requires your current password. New password must be at least 12 characters and contain upper, lower, and digit.
@@ -164,6 +166,6 @@ function ChangePasswordCard() {
           {submitting ? 'Updating…' : 'Update password'}
         </button>
       </form>
-    </div>
+    </Card>
   )
 }

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -49,7 +49,7 @@ export default function PreferencesPage() {
           <select
             value={pageSize}
             onChange={(e) => updatePreferences({ page_size: Number(e.target.value) })}
-            className="rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
           >
             {PAGE_SIZE_OPTIONS.map((n) => (
               <option key={n} value={n}>
@@ -126,7 +126,7 @@ function ChangePasswordCard() {
           value={current}
           onChange={(e) => setCurrent(e.target.value)}
           required
-          className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
         />
         <input
           type="password"
@@ -136,7 +136,7 @@ function ChangePasswordCard() {
           onChange={(e) => setNext(e.target.value)}
           required
           minLength={12}
-          className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
         />
         <input
           type="password"
@@ -146,7 +146,7 @@ function ChangePasswordCard() {
           onChange={(e) => setConfirm(e.target.value)}
           required
           minLength={12}
-          className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+          className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
         />
         {error && (
           <div className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">

--- a/frontend/src/pages/RateLimitSettingsPage.tsx
+++ b/frontend/src/pages/RateLimitSettingsPage.tsx
@@ -90,7 +90,7 @@ export default function RateLimitSettingsPage() {
               min={1}
               value={form.default_rpm}
               onChange={(e) => updateField('default_rpm', Number(e.target.value))}
-              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
             />
           </div>
           <div className="flex items-center justify-between gap-4 py-3">
@@ -105,7 +105,7 @@ export default function RateLimitSettingsPage() {
               min={1}
               value={form.default_rph}
               onChange={(e) => updateField('default_rph', Number(e.target.value))}
-              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
             />
           </div>
         </div>

--- a/frontend/src/pages/RateLimitSettingsPage.tsx
+++ b/frontend/src/pages/RateLimitSettingsPage.tsx
@@ -90,7 +90,7 @@ export default function RateLimitSettingsPage() {
               min={1}
               value={form.default_rpm}
               onChange={(e) => updateField('default_rpm', Number(e.target.value))}
-              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
             />
           </div>
           <div className="flex items-center justify-between gap-4 py-3">
@@ -105,7 +105,7 @@ export default function RateLimitSettingsPage() {
               min={1}
               value={form.default_rph}
               onChange={(e) => updateField('default_rph', Number(e.target.value))}
-              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+              className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
             />
           </div>
         </div>

--- a/frontend/src/pages/RateLimitSettingsPage.tsx
+++ b/frontend/src/pages/RateLimitSettingsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import { get, put } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface RateLimitSettings {
   default_rpm: number
@@ -58,10 +60,7 @@ export default function RateLimitSettingsPage() {
 
   return (
     <div className="animate-slide-in">
-      <h1 className="mb-4 text-xl font-bold">Rate Limits</h1>
-      <p className="mb-4 text-sm text-(--color-text-secondary)">
-        Default rate limits applied to API keys that don&apos;t specify their own limits.
-      </p>
+      <PageHeader title="Rate Limits" />
 
       {error && (
         <div className="mb-4 rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -74,7 +73,7 @@ export default function RateLimitSettingsPage() {
         </div>
       )}
 
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+      <Card className="overflow-hidden">
         <div className="px-4 py-3 bg-(--color-bg-secondary)">
           <h2 className="text-sm font-medium text-(--color-text-primary)">Default Limits</h2>
         </div>
@@ -110,7 +109,7 @@ export default function RateLimitSettingsPage() {
             />
           </div>
         </div>
-      </div>
+      </Card>
 
       <div className="mt-6 flex gap-3">
         <button

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -1,12 +1,14 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
+import { PageHeader } from '../components/PageHeader'
 import ToolResultDisplay from '../components/ToolResultDisplay'
 import { del, get } from '../api'
 import { useChat } from '../contexts/ChatContext'
 import { useResearch, type ToolCallEntry } from '../contexts/ResearchContext'
 import { useLLMStatus } from '../hooks/useLLMStatus'
 import { formatRelativeDate } from '../utils/dates'
+import { topicDotVar } from '../utils/topicDotColor'
 
 interface ResearchSummary {
   conversation_id: string
@@ -330,12 +332,14 @@ export default function ResearchPage() {
         <div className="p-3 pb-2">
           <button
             onClick={handleNewResearch}
-            className="group w-full flex items-center gap-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-[13px] font-medium text-gray-600 dark:text-gray-300 shadow-xs hover:shadow-md hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200"
+            className="mb-3 inline-flex w-full items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150"
+            style={{
+              backgroundColor: 'var(--area-accent-tint)',
+              color: 'var(--area-accent-text)',
+              border: '1px solid var(--area-accent)',
+            }}
           >
-            <span className="flex h-5 w-5 items-center justify-center rounded-md bg-amber-600 dark:bg-amber-500 text-white text-xs transition-transform duration-200 group-hover:scale-110">
-              +
-            </span>
-            New Research
+            <span aria-hidden>＋</span> New Research
           </button>
         </div>
 
@@ -359,6 +363,10 @@ export default function ResearchPage() {
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1.5">
+                    <span
+                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                      style={{ background: topicDotVar(task.conversation_id) }}
+                    />
                     {task.status === 'running' || (isRunning && task.conversation_id === conversationId) ? (
                       <svg className="shrink-0 h-3 w-3 text-blue-500 animate-spin" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
@@ -451,6 +459,9 @@ export default function ResearchPage() {
 
         {/* Content area */}
         <div className="flex-1 overflow-y-auto">
+          <div className="px-6 pt-5 pb-1">
+            <PageHeader title="Research" subtitle="Deep multi-step research over your corpus" />
+          </div>
           {/* State 1: Idle */}
           {isIdle && (
             <div className="flex h-full items-center justify-center p-8">

--- a/frontend/src/pages/RetrievalSettingsPage.tsx
+++ b/frontend/src/pages/RetrievalSettingsPage.tsx
@@ -66,7 +66,7 @@ function NumberField({ field, value, onChange }: { field: FieldDef; value: numbe
         step={field.step}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+        className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
       />
     </div>
   )
@@ -125,7 +125,7 @@ function SearchPaginationField({
             step={kStep}
             value={k}
             onChange={(e) => onKChange(Number(e.target.value))}
-            className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+            className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
           />
         </div>
       )}

--- a/frontend/src/pages/RetrievalSettingsPage.tsx
+++ b/frontend/src/pages/RetrievalSettingsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import { get, put } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface RetrievalSettings {
   max_history_messages: number
@@ -183,10 +185,7 @@ export default function RetrievalSettingsPage() {
 
   return (
     <div className="animate-slide-in">
-      <h1 className="mb-4 text-xl font-bold">Retrieval Settings</h1>
-      <p className="mb-4 text-sm text-(--color-text-secondary)">
-        Tune how Ask, Research, and MCP search tools retrieve passages from the knowledge base.
-      </p>
+      <PageHeader title="Retrieval" subtitle="Chat &amp; MCP search behavior" />
 
       {error && (
         <div className="mb-4 rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -201,7 +200,7 @@ export default function RetrievalSettingsPage() {
 
       <div className="space-y-6">
         {/* Ask Search */}
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+        <Card className="overflow-hidden">
           <div className="px-4 py-3 bg-(--color-bg-secondary)">
             <h2 className="text-sm font-medium text-(--color-text-primary)">Ask</h2>
           </div>
@@ -226,10 +225,10 @@ export default function RetrievalSettingsPage() {
               onKChange={(v) => updateField('chat_search_k', v)}
             />
           </div>
-        </div>
+        </Card>
 
         {/* Research Search */}
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+        <Card className="overflow-hidden">
           <div className="px-4 py-3 bg-(--color-bg-secondary)">
             <h2 className="text-sm font-medium text-(--color-text-primary)">Research</h2>
           </div>
@@ -246,10 +245,10 @@ export default function RetrievalSettingsPage() {
               onKChange={(v) => updateField('research_search_k', v)}
             />
           </div>
-        </div>
+        </Card>
 
         {/* MCP API */}
-        <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+        <Card className="overflow-hidden">
           <div className="px-4 py-3 bg-(--color-bg-secondary)">
             <h2 className="text-sm font-medium text-(--color-text-primary)">MCP API</h2>
           </div>
@@ -263,7 +262,7 @@ export default function RetrievalSettingsPage() {
               />
             ))}
           </div>
-        </div>
+        </Card>
       </div>
 
       <div className="mt-6 flex gap-3">

--- a/frontend/src/pages/RetrievalSettingsPage.tsx
+++ b/frontend/src/pages/RetrievalSettingsPage.tsx
@@ -66,7 +66,7 @@ function NumberField({ field, value, onChange }: { field: FieldDef; value: numbe
         step={field.step}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+        className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
       />
     </div>
   )
@@ -125,7 +125,7 @@ function SearchPaginationField({
             step={kStep}
             value={k}
             onChange={(e) => onKChange(Number(e.target.value))}
-            className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
+            className="w-24 shrink-0 rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm text-right text-(--color-text-primary) tabular-nums"
           />
         </div>
       )}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -246,7 +246,7 @@ export default function SearchPage() {
             }}
             placeholder="Search documents..."
             autoFocus
-            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-4 py-2 text-sm"
+            className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-4 py-2 text-sm"
           />
           {showHistory && history.length > 0 && (
             <div className="absolute z-10 mt-1 w-full rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac-lg ring-1 ring-(--color-border) overflow-hidden">
@@ -391,7 +391,7 @@ export default function SearchPage() {
                   <select
                     value={pageSize}
                     onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                    className="rounded-md border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) py-0.5 pl-2 pr-6 text-sm"
+                    className="rounded-md border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) py-0.5 pl-2 pr-6 text-sm"
                   >
                     {PAGE_SIZES.map((s) => (
                       <option key={s} value={s}>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -246,7 +246,7 @@ export default function SearchPage() {
             }}
             placeholder="Search documents..."
             autoFocus
-            className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-4 py-2 text-sm"
+            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-4 py-2 text-sm"
           />
           {showHistory && history.length > 0 && (
             <div className="absolute z-10 mt-1 w-full rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac-lg ring-1 ring-(--color-border) overflow-hidden">
@@ -391,7 +391,7 @@ export default function SearchPage() {
                   <select
                     value={pageSize}
                     onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                    className="rounded-md border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) py-0.5 pl-2 pr-6 text-sm"
+                    className="rounded-md border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) py-0.5 pl-2 pr-6 text-sm"
                   >
                     {PAGE_SIZES.map((s) => (
                       <option key={s} value={s}>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { post } from '../api'
+import { Card } from '../components/Card'
+import { PageHeader } from '../components/PageHeader'
 
 interface SearchHit {
   chunk_id: string
@@ -231,7 +233,7 @@ export default function SearchPage() {
 
   return (
     <div>
-      <h1 className="mb-4 text-xl font-bold">Search</h1>
+      <PageHeader title="Search" subtitle="Hybrid lexical + semantic retrieval" />
       <form onSubmit={handleSearch} className="mb-6 flex space-x-2">
         <div className="relative flex-1" ref={wrapperRef}>
           <input
@@ -290,7 +292,12 @@ export default function SearchPage() {
         <button
           type="submit"
           disabled={loading}
-          className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+          className="rounded-md px-4 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{
+            backgroundColor: 'var(--area-accent-tint)',
+            color: 'var(--area-accent-text)',
+            border: '1px solid var(--area-accent)',
+          }}
         >
           {loading ? 'Searching...' : 'Search'}
         </button>
@@ -334,10 +341,7 @@ export default function SearchPage() {
                 const linkState = { highlightChunkText: hit.chunk_text, highlightChunkId: hit.chunk_id }
 
                 return (
-                  <div
-                    key={hit.chunk_id}
-                    className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4"
-                  >
+                  <Card key={hit.chunk_id} className="p-4">
                     <div className="mb-2 flex items-center justify-between">
                       <Link
                         to={linkTo}
@@ -373,7 +377,7 @@ export default function SearchPage() {
                         </span>
                       )}
                     </div>
-                  </div>
+                  </Card>
                 )
               })}
 

--- a/frontend/src/pages/ServiceLogsPage.tsx
+++ b/frontend/src/pages/ServiceLogsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import { get } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface LogFile {
   name: string
@@ -58,53 +60,55 @@ export default function ServiceLogsPage() {
 
   return (
     <div className="animate-slide-in">
-      <h1 className="mb-4 text-xl font-bold">Service Logs</h1>
+      <PageHeader title="Service Logs" />
 
-      {loading ? (
-        <p className="text-sm text-gray-500">Loading...</p>
-      ) : !logs ? (
-        <p className="text-sm text-gray-500">Failed to load log information.</p>
-      ) : logs.mode === 'docker' ? (
-        <div className="space-y-2">
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Logs are sent to stdout in Docker mode. Use the Docker CLI to view them:
-          </p>
-          <div className="flex items-center">
-            <code className="block flex-1 rounded-sm bg-(--color-bg-tertiary) px-3 py-2 text-xs font-mono text-(--color-text-primary) select-all">
-              docker compose logs -f app worker-io worker-cpu
-            </code>
-            <CopyButton text="docker compose logs -f app worker-io worker-cpu" />
+      <Card className="p-4">
+        {loading ? (
+          <p className="text-sm text-gray-500">Loading...</p>
+        ) : !logs ? (
+          <p className="text-sm text-gray-500">Failed to load log information.</p>
+        ) : logs.mode === 'docker' ? (
+          <div className="space-y-2">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Logs are sent to stdout in Docker mode. Use the Docker CLI to view them:
+            </p>
+            <div className="flex items-center">
+              <code className="block flex-1 rounded-sm bg-(--color-bg-tertiary) px-3 py-2 text-xs font-mono text-(--color-text-primary) select-all">
+                docker compose logs -f app worker-io worker-cpu
+              </code>
+              <CopyButton text="docker compose logs -f app worker-io worker-cpu" />
+            </div>
           </div>
-        </div>
-      ) : logs.files.length === 0 ? (
-        <p className="text-sm text-gray-500">No log files found.</p>
-      ) : (
-        <div className="space-y-4">
-          {logs.logs_dir && <p className="text-xs text-gray-500 dark:text-gray-400 font-mono">{logs.logs_dir}</p>}
-          {logsByService &&
-            Object.entries(logsByService).map(([service, files]) => (
-              <div key={service}>
-                <h3 className="text-sm font-medium text-(--color-text-primary) mb-1.5">{service}</h3>
-                <div className="space-y-1.5">
-                  {files.map((f) => (
-                    <div key={f.name} className="rounded-lg bg-(--color-bg-secondary) p-3">
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-xs font-mono text-gray-500 dark:text-gray-400">{f.path}</span>
-                        <span className="text-xs text-gray-500 ml-3 shrink-0">{formatSize(f.size_bytes)}</span>
+        ) : logs.files.length === 0 ? (
+          <p className="text-sm text-gray-500">No log files found.</p>
+        ) : (
+          <div className="space-y-4">
+            {logs.logs_dir && <p className="text-xs text-gray-500 dark:text-gray-400 font-mono">{logs.logs_dir}</p>}
+            {logsByService &&
+              Object.entries(logsByService).map(([service, files]) => (
+                <div key={service}>
+                  <h3 className="text-sm font-medium text-(--color-text-primary) mb-1.5">{service}</h3>
+                  <div className="space-y-1.5">
+                    {files.map((f) => (
+                      <div key={f.name} className="rounded-lg bg-(--color-bg-secondary) p-3">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-xs font-mono text-gray-500 dark:text-gray-400">{f.path}</span>
+                          <span className="text-xs text-gray-500 ml-3 shrink-0">{formatSize(f.size_bytes)}</span>
+                        </div>
+                        <div className="flex items-center">
+                          <code className="block flex-1 rounded-sm bg-(--color-bg-tertiary) px-3 py-1.5 text-xs font-mono text-(--color-text-primary) select-all overflow-x-auto">
+                            tail -f &quot;{f.path}&quot;
+                          </code>
+                          <CopyButton text={`tail -f "${f.path}"`} />
+                        </div>
                       </div>
-                      <div className="flex items-center">
-                        <code className="block flex-1 rounded-sm bg-(--color-bg-tertiary) px-3 py-1.5 text-xs font-mono text-(--color-text-primary) select-all overflow-x-auto">
-                          tail -f &quot;{f.path}&quot;
-                        </code>
-                        <CopyButton text={`tail -f "${f.path}"`} />
-                      </div>
-                    </div>
-                  ))}
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))}
-        </div>
-      )}
+              ))}
+          </div>
+        )}
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../auth'
+import { Card } from '../components/Card'
+import { PageHeader } from '../components/PageHeader'
 
 interface PasswordCheck {
   label: string
@@ -83,72 +85,71 @@ export default function SetupPage() {
     <div className="flex min-h-screen items-center justify-center bg-(--color-bg-secondary)">
       <div className="w-full max-w-sm">
         <img src="/logo.png" alt="Harbor Clerk" className="mx-auto mb-4 h-16 object-contain" />
-        <h1 className="mb-2 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">Harbor Clerk</h1>
-        <p className="mb-6 text-center text-sm text-gray-500 dark:text-gray-400">
-          Create your admin account to get started.
-        </p>
-        <form onSubmit={handleSubmit} className="rounded-xl bg-white dark:bg-[#2c2c2e] p-6 shadow-mac-lg">
-          {error && (
-            <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
-              {error}
-            </div>
-          )}
-          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoFocus
-            autoComplete="username"
-            autoCapitalize="off"
-            className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
-          />
-          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="new-password"
-            autoCapitalize="off"
-            passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
-            className="mb-2 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
-          />
-          {password.length > 0 && (
-            <ul className="mb-4 space-y-1 text-xs">
-              {checks.map((c) => (
-                <li
-                  key={c.label}
-                  className={c.passed ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}
-                >
-                  {c.passed ? '\u2713' : '\u2717'} {c.label}
-                </li>
-              ))}
-            </ul>
-          )}
-          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Confirm password</label>
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            required
-            autoComplete="new-password"
-            autoCapitalize="off"
-            passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
-            className="mb-1 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
-          />
-          {confirmPassword.length > 0 && !passwordsMatch && (
-            <p className="mb-4 text-xs text-red-500 dark:text-red-400">Passwords do not match</p>
-          )}
-          <button
-            type="submit"
-            disabled={submitting || !allPassed || !passwordsMatch}
-            className="mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
-          >
-            {submitting ? 'Creating account...' : 'Create admin account'}
-          </button>
-        </form>
+        <Card className="mx-auto max-w-sm p-6">
+          <PageHeader title="Setup" subtitle="Create your admin account to get started." />
+          <form onSubmit={handleSubmit}>
+            {error && (
+              <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+                {error}
+              </div>
+            )}
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoFocus
+              autoComplete="username"
+              autoCapitalize="off"
+              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+            />
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+              autoCapitalize="off"
+              passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
+              className="mb-2 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+            />
+            {password.length > 0 && (
+              <ul className="mb-4 space-y-1 text-xs">
+                {checks.map((c) => (
+                  <li
+                    key={c.label}
+                    className={c.passed ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}
+                  >
+                    {c.passed ? '\u2713' : '\u2717'} {c.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Confirm password</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+              autoCapitalize="off"
+              passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
+              className="mb-1 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+            />
+            {confirmPassword.length > 0 && !passwordsMatch && (
+              <p className="mb-4 text-xs text-red-500 dark:text-red-400">Passwords do not match</p>
+            )}
+            <button
+              type="submit"
+              disabled={submitting || !allPassed || !passwordsMatch}
+              className="mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? 'Creating account...' : 'Create admin account'}
+            </button>
+          </form>
+        </Card>
       </div>
     </div>
   )

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -102,7 +102,7 @@ export default function SetupPage() {
               autoFocus
               autoComplete="username"
               autoCapitalize="off"
-              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
             <input
@@ -113,7 +113,7 @@ export default function SetupPage() {
               autoComplete="new-password"
               autoCapitalize="off"
               passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
-              className="mb-2 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-2 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             {password.length > 0 && (
               <ul className="mb-4 space-y-1 text-xs">
@@ -136,7 +136,7 @@ export default function SetupPage() {
               autoComplete="new-password"
               autoCapitalize="off"
               passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
-              className="mb-1 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-1 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             {confirmPassword.length > 0 && !passwordsMatch && (
               <p className="mb-4 text-xs text-red-500 dark:text-red-400">Passwords do not match</p>

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -102,7 +102,7 @@ export default function SetupPage() {
               autoFocus
               autoComplete="username"
               autoCapitalize="off"
-              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-4 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Password</label>
             <input
@@ -113,7 +113,7 @@ export default function SetupPage() {
               autoComplete="new-password"
               autoCapitalize="off"
               passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
-              className="mb-2 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-2 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             {password.length > 0 && (
               <ul className="mb-4 space-y-1 text-xs">
@@ -136,7 +136,7 @@ export default function SetupPage() {
               autoComplete="new-password"
               autoCapitalize="off"
               passwordrules="minlength: 12; required: upper; required: lower; required: digit;"
-              className="mb-1 w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
+              className="mb-1 w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-2 text-sm focus:outline-hidden"
             />
             {confirmPassword.length > 0 && !passwordsMatch && (
               <p className="mb-4 text-xs text-red-500 dark:text-red-400">Passwords do not match</p>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -10,6 +10,8 @@ import PipelineDiagram from '../components/stats/PipelineDiagram'
 import PipelineTimingChart, { type StageTiming } from '../components/stats/PipelineTimingChart'
 import QueueWaitChart from '../components/stats/QueueWaitChart'
 import { InfoTip } from '../components/InfoTip'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface TopicCluster {
   cluster_id: number
@@ -42,15 +44,15 @@ type TabId = 'corpus' | 'pipeline'
 
 function StatBadge({ label, value, tip }: { label: string; value: string | number; tip?: string }) {
   return (
-    <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) px-4 py-3">
+    <Card className="px-4 py-3">
       <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide">
         {label}
         {tip && <InfoTip text={tip} />}
       </p>
-      <p className="mt-0.5 text-xl font-semibold text-(--color-text-primary) tabular-nums">
+      <p className="mt-0.5 font-serif text-xl font-semibold text-(--color-text-primary) tabular-nums">
         {typeof value === 'number' ? value.toLocaleString() : value}
       </p>
-    </div>
+    </Card>
   )
 }
 
@@ -74,7 +76,7 @@ function TabButton({ id, current, onClick, children }: TabButtonProps) {
       }`}
     >
       {children}
-      {active && <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-(--color-accent)" />}
+      {active && <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-(--area-accent)" />}
     </button>
   )
 }
@@ -130,6 +132,8 @@ export default function StatsPage() {
 
   return (
     <div className="space-y-6">
+      <PageHeader title="Observatory" subtitle="Corpus statistics and processing pipeline" />
+
       {/* Tab bar */}
       <div role="tablist" className="flex border-b border-(--color-border)">
         <TabButton id="corpus" current={tab} onClick={setTab}>
@@ -182,21 +186,21 @@ function CorpusTab({ stats, topics }: { stats: CorpusStats; topics: TopicsData |
         <div className="space-y-4">
           <h2 className="text-[15px] font-semibold text-(--color-text-primary)">Topics</h2>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+            <Card className="p-4">
               <h3 className="mb-3 text-[13px] font-semibold text-(--color-text-primary)">Topic Distribution</h3>
               <TopicTreemap topics={topics.clusters} />
-            </div>
-            <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+            </Card>
+            <Card className="p-4">
               <h3 className="mb-3 text-[13px] font-semibold text-(--color-text-primary)">Documents by Topic</h3>
               <TopicBarChart topics={topics.clusters} />
-            </div>
+            </Card>
           </div>
-          <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+          <Card className="p-4">
             <h3 className="mb-3 text-[13px] font-semibold text-(--color-text-primary)">Topic Keywords</h3>
             <div className="max-h-80 overflow-y-auto">
               <TopicKeywords topics={topics.clusters} />
             </div>
-          </div>
+          </Card>
         </div>
       )}
 
@@ -218,29 +222,29 @@ function PipelineTab({ pipelineTiming }: { pipelineTiming: CorpusStats['pipeline
       </h2>
 
       {/* Live diagram */}
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+      <Card className="p-4">
         <h3 className="mb-3 text-[13px] font-semibold text-(--color-text-primary)">Live activity</h3>
         <PipelineDiagram />
-      </div>
+      </Card>
 
       {/* Per-stage timing */}
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+      <Card className="p-4">
         <h3 className="mb-1 text-[13px] font-semibold text-(--color-text-primary)">Processing time per stage</h3>
         <p className="mb-3 text-[12px] text-(--color-text-secondary)">
           How long each stage takes once it starts running, across all completed jobs.
         </p>
         <PipelineTimingChart pipelineTiming={pipelineTiming} />
-      </div>
+      </Card>
 
       {/* Queue wait vs run time */}
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4">
+      <Card className="p-4">
         <h3 className="mb-1 text-[13px] font-semibold text-(--color-text-primary)">Queue wait vs processing time</h3>
         <p className="mb-3 text-[12px] text-(--color-text-secondary)">
           How long jobs wait in the queue before a worker picks them up, vs how long the work itself takes. A long grey
           tail on a stage means workers are saturated.
         </p>
         <QueueWaitChart pipelineTiming={pipelineTiming} />
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/SystemMaintenancePage.tsx
+++ b/frontend/src/pages/SystemMaintenancePage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { get, post } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 export default function SystemMaintenancePage() {
   const [error, setError] = useState('')
@@ -113,7 +115,7 @@ export default function SystemMaintenancePage() {
 
   return (
     <div className="animate-slide-in">
-      <h1 className="mb-4 text-xl font-bold">System Maintenance</h1>
+      <PageHeader title="System Maintenance" subtitle="Purge, reaper, and cleanup actions" />
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -127,7 +129,7 @@ export default function SystemMaintenancePage() {
         </div>
       )}
 
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) divide-y divide-(--color-border) overflow-hidden">
+      <Card className="divide-y divide-(--color-border) overflow-hidden">
         <div className="px-5 py-4">
           <p className="mb-1.5 text-sm text-gray-600 dark:text-gray-400">
             Permanently remove documents deleted more than 60 days ago, including stored files.
@@ -214,10 +216,10 @@ export default function SystemMaintenancePage() {
             {topicsRunning ? 'Computing topics\u2026' : 'Recompute Topics'}
           </button>
         </div>
-      </div>
+      </Card>
 
       {/* Clear Queue */}
-      <div className="mt-6 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-5">
+      <Card className="mt-6 p-5">
         <h2 className="text-lg font-semibold mb-2">Processing Queue</h2>
         <p className="mb-3 text-sm text-gray-600 dark:text-gray-400">
           Cancel all queued and running ingestion jobs. Use this if the queue is stuck from bugs or restarts. Documents
@@ -240,10 +242,10 @@ export default function SystemMaintenancePage() {
         >
           Clear Queue
         </button>
-      </div>
+      </Card>
 
       {/* Database Migrations */}
-      <div className="mt-6 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-5">
+      <Card className="mt-6 p-5">
         <h2 className="text-lg font-semibold mb-2">Database</h2>
         <p className="mb-3 text-sm text-gray-600 dark:text-gray-400">
           Run pending database migrations. Use this if services failed to start after an update.
@@ -263,10 +265,10 @@ export default function SystemMaintenancePage() {
         >
           Run Migrations
         </button>
-      </div>
+      </Card>
 
       {/* Delete All Documents */}
-      <div className="mt-6 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-red-200 dark:ring-red-800/50 p-5">
+      <Card className="mt-6 p-5 ring-red-200 dark:ring-red-800/50">
         <h2 className="text-lg font-semibold text-red-700 dark:text-red-400 mb-2">Danger Zone</h2>
         <p className="mb-3 text-sm text-gray-600 dark:text-gray-400">
           Permanently delete <strong>all</strong> documents, versions, chunks, and uploaded files.
@@ -348,7 +350,7 @@ export default function SystemMaintenancePage() {
             </div>
           </div>
         )}
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -1,44 +1,105 @@
 import { Link } from 'react-router-dom'
+import { useAuth } from '../auth'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { IconTile } from '../components/IconTile'
+import type { AreaHue } from '../hooks/useAreaAccent'
 
-const ITEMS = [
-  { to: '/admin/users', label: 'Users', description: 'Manage user accounts and roles' },
-  { to: '/admin/keys', label: 'API Keys', description: 'Create and revoke API keys' },
-  { to: '/admin/models', label: 'Models', description: 'Download and manage LLM models' },
-  { to: '/admin/languages', label: 'Languages', description: 'Enable additional languages for OCR and entities' },
-  { to: '/admin/retrieval', label: 'Retrieval', description: 'Chat and MCP search behavior' },
-  { to: '/admin/rate-limits', label: 'Rate Limits', description: 'Default API key rate limits' },
-  { to: '/admin/system/status', label: 'System Status', description: 'Health checks and statistics' },
-  { to: '/admin/system/logs', label: 'Service Logs', description: 'View log files and tail commands' },
-  { to: '/admin/system/maintenance', label: 'System Maintenance', description: 'Purge, reaper, and cleanup' },
+interface SettingsItem {
+  to: string
+  label: string
+  sub: string
+  icon: string
+  hue: AreaHue
+}
+
+const SECTIONS: { label: string; items: SettingsItem[] }[] = [
+  {
+    label: 'Access & identity',
+    items: [
+      { to: '/admin/users', label: 'Users', sub: 'Manage accounts and roles', icon: '👥', hue: 'docs' },
+      { to: '/admin/keys', label: 'API Keys', sub: 'Create and revoke API keys', icon: '🔑', hue: 'research' },
+    ],
+  },
+  {
+    label: 'Models & languages',
+    items: [
+      { to: '/admin/models', label: 'Models', sub: 'Download and manage LLM models', icon: '🧠', hue: 'observatory' },
+      { to: '/admin/languages', label: 'Languages', sub: 'OCR & entity language packs', icon: '🌐', hue: 'explore' },
+    ],
+  },
+  {
+    label: 'Behavior & limits',
+    items: [
+      { to: '/admin/retrieval', label: 'Retrieval', sub: 'Chat & MCP search behavior', icon: '🔍', hue: 'search' },
+      { to: '/admin/rate-limits', label: 'Rate Limits', sub: 'Default API key rate limits', icon: '⏱', hue: 'ask' },
+    ],
+  },
+  {
+    label: 'Operations',
+    items: [
+      {
+        to: '/admin/system/status',
+        label: 'System Status',
+        sub: 'Health checks and statistics',
+        icon: '💚',
+        hue: 'observatory',
+      },
+      {
+        to: '/admin/system/logs',
+        label: 'Service Logs',
+        sub: 'View log files and tail commands',
+        icon: '📜',
+        hue: 'settings',
+      },
+      {
+        to: '/admin/system/maintenance',
+        label: 'System Maintenance',
+        sub: 'Purge, reaper, and cleanup',
+        icon: '🧹',
+        hue: 'ask',
+      },
+    ],
+  },
 ]
 
 export default function SystemSettingsPage() {
-  return (
-    <div>
-      <h1 className="mb-4 text-xl font-bold">System Settings</h1>
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden divide-y divide-(--color-border)">
-        {ITEMS.map((item) => (
-          <Link
-            key={item.to}
-            to={item.to}
-            className="flex items-center justify-between px-4 py-3.5 hover:bg-black/3 dark:hover:bg-white/3 transition-colors"
-          >
-            <div>
-              <div className="text-[14px] font-medium text-(--color-text-primary)">{item.label}</div>
-              <div className="text-[12px] text-(--color-text-secondary) mt-0.5">{item.description}</div>
-            </div>
-            <svg
-              className="h-4 w-4 text-gray-300 dark:text-gray-600 shrink-0"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-            </svg>
-          </Link>
-        ))}
+  const { user } = useAuth()
+  if (user?.role !== 'admin') {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        <PageHeader title="System Settings" />
+        <p className="text-sm text-(--color-text-secondary)">Admins only.</p>
       </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <PageHeader title="System Settings" />
+      {SECTIONS.map((section) => (
+        <div key={section.label} className="mb-6">
+          <h2 className="mb-2 font-serif text-base font-semibold tracking-tight text-(--color-text-primary)">
+            {section.label}
+          </h2>
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            {section.items.map((item) => (
+              <Card key={item.to} className="p-0">
+                <Link to={item.to} className="flex items-center gap-3 px-3.5 py-3 text-sm">
+                  <IconTile hue={item.hue} size={28}>
+                    {item.icon}
+                  </IconTile>
+                  <div className="flex-1">
+                    <div className="font-medium text-(--color-text-primary)">{item.label}</div>
+                    <div className="text-[11px] text-(--color-text-secondary)">{item.sub}</div>
+                  </div>
+                  <span className="text-(--color-text-secondary) opacity-50">›</span>
+                </Link>
+              </Card>
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -84,7 +84,7 @@ export default function SystemSettingsPage() {
           </h2>
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
             {section.items.map((item) => (
-              <Card key={item.to} className="p-0">
+              <Card key={item.to} className="p-0" interactive>
                 <Link to={item.to} className="flex items-center gap-3 px-3.5 py-3 text-sm">
                   <IconTile hue={item.hue} size={28}>
                     {item.icon}

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react'
 import { get } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
+import { StatusPill } from '../components/StatusPill'
 
 interface HealthCheck {
   status: string
@@ -86,15 +89,18 @@ export default function SystemStatusPage() {
 
   return (
     <div className="animate-slide-in">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold">System Status</h1>
-        <button
-          onClick={handleRefresh}
-          className="rounded-lg bg-(--color-bg-tertiary) px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
-        >
-          Refresh
-        </button>
-      </div>
+      <PageHeader
+        title="System Status"
+        subtitle="Health checks and service statistics"
+        actions={
+          <button
+            onClick={handleRefresh}
+            className="rounded-lg bg-(--color-bg-tertiary) px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+          >
+            Refresh
+          </button>
+        }
+      />
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -122,16 +128,9 @@ export default function SystemStatusPage() {
       )}
 
       {health && (
-        <div className="mb-6">
-          <span
-            className={`rounded-md px-3 py-1 text-[11px] font-medium ${
-              health.status === 'healthy'
-                ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-            }`}
-          >
-            Overall: {health.status}
-          </span>
+        <div className="mb-6 flex items-center gap-2">
+          <span className="text-sm text-(--color-text-secondary)">Overall:</span>
+          <StatusPill state={health.status === 'healthy' ? 'active' : 'error'} label={health.status} />
         </div>
       )}
     </div>
@@ -153,17 +152,9 @@ function HealthCard({
   const statEntries = stats ? Object.entries(stats).filter(([k]) => k !== 'error') : []
 
   return (
-    <div
-      className={`rounded-xl shadow-mac ring-1 ring-(--color-border) p-4 ${
-        ok ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'
-      }`}
-    >
-      <div className="text-sm font-medium text-gray-700 dark:text-gray-300">{name}</div>
-      <div
-        className={`mt-1 text-lg font-bold ${ok ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}
-      >
-        {ok ? 'OK' : status}
-      </div>
+    <Card className={`p-4 ${ok ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+      <div className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">{name}</div>
+      <StatusPill state={ok ? 'active' : 'error'} label={ok ? 'OK' : status} />
       {statsLoading && !stats && <div className="mt-2 text-xs text-gray-400">Loading stats...</div>}
       {stats?.error && <div className="mt-2 text-xs text-red-500">{String(stats.error)}</div>}
       {statEntries.length > 0 && (
@@ -176,6 +167,6 @@ function HealthCard({
           ))}
         </dl>
       )}
-    </div>
+    </Card>
   )
 }

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -198,7 +198,7 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
             />
           </div>
           <div>
@@ -208,7 +208,7 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
             />
           </div>
           <div>
@@ -216,7 +216,7 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
             <select
               value={role}
               onChange={(e) => setRole(e.target.value)}
-              className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
             >
               <option value="user">user</option>
               <option value="admin">admin</option>

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -198,7 +198,7 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+              className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
             />
           </div>
           <div>
@@ -208,7 +208,7 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+              className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
             />
           </div>
           <div>
@@ -216,7 +216,7 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
             <select
               value={role}
               onChange={(e) => setRole(e.target.value)}
-              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+              className="w-full rounded-lg border-0 bg-(--color-bg-primary) dark:bg-(--color-bg-secondary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
             >
               <option value="user">user</option>
               <option value="admin">admin</option>

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,5 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { del, get, patch, post } from '../api'
+import { PageHeader } from '../components/PageHeader'
+import { Card } from '../components/Card'
 
 interface UserInfo {
   user_id: string
@@ -69,15 +71,17 @@ export default function UsersPage() {
 
   return (
     <div className="animate-slide-in">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold">Users</h1>
-        <button
-          onClick={() => setShowCreate(!showCreate)}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
-        >
-          {showCreate ? 'Cancel' : 'Create User'}
-        </button>
-      </div>
+      <PageHeader
+        title="Users"
+        actions={
+          <button
+            onClick={() => setShowCreate(!showCreate)}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
+          >
+            {showCreate ? 'Cancel' : 'Create User'}
+          </button>
+        }
+      />
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
@@ -95,7 +99,7 @@ export default function UsersPage() {
         />
       )}
 
-      <div className="rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) overflow-hidden">
+      <Card className="overflow-hidden">
         <table className="min-w-full divide-y divide-(--color-border)">
           <thead className="bg-(--color-bg-secondary)">
             <tr>
@@ -159,7 +163,7 @@ export default function UsersPage() {
             ))}
           </tbody>
         </table>
-      </div>
+      </Card>
     </div>
   )
 }
@@ -184,50 +188,49 @@ function CreateUserForm({ onCreated, onError }: { onCreated: () => void; onError
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="mb-4 rounded-xl bg-white dark:bg-[#2c2c2e] shadow-mac ring-1 ring-(--color-border) p-4"
-    >
-      <div className="grid grid-cols-3 gap-3">
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
-          />
+    <Card className="mb-4 p-4">
+      <form onSubmit={handleSubmit}>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Role</label>
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
+            >
+              <option value="user">user</option>
+              <option value="admin">admin</option>
+            </select>
+          </div>
         </div>
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Password</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
-          />
-        </div>
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">Role</label>
-          <select
-            value={role}
-            onChange={(e) => setRole(e.target.value)}
-            className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-3 py-1.5 text-sm"
-          >
-            <option value="user">user</option>
-            <option value="admin">admin</option>
-          </select>
-        </div>
-      </div>
-      <button
-        type="submit"
-        disabled={submitting}
-        className="mt-3 rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
-      >
-        Create
-      </button>
-    </form>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="mt-3 rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 disabled:opacity-50"
+        >
+          Create
+        </button>
+      </form>
+    </Card>
   )
 }

--- a/frontend/src/utils/documentTypeIcon.ts
+++ b/frontend/src/utils/documentTypeIcon.ts
@@ -1,0 +1,107 @@
+import type { AreaHue } from '../hooks/useAreaAccent'
+
+export interface DocLike {
+  doc_type?: string | null
+  mime_type?: string | null
+  canonical_filename?: string | null
+}
+
+export interface DocumentIconResult {
+  glyph: string
+  hue: AreaHue
+}
+
+/** Pattern → icon. First match wins, so order matters (most specific first). */
+const DOC_TYPE_PATTERNS: { pattern: RegExp; glyph: string; hue: AreaHue }[] = [
+  // The travel-vs-guide tie: 'travel' must come before generic 'guide'.
+  { pattern: /\btravel(ogue|\s+(writing|journal|guide))?\b/i, glyph: '🧭', hue: 'explore' },
+  { pattern: /\b(restaurant\s+menu|menu)\b/i, glyph: '🍽', hue: 'observatory' },
+  { pattern: /\b(recipe|cookbook|cooking\s+guide)\b/i, glyph: '🍳', hue: 'observatory' },
+  { pattern: /\breview\b/i, glyph: '⭐', hue: 'research' },
+  // Research/journal articles must be checked BEFORE the generic article pattern,
+  // otherwise "Journal Article" matches `article` first and resolves to 📰 instead of 🔬.
+  { pattern: /\b(research\s+paper|journal\s+article|paper)\b/i, glyph: '🔬', hue: 'docs' },
+  { pattern: /\b(magazine\s+article|article|blog)\b/i, glyph: '📰', hue: 'docs' },
+  { pattern: /\bmagazine\b/i, glyph: '🗞', hue: 'explore' },
+  { pattern: /\b(essay|philosophical\s+dialogue|dialogue)\b/i, glyph: '🎓', hue: 'search' },
+  { pattern: /\bguide\b/i, glyph: '🗺', hue: 'explore' },
+  { pattern: /\b(memoir|personal\s+narrative|narrative)\b/i, glyph: '📓', hue: 'ask' },
+  { pattern: /\b(contract|agreement|license|legal)\b/i, glyph: '⚖', hue: 'settings' },
+  { pattern: /\b(personal\s+letter|letter)\b/i, glyph: '💌', hue: 'ask' },
+  { pattern: /\b(invoice|receipt)\b/i, glyph: '🧾', hue: 'observatory' },
+  // Plain "novel" / "book" — but not "cookbook" / "recipe book" (caught above).
+  { pattern: /\b(novel|book)\b/i, glyph: '📕', hue: 'docs' },
+  { pattern: /\bdescription\b/i, glyph: '📋', hue: 'settings' },
+]
+
+/** MIME-type → icon (used when doc_type doesn't match anything). */
+const MIME_PATTERNS: { test: (mime: string) => boolean; glyph: string; hue: AreaHue }[] = [
+  { test: (m) => m === 'application/pdf', glyph: '📄', hue: 'ask' },
+  { test: (m) => m.includes('spreadsheet') || m === 'text/csv', glyph: '📊', hue: 'observatory' },
+  { test: (m) => m === 'message/rfc822', glyph: '✉', hue: 'research' },
+  { test: (m) => m.includes('presentation'), glyph: '🎞', hue: 'explore' },
+  { test: (m) => m.startsWith('audio/'), glyph: '🎙', hue: 'ask' },
+  { test: (m) => m.startsWith('image/'), glyph: '🖼', hue: 'search' },
+  { test: (m) => m === 'text/html', glyph: '🌐', hue: 'explore' },
+  { test: (m) => m.startsWith('text/x-') || m === 'application/json', glyph: '💻', hue: 'explore' },
+  { test: (m) => m.startsWith('text/'), glyph: '📜', hue: 'settings' },
+]
+
+/** Filename-extension → icon (final fallback when both above miss). */
+const EXT_PATTERNS: { exts: string[]; glyph: string; hue: AreaHue }[] = [
+  { exts: ['pdf'], glyph: '📄', hue: 'ask' },
+  { exts: ['xlsx', 'xls', 'csv', 'numbers'], glyph: '📊', hue: 'observatory' },
+  { exts: ['eml', 'msg', 'mbox'], glyph: '✉', hue: 'research' },
+  { exts: ['pptx', 'ppt', 'key'], glyph: '🎞', hue: 'explore' },
+  { exts: ['mp3', 'wav', 'm4a', 'flac', 'aac', 'ogg'], glyph: '🎙', hue: 'ask' },
+  { exts: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'tiff', 'bmp', 'heic'], glyph: '🖼', hue: 'search' },
+  { exts: ['html', 'htm'], glyph: '🌐', hue: 'explore' },
+  {
+    exts: ['py', 'js', 'ts', 'tsx', 'jsx', 'rb', 'go', 'rs', 'c', 'h', 'cpp', 'java', 'json'],
+    glyph: '💻',
+    hue: 'explore',
+  },
+  { exts: ['txt', 'md', 'log', 'rtf'], glyph: '📜', hue: 'settings' },
+]
+
+const FALLBACK: DocumentIconResult = { glyph: '📦', hue: 'settings' }
+
+/**
+ * Resolve a document to an icon glyph + area hue.
+ *
+ * Resolution order:
+ *   1. doc_type (LLM-derived, free-form — case-insensitive substring match).
+ *   2. mime_type.
+ *   3. canonical_filename extension.
+ *   4. Fallback: 📦 (slate).
+ *
+ * The doc_type list and coverage rationale are documented in the
+ * 2026-05-03 spec ("Coverage audit" section).
+ */
+export function documentTypeIcon(doc: DocLike): DocumentIconResult {
+  if (doc.doc_type) {
+    const dt = doc.doc_type
+    for (const { pattern, glyph, hue } of DOC_TYPE_PATTERNS) {
+      if (pattern.test(dt)) return { glyph, hue }
+    }
+  }
+
+  if (doc.mime_type) {
+    const mime = doc.mime_type.toLowerCase()
+    for (const { test, glyph, hue } of MIME_PATTERNS) {
+      if (test(mime)) return { glyph, hue }
+    }
+  }
+
+  if (doc.canonical_filename) {
+    const dot = doc.canonical_filename.lastIndexOf('.')
+    const ext = dot >= 0 ? doc.canonical_filename.slice(dot + 1).toLowerCase() : ''
+    if (ext) {
+      for (const { exts, glyph, hue } of EXT_PATTERNS) {
+        if (exts.includes(ext)) return { glyph, hue }
+      }
+    }
+  }
+
+  return FALLBACK
+}

--- a/frontend/src/utils/entityTypeColors.ts
+++ b/frontend/src/utils/entityTypeColors.ts
@@ -1,0 +1,37 @@
+// Color palette covering all spaCy entity types we might see. Grouped by
+// semantic kind so related types share a hue family:
+//   blue/indigo:  people + groups (PERSON, NORP)
+//   green/teal:   organizations + products (ORG, PRODUCT, WORK_OF_ART)
+//   amber/orange: places (GPE, LOC, FAC)
+//   cyan/sky:     time (DATE, TIME)
+//   pink/rose:    events + law (EVENT, LAW)
+//   violet/fuchsia: language + culture (LANGUAGE)
+//   lime/green:   money/percent (MONEY, PERCENT)
+//   stone:        numbers (CARDINAL, ORDINAL, QUANTITY)
+export const ENTITY_TYPE_COLORS: Record<string, string> = {
+  PERSON: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  NORP: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  ORG: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  PRODUCT: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
+  WORK_OF_ART: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  GPE: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  LOC: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  FAC: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  DATE: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
+  TIME: 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400',
+  EVENT: 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400',
+  LAW: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400',
+  LANGUAGE: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
+  MONEY: 'bg-lime-100 text-lime-700 dark:bg-lime-900/30 dark:text-lime-400',
+  PERCENT: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  CARDINAL: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
+  ORDINAL: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
+  QUANTITY: 'bg-stone-100 text-stone-700 dark:bg-stone-800/40 dark:text-stone-300',
+}
+
+export const DEFAULT_HIDDEN_ENTITY_TYPES = new Set(['CARDINAL', 'ORDINAL', 'QUANTITY'])
+
+/** Returns the Tailwind class string for an entity type, with a sensible gray fallback. */
+export function entityTypeClass(type: string): string {
+  return ENTITY_TYPE_COLORS[type] || 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+}

--- a/frontend/src/utils/topicDotColor.ts
+++ b/frontend/src/utils/topicDotColor.ts
@@ -1,0 +1,26 @@
+import type { AreaHue } from '../hooks/useAreaAccent'
+
+const HUES: AreaHue[] = ['ask', 'research', 'folders', 'docs', 'explore', 'search', 'observatory', 'settings']
+
+/**
+ * Deterministic-hash-of-id → one of the eight area-accent hues.
+ *
+ * Used by the conversation list (Ask + Research sidebars) so each
+ * conversation gets a stable colored dot. v1 derivation per the
+ * 2026-05-03 spec: hash of conversation_id mod 8. Smarter "color by
+ * dominant topic / top-cited entity" is a deferred follow-up.
+ */
+export function topicDotColor(id: string): AreaHue {
+  // FNV-1a, 32-bit. Deterministic, low collision, no deps.
+  let hash = 0x811c9dc5
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return HUES[hash % HUES.length]
+}
+
+/** Convenience: returns the CSS var() reference for the hue's accent value. */
+export function topicDotVar(id: string): string {
+  return `var(--area-${topicDotColor(id)}-accent)`
+}

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -700,6 +700,9 @@ async def find_related_documents(
                 "title": rdoc.title,
                 "summary": rdoc.summary,
                 "similarity": round(1.0 - distances[rid], 4),
+                "doc_type": rdoc.doc_type,
+                "mime_type": rdoc.mime_type,
+                "canonical_filename": rdoc.canonical_filename,
             }
         )
 

--- a/src/harbor_clerk/api/schemas/documents.py
+++ b/src/harbor_clerk/api/schemas/documents.py
@@ -130,6 +130,9 @@ class RelatedDocument(BaseModel):
     title: str
     summary: str | None = None
     similarity: float
+    doc_type: str | None = None
+    mime_type: str | None = None
+    canonical_filename: str | None = None
 
 
 class RelatedDocumentsResponse(BaseModel):

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -1497,6 +1497,9 @@ async def kb_find_related(doc_id: str, k: int = 5) -> str:
                 "title": rdoc.title,
                 "summary": rdoc.summary,
                 "similarity": round(1.0 - distances[rid], 4),
+                "doc_type": rdoc.doc_type,
+                "mime_type": rdoc.mime_type,
+                "canonical_filename": rdoc.canonical_filename,
             }
         )
 


### PR DESCRIPTION
## Summary

Implements [`docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md`](docs/superpowers/specs/2026-05-03-frontend-design-pass-design.md) — option A's per-area structure (per-page hue + icon + subtle depth) executed with option B's restraint (muted earth-tone palette, serif title face, hairline rules).

## What changed

**Tokens** (`frontend/src/index.css`):
- 8 per-area accent triples (`--area-{name}-accent[-tint|-text]`) for both light and dark modes (terracotta / ochre / khaki / dusty blue / mauve / dusty teal / sage / slate).
- `--font-serif` New York stack with Georgia fallback.
- `.surface-card` layer-class with subtle gradient (top→bottom highlight in dark, shadow in light), opt-in hover via `.surface-card-interactive`.

**New shared components / utilities:**
- `PageHeader` — serif title + accent bar + optional subtitle + optional actions slot
- `StatusPill` — 5 states (active/running/idle/error/pending) with glyph + state-tinted bg
- `IconTile` — colored rounded-square tile, defaults to active area accent
- `Card` — wrapper around `.surface-card`, `interactive` prop opts into hover
- `documentTypeIcon` util — pattern-matched LLM doc_type → glyph + hue (~80% coverage on the live corpus's top doc_types)
- `topicDotColor` util — FNV-1a hash mod 8 → area-accent hue for conversation dots
- `useAreaAccent` hook — binds the active route's hue to `--area-accent` on the layout root

**Per-page sweeps:** every route gets the new PageHeader + StatusPill + IconTile + Card treatment with its area's accent — Ask (terracotta), Research (ochre), Folders (warm khaki), Documents (dusty blue), Explore (mauve), Search (dusty teal), Observatory (sage), Settings hub + 12 subpages (slate). LoginPage + SetupPage + OnboardingWizard also covered.

**TabLink** in `Layout.tsx` gains emoji icons + per-area accent active state (replacing hard-coded blue).

**Backend** (Task 13 amend + Fix 1 above):
- `RelatedDocument` Pydantic schema gained 3 optional fields (`doc_type`, `mime_type`, `canonical_filename`); REST `find_related` and MCP `kb_find_related` both populate them so document-type icons render on related-doc rows.

## What didn't change

Per the spec, these were already working and stay untouched:
- Entity-type colors in DocumentDetail (`ENTITY_TYPE_COLORS`)
- Observatory chart colors (Top Entities, Topic Distribution treemap, Entity Network graph)
- Research page octopus illustration + amber Start Research CTA
- Documents page "Continue viewing" affordance + filter row layout
- All backend behavior, schemas (other than the additive RelatedDocument fields), API surfaces, MCP tools (other than the additive related-doc fields), ingestion pipeline

## Out of scope (captured in `pr_followups.md`)

- Motion / micro-interactions
- KPI trend deltas
- Topic-aware conversation dot color (v1 ships with hash-of-id)
- Webfont fallback for Docker-served SPA
- Login brand mark / illustration
- Per-page background atmosphere
- Tailwind v4 token migration audit
- Document-type icon coverage rescan after each new test corpus

## Validation

- `npm run type-check` ✓
- `npm run lint` ✓ (0 errors; 13 pre-existing warnings unchanged)
- `npm run format:check` ✓
- `npm run build` ✓
- Backend tests for related-document endpoints ✓
- Manual smoke walk through every page in dark + light modes — see plan task 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)