### PR TITLE
fix(frontend): hide download UI when allow_source_download is off

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents } from '../hooks/useJobEvents'
+import { useSystemConfig } from '../hooks/useSystemConfig'
 import { PageHeader } from '../components/PageHeader'
 import { StatusPill, type PillState } from '../components/StatusPill'
 import { IconTile } from '../components/IconTile'
@@ -147,6 +148,8 @@ function Pagination({
 export default function DocumentsPage() {
   const { user, isAdmin, updatePreferences } = useAuth()
   const [searchParams] = useSearchParams()
+  const sysConfig = useSystemConfig()
+  const canDownload = sysConfig.allowSourceDownload && sysConfig.loaded
   const [pageSize, setPageSize] = useState(user?.preferences?.page_size || 10)
   const [docs, setDocs] = useState<DocSummary[]>([])
   const [total, setTotal] = useState(0)
@@ -802,6 +805,7 @@ export default function DocumentsPage() {
               isAdmin={isAdmin}
               bulkAction={bulkAction}
               confirmingDelete={confirmingDelete}
+              canDownload={canDownload}
               onReprocess={handleBulkReprocess}
               onResummarize={handleBulkResummarize}
               onDelete={handleBulkDelete}
@@ -979,25 +983,27 @@ export default function DocumentsPage() {
                           {new Date(doc.updated_at).toLocaleDateString()}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <button
-                            onClick={() => handleDownload(doc.doc_id)}
-                            className="rounded-sm p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                            title="Download original"
-                          >
-                            <svg
-                              className="h-4 w-4"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2}
+                          {canDownload && (
+                            <button
+                              onClick={() => handleDownload(doc.doc_id)}
+                              className="rounded-sm p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                              title="Download original"
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                              />
-                            </svg>
-                          </button>
+                              <svg
+                                className="h-4 w-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                                />
+                              </svg>
+                            </button>
+                          )}
                         </td>
                       </tr>
                       {isExpanded && (
@@ -1083,6 +1089,7 @@ export default function DocumentsPage() {
               isAdmin={isAdmin}
               bulkAction={bulkAction}
               confirmingDelete={confirmingDelete}
+              canDownload={canDownload}
               onReprocess={handleBulkReprocess}
               onResummarize={handleBulkResummarize}
               onDelete={handleBulkDelete}
@@ -1134,6 +1141,7 @@ function BulkActionsBar({
   isAdmin,
   bulkAction,
   confirmingDelete,
+  canDownload,
   onReprocess,
   onResummarize,
   onDelete,
@@ -1145,6 +1153,7 @@ function BulkActionsBar({
   isAdmin: boolean
   bulkAction: string
   confirmingDelete: boolean
+  canDownload: boolean
   onReprocess: () => void
   onResummarize: () => void
   onDelete: () => void
@@ -1174,13 +1183,15 @@ function BulkActionsBar({
           </button>
         </>
       )}
-      <button
-        onClick={onDownload}
-        disabled={!!bulkAction}
-        className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 disabled:opacity-50"
-      >
-        {bulkAction === 'download' ? 'Downloading...' : 'Download'}
-      </button>
+      {canDownload && (
+        <button
+          onClick={onDownload}
+          disabled={!!bulkAction}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 disabled:opacity-50"
+        >
+          {bulkAction === 'download' ? 'Downloading...' : 'Download'}
+        </button>
+      )}
       {isAdmin &&
         (confirmingDelete ? (
           <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

- `DocumentsPage` rendered the per-row download icon and the bulk Download button unconditionally, so on every default deployment (macOS native, Docker without `ALLOW_SOURCE_DOWNLOAD=true`) clicking either returned 403 from `/api/docs/{id}/download`.
- `DocumentDetailPage` already feature-detects via `useSystemConfig` (see [frontend/src/pages/DocumentDetailPage.tsx:330](https://github.com/r0shi/harborclerk/blob/main/frontend/src/pages/DocumentDetailPage.tsx#L330)). This PR applies the same gate to `DocumentsPage`: per-row download button + bulk-action Download button now only render when `sysConfig.allowSourceDownload && sysConfig.loaded`.
- No backend change. The endpoint and the `allow_source_download` setting (default `false`) are unchanged — this just stops the UI from offering an action that the server is configured to refuse.

## Reviewer notes

- On macOS the user-facing path for accessing the original file is still `Reveal in Finder`, surfaced by `DocumentDetailPage` via `window.harborclerk?.revealInFinder`. There is no equivalent surface on the Documents list and we deliberately do not add one here — list-level Reveal would multiply Finder windows; the per-document detail view is the right place for it.
- The empty `<td>` is preserved when `canDownload` is false to keep the table column count aligned with the (empty) header `<th>`.
- `BulkActionsBar` gains a required `canDownload` prop. Both call sites in `DocumentsPage` pass it through.

## Test plan

- [x] `npm run lint` — 0 errors (13 pre-existing warnings, none in `DocumentsPage.tsx`)
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
