### PR TITLE
chore(macos): refresh bundled toolchain + harden Tika download

### DIFF
--- a/macos/scripts/build-llama.sh
+++ b/macos/scripts/build-llama.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DEST_DIR="${DEST_DIR:?DEST_DIR must be set}"
 BUILD_DIR="${BUILD_DIR:-/tmp/llama-build}"
-LLAMA_CPP_TAG="${LLAMA_CPP_TAG:-b8770}"
+LLAMA_CPP_TAG="${LLAMA_CPP_TAG:-b9018}"
 
 mkdir -p "$DEST_DIR" "$BUILD_DIR"
 DEST_DIR="$(cd "$DEST_DIR" && pwd)"

--- a/macos/scripts/build-tika.sh
+++ b/macos/scripts/build-tika.sh
@@ -7,14 +7,28 @@ DEST_DIR="${DEST_DIR:-$(pwd)/build}"
 JAVA_DIR="$DEST_DIR/java"
 TIKA_DIR="$DEST_DIR/tika"
 
-TEMURIN_VERSION="21.0.10+7"
+TEMURIN_VERSION="21.0.11+10"
 TEMURIN_URL="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${TEMURIN_VERSION}/OpenJDK21U-jre_aarch64_mac_hotspot_${TEMURIN_VERSION//+/_}.tar.gz"
 
-TIKA_VERSION="3.2.3"
+TIKA_VERSION="3.3.0"
 TIKA_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar"
+TIKA_SHA512_URL="${TIKA_URL}.sha512"
+
+# Apache mirrors and the GitHub releases CDN occasionally close connections
+# mid-flight; `curl -fSL` returns success on a partial download, leaving a
+# corrupt artifact that breaks subsequent builds. Use --retry-all-errors so
+# transient drops are retried, and verify checksums where the upstream
+# publishes them.
+CURL_OPTS=(--fail --location --silent --show-error
+           --retry 5 --retry-delay 5 --retry-all-errors --retry-max-time 600)
+
+# JRE is structured differently on macOS (Contents/Home/...) vs Linux (bin/).
+java_present() {
+    [ -x "$JAVA_DIR/bin/java" ] || [ -x "$JAVA_DIR/Contents/Home/bin/java" ]
+}
 
 # Skip if already built
-if [ -d "$JAVA_DIR/bin" ] && [ -f "$TIKA_DIR/tika-server.jar" ]; then
+if java_present && [ -f "$TIKA_DIR/tika-server.jar" ]; then
     echo "==> JRE + Tika already present, skipping"
     exit 0
 fi
@@ -22,10 +36,10 @@ fi
 mkdir -p "$JAVA_DIR" "$TIKA_DIR"
 
 # ── Eclipse Temurin JRE 21 (GPLv2+CE — Classpath Exception) ──
-if [ ! -d "$JAVA_DIR/bin" ]; then
+if ! java_present; then
     echo "==> Downloading Eclipse Temurin JRE 21 for aarch64..."
     TMPTAR="$(mktemp)"
-    curl -fSL -o "$TMPTAR" "$TEMURIN_URL"
+    curl "${CURL_OPTS[@]}" -o "$TMPTAR" "$TEMURIN_URL"
 
     echo "==> Extracting JRE..."
     # Extract, stripping the top-level directory
@@ -33,10 +47,12 @@ if [ ! -d "$JAVA_DIR/bin" ]; then
     rm "$TMPTAR"
 
     # Strip to runtime-only (remove non-essential files to save ~50MB)
-    rm -rf "$JAVA_DIR/man"
-    rm -rf "$JAVA_DIR/demo"
-    rm -f  "$JAVA_DIR/lib/src.zip"
-    rm -rf "$JAVA_DIR/jmods"
+    JAVA_HOME_DIR="$JAVA_DIR"
+    [ -d "$JAVA_DIR/Contents/Home" ] && JAVA_HOME_DIR="$JAVA_DIR/Contents/Home"
+    rm -rf "$JAVA_HOME_DIR/man"
+    rm -rf "$JAVA_HOME_DIR/demo"
+    rm -f  "$JAVA_HOME_DIR/lib/src.zip"
+    rm -rf "$JAVA_HOME_DIR/jmods"
 
     echo "==> JRE installed to $JAVA_DIR ($(du -sh "$JAVA_DIR" | cut -f1))"
 fi
@@ -44,8 +60,26 @@ fi
 # ── Apache Tika Server (Apache 2.0) ──
 if [ ! -f "$TIKA_DIR/tika-server.jar" ]; then
     echo "==> Downloading Apache Tika Server ${TIKA_VERSION}..."
-    curl -fSL -o "$TIKA_DIR/tika-server.jar" "$TIKA_URL"
-    echo "==> Tika JAR downloaded ($(du -sh "$TIKA_DIR/tika-server.jar" | cut -f1))"
+    TMPJAR="$TIKA_DIR/tika-server.jar.partial"
+    curl "${CURL_OPTS[@]}" -o "$TMPJAR" "$TIKA_URL"
+
+    # Verify the SHA512 published by the Apache release. Apache's archive
+    # mirror has been known to truncate large downloads silently — without
+    # this check, a 75 MB partial JAR would be cached as the canonical
+    # artifact and break Tika startup on every subsequent run.
+    echo "==> Verifying SHA512..."
+    EXPECTED_SHA512="$(curl "${CURL_OPTS[@]}" "$TIKA_SHA512_URL" | awk '{print $1}')"
+    ACTUAL_SHA512="$(shasum -a 512 "$TMPJAR" | awk '{print $1}')"
+    if [ "$EXPECTED_SHA512" != "$ACTUAL_SHA512" ]; then
+        echo "ERROR: Tika JAR SHA512 mismatch"
+        echo "  expected: $EXPECTED_SHA512"
+        echo "  actual:   $ACTUAL_SHA512"
+        rm -f "$TMPJAR"
+        exit 1
+    fi
+
+    mv "$TMPJAR" "$TIKA_DIR/tika-server.jar"
+    echo "==> Tika JAR verified ($(du -sh "$TIKA_DIR/tika-server.jar" | cut -f1))"
 fi
 
 echo "==> Tika build complete"

--- a/macos/scripts/build-venv.sh
+++ b/macos/scripts/build-venv.sh
@@ -50,16 +50,22 @@ fi
 # Use the venv's python directly (not pip script, since shebangs get patched later)
 VENV_PYTHON="$VENV_DIR/bin/python3"
 
+# ── Upgrade pip ──
+# python-build-standalone ships an older pip; upgrade so subsequent installs
+# don't print the "new release available" notice on every invocation.
+echo "==> Upgrading pip"
+"$VENV_PYTHON" -m pip install --no-cache-dir --upgrade --disable-pip-version-check pip
+
 # ── Install packages ──
 echo "==> Installing harbor-clerk"
-"$VENV_PYTHON" -m pip install --no-cache-dir --upgrade "$PROJECT_ROOT"
+"$VENV_PYTHON" -m pip install --no-cache-dir --disable-pip-version-check --upgrade "$PROJECT_ROOT"
 
 echo "==> Installing embedder"
-"$VENV_PYTHON" -m pip install --no-cache-dir --upgrade "$PROJECT_ROOT/embedder"
+"$VENV_PYTHON" -m pip install --no-cache-dir --disable-pip-version-check --upgrade "$PROJECT_ROOT/embedder"
 
 if ! "$VENV_PYTHON" -c "import striprtf" 2>/dev/null; then
     echo "==> Installing striprtf"
-    "$VENV_PYTHON" -m pip install --no-cache-dir striprtf
+    "$VENV_PYTHON" -m pip install --no-cache-dir --disable-pip-version-check striprtf
 else
     echo "==> striprtf already installed, skipping"
 fi


### PR DESCRIPTION
## Summary

Refresh the macOS native-app toolchain so a `make clean && make all` no longer prints stale-version notices and so we're not running months-behind security patches on bundled binaries. While verifying, also caught and fixed a real silent-corruption bug in the Tika download path.

| Component | Was | Now |
| --- | --- | --- |
| pip (in build venv) | 25.0.1 | 26.1+ (auto-upgraded in `build-venv.sh`) |
| llama.cpp | `b8770` | `b9018` |
| Apache Tika Server | 3.2.3 | 3.3.0 |
| Eclipse Temurin JRE | 21.0.10+7 | 21.0.11+10 (security patch) |

Already current: PostgreSQL 18.3, pgvector 0.8.2, Tesseract (Homebrew, follows host), Python 3.12 (python-build-standalone uses `latest`).

## Why

`make venv` was emitting `[notice] A new release of pip is available: 25.0.1 -> 26.1` on every install — caused by python-build-standalone shipping with whatever pip was current at its release. Fix: explicitly upgrade pip right after venv creation, and pass `--disable-pip-version-check` on subsequent installs to silence redundant notices.

While in the build scripts, swept the other version pins:
- llama.cpp `b9018` is the current `latest` release tag (we were ~250 tags behind, normal lag).
- Tika 3.3.0 is a minor bump within 3.x — REST API surface is stable, no client changes needed.
- Temurin 21.0.11+10 is a patch update over 21.0.10+7 with security fixes.

## Bonus fix: Tika download integrity

While re-running `make tika` to verify the version bump, the new Tika JAR landed truncated (75 MB instead of 78 MB) but `curl -fSL` reported success and `make tika` exited 0. Tika then refused to start with `Error: Invalid or corrupt jarfile`. Apache mirrors occasionally drop connections mid-flight, and the previous download path had no integrity check, which means a partial JAR would have been cached as the canonical artifact and silently broken every subsequent build until someone manually `rm`'d it.

`build-tika.sh` now:
- Uses `curl --retry 5 --retry-delay 5 --retry-all-errors --retry-max-time 600` for both downloads, so transient drops are retried.
- Downloads the upstream `.sha512` for the Tika JAR and verifies it before moving the artifact into place. Mismatch → fail loudly with both expected and actual hashes.
- Writes the JAR to `tika-server.jar.partial` first and only `mv`s on successful verification.
- Fixes a pre-existing macOS-only bug: the `[ -d "$JAVA_DIR/bin" ]` skip-check never matched on macOS (where the JRE lives at `Contents/Home/bin`), so every build was re-extracting the JRE unnecessarily. New `java_present()` helper checks both layouts.

## What changed

- `macos/scripts/build-venv.sh`: explicit `pip install --upgrade pip` after venv creation; `--disable-pip-version-check` on all subsequent pip calls so the venv pip stays quiet.
- `macos/scripts/build-llama.sh`: `LLAMA_CPP_TAG` default → `b9018`.
- `macos/scripts/build-tika.sh`: `TEMURIN_VERSION` → `21.0.11+10`, `TIKA_VERSION` → `3.3.0`, plus the integrity hardening described above.

## Verification

Did a partial clean rebuild (preserving postgres/tesseract/model since those didn't change):

```bash
rm -rf macos/build/{venv,python,tika,java,llama,llama-build}
make venv          # pip 25.0.1 → 26.1 upgraded silently, no notices on subsequent installs
make tika          # JRE 21.0.11+10 + Tika 3.3.0 (SHA512 verified, 80M)
make llama         # b9018 cloned, llama-server (8.6M) built with Metal
make spacy-models  # en_core_web_sm + fr_core_news_sm 3.8.0 installed silently
```

Smoke tests:

```
$ build/java/Contents/Home/bin/java -version
openjdk version "21.0.11" 2026-04-21 LTS
OpenJDK Runtime Environment Temurin-21.0.11+10 (build 21.0.11+10-LTS)

$ build/java/Contents/Home/bin/java -jar build/tika/tika-server.jar --help
usage:  tikaserver [-?] [-c <arg>] [-h <arg>] [-i <arg>] [-noFork] [-p <arg>]
...

$ build/llama/llama-server --version
ggml_metal_device_init: GPU name:   MTL0 (Apple M2 Max)
version: 1 (c84e6d6)  [== llama.cpp tag b9018]
```

The truncated-JAR scenario was reproduced live during this very session — the new SHA512 check was the difference between "build succeeds, Tika silently broken" and "build fails loudly with a clear error".

## Test plan

- [ ] Fresh `make clean && make all` runs without any "new release available" notices
- [ ] HarborClerk client launches and Tika extraction works on a sample PDF
- [ ] LLM model loads and responds via llama-server
- [ ] No regression in OCR (Tesseract eng+fra unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
