### PR TITLE
fix(test-corpora): MCP endpoint URL is /mcp/mcp not /mcp

### DIFF
--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -129,6 +129,17 @@ curl -X POST "$HC_API_BASE/api/auth/login" \
     -H "Content-Type: application/json" \
     -d "{\"email\":\"$HC_USERNAME\",\"password\":\"$HC_PASSWORD\"}" | jq .access_token
 # expect a non-null JWT string
+
+# Optional: verify the MCP endpoint accepts JWT bearer tokens. Phase 1 baselines
+# need this. The path is /mcp/mcp because Harbor Clerk mounts the MCP ASGI
+# app at /mcp and FastMCP's streamable_http_app() in turn mounts its handler
+# at /mcp internally. Override the canonical path via HC_MCP_URL if your
+# deployment differs.
+JWT=$(curl -sX POST "$HC_API_BASE/api/auth/login" -H "Content-Type: application/json" \
+    -d "{\"email\":\"$HC_USERNAME\",\"password\":\"$HC_PASSWORD\"}" | jq -r .access_token)
+curl -sI -X POST "$HC_API_BASE/mcp/mcp" -H "Authorization: Bearer $JWT" | head -1
+# expect 4xx with a body explaining missing MCP protocol headers — NOT 404 or 405.
+# A 405 means the path is wrong; 404 means the MCP app isn't mounted.
 ```
 
 ---

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -472,12 +472,18 @@ def main(argv: list[str] | None = None) -> int:
                         out["manifest"]["ingest_dir"] = str(out["manifest"]["ingest_dir"])
                     elif phase == 1:
                         # Lazily open the MCP session on first Phase 1 unit.
+                        # Harbor Clerk mounts the MCP ASGI app at /mcp and
+                        # FastMCP's streamable_http_app() exposes its handler
+                        # at /mcp internally, so the canonical full path is
+                        # /mcp/mcp. Override via HC_MCP_URL env var for
+                        # non-standard deployments.
                         if mcp_session is None:
-                            log.info("opening MCP session at %s/mcp for Phase 1 baselines", args.api_base)
+                            mcp_url = os.environ.get("HC_MCP_URL") or f"{args.api_base}/mcp/mcp"
+                            log.info("opening MCP session at %s for Phase 1 baselines", mcp_url)
                             bearer = hc._client.headers.get("Authorization")
                             mcp_headers: dict[str, str] = {"Authorization": bearer} if bearer else {}
                             mcp_session = SyncMcpSession(
-                                url=f"{args.api_base}/mcp",
+                                url=mcp_url,
                                 headers=mcp_headers,
                             )
                         text, _lang = _question_text(questions_by_corpus[u.corpus], u.question_id)


### PR DESCRIPTION
## Summary

Harbor Clerk's FastAPI app mounts the MCP ASGI app at `/mcp`, and inside that ASGI app FastMCP's `streamable_http_app()` mounts its handler at `/mcp` internally — so the canonical URL is `/mcp/mcp`.

The harness was POSTing to `/mcp` and getting a 405 from the outer FastAPI router (which has no handler at that path) the moment Phase 1 tried to open the MCP session:

```
2026-05-05 21:14:32 INFO sweep === phase 1: 50 pending units ===
2026-05-05 21:14:32 INFO sweep opening MCP session at http://localhost:8100/mcp for Phase 1 baselines
2026-05-05 21:14:32 INFO httpx HTTP Request: POST http://localhost:8100/mcp "HTTP/1.1 405 Method Not Allowed"
```

This is the second bug in a row to surface at the Phase-0 → Phase-1 transition and the second hour of sweep wall-clock lost to the MCP integration that landed in PR #276. The first was the SDK-name confusion fixed in PR #291.

## What changed

- `runner/sweep.py`: hardcode `/mcp/mcp` with a comment explaining the double-mount. Add `HC_MCP_URL` env-var override for deployments that route differently.
- `RUNBOOK.md`: a curl-based MCP-reachability check in the pre-flight section. **A 405 (the current bug) means the path is wrong; 404 means the MCP app isn't mounted; a 4xx with MCP-protocol-header complaints means the path is right and you're at the protocol layer.**

## Test plan

- [x] 63 unit tests pass
- [ ] User runs `--phases 0-1 --resume` and Phase 1 actually starts producing baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
