### PR TITLE
feat(test-corpora): --models filter + supervisor.py + RUNBOOK

### DIFF
--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -1,0 +1,390 @@
+# Test Corpora Sweep Runbook
+
+How to run the full six-phase LLM evaluation sweep across two machines, mostly unattended.
+
+This runbook is the operations companion to:
+- [README.md](README.md) — quickstart + dev orientation
+- [`docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md`](../../docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md) — the design
+
+---
+
+## Moving parts
+
+```
+                                    ┌──────────────────────────┐
+                                    │  Anthropic API           │
+                                    │  (baselines + judge)     │
+                                    └────────────┬─────────────┘
+                                                 │
+   ┌─────────────────────────────┐               │              ┌──────────────────────────┐
+   │  BIG  (~36 GB+ Mac, current)│               │              │  MINI (32 GB M4 Pro)     │
+   │                             │               │              │                          │
+   │  Harbor Clerk (native app)  │◀─── REST ─────┤              │  Harbor Clerk (native)   │
+   │   ├ Postgres                │               │              │   ├ Postgres             │
+   │   ├ Tika                    │               │              │   ├ Tika                 │
+   │   ├ Embedder                │               │              │   ├ Embedder             │
+   │   └ llama-server            │               │              │   └ llama-server         │
+   │                             │               │              │                          │
+   │  sweep harness              │               │              │  sweep harness           │
+   │   ├ Phase 0,1,5,6           │◀──────────────┘              │   ├ Phase 0 (cached)     │
+   │   └ Phase 4 top 2 models    │                              │   └ Phase 4 6 small      │
+   │      (gemma-26b, qwen3.6)   │                              │      (smollm3-3b...      │
+   │                             │                              │       gpt-oss-20b)       │
+   │  supervisor.py              │                              │  supervisor.py           │
+   │   └ tail log → notify       │                              │   └ tail log → notify    │
+   │                             │                              │                          │
+   │  tmux session "sweep-big"   │                              │  tmux session "sweep-mini"│
+   │  ~/sweep-logs/phase4-big.log│                              │  ~/sweep-logs/phase4-mini│
+   │                             │                              │   .log                   │
+   └────────────────┬────────────┘                              └──────────┬───────────────┘
+                    │                                                      │
+                    │           rsync results/<run-id>/                    │
+                    └──────────────────────────────────────────────────────┘
+                              ⇩  combined results live on BIG
+                                 metrics.csv + judge JSON + state.json
+```
+
+| Component | Where | Purpose | Lifetime |
+| --- | --- | --- | --- |
+| `runner/sweep.py` | both machines | the actual harness — runs the six-phase loop | per phase invocation, hours |
+| `runner/supervisor.py` | both machines | tails the harness log, posts macOS notifications, recommends skips | runs alongside the sweep |
+| `tmux` session | both machines | keeps the harness alive across SSH disconnects + Claude session ends | session lifetime |
+| Anthropic API key | both machines | Sonnet 4.6 baselines (Phase 1) and judge (Phase 5) | the sweep |
+| Harbor Clerk admin login (`HC_USERNAME`/`HC_PASSWORD`) | both machines | required for `delete_all_documents` between corpora | the sweep |
+| Claude subagent (Sonnet) | optional, on either machine's Claude session | reads supervisor stdout, decides what to do for ambiguous events | session lifetime |
+| `results/<run-id>/` directory | rsynced between machines | shared state — baselines from BIG, responses from both | through to the final report |
+
+---
+
+## Pre-flight (do once, before any sweep starts)
+
+### On both machines
+
+```bash
+cd /path/to/mcp-gateway/scripts/test_corpora
+uv sync --extra test
+uv run python -m spacy download en_core_web_sm
+
+# verify all 38+ unit tests pass
+uv run pytest -q
+```
+
+### On `BIG` only
+
+Generate an SSH alias to `MINI` so rsync is a one-liner:
+
+```bash
+# one-time: ssh-keygen + ssh-copy-id alex@mini.local
+echo "Host mini" >> ~/.ssh/config
+echo "  HostName mini.local" >> ~/.ssh/config
+echo "  User $USER" >> ~/.ssh/config
+ssh mini "echo ok"   # should print 'ok' without password prompt
+```
+
+### On both machines
+
+Pick a stable run-id and shared workdir. **Use the same run-id on both machines.**
+
+```bash
+export RUN=2026-05-05-prod
+export WORKDIR=~/Library/Application\ Support/Harbor\ Clerk/test-corpora
+mkdir -p ~/sweep-logs
+```
+
+### On both machines
+
+Check Harbor Clerk is running and admin login works:
+
+```bash
+curl -k https://localhost/api/system/health    # expect {ok: true}
+```
+
+Set env vars for the sweep:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+export HC_USERNAME="admin@example.com"          # must be admin role
+export HC_PASSWORD="..."
+```
+
+---
+
+## Phase 0 + 1: corpus acquisition + Claude baselines
+
+Phase 0 acquires all three corpora (cuad, enron, synthetic). Phase 1 generates 48 Claude baselines using Sonnet 4.6 + the Harbor Clerk MCP server. Both run on `BIG` so the `baselines/` dir is colocated with where Phase 5 will read it.
+
+```bash
+# on BIG
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-prep "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 0-1 --insecure \
+    2>&1 | tee ~/sweep-logs/phase01-big.log"
+
+# detach is automatic with -d. Reattach with: tmux attach -t sweep-prep
+```
+
+In a second terminal, start the supervisor:
+
+```bash
+# on BIG
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase01-big.log
+```
+
+Expected wall-clock: ~10 min for Phase 0 (synthetic generation dominates) + ~30-60 min for Phase 1 (48 questions × ~30-60 s each, Sonnet tool-call rounds).
+
+When supervisor emits a `completion` event (and you get a macOS notification), proceed to sync.
+
+### Sync results to `MINI`
+
+```bash
+# on BIG
+rsync -av --progress \
+    "$WORKDIR/cuad" "$WORKDIR/enron" "$WORKDIR/synthetic" \
+    "$WORKDIR/results/" \
+    "mini:$WORKDIR/"
+```
+
+`MINI` now has the corpora pre-acquired (so its Phase 0 short-circuits) and the baselines (so it could run Phase 5 too, though Phase 5 is reserved for `BIG`).
+
+---
+
+## Phase 4: split sweep across both machines
+
+These two commands run **at the same time** on the two machines. The harness state files don't conflict because each machine has its own `state.json` keyed by the same `run-id`.
+
+### On `MINI` (6 smaller models)
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-mini "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    --models smollm3-3b,qwen3-4b,phi-4-mini,qwen3-8b,deepseek-r1-8b,gpt-oss-20b \
+    --insecure \
+    2>&1 | tee ~/sweep-logs/phase4-mini.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4-mini.log
+```
+
+Wall-clock estimate: 6 models × 50 questions × ~5 min average = **~25 hours**. The corpus-outer loop ordering means only 3 DB wipes total (one per corpus), not 18.
+
+### On `BIG` (top 2 models)
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-big "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    --models gemma-26b,qwen3.6-35b \
+    --insecure \
+    2>&1 | tee ~/sweep-logs/phase4-big.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4-big.log
+```
+
+Wall-clock estimate: 2 models × 50 questions × ~10-15 min average = **~17-25 hours** (the larger models are slower).
+
+### Sync `MINI`'s responses back
+
+When `MINI`'s supervisor signals completion:
+
+```bash
+# on BIG
+rsync -av --progress \
+    "mini:$WORKDIR/results/$RUN/responses/" \
+    "$WORKDIR/results/$RUN/responses/"
+
+# also pull MINI's metrics.csv rows
+ssh mini "tail -n +2 \"$WORKDIR/results/$RUN/metrics.csv\"" \
+    >> "$WORKDIR/results/$RUN/metrics.csv"
+```
+
+(The CSV append assumes both machines started from the header-only state file. Skip the `tail -n +2` step if you're doing it differently.)
+
+---
+
+## Phase 5 (parity) on `BIG`
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-parity "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 5 --insecure \
+    2>&1 | tee ~/sweep-logs/phase5-big.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase5-big.log
+```
+
+Wall-clock estimate: ~17-25 hours of model runs + ~$1-2 in Sonnet judge calls (100 calls × ~$0.01-0.02 each).
+
+---
+
+## Phase 6 (unified) on `BIG`
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-unified "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 6 --insecure \
+    2>&1 | tee ~/sweep-logs/phase6-big.log"
+```
+
+Wall-clock: ~3-5 hours.
+
+---
+
+## Spawning a Claude subagent supervisor (optional, recommended)
+
+`supervisor.py` posts macOS notifications and prints structured events to stdout. A Claude Sonnet subagent can read those events from a log file and apply richer judgment — e.g. distinguishing a transient API rate-limit (just wait) from a stuck llama-server (restart needed).
+
+In a Claude Code session on the relevant machine:
+
+> Watch `~/sweep-logs/phase4-mini.log` via `tail -f`. The `scripts/test_corpora/runner/supervisor.py` watcher prints structured JSON events to its stdout — you have access to that log file at the same path. Your job is to act on these events:
+>
+> - **`phase_boundary`** — log it; no action needed
+> - **`completion`** — log it; tell me the sweep is done
+> - **`skip_recommendation`** — investigate the last 50 lines of the harness log around the failure. If the model is `deepseek-r1-8b` (known research-mode flake), accept the recommendation and run `uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep --run-id $RUN --skip "model=<model>"` to mark its remaining units SKIPPED. For any other model, page me with the failure context and don't auto-skip.
+> - **`stuck`** — investigate the last 100 lines of the harness log. If you see `llama-server` errors or `Connection refused`, ask me whether to restart Harbor Clerk's LLM service. If you see only Anthropic 429/503, just wait.
+> - **`rate_limit`** — log and wait; the harness retries with exponential backoff
+> - **any unhandled event type** — page me
+>
+> Don't touch the harness directly other than `--skip` for known-flake models. For everything else, page me.
+
+The subagent's session needs to stay open. Best with a long-running Claude Code session in a separate window.
+
+---
+
+## Recovery procedures
+
+### Sweep killed mid-run (machine reboot, OOM, Ctrl-C)
+
+The harness state file (`results/<run-id>/state.json`) tracks every cell. To resume:
+
+```bash
+# add --resume to any sweep invocation
+uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir "$WORKDIR" \
+    --phases 4 --models <same-list> --resume --insecure 2>&1 | tee -a ~/sweep-logs/phase4-mini.log
+```
+
+The `--resume` flag is largely a no-op — the state file already auto-resumes — but it makes intent explicit. Stale `IN_PROGRESS` rows older than 2× the time-budget revert to `PENDING` automatically.
+
+### Stale `state.lock`
+
+After a hard kill, the `state.lock` file may persist:
+
+```
+RuntimeError: state file is locked by another runner (pid 12345)
+```
+
+If `pid 12345` isn't running, delete the lock:
+
+```bash
+rm "$WORKDIR/results/$RUN/state.json.lock"
+```
+
+### llama-server crashed mid-Phase-4
+
+Restart Harbor Clerk's LLM model via the UI or:
+
+```bash
+curl -k -X PUT https://localhost/api/chat/models/<model_id>/activate
+```
+
+Then re-run the sweep with `--resume`.
+
+### Anthropic rate-limit storm
+
+Phase 1 baselines are sequential and Sonnet's rate limit allows them. If you hit 429s repeatedly, either:
+
+- Wait an hour and resume, or
+- Add `--rerun "phase=1,corpus=<one>"` to scope the retry
+
+### A model is broken and won't progress
+
+Skip it:
+
+```bash
+uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir "$WORKDIR" \
+    --skip "model=deepseek-r1-8b" --insecure
+```
+
+This is exactly what the supervisor recommends after 3 consecutive errors. Re-run the sweep to skip the rest of that model's units.
+
+---
+
+## Final aggregation
+
+When all phases are complete:
+
+```bash
+# on BIG, summarize Phase 4 completion
+awk -F, 'NR>1 && $1==4 {key=$3"|"$2; total[key]++; if($6=="done")done[key]++} END {for(k in total) printf "%-30s %3d/%-3d\n", k, done[k], total[k]}' \
+    "$WORKDIR/results/$RUN/metrics.csv" | sort
+
+# Phase 5 judge verdicts
+awk -F, 'NR>1 && $1==5 {v[$11]++} END {for(k in v) printf "%-12s %d\n", k, v[k]}' \
+    "$WORKDIR/results/$RUN/metrics.csv"
+
+# Phase 5 mean citation overlap per (model, corpus)
+awk -F, 'NR>1 && $1==5 {sum[$3"|"$2]+=$7; n[$3"|"$2]++} END {for(k in sum) printf "%-30s %.2f\n", k, sum[k]/n[k]}' \
+    "$WORKDIR/results/$RUN/metrics.csv" | sort
+```
+
+The full per-question detail lives in:
+- `results/$RUN/baselines/<corpus>/<question_id>.json`
+- `results/$RUN/responses/<corpus>/<model>/<question_id>__<depth>.json`
+- `results/$RUN/judge/<corpus>/<model>/<question_id>__<depth>.json`
+
+---
+
+## Cost summary
+
+| Stage | Cost |
+| --- | --- |
+| Phase 0 synthetic generation | ~$3-5 (Sonnet 4.6, ~280 docs × ~4K tokens each) |
+| Phase 1 Claude baselines | ~$0.50-2 (48 questions × Sonnet tool-call rounds) |
+| Phase 4 (local) | $0 in API; 25-50 GPU-hours total across both machines |
+| Phase 5 model runs | $0 in API; 17-25 GPU-hours on BIG |
+| Phase 5 judge | ~$1-2 (100 judge calls × ~$0.01-0.02) |
+| Phase 6 | $0 in API; 3-5 GPU-hours on BIG |
+| **Total Anthropic spend** | **~$5-10** |
+
+---
+
+## What to do if it ALL goes wrong
+
+Wipe and start over:
+
+```bash
+# Wipe the run dir on both machines
+rm -rf "$WORKDIR/results/$RUN"
+ssh mini "rm -rf \"$WORKDIR/results/$RUN\""
+
+# Pick a new run-id
+export RUN=2026-05-06-retry
+
+# Start from Phase 0 again
+```
+
+Phase 0's `.acquired` markers stay, so the actual corpus downloads are cached — only the run-specific state (responses, baselines, metrics) is regenerated.

--- a/scripts/test_corpora/runner/supervisor.py
+++ b/scripts/test_corpora/runner/supervisor.py
@@ -1,0 +1,272 @@
+"""Watchdog for an in-flight sweep.
+
+Tails the harness log, recognises three classes of events, posts macOS
+notifications, and applies simple auto-skip rules so the user can leave
+the sweep unattended for many hours.
+
+The supervisor is intentionally dumb — it doesn't make subjective calls
+about partial answers or near-OOM conditions. For ambiguous events it
+posts a notification and pauses (no automatic recovery). A Claude
+subagent, with broader judgment, can be layered on top by watching the
+same JSON event stream the supervisor prints to stdout.
+
+Usage:
+    python -m scripts.test_corpora.runner.supervisor \\
+        --log-file phase4-mini.log \\
+        [--rules rules.yaml] \\
+        [--no-notify]
+
+Output: one JSON event per line on stdout. Each event has at least
+``{"event": <type>, "line": <log line>}`` plus type-specific fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TextIO
+
+# ── Patterns ──────────────────────────────────────────────────────────────────
+#
+# Each pattern matches a class of log line emitted by the harness.
+# The harness prints:
+#   - sample cards every 5 completions: "[Phase 4 · qwen3-8b · cuad · q07] elapsed 0:42:13"
+#   - phase boundary tables: "=== Phase 4 complete ==="
+#   - completion: "sweep complete after Ns"
+#   - errors: "ERROR" / "Traceback" / etc.
+#
+# Patterns are evaluated in declaration order; first match wins.
+
+PATTERNS: dict[str, re.Pattern] = {
+    "completion": re.compile(r"sweep complete after"),
+    "phase_boundary": re.compile(r"=== Phase (?P<phase>\d+) complete ==="),
+    "sample_card": re.compile(r"^\[Phase (?P<phase>\d+) · (?P<model>[\w.\-]+) · (?P<corpus>\w+) · (?P<qid>[\w-]+)\]"),
+    "blocked": re.compile(r"sweep stops|^blocked\b", re.IGNORECASE),
+    "error": re.compile(r"\b(ERROR|Traceback|OOM|Killed|Connection refused|HTTPStatusError|ReadTimeout)\b"),
+    "rate_limit": re.compile(r"\b429\b|rate.?limit", re.IGNORECASE),
+    "model_activate": re.compile(r"activating model (?P<model>[\w.\-]+)"),
+    "ingest_start": re.compile(r"clearing existing watch folders|delete_all_documents before ingesting"),
+}
+
+# How long without ANY recognised activity before we flag the sweep as stuck.
+STUCK_THRESHOLD_SECONDS = 30 * 60
+
+
+# ── Auto-skip rules ──────────────────────────────────────────────────────────
+#
+# Per-(model, corpus) error counter. When a (model, corpus) accumulates this many
+# consecutive ERROR events without an intervening sample_card, the supervisor
+# emits a "skip_recommendation" event. A wrapping Claude subagent (or the user)
+# then runs `sweep --skip "model=<m>"` to mark all that model's units as SKIPPED.
+
+CONSECUTIVE_ERROR_THRESHOLD = 3
+
+
+@dataclasses.dataclass
+class SupervisorState:
+    last_progress_at: float
+    # Per-model error streak. A sample_card for that model clears it. The streak
+    # is intentionally model-only, not per-(model, corpus): if a model is broken
+    # for one corpus it'll usually be broken for all of them, so attributing the
+    # streak to the model speeds up the skip recommendation.
+    consecutive_errors: dict[str, int]
+    last_phase_seen: int | None
+    current_model: str | None
+
+    @classmethod
+    def fresh(cls) -> SupervisorState:
+        return cls(
+            last_progress_at=time.time(),
+            consecutive_errors=defaultdict(int),
+            last_phase_seen=None,
+            current_model=None,
+        )
+
+
+# ── Notifications ─────────────────────────────────────────────────────────────
+
+
+def macos_notify(title: str, message: str) -> None:
+    """Post a system notification via osascript. Silent failure on non-macOS."""
+    try:
+        subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'display notification "{message[:200]}" with title "{title[:80]}"',
+            ],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+
+# ── Tail loop ─────────────────────────────────────────────────────────────────
+
+
+def tail_lines(path: Path, poll_seconds: float = 1.0) -> Iterator[str | None]:
+    """Yield log lines as they are appended. Yields ``None`` whenever the
+    poll interval elapses without new content — callers use that for
+    'stuck' detection."""
+    with path.open("r") as f:
+        f.seek(0, 2)  # tail mode
+        while True:
+            line = f.readline()
+            if line:
+                yield line.rstrip("\n")
+            else:
+                time.sleep(poll_seconds)
+                yield None
+
+
+def classify(line: str) -> tuple[str, dict] | None:
+    """Match line against PATTERNS. Return (event_type, named_groups) or None."""
+    for name, pat in PATTERNS.items():
+        m = pat.search(line)
+        if m:
+            return name, m.groupdict()
+    return None
+
+
+def emit(event: dict, out: TextIO) -> None:
+    out.write(json.dumps(event) + "\n")
+    out.flush()
+
+
+def supervise(
+    log_path: Path,
+    out: TextIO = sys.stdout,
+    notify: bool = True,
+    stuck_threshold: float = STUCK_THRESHOLD_SECONDS,
+) -> None:
+    """Main loop. Returns only when 'completion' is seen or the log file disappears."""
+    state = SupervisorState.fresh()
+
+    for line in tail_lines(log_path):
+        # Stuck check (fires when tail returns None and we've been idle too long)
+        if line is None:
+            idle = time.time() - state.last_progress_at
+            if idle > stuck_threshold:
+                event = {"event": "stuck", "idle_seconds": int(idle), "log": str(log_path)}
+                emit(event, out)
+                if notify:
+                    macos_notify("Sweep stuck", f"No progress in {int(idle / 60)} min")
+                state.last_progress_at = time.time()  # reset to avoid re-firing every poll
+            continue
+
+        match = classify(line)
+        if not match:
+            continue
+        kind, groups = match
+
+        # Track current model so we can attribute errors to the right (model, corpus) bucket
+        if kind == "model_activate":
+            state.current_model = groups.get("model")
+
+        if kind == "sample_card":
+            state.last_progress_at = time.time()
+            sample_model = groups.get("model", "")
+            if sample_model:
+                state.consecutive_errors[sample_model] = 0
+            event = {"event": "sample_card", **groups, "line": line[:300]}
+            emit(event, out)
+
+        elif kind == "phase_boundary":
+            phase = int(groups["phase"])
+            state.last_phase_seen = phase
+            state.last_progress_at = time.time()
+            event = {"event": "phase_boundary", "phase": phase, "line": line.strip()}
+            emit(event, out)
+            if notify:
+                macos_notify(f"Phase {phase} complete", line.strip())
+
+        elif kind == "completion":
+            event = {"event": "completion", "line": line.strip()}
+            emit(event, out)
+            if notify:
+                macos_notify("Sweep complete", line.strip())
+            return
+
+        elif kind == "blocked":
+            event = {"event": "blocked", "line": line.strip()}
+            emit(event, out)
+            if notify:
+                macos_notify("Sweep blocked", line.strip()[:80])
+            return
+
+        elif kind == "rate_limit":
+            event = {"event": "rate_limit", "line": line.strip()}
+            emit(event, out)
+            if notify:
+                macos_notify("API rate limit", "Anthropic rate limit hit; harness will retry")
+
+        elif kind == "error":
+            # Attribute to current model (best-effort; some errors arrive before any
+            # model is active, e.g. during corpus ingest — those aren't counted toward
+            # any streak).
+            model = state.current_model or ""
+            if model:
+                state.consecutive_errors[model] += 1
+                count = state.consecutive_errors[model]
+            else:
+                count = 0
+            event = {
+                "event": "error",
+                "model": state.current_model,
+                "consecutive": count,
+                "line": line.strip()[:300],
+            }
+            emit(event, out)
+            if model and count >= CONSECUTIVE_ERROR_THRESHOLD:
+                skip_event = {
+                    "event": "skip_recommendation",
+                    "model": model,
+                    "reason": f"{count} consecutive errors",
+                }
+                emit(skip_event, out)
+                if notify:
+                    macos_notify(
+                        "Skip recommended",
+                        f"{model}: {count} errors in a row",
+                    )
+                # Reset the counter so we only recommend skip once per streak
+                state.consecutive_errors[model] = 0
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def make_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="supervisor")
+    p.add_argument("--log-file", required=True, type=Path)
+    p.add_argument("--no-notify", action="store_true")
+    p.add_argument(
+        "--stuck-threshold-seconds",
+        type=int,
+        default=STUCK_THRESHOLD_SECONDS,
+        help="Idle time before flagging as stuck",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    if not args.log_file.exists():
+        print(f"log file not found: {args.log_file}", file=sys.stderr)
+        return 2
+    supervise(args.log_file, notify=not args.no_notify, stuck_threshold=args.stuck_threshold_seconds)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -124,10 +124,28 @@ def _find_owning_corpus(question_id: str, questions_by_corpus: dict) -> str:
     raise KeyError(f"no owning corpus for {question_id}")
 
 
-def _plan_units(questions_by_corpus: dict[str, dict], phases: set[int], depth: str) -> list[Unit]:
-    """Generate the full Unit set for the sweep — every cell across all phases."""
+def _plan_units(
+    questions_by_corpus: dict[str, dict],
+    phases: set[int],
+    depth: str,
+    models_filter: set[str] | None = None,
+) -> list[Unit]:
+    """Generate the full Unit set for the sweep — every cell across all phases.
+
+    ``models_filter`` (when set) restricts the model loops in phases 2-6 to
+    that subset. Useful for splitting Phase 4 across machines: a 32 GB Mac
+    mini runs the smaller 6 models while a bigger machine runs Gemma 26B
+    + Qwen3.6 35B in parallel.
+    """
     units: list[Unit] = []
     corpora = list(questions_by_corpus)
+
+    def _phase4_models() -> list[str]:
+        return [m for m in cfg.ALL_MODELS if models_filter is None or m in models_filter]
+
+    def _phase5_models() -> list[str]:
+        return [m for m in cfg.TOP_MODELS if models_filter is None or m in models_filter]
+
     for phase in sorted(phases):
         if phase == 0:
             for c in corpora:
@@ -137,14 +155,15 @@ def _plan_units(questions_by_corpus: dict[str, dict], phases: set[int], depth: s
                 for q in _question_ids(qs):
                     units.append(Unit(phase=1, corpus=c, model="claude-baseline", question_id=q, depth="n/a"))
         elif phase == 2:
-            # smoke — one model, one corpus. Skipped if cuad isn't in scope.
-            if "cuad" in questions_by_corpus:
+            # smoke — one model, one corpus. Skipped if cuad or qwen3.6-35b isn't in scope.
+            if "cuad" in questions_by_corpus and (models_filter is None or "qwen3.6-35b" in models_filter):
                 units.append(
                     Unit(phase=2, corpus="cuad", model="qwen3.6-35b", question_id="cuad-research-1", depth=depth)
                 )
         elif phase == 3:
-            # depth coverage — same model × all three depths on cuad. Skipped if cuad isn't in scope.
-            if "cuad" in questions_by_corpus:
+            # depth coverage — same model × all three depths on cuad. Skipped if cuad or
+            # qwen3.6-35b isn't in scope.
+            if "cuad" in questions_by_corpus and (models_filter is None or "qwen3.6-35b" in models_filter):
                 for d in cfg.DEPTHS:
                     for q in _question_ids(questions_by_corpus["cuad"]):
                         units.append(Unit(phase=3, corpus="cuad", model="qwen3.6-35b", question_id=q, depth=d))
@@ -152,18 +171,18 @@ def _plan_units(questions_by_corpus: dict[str, dict], phases: set[int], depth: s
             # Corpus is outer loop so each corpus change (= full re-ingest) happens only
             # once per corpus rather than once per (model, corpus) pair.
             for c, qs in questions_by_corpus.items():
-                for m in cfg.ALL_MODELS:
+                for m in _phase4_models():
                     for q in _question_ids(qs):
                         units.append(Unit(phase=4, corpus=c, model=m, question_id=q, depth=depth))
         elif phase == 5:
             # Same rationale: 3 re-ingests (one per corpus) instead of 6 (one per model×corpus).
             for c, qs in questions_by_corpus.items():
-                for m in cfg.TOP_MODELS:
+                for m in _phase5_models():
                     for q in _question_ids(qs):
                         units.append(Unit(phase=5, corpus=c, model=m, question_id=q, depth=depth))
         elif phase == 6:
             # unified pass — first 3 research questions from each available corpus
-            for m in cfg.TOP_MODELS:
+            for m in _phase5_models():
                 unified_qs: list[str] = []
                 for c in ("cuad", "enron", "synthetic"):
                     if c in questions_by_corpus:
@@ -316,10 +335,21 @@ def main(argv: list[str] | None = None) -> int:
             questions_by_corpus = {c: q for c, q in questions_by_corpus.items() if c in requested}
             log.info("--corpora filter: %s", sorted(questions_by_corpus))
 
+        # Apply --models filter: scope phase 2-6 model loops to listed models. Used for
+        # splitting Phase 4 across machines (32 GB Mac mini for the 6 smaller models, a
+        # bigger machine for Gemma 26B + Qwen3.6 35B).
+        models_filter: set[str] | None = None
+        if args.models:
+            models_filter = {m.strip() for m in args.models.split(",") if m.strip()}
+            unknown_m = models_filter - set(cfg.ALL_MODELS)
+            if unknown_m:
+                raise RuntimeError(f"--models has unknown values: {sorted(unknown_m)}. Known: {sorted(cfg.ALL_MODELS)}")
+            log.info("--models filter: %s", sorted(models_filter))
+
         # Plan units if state is empty
         phases = _phase_range(args.phases)
         if not sf.units():
-            sf.register(_plan_units(questions_by_corpus, phases, args.depth))
+            sf.register(_plan_units(questions_by_corpus, phases, args.depth, models_filter=models_filter))
             sf.save()
 
         # Apply --rerun / --skip

--- a/scripts/test_corpora/tests/test_plan_units.py
+++ b/scripts/test_corpora/tests/test_plan_units.py
@@ -1,0 +1,83 @@
+"""Tests for the unit-planning logic in sweep.py — particularly the --models filter
+and --corpora filter interaction with phase ranges."""
+
+from __future__ import annotations
+
+from scripts.test_corpora.runner.sweep import _plan_units
+
+
+def _qbc(corpora: list[str]) -> dict[str, dict]:
+    """Minimal questions_by_corpus stub: 1 research + 1 ask question per corpus,
+    no cross-language variants."""
+    return {
+        c: {
+            "research": [{"id": f"{c}-research-1", "text": "r1"}],
+            "ask": [{"id": f"{c}-ask-1", "text": "a1"}],
+        }
+        for c in corpora
+    }
+
+
+def test_models_filter_restricts_phase4_loop():
+    units = _plan_units(
+        _qbc(["cuad"]),
+        phases={4},
+        depth="standard",
+        models_filter={"qwen3-8b", "phi-4-mini"},
+    )
+    models = {u.model for u in units}
+    assert models == {"qwen3-8b", "phi-4-mini"}
+
+
+def test_models_filter_restricts_phase5_to_top_subset():
+    """Phase 5 normally includes both TOP_MODELS. A filter that excludes
+    qwen3.6-35b should leave only gemma-26b in Phase 5."""
+    units = _plan_units(
+        _qbc(["cuad"]),
+        phases={5},
+        depth="standard",
+        models_filter={"gemma-26b"},
+    )
+    models = {u.model for u in units}
+    assert models == {"gemma-26b"}
+
+
+def test_models_filter_excludes_phase2_smoke_when_qwen35_filtered_out():
+    """Phase 2 hard-codes qwen3.6-35b. If that model isn't in the filter, no
+    Phase 2 unit should be planned."""
+    units = _plan_units(
+        _qbc(["cuad"]),
+        phases={2},
+        depth="standard",
+        models_filter={"phi-4-mini"},
+    )
+    assert units == []
+
+
+def test_no_models_filter_means_all_models():
+    units = _plan_units(_qbc(["cuad"]), phases={4}, depth="standard", models_filter=None)
+    models = {u.model for u in units}
+    # Should be exactly the 8 ALL_MODELS
+    assert len(models) == 8
+
+
+def test_corpora_filter_phase0_only_lists_provided_corpora():
+    units = _plan_units(_qbc(["cuad"]), phases={0}, depth="standard")
+    assert {u.corpus for u in units} == {"cuad"}
+
+
+def test_phase4_corpus_then_model_ordering_minimizes_db_wipes():
+    """Critical for sweep cost: corpus is the outer loop so each corpus
+    re-ingest happens only once per phase, regardless of how many models
+    we sweep through. A model-outer/corpus-inner ordering would force a
+    DB wipe + ingest between every model, blowing up wall-clock by ~24x."""
+    units = _plan_units(
+        _qbc(["cuad", "enron"]),
+        phases={4},
+        depth="standard",
+        models_filter={"qwen3-8b", "phi-4-mini"},
+    )
+    # Walk the unit list and count corpus transitions
+    transitions = sum(1 for a, b in zip(units, units[1:]) if a.corpus != b.corpus)
+    # 2 corpora → exactly 1 transition (cuad block, then enron block)
+    assert transitions == 1

--- a/scripts/test_corpora/tests/test_supervisor.py
+++ b/scripts/test_corpora/tests/test_supervisor.py
@@ -1,0 +1,153 @@
+"""Tests for the sweep supervisor's classifier + state machine.
+
+Network/notification side-effects are not exercised here — we just feed
+log lines through ``classify`` and ``supervise`` and assert what comes
+out on stdout."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from scripts.test_corpora.runner.supervisor import (
+    PATTERNS,
+    classify,
+)
+
+# ── classifier ───────────────────────────────────────────────────────────────
+
+
+def test_classify_sample_card():
+    line = "[Phase 4 · qwen3-8b · cuad · cuad-research-3] elapsed 0:42:13"
+    kind, groups = classify(line)
+    assert kind == "sample_card"
+    assert groups["phase"] == "4"
+    assert groups["model"] == "qwen3-8b"
+    assert groups["corpus"] == "cuad"
+    assert groups["qid"] == "cuad-research-3"
+
+
+def test_classify_phase_boundary():
+    line = "=== Phase 4 complete ==="
+    kind, groups = classify(line)
+    assert kind == "phase_boundary"
+    assert groups["phase"] == "4"
+
+
+def test_classify_completion():
+    line = "2026-05-05 13:00:00 INFO sweep complete after 8347.2s"
+    kind, _ = classify(line)
+    assert kind == "completion"
+
+
+def test_classify_error_traceback():
+    line = "Traceback (most recent call last):"
+    kind, _ = classify(line)
+    assert kind == "error"
+
+
+def test_classify_rate_limit():
+    line = "anthropic.RateLimitError: Error code: 429"
+    kind, _ = classify(line)
+    assert kind == "rate_limit"
+
+
+def test_classify_model_activate():
+    line = "2026-05-05 12:34:56 INFO activating model qwen3.6-35b (was qwen3-8b)"
+    kind, groups = classify(line)
+    assert kind == "model_activate"
+    assert groups["model"] == "qwen3.6-35b"
+
+
+def test_classify_no_match():
+    line = "2026-05-05 12:34:56 INFO routine info, nothing special"
+    assert classify(line) is None
+
+
+def test_pattern_priority_completion_beats_phase_boundary():
+    """Lines where multiple patterns could match must resolve in declaration order."""
+    line = "sweep complete after 100s. Phase 4 complete summary follows..."
+    assert PATTERNS["completion"].search(line)
+    kind, _ = classify(line)
+    assert kind == "completion"
+
+
+# ── end-to-end ───────────────────────────────────────────────────────────────
+
+
+def _run_supervisor_against(log_lines: list[str], tmp_path: Path) -> list[dict]:
+    log = tmp_path / "test.log"
+    # Pre-write completion sentinel so supervisor exits after consuming the input
+    log.write_text("\n".join(log_lines) + "\n")
+
+    out = io.StringIO()
+    # The tail loop seeks to end-of-file before reading. Pre-populate the file
+    # then call supervise — but it'd loop forever waiting for new content. So
+    # we patch tail_lines via a local generator.
+    from scripts.test_corpora.runner import supervisor as sup
+
+    original = sup.tail_lines
+
+    def fake_tail(path, poll_seconds=1.0):
+        yield from log.read_text().splitlines()
+
+    sup.tail_lines = fake_tail
+    try:
+        sup.supervise(log, out=out, notify=False, stuck_threshold=999)
+    finally:
+        sup.tail_lines = original
+
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+def test_supervisor_emits_phase_boundary_event(tmp_path: Path):
+    events = _run_supervisor_against(
+        [
+            "INFO some unrelated line",
+            "=== Phase 4 complete ===",
+            "sweep complete after 1234.5s",
+        ],
+        tmp_path,
+    )
+    types = [e["event"] for e in events]
+    assert "phase_boundary" in types
+    assert "completion" in types
+    pb = next(e for e in events if e["event"] == "phase_boundary")
+    assert pb["phase"] == 4
+
+
+def test_supervisor_attributes_consecutive_errors_to_active_model(tmp_path: Path):
+    """3 consecutive errors against the same model should emit a skip_recommendation."""
+    events = _run_supervisor_against(
+        [
+            "INFO activating model deepseek-r1-8b (was None)",
+            "ERROR research task failed: timeout",
+            "ERROR research task failed: timeout",
+            "ERROR research task failed: timeout",
+            "sweep complete after 10s",
+        ],
+        tmp_path,
+    )
+    types = [e["event"] for e in events]
+    assert "skip_recommendation" in types
+    rec = next(e for e in events if e["event"] == "skip_recommendation")
+    assert rec["model"] == "deepseek-r1-8b"
+
+
+def test_supervisor_resets_error_counter_on_sample_card(tmp_path: Path):
+    """A successful completion (sample_card) between errors clears the streak."""
+    events = _run_supervisor_against(
+        [
+            "INFO activating model qwen3-4b (was None)",
+            "ERROR something bad",
+            "ERROR something else bad",
+            "[Phase 4 · qwen3-4b · cuad · cuad-ask-1] elapsed 0:01:00",
+            "ERROR another error",
+            "sweep complete after 10s",
+        ],
+        tmp_path,
+    )
+    types = [e["event"] for e in events]
+    # Only 1 error after the sample_card → no skip recommendation
+    assert "skip_recommendation" not in types


### PR DESCRIPTION
## Summary

Three changes that turn the test-corpora harness from "babysit a 50-hour single-machine run" into "kick it off across two machines, get pinged at phase boundaries":

1. **`--models` filter** wired through `_plan_units` in `runner/sweep.py`. Restricts the sweep to a subset of the 8 LLM models — required for splitting Phase 4 across machines (32 GB Mac mini for the 6 smaller models in parallel with a bigger machine running Gemma 26B + Qwen3.6 35B). Phase 2/3 (hard-code `qwen3.6-35b`) skip cleanly when that model isn't in scope.

2. **`runner/supervisor.py`** — a small watchdog that tails the harness log, posts macOS notifications for phase boundaries / completion / errors / rate-limits, and emits a `skip_recommendation` event after 3 consecutive errors against the same model. Pattern-matching only; a Claude subagent can sit on top for ambiguous cases.

3. **`RUNBOOK.md`** — operations doc with an architecture diagram, the full split-across-two-machines flow, rsync handoff, recovery procedures, and a Claude subagent prompt template for unattended supervision.

## What changed

| File | Purpose |
| --- | --- |
| `scripts/test_corpora/runner/sweep.py` | `_plan_units` accepts `models_filter`; CLI wires `args.models` to it |
| `scripts/test_corpora/runner/supervisor.py` | New 220-line watchdog. Tails log, classifies events via regex, posts notifications, emits structured JSON to stdout |
| `scripts/test_corpora/RUNBOOK.md` | New operations doc |
| `scripts/test_corpora/tests/test_plan_units.py` | 6 new tests for the filter + corpus-outer ordering invariant |
| `scripts/test_corpora/tests/test_supervisor.py` | 11 new tests for classifier + state machine |

## Test plan

- [x] `cd scripts/test_corpora && uv run pytest -q` — 55 passing
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] On a real sweep, verify supervisor's `phase_boundary` / `completion` events fire macOS notifications
- [ ] On a real sweep, verify `--models gemma-26b,qwen3.6-35b` actually scopes Phase 4 (state file shows only those 2 models in the unit list)

## Why now

After PR #276 landed the harness, the user's smoke test surfaced two operational concerns:
1. The sweep would take ~50 hours of wall-clock — far too long to babysit.
2. Their 32 GB M4 Pro Mac mini can run 6 of the 8 models comfortably, freeing the bigger machine for the top 2. But the harness had no way to scope a sweep to a subset of models.

`--models` solves (2). `supervisor.py` + the `RUNBOOK` solve (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
