### PR TITLE
fix(macos): set JAVA_HOME/PATH for Tika child process

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/Services/TikaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/TikaService.swift
@@ -28,6 +28,13 @@ final class TikaService: ManagedService {
             "--port", String(port),
         ]
 
+        // Tika 3.x forks a child JVM that resolves `java` from PATH; point it at the bundled JRE.
+        let javaHome = Bundle.main.resourceURL!.appendingPathComponent("java/Contents/Home").path
+        proc.environment = [
+            "JAVA_HOME": javaHome,
+            "PATH": "\(javaHome)/bin:/usr/bin:/bin",
+        ]
+
         let pipe = Log.createPipe(category: "tika")
         proc.standardOutput = pipe
         proc.standardError = pipe


### PR DESCRIPTION
## Summary

- Tika 3.x runs a watchdog model: the parent JVM (launched with the bundled JRE) spawns a *child* JVM that does the actual work, and the child resolves `java` from `PATH` instead of inheriting the parent's executable.
- On a Mac with no system JDK installed (clean Mac mini / Studio target), the child fell through to macOS's `/usr/bin/java` stub ("Unable to locate a Java Runtime"), the fork died, and the parent watchdog kept retrying — surfacing only as `[Tika] Health check timeout` with no Tika stderr in the unified log.
- Set `JAVA_HOME` and a minimal `PATH` on the child `Process` so the bundled Temurin JRE is used for both parent and forked child.

The bug has been latent since Tika 3.x was adopted; it didn't show up on developer Macs because they typically have a system JDK on `PATH`.

## Reproduction

Running the bundled command directly with no env, exactly as `TikaService` invokes it:
```
$ <bundled java> -jar <bundled tika-server.jar> --host 127.0.0.1 --port 19998
The operation couldn't be completed. Unable to locate a Java Runtime.
ERROR ... Failed to start forked process -- forked is not alive
```
With `JAVA_HOME` and `PATH` set to the bundled JRE, Tika starts and binds the port within ~1s.

## Test plan

- [ ] Build Server app on a clean Mac without system Java; confirm `[Tika] Health check timeout` no longer appears and Tika serves on the configured port
- [ ] Confirm Tika still starts on a developer Mac with a system JDK installed
- [ ] Run a document through extraction (e.g. drop a PDF in a watched folder) and verify the `extract` stage completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)