### PR TITLE
fix(docs): gate Documents page download UI on allow_source_download

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents } from '../hooks/useJobEvents'
+import { useSystemConfig } from '../hooks/useSystemConfig'
 import { PageHeader } from '../components/PageHeader'
 import { StatusPill, type PillState } from '../components/StatusPill'
 import { IconTile } from '../components/IconTile'
@@ -146,6 +147,12 @@ function Pagination({
 
 export default function DocumentsPage() {
   const { user, isAdmin, updatePreferences } = useAuth()
+  const sysConfig = useSystemConfig()
+  // Mirror DocumentDetailPage's SourceFileSection: only show download UI when
+  // the deployment has enabled `allow_source_download`. Default off everywhere
+  // (the API returns 403); on macOS the user-facing escape hatch is Reveal in
+  // Finder via `window.harborclerk.revealInFinder`, not download.
+  const canDownload = sysConfig.allowSourceDownload && sysConfig.loaded
   const [searchParams] = useSearchParams()
   const [pageSize, setPageSize] = useState(user?.preferences?.page_size || 10)
   const [docs, setDocs] = useState<DocSummary[]>([])
@@ -802,6 +809,7 @@ export default function DocumentsPage() {
               isAdmin={isAdmin}
               bulkAction={bulkAction}
               confirmingDelete={confirmingDelete}
+              canDownload={canDownload}
               onReprocess={handleBulkReprocess}
               onResummarize={handleBulkResummarize}
               onDelete={handleBulkDelete}
@@ -979,25 +987,27 @@ export default function DocumentsPage() {
                           {new Date(doc.updated_at).toLocaleDateString()}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <button
-                            onClick={() => handleDownload(doc.doc_id)}
-                            className="rounded-sm p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                            title="Download original"
-                          >
-                            <svg
-                              className="h-4 w-4"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2}
+                          {canDownload && (
+                            <button
+                              onClick={() => handleDownload(doc.doc_id)}
+                              className="rounded-sm p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                              title="Download original"
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                              />
-                            </svg>
-                          </button>
+                              <svg
+                                className="h-4 w-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                                />
+                              </svg>
+                            </button>
+                          )}
                         </td>
                       </tr>
                       {isExpanded && (
@@ -1083,6 +1093,7 @@ export default function DocumentsPage() {
               isAdmin={isAdmin}
               bulkAction={bulkAction}
               confirmingDelete={confirmingDelete}
+              canDownload={canDownload}
               onReprocess={handleBulkReprocess}
               onResummarize={handleBulkResummarize}
               onDelete={handleBulkDelete}
@@ -1134,6 +1145,7 @@ function BulkActionsBar({
   isAdmin,
   bulkAction,
   confirmingDelete,
+  canDownload,
   onReprocess,
   onResummarize,
   onDelete,
@@ -1145,6 +1157,7 @@ function BulkActionsBar({
   isAdmin: boolean
   bulkAction: string
   confirmingDelete: boolean
+  canDownload: boolean
   onReprocess: () => void
   onResummarize: () => void
   onDelete: () => void
@@ -1174,13 +1187,15 @@ function BulkActionsBar({
           </button>
         </>
       )}
-      <button
-        onClick={onDownload}
-        disabled={!!bulkAction}
-        className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 disabled:opacity-50"
-      >
-        {bulkAction === 'download' ? 'Downloading...' : 'Download'}
-      </button>
+      {canDownload && (
+        <button
+          onClick={onDownload}
+          disabled={!!bulkAction}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 disabled:opacity-50"
+        >
+          {bulkAction === 'download' ? 'Downloading...' : 'Download'}
+        </button>
+      )}
       {isAdmin &&
         (confirmingDelete ? (
           <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

The Documents page (`frontend/src/pages/DocumentsPage.tsx`) was calling `/api/docs/{id}/download` from both the per-row icon button and the bulk Download action without checking whether the deployment allows source-file downloads. That endpoint returns **403** unless `ALLOW_SOURCE_DOWNLOAD=true` (default off everywhere — see [config.py:117](src/harbor_clerk/config.py:117) for the rationale). [DocumentDetailPage.tsx:330](frontend/src/pages/DocumentDetailPage.tsx:330) already feature-detected this via `useSystemConfig`; this PR mirrors that pattern in DocumentsPage so the buttons disappear instead of dead-clicking.

## Behavior

| Deployment | Before | After |
|---|---|---|
| macOS native (default) | Buttons visible, click → 403 toast | Buttons hidden; user uses Reveal in Finder on the detail page |

| Docker, default | Buttons visible, click → 403 toast | Buttons hidden |

| Docker, `ALLOW_SOURCE_DOWNLOAD=true` | Buttons visible, click → download | Unchanged |
## Test plan
- [x] `npm run type-check` clean.
- [x] `npm run lint` — no new warnings in DocumentsPage.tsx.
- [x] `npm run format:check` clean.

- [ ] Manual smoke: open `/docs` on macOS native and confirm the download icon column and the bulk Download button are gone; on a Docker stack with `ALLOW_SOURCE_DOWNLOAD=true`, confirm both still render and work.