### PR TITLE
fix(test-corpora): clean up orphan research before start_research

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -170,6 +170,29 @@ class HarborClerkClient:
 
     # ── research ──
 
+    def active_research(self) -> dict[str, Any]:
+        """GET /api/research/active — returns ``{conversation_id, status}`` or
+        a falsy ``conversation_id`` when nothing is running."""
+        r = self._client.get("/api/research/active")
+        r.raise_for_status()
+        return r.json()
+
+    def delete_research(self, conv_id: str) -> None:
+        """DELETE /api/research/{conv_id}. Used to clean up orphaned
+        research tasks left behind when a previous sweep was killed
+        mid-Phase-4."""
+        r = self._client.delete(f"/api/research/{conv_id}")
+        r.raise_for_status()
+
+    def cleanup_orphan_research(self) -> str | None:
+        """If a research task is currently active, delete it. Returns the
+        conv_id that was deleted (or None). Idempotent."""
+        active = self.active_research()
+        conv_id = active.get("conversation_id")
+        if conv_id:
+            self.delete_research(conv_id)
+        return conv_id
+
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=15))
     def start_research(
         self,

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -227,6 +227,12 @@ def _run_local(
 ) -> dict:
     """Run one local-model question. Assumes the right model is already active and loaded."""
     if is_research:
+        # Clean up any orphan research task from a prior killed sweep before
+        # POSTing a new one — otherwise Harbor Clerk returns 409 Conflict
+        # and the harness wedges. Idempotent: no-op when nothing is active.
+        orphan = hc.cleanup_orphan_research()
+        if orphan:
+            log.warning("cleaned up orphan research task %s before starting new one", orphan)
         conv_id = hc.start_research(question_text, depth=depth, time_limit_minutes=time_limit_minutes)
         result = hc.wait_for_research(conv_id, max_wait_seconds=time_limit_minutes * 60 + 120)
         # Normalize: ResearchDetail returns "report", chat returns "answer".

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -264,3 +264,51 @@ def test_sync_mcp_session_uses_correct_streamable_function():
         "client.py should import streamablehttp_client (with headers support), "
         "not streamable_http_client (which doesn't take headers)."
     )
+
+
+def test_active_research_returns_state():
+    """Light coverage for the GET /api/research/active happy path."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/research/active"
+        return httpx.Response(200, json={"conversation_id": "conv-orphan", "status": "running"})
+
+    c = make_client(handler)
+    res = c.active_research()
+    assert res["conversation_id"] == "conv-orphan"
+
+
+def test_cleanup_orphan_research_deletes_when_active():
+    """If GET /research/active returns a conv_id, cleanup_orphan_research
+    must DELETE it. This prevents the 409 Conflict on the very next
+    start_research after a killed sweep."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        if request.method == "GET" and request.url.path == "/api/research/active":
+            return httpx.Response(200, json={"conversation_id": "conv-orphan", "status": "running"})
+        if request.method == "DELETE" and request.url.path == "/api/research/conv-orphan":
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    deleted = c.cleanup_orphan_research()
+    assert deleted == "conv-orphan"
+    assert "GET /api/research/active" in seen
+    assert "DELETE /api/research/conv-orphan" in seen
+
+
+def test_cleanup_orphan_research_no_op_when_idle():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        return httpx.Response(200, json={"conversation_id": None, "status": None})
+
+    c = make_client(handler)
+    deleted = c.cleanup_orphan_research()
+    assert deleted is None
+    # Should have called GET but NOT DELETE
+    assert any("GET" in s for s in seen)
+    assert not any("DELETE" in s for s in seen)


### PR DESCRIPTION
## Summary

User killed the sweep mid-Phase-4. On restart, Phase 4 wedged immediately:

```
INFO sweep activating model qwen3-4b (was None)
INFO httpx HTTP Request: PUT /api/chat/models/qwen3-4b/activate "200 OK"
INFO httpx HTTP Request: POST /api/research "HTTP/1.1 409 Conflict"
INFO httpx HTTP Request: POST /api/research "HTTP/1.1 409 Conflict"
INFO httpx HTTP Request: POST /api/research "HTTP/1.1 409 Conflict"
... tenacity.RetryError ... httpx.HTTPStatusError: '409 Conflict'
```

Root cause: Harbor Clerk's `POST /api/research` rejects (409) if any `ResearchState` row has `status=running`. Killing a sweep mid-research leaves an orphan in the DB. The harness has watch-folder auto-cleanup before each ingest (PR #276) but no equivalent for research tasks.

## Fix

Adds `HarborClerkClient.cleanup_orphan_research()`: calls `GET /api/research/active`, deletes the running task if any, returns the deleted conv_id (or None). Idempotent.

`_run_local` invokes it before every `start_research`, logging a WARNING if it actually had to clean something up.

## Test plan

- [x] 3 new unit tests cover active / orphan-delete / no-op-when-idle
- [x] 66/66 tests pass; ruff check + format clean
- [ ] User runs the cleanup curl once manually to clear the current orphan, then `--resume` should run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
