### PR TITLE
feat(supervisor): periodic heartbeat events with progress summary

### DIFF
--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -156,7 +156,12 @@ In a second terminal, start the supervisor:
 # on BIG
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
     scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase01-big.log
+    --log-file ~/sweep-logs/phase01-big.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+# --workdir + --run-id let the heartbeat events include real progress
+# numbers (state.json summary, corpus/baseline file counts).
+# --heartbeat-seconds N changes the cadence (default 600s = 10 min,
+# 0 disables).
 ```
 
 Expected wall-clock: ~10 min for Phase 0 (synthetic generation dominates) + ~30-60 min for Phase 1 (48 questions × ~30-60 s each, Sonnet tool-call rounds).
@@ -196,7 +201,8 @@ tmux new -d -s sweep-mini "uv --project scripts/test_corpora run python -m \
 
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
     scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase4-mini.log
+    --log-file ~/sweep-logs/phase4-mini.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
 ```
 
 Wall-clock estimate: 6 models × 50 questions × ~5 min average = **~25 hours**. The corpus-outer loop ordering means only 3 DB wipes total (one per corpus), not 18.
@@ -216,7 +222,8 @@ tmux new -d -s sweep-big "uv --project scripts/test_corpora run python -m \
 
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
     scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase4-big.log
+    --log-file ~/sweep-logs/phase4-big.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
 ```
 
 Wall-clock estimate: 2 models × 50 questions × ~10-15 min average = **~17-25 hours** (the larger models are slower).
@@ -253,7 +260,8 @@ tmux new -d -s sweep-parity "uv --project scripts/test_corpora run python -m \
 
 uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
     scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase5-big.log
+    --log-file ~/sweep-logs/phase5-big.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
 ```
 
 Wall-clock estimate: ~17-25 hours of model runs + ~$1-2 in Sonnet judge calls (100 calls × ~$0.01-0.02 each).

--- a/scripts/test_corpora/runner/supervisor.py
+++ b/scripts/test_corpora/runner/supervisor.py
@@ -68,6 +68,11 @@ PATTERNS: dict[str, re.Pattern] = {
 # How long without ANY recognised activity before we flag the sweep as stuck.
 STUCK_THRESHOLD_SECONDS = 30 * 60
 
+# How often to emit a "heartbeat" event with summary stats. Useful as a
+# liveness check during long Phase 0 / Phase 1 stretches that don't emit
+# sample_cards. Default 10 minutes; pass --heartbeat-seconds 0 to disable.
+HEARTBEAT_INTERVAL_SECONDS = 10 * 60
+
 
 # ── Auto-skip rules ──────────────────────────────────────────────────────────
 #
@@ -81,7 +86,11 @@ CONSECUTIVE_ERROR_THRESHOLD = 3
 
 @dataclasses.dataclass
 class SupervisorState:
+    started_at: float
     last_progress_at: float
+    last_heartbeat_at: float
+    last_classifier_match_at: float
+    lines_seen: int
     # Per-model error streak. A sample_card for that model clears it. The streak
     # is intentionally model-only, not per-(model, corpus): if a model is broken
     # for one corpus it'll usually be broken for all of them, so attributing the
@@ -92,12 +101,63 @@ class SupervisorState:
 
     @classmethod
     def fresh(cls) -> SupervisorState:
+        now = time.time()
         return cls(
-            last_progress_at=time.time(),
+            started_at=now,
+            last_progress_at=now,
+            last_heartbeat_at=now,
+            last_classifier_match_at=now,
+            lines_seen=0,
             consecutive_errors=defaultdict(int),
             last_phase_seen=None,
             current_model=None,
         )
+
+
+# ── Progress probe ────────────────────────────────────────────────────────────
+
+
+def summarize_progress(workdir: Path | None, run_id: str | None) -> dict:
+    """Read state.json + corpus / baseline / response dirs and return a
+    summary dict for inclusion in heartbeat events. Empty dict when neither
+    workdir nor run_id is set, which is the no-config case."""
+    if not workdir or not run_id:
+        return {}
+    summary: dict[str, object] = {}
+
+    state_path = workdir / "results" / run_id / "state.json"
+    if state_path.exists():
+        try:
+            data = json.loads(state_path.read_text())
+            by_phase: dict[str, dict[str, int]] = {}
+            for u in data.get("units", []):
+                phase_key = str(u.get("phase"))
+                status = u.get("status", "?")
+                by_phase.setdefault(phase_key, {})
+                by_phase[phase_key][status] = by_phase[phase_key].get(status, 0) + 1
+            summary["state"] = by_phase
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    # Per-corpus ingest dir file counts (Phase 0 visibility).
+    for corpus in ("cuad", "enron", "synthetic"):
+        ingest = workdir / corpus / "ingest"
+        if ingest.exists():
+            summary[f"corpus_{corpus}_files"] = sum(1 for _ in ingest.glob("*"))
+
+    # Per-corpus baseline counts (Phase 1 visibility).
+    baselines = workdir / "results" / run_id / "baselines"
+    if baselines.exists():
+        for corpus_dir in baselines.iterdir():
+            if corpus_dir.is_dir():
+                summary[f"baselines_{corpus_dir.name}"] = sum(1 for _ in corpus_dir.glob("*.json"))
+
+    # Total response count (Phase 4/5 visibility — flat sum, not per model).
+    responses = workdir / "results" / run_id / "responses"
+    if responses.exists():
+        summary["responses_total"] = sum(1 for _ in responses.rglob("*.json"))
+
+    return summary
 
 
 # ── Notifications ─────────────────────────────────────────────────────────────
@@ -152,16 +212,73 @@ def emit(event: dict, out: TextIO) -> None:
     out.flush()
 
 
+def _maybe_heartbeat(
+    state: SupervisorState,
+    out: TextIO,
+    log_path: Path,
+    workdir: Path | None,
+    run_id: str | None,
+    interval: float,
+) -> None:
+    """Emit a heartbeat event if enough time has passed since the last one.
+    Heartbeats include uptime + lines seen + state.json summary so the
+    operator (or a downstream subagent) can see real progress without
+    waiting for the harness's next sample_card."""
+    if interval <= 0:
+        return
+    now = time.time()
+    if now - state.last_heartbeat_at < interval:
+        return
+    state.last_heartbeat_at = now
+    event: dict = {
+        "event": "heartbeat",
+        "uptime_seconds": int(now - state.started_at),
+        "lines_seen": state.lines_seen,
+        "seconds_since_last_match": int(now - state.last_classifier_match_at),
+        "log": str(log_path),
+    }
+    progress = summarize_progress(workdir, run_id)
+    if progress:
+        event["progress"] = progress
+    emit(event, out)
+
+
 def supervise(
     log_path: Path,
     out: TextIO = sys.stdout,
     notify: bool = True,
     stuck_threshold: float = STUCK_THRESHOLD_SECONDS,
+    heartbeat_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
+    workdir: Path | None = None,
+    run_id: str | None = None,
 ) -> None:
     """Main loop. Returns only when 'completion' is seen or the log file disappears."""
     state = SupervisorState.fresh()
 
+    # Initial heartbeat at startup so the operator gets immediate feedback
+    # ("supervisor is alive, here's the current state of the sweep") rather
+    # than silence until the first classifier match.
+    if heartbeat_seconds > 0:
+        initial = {
+            "event": "heartbeat",
+            "uptime_seconds": 0,
+            "lines_seen": 0,
+            "seconds_since_last_match": 0,
+            "log": str(log_path),
+            "initial": True,
+        }
+        progress = summarize_progress(workdir, run_id)
+        if progress:
+            initial["progress"] = progress
+        emit(initial, out)
+
     for line in tail_lines(log_path):
+        # Periodic heartbeat — fires whether or not new log lines arrived,
+        # so the operator gets a regular "still alive" signal even during
+        # silent stretches (rare in practice; common during synthetic-corpus
+        # generation in Phase 0).
+        _maybe_heartbeat(state, out, log_path, workdir, run_id, heartbeat_seconds)
+
         # Stuck check (fires when tail returns None and we've been idle too long).
         # "Stuck" means the log file itself has stopped growing — a true hang.
         # Phases like baseline generation don't emit sample_cards but do produce
@@ -179,10 +296,12 @@ def supervise(
 
         # Any incoming log line counts as evidence the harness is alive.
         state.last_progress_at = time.time()
+        state.lines_seen += 1
 
         match = classify(line)
         if not match:
             continue
+        state.last_classifier_match_at = time.time()
         kind, groups = match
 
         # Track current model so we can attribute errors to the right (model, corpus) bucket
@@ -272,6 +391,23 @@ def make_parser() -> argparse.ArgumentParser:
         default=STUCK_THRESHOLD_SECONDS,
         help="Idle time before flagging as stuck",
     )
+    p.add_argument(
+        "--heartbeat-seconds",
+        type=int,
+        default=HEARTBEAT_INTERVAL_SECONDS,
+        help="Emit a periodic heartbeat event every N seconds (0 disables)",
+    )
+    p.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help="Harness workdir; if set, heartbeats include corpus/baseline/response file counts",
+    )
+    p.add_argument(
+        "--run-id",
+        default=None,
+        help="Run id; combined with --workdir, heartbeats include state.json summary",
+    )
     return p
 
 
@@ -280,7 +416,15 @@ def main(argv: list[str] | None = None) -> int:
     if not args.log_file.exists():
         print(f"log file not found: {args.log_file}", file=sys.stderr)
         return 2
-    supervise(args.log_file, notify=not args.no_notify, stuck_threshold=args.stuck_threshold_seconds)
+    workdir = args.workdir.expanduser() if args.workdir else None
+    supervise(
+        args.log_file,
+        notify=not args.no_notify,
+        stuck_threshold=args.stuck_threshold_seconds,
+        heartbeat_seconds=args.heartbeat_seconds,
+        workdir=workdir,
+        run_id=args.run_id,
+    )
     return 0
 
 

--- a/scripts/test_corpora/tests/test_supervisor.py
+++ b/scripts/test_corpora/tests/test_supervisor.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from scripts.test_corpora.runner.supervisor import (
     PATTERNS,
     classify,
+    summarize_progress,
 )
 
 # ── classifier ───────────────────────────────────────────────────────────────
@@ -197,6 +198,117 @@ def test_supervisor_does_not_flag_stuck_when_log_is_noisy(tmp_path: Path):
     types = [e["event"] for e in events]
     assert "stuck" not in types
     assert "completion" in types
+
+
+# ── progress summary ────────────────────────────────────────────────────────
+
+
+def test_summarize_progress_empty_when_no_workdir():
+    assert summarize_progress(None, "run") == {}
+    assert summarize_progress(Path("/nope"), None) == {}
+
+
+def test_summarize_progress_reads_state_and_dirs(tmp_path: Path):
+    workdir = tmp_path / "wd"
+    run_id = "test-run"
+    run_dir = workdir / "results" / run_id
+    run_dir.mkdir(parents=True)
+
+    # state.json: 2 phase-0 done, 1 phase-0 in_progress, 50 phase-1 pending
+    (run_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "units": [
+                    {"phase": 0, "status": "done", "corpus": "cuad"},
+                    {"phase": 0, "status": "done", "corpus": "enron"},
+                    {"phase": 0, "status": "in_progress", "corpus": "synthetic"},
+                ]
+                + [{"phase": 1, "status": "pending", "corpus": "cuad"} for _ in range(50)]
+            }
+        )
+    )
+
+    # synthetic generation 42 docs in
+    (workdir / "synthetic" / "ingest").mkdir(parents=True)
+    for i in range(42):
+        (workdir / "synthetic" / "ingest" / f"doc-{i:04d}.txt").write_text("x")
+
+    # 7 baselines for cuad written so far
+    (run_dir / "baselines" / "cuad").mkdir(parents=True)
+    for i in range(7):
+        (run_dir / "baselines" / "cuad" / f"q{i}.json").write_text("{}")
+
+    summary = summarize_progress(workdir, run_id)
+    assert summary["state"] == {
+        "0": {"done": 2, "in_progress": 1},
+        "1": {"pending": 50},
+    }
+    assert summary["corpus_synthetic_files"] == 42
+    assert summary["baselines_cuad"] == 7
+
+
+def test_supervisor_emits_heartbeat_event(tmp_path: Path):
+    """heartbeat_seconds=0.0 forces a heartbeat on every loop iteration."""
+    log = tmp_path / "test.log"
+    log.write_text(
+        "\n".join(
+            [
+                "INFO routine activity 1",
+                "INFO routine activity 2",
+                "sweep complete after 10s",
+            ]
+        )
+        + "\n"
+    )
+
+    out = io.StringIO()
+    from scripts.test_corpora.runner import supervisor as sup
+
+    original = sup.tail_lines
+
+    def fake_tail(path, poll_seconds=1.0):
+        yield from log.read_text().splitlines()
+
+    sup.tail_lines = fake_tail
+    try:
+        sup.supervise(
+            log,
+            out=out,
+            notify=False,
+            stuck_threshold=999,
+            heartbeat_seconds=0.0001,  # tiny → fires basically every iteration
+        )
+    finally:
+        sup.tail_lines = original
+
+    events = [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+    types = [e["event"] for e in events]
+    assert "heartbeat" in types
+    hb = next(e for e in events if e["event"] == "heartbeat")
+    assert "uptime_seconds" in hb
+    assert "lines_seen" in hb
+    assert "log" in hb
+
+
+def test_supervisor_does_not_emit_heartbeat_when_disabled(tmp_path: Path):
+    log = tmp_path / "test.log"
+    log.write_text("INFO line\nsweep complete after 1s\n")
+    out = io.StringIO()
+    from scripts.test_corpora.runner import supervisor as sup
+
+    original = sup.tail_lines
+
+    def fake_tail(path, poll_seconds=1.0):
+        yield from log.read_text().splitlines()
+
+    sup.tail_lines = fake_tail
+    try:
+        sup.supervise(log, out=out, notify=False, stuck_threshold=999, heartbeat_seconds=0)
+    finally:
+        sup.tail_lines = original
+
+    events = [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+    assert "heartbeat" not in [e["event"] for e in events]
 
 
 def test_supervisor_resets_error_counter_on_sample_card(tmp_path: Path):


### PR DESCRIPTION
## Summary

The supervisor was silent between classifier matches. During Phase 0 synthetic generation and Phase 1 baseline runs (both of which can go 30-60 minutes without emitting a `sample_card`), it looked like nothing was happening even when the harness was steadily working through ~280 docs / 48 baselines.

This adds a periodic `heartbeat` event with real progress numbers pulled from `state.json` and the corpus / baseline / response directories. Default cadence is every 10 minutes; `--heartbeat-seconds 0` disables.

## Sample heartbeat output

With `--workdir "$WORKDIR" --run-id $RUN`:

```json
{
  "event": "heartbeat",
  "uptime_seconds": 1812,
  "lines_seen": 1842,
  "seconds_since_last_match": 12,
  "log": "/Users/alex/sweep-logs/phase01-big.log",
  "progress": {
    "state": {
      "0": {"done": 2, "in_progress": 1},
      "1": {"pending": 50}
    },
    "corpus_cuad_files": 80,
    "corpus_enron_files": 3000,
    "corpus_synthetic_files": 142,
    "baselines_cuad": 0,
    "baselines_enron": 0,
    "baselines_synthetic": 0,
    "responses_total": 0
  }
}
```

A startup heartbeat fires immediately so the operator gets instant feedback that the supervisor connected to the log + a snapshot of current state.

## What changed

- `runner/supervisor.py`: new `summarize_progress()`, `_maybe_heartbeat()`, expanded `SupervisorState` (started_at, last_heartbeat_at, last_classifier_match_at, lines_seen). New CLI flags: `--heartbeat-seconds`, `--workdir`, `--run-id`.
- `tests/test_supervisor.py`: 4 new tests covering progress summary + heartbeat firing + heartbeat disabled.
- `RUNBOOK.md`: all four supervisor invocations now include `--workdir "$WORKDIR" --run-id "$RUN"` so heartbeats include progress data out of the box.

## Test plan

- [x] `uv run pytest -q` — 62 passing (up from 57)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
