### PR TITLE
docs(readme): bust camo cache for license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Local-first document knowledge base with OCR, hybrid search, and chat.
 Drop in PDFs, scans, notes, or research files — Harbor Clerk turns them into a private corpus you can search, explore, and query with local or external LLMs.
 
-![License](https://img.shields.io/github/license/r0shi/harborclerk)
+![License](https://img.shields.io/github/license/r0shi/harborclerk?v=2)
 ![Release](https://img.shields.io/github/v/release/r0shi/harborclerk)
 ![Python](https://img.shields.io/badge/python-3.12+-blue)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Docker-lightgrey)


### PR DESCRIPTION
## Summary

Bust the camo cache for the license badge in the README.

## Why
- shields.io correctly returns `MIT` for this repo, but GitHub camo had cached an old `invalid` response, so the rendered badge stuck on `license | invalid`.
- Adding `?v=2` makes GitHub treat it as a new image and re-fetch from shields.

## Test plan
- [x] Open the rendered README on github.com after merge and confirm the badge shows `license | MIT` (green).
- [x] Other badges unchanged.