### PR TITLE
docs: refresh README + architecture for watched-folder-only model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Two native macOS apps under `macos/`:
 
 Build scripts in `macos/scripts/`, orchestrated by `macos/Makefile`.
 
-**Watched Folders** (macOS only): FSEvents-based directory monitoring with macOS bookmark data for file identity tracking. Files referenced in place (not copied). UTType-based file type detection with extension fallback. 30-day soft-delete reaper for removed files. Priority-aware job queue (GUI uploads preempt watched folder ingestion). Managed by `WatchedFolderManager.swift`, configured via native preferences, state stored in PostgreSQL (`watched_folders`, `watched_files` tables).
+**Watched Folders** (macOS + Docker): the only user-facing ingest path. Implemented as the Python `harbor-clerk-watcher` daemon using `watchdog` (FSEvents on macOS, inotify on Linux, polling fallback for NFS / SMB / fuse). Files referenced in place — never copied. 30-day soft-delete reaper for removed files. State stored in PostgreSQL (`watched_folders`, `watched_files`). On macOS, Swift retains only the `pickFolder` and `revealInFinder` JS bridges (NSOpenPanel + NSWorkspace); folder management UI lives at `/folders` in the web app. On Docker, top-level subdirs of `WATCH_ROOT` (`/data/watch`) are auto-discovered — there is no add/remove via the web UI.
 
 ### Storage Backend
 
@@ -55,11 +55,12 @@ Package name: `harbor_clerk` (under `src/harbor_clerk/`).
 Entry points:
 - `harbor-clerk-api` — FastAPI server
 - `harbor-clerk-worker` — PostgreSQL-polling background worker
+- `harbor-clerk-watcher` — folder watcher (one process per deployment; macOS subprocess or Docker `watcher` container)
 - `harbor-clerk-seed` — Database seeder
 
 ## Ingestion Pipeline
 
-Seven idempotent stages, each guarded by row-level lock on `(version_id, stage)` in `ingestion_jobs`:
+Seven idempotent stages, each guarded by row-level lock on `(doc_id, stage)` in `ingestion_jobs`:
 
 1. **extract** (io, 600s) — Apache Tika for PDF/Office/eBook/HTML/email, plain text fallback for TXT/MD/CSV
 2. **ocr** (cpu, 7200s) — conditional: always for images (JPEG/PNG/TIFF); PDF if `extracted_chars < 500` or `alpha_ratio < 0.2`; never for text-native formats. Uses pypdfium2 + Tesseract (eng+fra). Skipped if not needed.
@@ -73,15 +74,20 @@ Seven idempotent stages, each guarded by row-level lock on `(version_id, stage)`
 
 **Worker wakeup:** Workers use PostgreSQL `LISTEN` on per-queue channels (`job_enqueued_io`, `job_enqueued_cpu`) for instant wakeup instead of polling.
 
-## Upload Flow
+## Ingestion Flow
 
-1. Compute SHA256 of uploaded file
-2. If SHA256 matches existing version → duplicate
-3. Otherwise ask user: "New document" or "New version of existing?" (future: auto-detect)
+The watcher is the only user-facing entry point:
+
+1. File appears (created/moved/modified) in a watched folder.
+2. Watcher computes SHA256, identifies it via `(folder_id, relative_path)`, and writes a `watched_files` row.
+3. New SHA → create a `documents` row and enqueue the `extract` stage. Same SHA on a previously-seen file → no-op (duplicate). Same path with different SHA → reprocess in place (the existing `documents` row is updated; the document model is flat, so there is no separate version table).
+4. Deletes mark the document inactive; a 30-day reaper purges it permanently if the source stays gone.
+
+The legacy `POST /api/uploads/*` endpoints are intentionally kept callable (no UI affordance) for future non-interactive ingest paths such as email.
 
 ## Retrieval
 
-Hybrid search: Postgres FTS (bilingual, queries both `fts_en` and `fts_fr` columns) + pgvector cosine → merge/dedupe with boosts for latest version and higher OCR confidence → top K (default 10). All results include citations. Returns `possible_conflict=true` when top results have similar scores across different versions/documents.
+Hybrid search: Postgres FTS (bilingual, queries both `fts_en` and `fts_fr` columns) + pgvector cosine → normalize and merge per-chunk scores with a small OCR-confidence boost → top K (default 10). All results include citations. Returns `possible_conflict=true` when the top hits have similar scores across different documents.
 
 ## Auth Model
 
@@ -90,20 +96,22 @@ Hybrid search: Postgres FTS (bilingual, queries both `fts_en` and `fts_fr` colum
 
 ## Key API Surface
 
-- REST: `/api/auth/login`, `/api/uploads`, `/api/docs`, `/api/search`, `/api/passages/read`, `/api/system/health`
+- REST: `/api/auth/login`, `/api/docs`, `/api/search`, `/api/passages/read`, `/api/system/health`
+- Watch: `/api/watch/system`, `/api/watch/folders` (CRUD; POST gated to macOS via `picker=ui`), `/api/watch/folders/{id}/progress`, `/api/watch/folders/stream`, `/api/watch/folders/{id}/rescan`, `/api/watch/ingest`, `/api/watch/remove`, `/api/watch/rename`, `/api/watch/allowed-extensions`
+- Source files: `/api/docs/{id}/download` (gated by `ALLOW_SOURCE_DOWNLOAD`, default off; macOS uses `window.harborclerk.revealInFinder` instead)
+- Legacy: `/api/uploads*` — endpoints retained for non-interactive ingest paths (planned email ingestion); no UI affordance
 - MCP: `POST /mcp` — 16 tools: `kb_search`, `kb_batch_search`, `kb_read_passages`, `kb_expand_context`, `kb_get_document`, `kb_list_recent`, `kb_corpus_overview`, `kb_document_outline`, `kb_find_related`, `kb_entity_search`, `kb_entity_overview`, `kb_entity_cooccurrence`, `kb_read_document`, `kb_ingest_status`, `kb_reprocess`, `kb_system_health`
 - SSE: `GET /api/jobs/stream` — streams job progress events (server→client only)
-- Watch: `/api/watch/folders` (CRUD), `/api/watch/ingest`, `/api/watch/remove`, `/api/watch/rename`, `/api/watch/allowed-extensions`
 
 ## Database
 
 PostgreSQL 18 with extensions: `vector`, `pg_trgm`, `citext`. No tenant table or tenant_id columns.
 
-Key tables: `users`, `api_keys`, `documents`, `document_versions`, `document_pages`, `document_headings`, `chunks`, `entities`, `ingestion_jobs`, `uploads`, `upload_sessions`, `audit_log`, `conversations`, `chat_messages`, `watched_folders`, `watched_files`.
+Key tables: `users`, `api_keys`, `documents` (flat — was split into `documents` + `document_versions` pre-0017), `document_pages`, `document_headings`, `chunks`, `entities`, `ingestion_jobs`, `audit_log`, `api_request_log`, `conversations`, `chat_messages`, `watched_folders`, `watched_files`, `corpus_topics`, `corpus_topics_meta`, `model_settings`, `research_state`. The `uploads` and `upload_sessions` tables remain for the legacy upload endpoints.
 
-`chunks` has dual FTS columns (`fts_en` TSVECTOR, `fts_fr` TSVECTOR) both as generated stored columns with GIN indexes, plus `embedding vector(384)` with HNSW index. Full DDL in `spec.txt` section I.
+`chunks` has dual FTS columns (`fts_en` TSVECTOR, `fts_fr` TSVECTOR) both as generated stored columns with GIN indexes, plus `embedding vector(384)` with HNSW index. Full DDL in `spec.txt` section I (pre-flatten — current state is in `alembic/versions/`).
 
-Storage bucket: `originals`, key pattern: `originals/versions/<version_id>/<original_filename>`.
+Storage (legacy uploads only): bucket `originals`, key pattern `originals/<doc_id>/<original_filename>`. Watched-folder docs do not store originals in MinIO — they are read in place from `source_path` on the host filesystem.
 
 ## Linting & Formatting
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 ### Keep your data. Ask it anything.
 
-Local-first document knowledge base with OCR, hybrid search, and chat.
-Drop in PDFs, scans, notes, or research files — Harbor Clerk turns them into a private corpus you can search, explore, and query with local or external LLMs.
+Local-first document archive for non-technical offices. Point Harbor Clerk at a folder of PDFs, scans, notes, or research files; it OCRs, indexes, and lets you search, browse, and chat with everything — all on your own machine, all with citations.
 
 ![License](https://img.shields.io/github/license/r0shi/harborclerk?v=2)
 ![Release](https://img.shields.io/github/v/release/r0shi/harborclerk)
@@ -16,11 +15,11 @@ Drop in PDFs, scans, notes, or research files — Harbor Clerk turns them into a
 
 ---
 
-Harbor Clerk is a safe harbor for your documents — and a capable clerk who knows where everything is. Drop in PDFs, scans, notes, contracts, or research files, and Harbor Clerk turns them into a searchable knowledge base you can actually talk to.
+Harbor Clerk is a safe harbor for your documents — and a capable clerk who knows where everything is. Tell it which folders to watch — contracts, scans, research, anything — and Harbor Clerk continuously reads what lands there and turns it into a searchable archive you can actually talk to.
 
-It reads your files, extracts text (including OCR for scanned documents), splits them into searchable passages, and indexes everything locally so you can search or ask questions across your entire collection. Results always come with clear citations so you can jump straight back to the original document and verify the source.
+It reads your files in place, extracts text (including OCR for scanned documents), splits them into searchable passages, and indexes everything locally so you can search or ask questions across your entire collection. Results always come with clear citations so you can jump straight back to the original document and verify the source.
 
-Everything runs on your machine. No SaaS account. No background sync. No shared tenancy. Your documents stay local.
+Everything runs on your machine. No SaaS account. No background sync. No shared tenancy. Your originals never move — Harbor Clerk just reads them where they live.
 
 Harbor Clerk is designed for small offices, independent operators, and privacy-focused individuals. It runs comfortably on a Mac mini or similar hardware and includes a built-in chat assistant powered by a local LLM.
 
@@ -33,9 +32,9 @@ It keeps your documents where they belong — and makes them useful.
 
 ```mermaid
 graph LR
-    docs["Add your documents<br/>PDFs • Scans • Notes"]
+    docs["Drop documents into a watched folder<br/>PDFs • Scans • Notes"]
     process["Harbor Clerk organizes them<br/>Text Extraction • OCR • Chunking • Hybrid Search + Embeddings"]
-    ask["Search or chat with your knowledge<br/>Answers include citations"]
+    ask["Search or chat with your archive<br/>Answers include citations"]
     docs --> process --> ask
 ```
 
@@ -72,8 +71,9 @@ Chat locally with built-in models, or connect external AI tools through MCP. The
 
 1. Download Harbor Clerk from the [releases page](https://github.com/r0shi/harborclerk/releases)
 2. Launch **Harbor Clerk Server** (menubar app — starts all backend services)
-3. Open **Harbor Clerk** (opens the web UI)
-4. Drop in a few PDFs and start asking questions — or run a deep research task
+3. Open **Harbor Clerk** (web UI inside a native window)
+4. Click **Folders → Add Folder**, pick a directory full of documents, and let ingestion run
+5. Ask questions, browse the corpus, or kick off a deep research task
 
 That's it — everything runs locally.
 
@@ -83,10 +83,11 @@ That's it — everything runs locally.
 git clone https://github.com/r0shi/harborclerk.git
 cd harborclerk
 cp .env.example .env
+mkdir -p data/watch/inbox       # any subdirectory of ./data/watch becomes a watched folder
 docker compose up --build
 ```
 
-Then open https://localhost
+Then open https://localhost, accept the self-signed certificate, and create your admin account. Drop documents into `./data/watch/inbox/` (or any subdirectory of `./data/watch/`) and they'll start ingesting within ~60 seconds. See [docs/watched-folders-docker.md](docs/watched-folders-docker.md) for mounting external paths and other operator details.
 
 ## Who Harbor Clerk Is For
 
@@ -120,19 +121,20 @@ Harbor Clerk can run in two ways:
 | | macOS Native | Docker Compose |
 |---|---|---|
 | **Best for** | Target audience — small offices with a Mac | DIY / Linux servers |
-| **Services** | Managed by menubar app as subprocesses | Eight Docker containers |
-| **Storage** | Local filesystem (`~/Library/Application Support/Harbor Clerk/`) | MinIO object storage + Docker volumes |
+| **Services** | Managed by menubar app as subprocesses | Ten Docker containers |
+| **Folder picker** | Native folder picker in the UI | Operator mounts host paths into the watcher container |
+| **Originals** | Read in place from your filesystem | Read in place from bind-mounted volumes |
 | **HTTPS** | Direct localhost access | Caddy reverse proxy with self-signed cert |
+
+Both deployments use the same Python `watchdog`-based watcher under the hood (FSEvents on macOS, inotify on Linux, polling fallback for NFS/SMB/fuse mounts).
 
 ### macOS Native App
 
 **Requirements:** Mac mini M2 or newer (M1 works, M2+ recommended), macOS 15.0+, 16 GB RAM minimum.
 
-All data lives in `~/Library/Application Support/Harbor Clerk/` — PostgreSQL database, uploaded files, downloaded LLM models, logs, and settings.
+App data lives in `~/Library/Application Support/Harbor Clerk/` — PostgreSQL database, downloaded LLM models, logs, and settings. **Your source documents stay where you put them**; Harbor Clerk only references them by path.
 
-Open Preferences (Cmd+,) from the menubar to configure network access, worker preset, ports, log level, and watched folders.
-
-**Watched folders** (macOS only): Point Harbor Clerk at directories on your Mac and files are automatically ingested as they appear. Renames, modifications, and deletions are tracked in real time via FSEvents and macOS bookmark data. Originals stay in place — no copying. Configure in Preferences.
+Open Preferences (Cmd+,) from the menubar to configure network access, worker preset, ports, and log level. Manage watched folders from the **Folders** tab in the web UI — the native folder picker dialog walks you through picking a directory, and macOS bookmark data keeps it tracked across renames and moves.
 
 ### Docker Compose
 
@@ -146,13 +148,17 @@ python3 -c "import secrets; print(secrets.token_urlsafe(48))"
 
 Open **https://localhost/** and accept the self-signed certificate. Create your admin account on the setup page.
 
+**Watched folders on Docker** are operator-controlled: the `watcher` service auto-discovers any top-level subdirectory of `WATCH_ROOT` (`/data/watch` inside the container, bind-mounted from `./data/watch` on the host) and ingests files dropped into it. There is no "Add Folder" button on Docker — you create directories, or mount external paths into `/data/watch/<name>`. See [docs/watched-folders-docker.md](docs/watched-folders-docker.md) for the full operator guide.
+
 | Variable | Default | Description |
 |---|---|---|
 | `SECRET_KEY` | `change-me-in-production` | JWT signing key — **change this** |
 | `DATABASE_URL` | `postgresql+asyncpg://harbor_clerk:...` | PostgreSQL connection string |
-| `MINIO_ENDPOINT` | `minio:9000` | MinIO endpoint |
+| `WATCH_ROOT` | `/data/watch` | Container path whose top-level subdirs become watched folders |
+| `MINIO_ENDPOINT` | `minio:9000` | MinIO endpoint (currently used by legacy upload API; watched-folder originals are read in place from `./data/watch`) |
 | `MINIO_ACCESS_KEY` | `minioadmin` | MinIO access key |
 | `MINIO_SECRET_KEY` | `minioadmin123` | MinIO secret key |
+| `ALLOW_SOURCE_DOWNLOAD` | `false` | Set `true` to expose `/api/docs/{id}/download` (see [Source files](#source-files-reveal-vs-download) below) |
 | `LOG_LEVEL` | `INFO` | Logging level |
 
 ```bash
@@ -161,9 +167,10 @@ docker compose up --build -d      # build and start (background)
 docker compose down               # stop (keeps data)
 docker compose down -v            # stop and delete all data
 docker compose logs -f app        # tail app logs
+docker compose logs -f watcher    # see what the watcher is picking up
 ```
 
-**Services:** gateway (Caddy), app (FastAPI + React SPA), worker-io, worker-cpu, embedder (multilingual-e5-small), postgres (pgvector + pg_trgm), minio, tika.
+**Services:** `gateway` (Caddy), `app` (FastAPI + React SPA), `worker-io`, `worker-cpu`, `watcher` (folder watching + ingest queueing), `embedder` (multilingual-e5-small), `postgres` (pgvector + pg_trgm), `minio`, `tika`, `llama-server` (local LLM inference).
 
 ---
 
@@ -171,7 +178,7 @@ docker compose logs -f app        # tail app logs
 
 ### Ingestion Pipeline
 
-Upload a file and it goes through seven idempotent stages:
+Drop a file into a watched folder and it flows through seven idempotent stages:
 
 1. **Extract** — pull text from PDF, Office, eBook, HTML, email, and other formats via Apache Tika (TXT/MD/CSV decoded directly)
 2. **OCR** — conditional: always for images (JPEG/PNG/TIFF), for PDFs with little extractable text; never for text-native formats. Uses Tesseract (English + French)
@@ -181,11 +188,24 @@ Upload a file and it goes through seven idempotent stages:
 6. **Summarize** — generate a document summary (local LLM, with extractive fallback)
 7. **Finalize** — mark ingestion complete
 
-Progress is streamed to the UI via server-sent events with a visual stage ring showing each step. Processing can be cancelled from the admin UI.
+Progress is streamed to the UI via server-sent events with a visual stage ring showing each step. Processing can be cancelled from the admin UI. Renames, edits, and deletions in the watched folder propagate automatically — Harbor Clerk reprocesses the file or soft-deletes the document, and a 30-day reaper purges originals that stay missing.
+
+### Source Files: Reveal vs Download
+
+Because Harbor Clerk reads originals in place, getting back to the actual file on disk works differently in each deployment — and intentionally so:
+
+| | macOS Native | Docker Compose |
+|---|---|---|
+| **Default action** | **Reveal in Finder** opens the original in its enclosing folder | No file-access action — users read passages and citations |
+| **Download API** | Disabled by design; the menu app does not expose a way to enable it | Disabled by default; an admin opts in via `ALLOW_SOURCE_DOWNLOAD=true` |
+
+On macOS, the document detail page shows a **Reveal in Finder** button that opens the file's enclosing folder via the native bridge — no HTTP, no bytes leaving the machine. On Docker the same button isn't available (no native bridge), and `GET /api/docs/{id}/download` returns 403 unless an admin sets `ALLOW_SOURCE_DOWNLOAD=true` in the compose env.
+
+The reason the download endpoint is locked down by default: it returns the *raw bytes* of any document the caller can already see in search, which is a meaningful escalation over the chunk-excerpt access read-only API keys are designed for. Reveal in Finder sidesteps this entirely because it never touches the API.
 
 ### Hybrid Search
 
-Results combine PostgreSQL full-text search (bilingual English/French) and pgvector cosine similarity, merged and ranked with boosts for latest document versions and higher OCR confidence. All results include source citations with page numbers. Search supports filtering by document, date range, language, and MIME type, with faceted results grouping hits by document.
+Results combine PostgreSQL full-text search (bilingual English/French) and pgvector cosine similarity, normalized and merged into a single score with a small boost for higher-confidence OCR text. All results include source citations with page numbers. Search supports filtering by document, date range, language, and MIME type, with faceted results grouping hits by document.
 
 ### Local Chat
 
@@ -245,17 +265,20 @@ Connect ChatGPT, Claude Desktop, Claude Code, Gemini CLI, OpenClaw, or any MCP-c
 | `/api/auth/refresh` | POST | Refresh access token |
 | `/api/system/setup-status` | GET | Check if first-time setup is needed |
 | `/api/setup` | POST | Create initial admin account |
-| `/api/uploads` | POST | Upload documents |
-| `/api/uploads/confirm` | POST | Confirm upload action |
-| `/api/uploads/confirm-batch` | POST | Confirm multiple uploads |
+| `/api/watch/system` | GET | Deployment context for the folder UI (`platform`, `picker`, `watch_root`) |
+| `/api/watch/folders` | GET/POST | List or register watched folders (POST is macOS-only) |
+| `/api/watch/folders/{id}` | PATCH/DELETE | Update or remove a watched folder |
+| `/api/watch/folders/{id}/progress` | GET | Per-folder ingestion stats across all 7 stages |
+| `/api/watch/folders/stream` | GET | SSE stream of per-folder progress deltas |
+| `/api/watch/folders/{id}/rescan` | POST | Trigger a full rescan of a folder |
 | `/api/docs` | GET | List documents |
 | `/api/docs/overview` | GET | Corpus overview stats |
-| `/api/docs/{id}` | GET | Document detail with versions |
+| `/api/docs/{id}` | GET | Document detail |
 | `/api/docs/{id}/content` | GET | Read document text (with page ranges) |
 | `/api/docs/{id}/outline` | GET | Document heading structure |
 | `/api/docs/{id}/entities` | GET | Named entities in document |
 | `/api/docs/{id}/related` | GET | Similar documents |
-| `/api/docs/{id}/download` | GET | Download original file |
+| `/api/docs/{id}/download` | GET | Download original file (gated by `ALLOW_SOURCE_DOWNLOAD`; see [Source Files](#source-files-reveal-vs-download)) |
 | `/api/docs/{id}` | DELETE | Soft-delete a document |
 | `/api/docs/{id}/reprocess` | POST | Re-run ingestion |
 | `/api/docs/{id}/cancel` | POST | Cancel in-progress ingestion |
@@ -290,7 +313,7 @@ Connect ChatGPT, Claude Desktop, Claude Code, Gemini CLI, OpenClaw, or any MCP-c
 | `kb_search` | Hybrid search with pagination, detail modes, and optional filters |
 | `kb_read_passages` | Read specific passages by chunk ID |
 | `kb_expand_context` | Get surrounding chunks for a given chunk |
-| `kb_get_document` | Document metadata, versions, and summary |
+| `kb_get_document` | Document metadata and summary |
 | `kb_list_recent` | Recently added documents with summaries |
 | `kb_corpus_overview` | Aggregate corpus stats (languages, types, dates) |
 | `kb_document_outline` | Document heading structure and page layout |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,10 @@ graph TB
         api["FastAPI<br/>REST API + MCP + SPA"]
     end
 
+    subgraph Watcher
+        watcher["Watcher<br/>Python watchdog<br/>FSEvents / inotify / polling"]
+    end
+
     subgraph Workers
         wio["Worker (io queue)<br/>extract, chunk, entities,<br/>summarize, finalize"]
         wcpu["Worker (cpu queue)<br/>OCR, embed"]
@@ -24,12 +28,12 @@ graph TB
 
     subgraph Data
         pg[("PostgreSQL 18<br/>+ pgvector + pg_trgm")]
-        store["Object Storage<br/>MinIO or Filesystem"]
+        fs["Source filesystem<br/>(read in place)"]
     end
 
     subgraph Services
         tika["Apache Tika<br/>text extraction"]
-        embedder["Embedder<br/>all-MiniLM-L6-v2<br/>384-dim"]
+        embedder["Embedder<br/>multilingual-e5-small<br/>384-dim"]
         llama["llama.cpp<br/>local LLM inference"]
     end
 
@@ -38,27 +42,30 @@ graph TB
     caddy --> api
 
     api -- "async queries" --> pg
-    api -- "upload/download" --> store
     api -- "chat streaming" --> llama
     api -- "SSE /api/jobs/stream" --> browser
 
+    watcher -- "scan + LISTEN" --> fs
+    watcher -- "enqueue ingest jobs" --> pg
+
     wio -- "poll jobs<br/>LISTEN/NOTIFY" --> pg
     wcpu -- "poll jobs<br/>LISTEN/NOTIFY" --> pg
+    wio -- "read source" --> fs
+    wcpu -- "read source" --> fs
     wio -- "extract" --> tika
     wcpu -- "OCR" --> tika
     wcpu -- "embed" --> embedder
-    wio -- "store originals" --> store
 
     llama -. "tool calls<br/>via API" .-> api
 ```
 
 ## Ingestion Pipeline
 
-Seven idempotent stages, each guarded by row-level lock on `(version_id, stage)`:
+Seven idempotent stages, each guarded by a row-level lock on `(doc_id, stage)`:
 
 ```mermaid
 graph LR
-    upload(("Upload"))
+    drop(("File appears in<br/>watched folder"))
 
     extract["1. extract<br/><i>io queue</i><br/>Tika / plain text"]
     ocr["2. ocr<br/><i>cpu queue</i><br/>pypdfium2 + Tesseract"]
@@ -70,7 +77,7 @@ graph LR
 
     finalize["7. finalize<br/><i>io queue</i><br/>mark complete"]
 
-    upload --> extract --> ocr --> chunk
+    drop --> extract --> ocr --> chunk
 
     chunk --> entities & embed & summarize
 
@@ -90,7 +97,7 @@ graph LR
     query["Search Query"]
     fts["PostgreSQL FTS<br/>bilingual (en + fr)"]
     vec["pgvector<br/>cosine similarity"]
-    merge["Merge & Dedupe<br/>version boost<br/>OCR confidence boost"]
+    merge["Normalize & merge scores<br/>OCR-confidence boost"]
     results["Top K Results<br/>with citations"]
 
     query --> fts & vec
@@ -108,19 +115,27 @@ graph TB
     subgraph docker["Docker Compose"]
         gw["gateway<br/>Caddy"]
         app["app<br/>FastAPI"]
+        watcher["watcher<br/>(harbor-clerk-watcher)"]
         wio["worker-io"]
         wcpu["worker-cpu"]
         emb["embedder"]
         pg[("postgres<br/>pgvector/pgvector:pg18")]
-        minio["minio"]
+        minio["minio<br/>(legacy upload API)"]
         tika["tika"]
         llama["llama-server"]
     end
 
+    host_fs["Host bind mount<br/>./data/watch"]
+
     gw --> app
-    app --> pg & minio & llama
-    wio --> pg & tika & minio
+    app --> pg & llama
+    app -. "legacy uploads" .-> minio
+    watcher --> pg
+    watcher -- "WATCH_ROOT<br/>/data/watch" --> host_fs
+    wio --> pg & tika
+    wio --> host_fs
     wcpu --> pg & tika & emb
+    wcpu --> host_fs
 ```
 
 ### macOS Native
@@ -134,17 +149,30 @@ graph TB
         emb["Embedder<br/>(subprocess)"]
         llama["llama.cpp<br/>(subprocess)"]
         api["harbor-clerk-api<br/>(subprocess)"]
+        watcher["harbor-clerk-watcher<br/>(subprocess)"]
         wio["worker io<br/>(subprocess)"]
         wcpu["worker cpu<br/>(subprocess)"]
     end
 
-    client["Harbor Clerk<br/>(WKWebView app)"]
+    subgraph client["Harbor Clerk (WKWebView app)"]
+        spa["React SPA"]
+        bridge["Swift JS bridges<br/>pickFolder · revealInFinder"]
+    end
 
-    sm --> pg & tika & emb & llama & api & wio & wcpu
-    client -- "http://localhost:8000" --> api
+    user_dirs["User-picked folders<br/>(anywhere on disk)"]
+
+    sm --> pg & tika & emb & llama & api & watcher & wio & wcpu
+    spa -- "http://localhost:8000" --> api
+    spa -. "window.harborclerk" .-> bridge
+    bridge -. "NSOpenPanel · NSWorkspace" .-> user_dirs
+    watcher --> user_dirs
+    wio --> user_dirs
+    wcpu --> user_dirs
 ```
 
 ## Data Model (key tables)
+
+The document model is flat: each `documents` row tracks one source file, including its current ingestion status, summary, and OCR/extraction metadata. Previous versions are not retained as a separate table — reprocessing updates the row in place.
 
 ```mermaid
 erDiagram
@@ -152,15 +180,14 @@ erDiagram
     users ||--o{ conversations : has
     conversations ||--o{ chat_messages : contains
 
-    documents ||--o{ document_versions : has
-    document_versions ||--o{ document_pages : has
-    document_versions ||--o{ document_headings : has
-    document_versions ||--o{ chunks : has
-    document_versions ||--o{ entities : has
-    document_versions ||--o{ ingestion_jobs : tracks
+    watched_folders ||--o{ watched_files : tracks
+    watched_files ||--o| documents : "ingests as"
 
-    upload_sessions ||--o{ uploads : groups
-    uploads ||--o| document_versions : creates
+    documents ||--o{ document_pages : has
+    documents ||--o{ document_headings : has
+    documents ||--o{ chunks : has
+    documents ||--o{ entities : has
+    documents ||--o{ ingestion_jobs : tracks
 
     chunks {
         text content
@@ -171,12 +198,11 @@ erDiagram
 
     documents {
         text title
-        text filename
-    }
-
-    document_versions {
+        text canonical_filename
+        text source_path
         enum status
         text summary
+        bytea sha256
     }
 
     ingestion_jobs {
@@ -184,7 +210,16 @@ erDiagram
         enum status
         timestamp heartbeat_at
     }
+
+    watched_folders {
+        text path
+        text label
+        bool auto_discovered
+        text unavailable_reason
+    }
 ```
+
+> The legacy `uploads` and `upload_sessions` tables remain in the schema to keep the `POST /api/uploads/*` endpoints alive for non-interactive callers (planned email ingestion). The web UI no longer offers a direct upload affordance.
 
 ## Auth Model
 
@@ -200,6 +235,6 @@ graph LR
     hash --> api
 
     api -- "role: admin" --> full["Full Access"]
-    api -- "role: user" --> limited["Read + Upload"]
-    api -- "api_key" --> readonly["Read-Only"]
+    api -- "role: user" --> limited["Read"]
+    api -- "api_key" --> readonly["Read-Only (scoped)"]
 ```


### PR DESCRIPTION
## Summary

Audit and refresh the user-facing docs for the watched-folder-only model that landed in the Stage 1–3 refactor (#245 / #253 / #255 + follow-ups). The README still framed ingestion as upload-first, listed `document_versions` and an outdated container count, and never explained the Reveal-in-Finder vs Download split. This PR brings README, `docs/architecture.md`, and `CLAUDE.md` back in line with main.

## What was stale

- README framed ingestion as upload-first ("Upload a file and it goes through seven stages") and listed `/api/uploads*` as the primary REST surface.
- README claimed "Eight Docker containers" — actually 10 once the `watcher` and `llama-server` services were added.
- README said watched folders were "macOS only" — they have been on Docker since #245.
- README listed a "latest version" rank boost; only an OCR-confidence boost remains post-flatten.
- `docs/architecture.md` named the embedder as `all-MiniLM-L6-v2` (it has been `multilingual-e5-small` for a while), missed the `watcher` service, and the ER diagram still showed the `document_versions` table that migration 0017 dropped.
- `CLAUDE.md` still claimed `WatchedFolderManager.swift` and listed `document_versions` as a key table.
- Reveal-in-Finder vs Download (gated by `ALLOW_SOURCE_DOWNLOAD`, off by default) was not documented anywhere user-visible — and it is **not** intuitive that Download is locked-down by default while Reveal-in-Finder is the macOS-native escape hatch.
- Tagline "Local-first document knowledge base..." was fine but a little dry; tightened to lean on the folder-watching reality.

## Notable adjustments

- New **Source Files: Reveal vs Download** section in the README (with cross-references from the env-var table and the `/api/docs/{id}/download` row) explaining why the download endpoint returns 403 by default and what the macOS user gets instead.
- Architecture diagrams now show the `watcher` subsystem reading the source filesystem and enqueueing jobs alongside the workers, in both Docker and macOS forms; macOS diagram clarifies the WKWebView `pickFolder` / `revealInFinder` JS bridges.

## Out of scope (flagged separately)

The Documents page (`frontend/src/pages/DocumentsPage.tsx`) still has per-row and bulk download buttons that hit the gated endpoint unconditionally, while DocumentDetailPage feature-detects via `sysConfig.allowSourceDownload`. That is a UX inconsistency, not a docs bug — flagged as a separate task chip from this session.

## Test plan
- [ ] Render the README on github.com and confirm the new prose reads cleanly without the watched-folder model needing further explanation.
- [ ] Spot-check that the new mermaid diagrams render (watcher subsystem on the System Overview, both deployment diagrams).
- [ ] Confirm the `#source-files-reveal-vs-download` anchor links work from the env-var table and the REST endpoint table.
- [ ] Anyone hitting the README cold can identify the watched-folder-first ingest model without reading the spec.