### PR TITLE
fix(test-corpora): recover lost API_BASE default fix from #280's branch

### DIFF
--- a/scripts/test_corpora/README.md
+++ b/scripts/test_corpora/README.md
@@ -9,8 +9,12 @@ See [`docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md`](../..
 
 ## Quickstart
 
-Prerequisite: Harbor Clerk is running locally — either the macOS Server
-app or `docker compose up`. The harness talks to it over `https://localhost`.
+Prerequisite: Harbor Clerk is running locally — either the macOS Server menubar app or `docker compose up`.
+
+| Setup | URL | TLS? |
+| --- | --- | --- |
+| **macOS native** | `http://localhost:8100` (default; check Preferences if changed) | no |
+| **Docker Compose** | `https://localhost:443` (Caddy + self-signed) | yes — pass `--insecure` |
 
 The harness has its own `pyproject.toml` and venv (separate from Harbor
 Clerk's main venv, since it needs different deps — `anthropic`, `mcp`,
@@ -22,11 +26,12 @@ uv picks the harness venv but the cwd stays at the repo root (so the
 export ANTHROPIC_API_KEY="sk-ant-..."
 export HC_USERNAME="admin@example.com"
 export HC_PASSWORD="..."
+export HC_API_BASE="http://localhost:8100"   # or "https://localhost" for Docker
 cd /path/to/mcp-gateway
 uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
     --run-id 2026-05-05-full \
-    --workdir ~/Library/Application\ Support/Harbor\ Clerk/test-corpora \
-    --insecure   # if Harbor Clerk uses Caddy's self-signed cert
+    --workdir ~/Library/Application\ Support/Harbor\ Clerk/test-corpora
+    # add --insecure if you're on Docker Compose with Caddy's self-signed cert
 ```
 
 First-time setup (one-time per fresh harness venv):
@@ -49,7 +54,7 @@ env vars are missing, only `--phases 0` and `--dry-run` will succeed.
 # Phase 0 acquisition for CUAD only — skips the synthetic generation that
 # would cost ~$3-5 in Anthropic API spend
 uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
-    --run-id smoke-$(date +%s) --phases 0 --corpora cuad --insecure
+    --run-id smoke-$(date +%s) --phases 0 --corpora cuad
 ```
 
 `--phases` filters to a subset of phases (range or comma list): `--phases 0`,
@@ -84,7 +89,7 @@ uv run python -m scripts.test_corpora.runner.sweep \
 
 ## Troubleshooting
 
-- **API unreachable:** check `curl -k https://localhost/api/system/health`
+- **API unreachable:** check `curl "$HC_API_BASE/api/system/health"`. The default `HC_API_BASE` is `https://localhost` (Docker); on macOS native, set it to `http://localhost:8100` (or whatever port your Harbor Clerk Server is configured for).
 - **State file locked:** another runner is using it; check `state.lock`. After a hard crash, delete the lock file manually after confirming no `python -m scripts.test_corpora.runner.sweep` process is running.
 - **DB pool exhausted under sweep load:** see `docs/debugging.md`
 - **`401 Unauthorized` on Phase 1+:** `HC_USERNAME` / `HC_PASSWORD` aren't set or the account isn't admin. Phase 4 needs admin (it calls `/system/delete-all-documents`).
@@ -98,7 +103,7 @@ These are known footguns surfaced during the build-out:
 - **Enron HuggingFace dataset.** `corbt/enron-emails` may not exist or may have a different layout. Alternates: `snoop2head/enron_aeslc_emails`. Edit `_download_corpus` in `corpora/enron.py` if the real download fails.
 - **Synthetic generation cost.** Default produces ~280 documents via Sonnet 4.6, costing roughly $3-5 in API spend. Run a small subset first (e.g. `synthetic.acquire(workdir, doc_counts={"invoice": 5}, ocr_subset_count=0)`) to spot-check tone and structure before committing to the full set.
 - **spaCy entity-overlap test.** `test_entity_overlap_english` requires `en_core_web_sm` to be installed in whichever venv pytest uses. If it fails with `ModuleNotFoundError`, install the model: `uv run python -m spacy download en_core_web_sm`. Harbor Clerk's main venv already has it; the harness's own venv may not.
-- **Self-signed TLS.** Pass `--insecure` if your local Harbor Clerk uses Caddy's self-signed cert (the default for the macOS native app).
+- **Self-signed TLS.** Pass `--insecure` only if you're running Harbor Clerk via Docker Compose (Caddy + self-signed cert). The macOS native app serves plain HTTP on `localhost:<api_port>` — `--insecure` is a no-op there but harmless.
 - **Model-switch warmup.** Each `activate_model()` triggers llama-server to (re)load weights. For a 22 GB model this takes 30-60 s before queries can succeed. The harness's `wait_for_model_ready` polls until ready, but the first cell of a new model still pays this cost.
 
 ## Running the test suite

--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -93,18 +93,42 @@ mkdir -p ~/sweep-logs
 
 ### On both machines
 
-Check Harbor Clerk is running and admin login works:
+Harbor Clerk listens differently depending on how you run it:
+
+| Setup | URL | TLS? |
+| --- | --- | --- |
+| **macOS native** (Harbor Clerk Server menubar app) | `http://localhost:<api_port>` (default 8100, configurable in Preferences) | no |
+| **Docker Compose** | `https://localhost:443` (Caddy with self-signed cert) | yes (use `--insecure` to skip verify) |
+
+Find your `api_port` if you've changed the default:
 
 ```bash
-curl -k https://localhost/api/system/health    # expect {ok: true}
+jq .api_port "$HOME/Library/Application Support/Harbor Clerk/config.json"
 ```
 
-Set env vars for the sweep:
+Set env vars for the sweep. Adjust `HC_API_BASE` to match your setup:
 
 ```bash
+# macOS native (most common)
+export HC_API_BASE="http://localhost:8100"
+
+# OR Docker Compose
+# export HC_API_BASE="https://localhost"   # then add --insecure to sweep invocations
+
 export ANTHROPIC_API_KEY="sk-ant-..."
 export HC_USERNAME="admin@example.com"          # must be admin role
 export HC_PASSWORD="..."
+```
+
+Verify Harbor Clerk is up and admin login works:
+
+```bash
+curl "$HC_API_BASE/api/system/health"          # expect {ok: true, ...}
+
+curl -X POST "$HC_API_BASE/api/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$HC_USERNAME\",\"password\":\"$HC_PASSWORD\"}" | jq .access_token
+# expect a non-null JWT string
 ```
 
 ---
@@ -120,7 +144,7 @@ cd /path/to/mcp-gateway
 tmux new -d -s sweep-prep "uv --project scripts/test_corpora run python -m \
     scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 0-1 --insecure \
+    --phases 0-1 \
     2>&1 | tee ~/sweep-logs/phase01-big.log"
 
 # detach is automatic with -d. Reattach with: tmux attach -t sweep-prep
@@ -167,7 +191,7 @@ tmux new -d -s sweep-mini "uv --project scripts/test_corpora run python -m \
     --run-id $RUN --workdir \"$WORKDIR\" \
     --phases 4 \
     --models smollm3-3b,qwen3-4b,phi-4-mini,qwen3-8b,deepseek-r1-8b,gpt-oss-20b \
-    --insecure \
+    \
     2>&1 | tee ~/sweep-logs/phase4-mini.log"
 
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
@@ -187,7 +211,7 @@ tmux new -d -s sweep-big "uv --project scripts/test_corpora run python -m \
     --run-id $RUN --workdir \"$WORKDIR\" \
     --phases 4 \
     --models gemma-26b,qwen3.6-35b \
-    --insecure \
+    \
     2>&1 | tee ~/sweep-logs/phase4-big.log"
 
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
@@ -224,7 +248,7 @@ cd /path/to/mcp-gateway
 tmux new -d -s sweep-parity "uv --project scripts/test_corpora run python -m \
     scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 5 --insecure \
+    --phases 5 \
     2>&1 | tee ~/sweep-logs/phase5-big.log"
 
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
@@ -244,7 +268,7 @@ cd /path/to/mcp-gateway
 tmux new -d -s sweep-unified "uv --project scripts/test_corpora run python -m \
     scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 6 --insecure \
+    --phases 6 \
     2>&1 | tee ~/sweep-logs/phase6-big.log"
 ```
 
@@ -283,7 +307,7 @@ The harness state file (`results/<run-id>/state.json`) tracks every cell. To res
 # add --resume to any sweep invocation
 uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir "$WORKDIR" \
-    --phases 4 --models <same-list> --resume --insecure 2>&1 | tee -a ~/sweep-logs/phase4-mini.log
+    --phases 4 --models <same-list> --resume 2>&1 | tee -a ~/sweep-logs/phase4-mini.log
 ```
 
 The `--resume` flag is largely a no-op — the state file already auto-resumes — but it makes intent explicit. Stale `IN_PROGRESS` rows older than 2× the time-budget revert to `PENDING` automatically.
@@ -307,7 +331,7 @@ rm "$WORKDIR/results/$RUN/state.json.lock"
 Restart Harbor Clerk's LLM model via the UI or:
 
 ```bash
-curl -k -X PUT https://localhost/api/chat/models/<model_id>/activate
+curl -X PUT "$HC_API_BASE/api/chat/models/<model_id>/activate"
 ```
 
 Then re-run the sweep with `--resume`.
@@ -326,7 +350,7 @@ Skip it:
 ```bash
 uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir "$WORKDIR" \
-    --skip "model=deepseek-r1-8b" --insecure
+    --skip "model=deepseek-r1-8b"
 ```
 
 This is exactly what the supervisor recommends after 3 consecutive errors. Re-run the sweep to skip the rest of that model's units.

--- a/scripts/test_corpora/conftest.py
+++ b/scripts/test_corpora/conftest.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-API_BASE = os.environ.get("HC_API_BASE", "https://localhost")
+# Default targets the macOS native Harbor Clerk Server on its default api_port.
+# Override via HC_API_BASE if you've changed the port (Preferences → API port)
+# or if you're running Harbor Clerk via Docker Compose (use "https://localhost"
+# and pass --insecure on sweep invocations to tolerate Caddy's self-signed cert).
+API_BASE = os.environ.get("HC_API_BASE", "http://localhost:8100")
 ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
 
 # All eight downloaded models, by Harbor Clerk model_id. Phase 4 sweeps over


### PR DESCRIPTION
## Summary

Recovers commit `34268fa` from `feat/test-corpora-supervisor` (PR #280's branch) — a follow-up fix that was committed AFTER #280 squash-merged and consequently never made it to main.

The orphan commit (cherry-picked here as `cc66c5d`) updates the test-corpora harness so its default API base is the macOS native app's `http://localhost:8100` instead of the Docker-Caddy `https://localhost`. Without this, every macOS-native invocation of the harness has to pass `--insecure` and an explicit `HC_API_BASE` env var; the README and RUNBOOK promised that this was unnecessary.

### What changes

- `scripts/test_corpora/conftest.py` — default `API_BASE` constant flips to `http://localhost:8100`
- `scripts/test_corpora/README.md` — Quickstart table covers both setups; example commands drop the gratuitous `--insecure`
- `scripts/test_corpora/RUNBOOK.md` — pre-flight section gains the same setup table + `HC_API_BASE` env var pattern + `curl "$HC_API_BASE/api/system/health"` instead of hardcoded `curl -k https://localhost/...`

### Why this was lost

`feat/test-corpora-supervisor` was squash-merged as #280 on 2026-05-04 23:36 EDT. About 14h later, the original developer pushed `34268fa` to the same branch (which was already merged) and it was never re-opened as a follow-up PR. Discovered today during a sweep of post-#270 PR branches for orphan commits.

## Test plan

- [x] `git diff origin/main..HEAD` matches `git show 34268fa` — no drift
- [ ] Harness still imports cleanly (`uv --project scripts/test_corpora run python -c "import scripts.test_corpora.runner.sweep"`)
- [ ] No CI surface: scripts/test_corpora/ is its own venv, not in main pyproject

🤖 Generated with [Claude Code](https://claude.com/claude-code)
