### PR TITLE
fix(supervisor): rate_limit regex no longer matches HF anon-download warning

### DIFF
--- a/scripts/test_corpora/runner/supervisor.py
+++ b/scripts/test_corpora/runner/supervisor.py
@@ -51,7 +51,16 @@ PATTERNS: dict[str, re.Pattern] = {
     "sample_card": re.compile(r"^\[Phase (?P<phase>\d+) · (?P<model>[\w.\-]+) · (?P<corpus>\w+) · (?P<qid>[\w-]+)\]"),
     "blocked": re.compile(r"sweep stops|^blocked\b", re.IGNORECASE),
     "error": re.compile(r"\b(ERROR|Traceback|OOM|Killed|Connection refused|HTTPStatusError|ReadTimeout)\b"),
-    "rate_limit": re.compile(r"\b429\b|rate.?limit", re.IGNORECASE),
+    # Match real rate-limit signals only:
+    #   - HTTP 429 status codes
+    #   - SDK exception class names (Anthropic, OpenAI)
+    #   - explicit "exceeded" / "hit" / "throttled" wording
+    # Crucially this does NOT match HuggingFace's informational warning
+    # "Please set a HF_TOKEN to enable higher rate limits", which is benign.
+    "rate_limit": re.compile(
+        r"\b429\b|RateLimitError|rate.?limit(?:[\- ](?:exceed|hit|reach|throttl)|ed\b)",
+        re.IGNORECASE,
+    ),
     "model_activate": re.compile(r"activating model (?P<model>[\w.\-]+)"),
     "ingest_start": re.compile(r"clearing existing watch folders|delete_all_documents before ingesting"),
 }

--- a/scripts/test_corpora/tests/test_supervisor.py
+++ b/scripts/test_corpora/tests/test_supervisor.py
@@ -53,6 +53,30 @@ def test_classify_rate_limit():
     assert kind == "rate_limit"
 
 
+def test_classify_does_not_match_hf_unauthenticated_warning():
+    """HF prints this on every anonymous download — it's informational, not a
+    rate-limit hit. The supervisor must not fire `rate_limit` events on it."""
+    line = (
+        "WARNING huggingface_hub.utils._http Warning: You are sending "
+        "unauthenticated requests to the HF Hub. Please set a HF_TOKEN to "
+        "enable higher rate limits and faster downloads."
+    )
+    assert classify(line) is None
+
+
+def test_classify_rate_limit_phrases():
+    """Exhaustive check of phrases that SHOULD trigger rate_limit."""
+    for line in (
+        "Error code: 429",
+        "anthropic.RateLimitError: too many requests",
+        "rate limit exceeded after 5 retries",
+        "we got rate-limited by upstream",
+        "request was rate limit hit at 17:53",
+    ):
+        kind, _ = classify(line)
+        assert kind == "rate_limit", f"missed: {line!r}"
+
+
 def test_classify_model_activate():
     line = "2026-05-05 12:34:56 INFO activating model qwen3.6-35b (was qwen3-8b)"
     kind, groups = classify(line)


### PR DESCRIPTION
## Summary

Tightens the supervisor's `rate_limit` event regex so HuggingFace's informational anonymous-download warning doesn't trigger false alarms.

## Why

Caught during the user's first real Phase 0 dry-run. The supervisor was firing `rate_limit` events on this benign HF SDK warning that prints on every anonymous download:

```
Warning: You are sending unauthenticated requests to the HF Hub.
Please set a HF_TOKEN to enable higher rate limits and faster downloads.
```

The previous regex `\b429\b|rate.?limit` (case-insensitive) over-matched on `rate limits` (plural). The new regex matches only:

- HTTP 429 status codes
- `RateLimitError` exception class names (Anthropic, OpenAI)
- Wording with explicit "exceeded" / "hit" / "reached" / "throttled" / `rate-limited`

## Tests

- New negative test: `test_classify_does_not_match_hf_unauthenticated_warning` — locks in that the HF warning gets `None` from the classifier
- New positive test: `test_classify_rate_limit_phrases` — exercises 5 real rate-limit phrasings to lock in coverage

13/13 supervisor tests pass; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
