### PR TITLE
fix(supervisor): treat any log line as liveness heartbeat

### DIFF
--- a/scripts/test_corpora/runner/supervisor.py
+++ b/scripts/test_corpora/runner/supervisor.py
@@ -162,16 +162,23 @@ def supervise(
     state = SupervisorState.fresh()
 
     for line in tail_lines(log_path):
-        # Stuck check (fires when tail returns None and we've been idle too long)
+        # Stuck check (fires when tail returns None and we've been idle too long).
+        # "Stuck" means the log file itself has stopped growing — a true hang.
+        # Phases like baseline generation don't emit sample_cards but do produce
+        # plenty of routine httpx/INFO log activity, so we treat ANY line as a
+        # heartbeat. last_progress_at is updated on every line read below.
         if line is None:
             idle = time.time() - state.last_progress_at
             if idle > stuck_threshold:
                 event = {"event": "stuck", "idle_seconds": int(idle), "log": str(log_path)}
                 emit(event, out)
                 if notify:
-                    macos_notify("Sweep stuck", f"No progress in {int(idle / 60)} min")
+                    macos_notify("Sweep stuck", f"No log activity in {int(idle / 60)} min")
                 state.last_progress_at = time.time()  # reset to avoid re-firing every poll
             continue
+
+        # Any incoming log line counts as evidence the harness is alive.
+        state.last_progress_at = time.time()
 
         match = classify(line)
         if not match:

--- a/scripts/test_corpora/tests/test_supervisor.py
+++ b/scripts/test_corpora/tests/test_supervisor.py
@@ -159,6 +159,46 @@ def test_supervisor_attributes_consecutive_errors_to_active_model(tmp_path: Path
     assert rec["model"] == "deepseek-r1-8b"
 
 
+def test_supervisor_does_not_flag_stuck_when_log_is_noisy(tmp_path: Path):
+    """Phase 1 baseline generation prints lots of unrecognized httpx INFO lines
+    but no sample_cards. The supervisor must treat any log activity as
+    liveness — only true silence (no lines at all) should trigger 'stuck'."""
+    log = tmp_path / "test.log"
+    # Many unrecognized lines, then a completion to end the supervisor cleanly.
+    log.write_text(
+        "\n".join(
+            [
+                "INFO httpx HTTP Request: POST https://api.anthropic.com/v1/messages 200 OK",
+                "INFO httpx HTTP Request: POST https://api.anthropic.com/v1/messages 200 OK",
+                "INFO httpx HTTP Request: POST https://api.anthropic.com/v1/messages 200 OK",
+                "sweep complete after 100s",
+            ]
+        )
+        + "\n"
+    )
+
+    out = io.StringIO()
+    from scripts.test_corpora.runner import supervisor as sup
+
+    original = sup.tail_lines
+
+    def fake_tail(path, poll_seconds=1.0):
+        yield from log.read_text().splitlines()
+
+    sup.tail_lines = fake_tail
+    try:
+        # stuck_threshold = 0 means any idle window triggers stuck — but since
+        # the lines are read sequentially without an idle gap, none should fire.
+        sup.supervise(log, out=out, notify=False, stuck_threshold=0)
+    finally:
+        sup.tail_lines = original
+
+    events = [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+    types = [e["event"] for e in events]
+    assert "stuck" not in types
+    assert "completion" in types
+
+
 def test_supervisor_resets_error_counter_on_sample_card(tmp_path: Path):
     """A successful completion (sample_card) between errors clears the streak."""
     events = _run_supervisor_against(


### PR DESCRIPTION
## Summary

Fixes a false-positive `stuck` alert during Phase 1 baseline generation.

The user kicked off their first real Phase 0+1 run and the supervisor fired this every 30 minutes:

```json
{"event": "stuck", "idle_seconds": 1800, "log": "/Users/alex/sweep-logs/phase01-big.log"}
```

Meanwhile the harness log was full of healthy Anthropic API activity:

```
2026-05-05 18:14:11 INFO httpx HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
2026-05-05 18:14:40 INFO httpx HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
...
```

Root cause: the supervisor's `last_progress_at` only advanced on classifier matches (`sample_card`, `phase_boundary`, etc.). Phase 1 doesn't emit `sample_card`s — the sampler runs in Phases 4/5 only — so 30+ minutes of healthy Sonnet tool-call activity registered as 1800s of "no progress."

## Fix

Move the `last_progress_at = time.time()` update into the main loop so **any** log line counts as a liveness heartbeat. `stuck` now means the log file has genuinely stopped growing — a true process hang — rather than the weaker "no recognized progress events" signal.

## Test plan

- [x] New regression test `test_supervisor_does_not_flag_stuck_when_log_is_noisy` feeds 3 unrecognized httpx INFO lines + a completion through the supervisor with `stuck_threshold=0` and asserts no `stuck` event is emitted
- [x] All 14 supervisor tests + 6 plan_units tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
