### PR TITLE
fix(test-corpora): use streamablehttp_client (not streamable_http_client)

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -53,10 +53,10 @@ class SyncMcpSession:
 
     async def _list_tools_async(self) -> list[Any]:
         from mcp import ClientSession
-        from mcp.client.streamable_http import streamable_http_client
+        from mcp.client.streamable_http import streamablehttp_client
 
         async with (
-            streamable_http_client(
+            streamablehttp_client(
                 self._url,
                 headers=self._headers,
                 timeout=self._timeout,
@@ -69,10 +69,10 @@ class SyncMcpSession:
 
     async def _call_tool_async(self, name: str, args: dict) -> Any:
         from mcp import ClientSession
-        from mcp.client.streamable_http import streamable_http_client
+        from mcp.client.streamable_http import streamablehttp_client
 
         async with (
-            streamable_http_client(
+            streamablehttp_client(
                 self._url,
                 headers=self._headers,
                 timeout=self._timeout,

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -236,3 +236,31 @@ def test_watch_folder_add_sends_path_only():
     c = make_client(handler)
     c.watch_folder_add("/some/path", name="my-folder")
     assert seen_body[0] == {"path": "/some/path"}
+
+
+def test_sync_mcp_session_uses_correct_streamable_function():
+    """Regression test for the streamable_http_client / streamablehttp_client
+    confusion. The MCP SDK exports both names; only one accepts a `headers`
+    kwarg, which we depend on for forwarding HC's bearer token. This test
+    checks the exact symbol is imported AND that its signature accepts
+    `headers`. Without it, Phase 1 baselines crash on the very first MCP
+    list_tools() call after Phase 0 completes."""
+    import inspect
+
+    from mcp.client.streamable_http import streamablehttp_client
+
+    sig = inspect.signature(streamablehttp_client)
+    assert "headers" in sig.parameters, (
+        f"MCP SDK's streamablehttp_client no longer accepts headers — signature is {sig}. "
+        f"The harness needs that param to forward HC's bearer token to the MCP endpoint."
+    )
+
+    # Also assert SyncMcpSession imports the right name (catches future regressions
+    # where someone swaps it back to the no-headers variant).
+    import scripts.test_corpora.runner.client as client_module
+
+    source = inspect.getsource(client_module)
+    assert "from mcp.client.streamable_http import streamablehttp_client" in source, (
+        "client.py should import streamablehttp_client (with headers support), "
+        "not streamable_http_client (which doesn't take headers)."
+    )


### PR DESCRIPTION
## Summary

Phase 1 baseline generation crashed on the very first MCP `list_tools()` call:

```
TypeError: streamable_http_client() got an unexpected keyword argument 'headers'
```

The MCP SDK exports two near-identically-named functions:

| Name | Accepts `headers`? | What we need |
| --- | --- | --- |
| `streamable_http_client` | no — wants `http_client=` | ❌ |
| `streamablehttp_client` | yes — `(url, headers=, timeout=, ...)` | ✅ |

The implementer used the first one. Two-character fix in `client.py` (drop the underscore between `http` and `client`).

## Why this hurts

This is the same MCP integration that was flagged in PR #276's final fresh-eyes review (Issue 6). The implementer chose to wire it up rather than document it as a limitation, but didn't verify the SDK signature against an installed version. The user lost ~1 hour of Phase 0 wall-clock waiting for the synthetic corpus to generate before Phase 1 immediately crashed.

## Regression test

`tests/test_client.py::test_sync_mcp_session_uses_correct_streamable_function` does two things:
1. Inspects the imported symbol's signature and asserts `headers` is in its parameters
2. Greps `client.py`'s source for the correct `from mcp.client.streamable_http import streamablehttp_client` import

Either change in the SDK or a regression in our import would catch this before Phase 1 starts. 63/63 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)