### PR TITLE
fix(test-corpora): close ingest race that started research on 0 docs

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -301,6 +301,34 @@ class HarborClerkClient:
             time.sleep(poll_seconds)
         return False
 
+    def wait_for_pipeline_activity(self, max_wait_seconds: int = 120, poll_seconds: int = 2) -> bool:
+        """Wait until the queue is *non*-empty (something has been enqueued).
+
+        Used right after ``watch_folder_add`` to close the race where the
+        watcher hasn't scanned the folder yet — without this, a quick
+        ``wait_for_quiet_pipeline`` poll could see an empty queue, declare
+        the corpus ingested, and start research on zero documents.
+        """
+        deadline = time.time() + max_wait_seconds
+        while time.time() < deadline:
+            if not self.pipeline_quiet():
+                return True
+            if poll_seconds > 0:
+                time.sleep(poll_seconds)
+        return False
+
+    def document_count(self) -> int:
+        """GET /api/docs?limit=0 — total active document count.
+
+        Used to verify ingestion landed the expected number of documents.
+        Note: counts everything HC's watcher decided to ingest, which may
+        include synthetic-corpus JSON sidecars unless HC's watcher filters
+        them.
+        """
+        r = self._client.get("/api/docs", params={"limit": 0})
+        r.raise_for_status()
+        return r.json().get("total", 0)
+
     def health(self) -> dict[str, Any]:
         """GET /api/system/health."""
         r = self._client.get("/api/system/health")

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -272,6 +272,14 @@ def _run_local(
 
 
 def _ingest_corpus(hc: HarborClerkClient, manifest: CorpusManifest) -> None:
+    """Wipe the DB, register the corpus's ingest dir, wait for ingestion to
+    fully complete before returning.
+
+    Three-phase wait closes the race where the harness checks ``pipeline_quiet``
+    in the brief window between ``watch_folder_add`` returning and the
+    watcher actually scanning the folder. Without this, the harness would
+    declare the corpus ingested and start research against zero documents.
+    """
     log.info("clearing existing watch folders before ingesting %s", manifest.corpus_id)
     for folder in hc.watch_folder_list():
         hc.watch_folder_delete(folder["folder_id"])
@@ -279,9 +287,42 @@ def _ingest_corpus(hc: HarborClerkClient, manifest: CorpusManifest) -> None:
     hc.delete_all_documents(confirm=True)
     log.info("adding watch folder for %s", manifest.ingest_dir)
     hc.watch_folder_add(str(manifest.ingest_dir), name=f"test-corpora-{manifest.corpus_id}")
+
+    # Phase 1: confirm watcher actually started enqueueing. Some corpora
+    # (CUAD's 80 PDFs) can finish ingesting in under the 30s poll interval,
+    # so this is essential — without it, the next poll could see an empty
+    # queue before the queue ever filled and proceed.
+    log.info("waiting for watcher to begin enqueueing files for %s", manifest.corpus_id)
+    if not hc.wait_for_pipeline_activity(max_wait_seconds=120):
+        raise RuntimeError(
+            f"watcher never enqueued any jobs for {manifest.corpus_id} within 120s — "
+            f"verify the ingest dir contains supported files: {manifest.ingest_dir}"
+        )
+
+    # Phase 2: wait for the queue to drain (existing behaviour).
     log.info("waiting for pipeline to drain (this can take a while)")
     if not hc.wait_for_quiet_pipeline(max_wait_seconds=4 * 3600):
         raise RuntimeError(f"pipeline never drained for {manifest.corpus_id}")
+
+    # Phase 3: warning-level sanity check on document count. Treated as
+    # informational because the synthetic corpus has JSON sidecars in the
+    # ingest dir that HC may or may not ingest depending on its allowed
+    # extensions, so an exact match isn't guaranteed.
+    actual = hc.document_count()
+    if actual < manifest.doc_count * 0.5:
+        log.error(
+            "ingest looks incomplete for %s: HC has %d active docs, manifest expected %d",
+            manifest.corpus_id,
+            actual,
+            manifest.doc_count,
+        )
+    else:
+        log.info(
+            "ingest verified for %s: HC has %d active docs (manifest expected %d)",
+            manifest.corpus_id,
+            actual,
+            manifest.doc_count,
+        )
 
 
 # ── model switch helper ──

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -312,3 +312,50 @@ def test_cleanup_orphan_research_no_op_when_idle():
     # Should have called GET but NOT DELETE
     assert any("GET" in s for s in seen)
     assert not any("DELETE" in s for s in seen)
+
+
+def test_wait_for_pipeline_activity_returns_true_on_first_busy_poll():
+    """When the queue is empty initially and becomes busy, the helper
+    returns True. With poll_seconds=0 we hit the second response on the
+    next iteration."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(
+                200, json={"queues": {"io": {"queued": 0, "running": 0}, "cpu": {"queued": 0, "running": 0}}}
+            )
+        return httpx.Response(
+            200, json={"queues": {"io": {"queued": 7, "running": 0}, "cpu": {"queued": 0, "running": 0}}}
+        )
+
+    c = make_client(handler)
+    assert c.wait_for_pipeline_activity(max_wait_seconds=5, poll_seconds=0) is True
+
+
+def test_wait_for_pipeline_activity_returns_false_on_timeout():
+    """If the queue stays empty until the deadline, the helper returns False —
+    the caller can decide whether that's a watcher misconfiguration."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"queues": {"io": {"queued": 0, "running": 0}, "cpu": {"queued": 0, "running": 0}}}
+        )
+
+    c = make_client(handler)
+    # max_wait_seconds=0 → first poll only, no busy state ever → False
+    assert c.wait_for_pipeline_activity(max_wait_seconds=0, poll_seconds=0) is False
+
+
+def test_document_count_uses_total_field():
+    """document_count returns the response body's `total` field, ignoring
+    `items` (we pass limit=0 to avoid the actual list)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/docs"
+        assert request.url.params.get("limit") == "0"
+        return httpx.Response(200, json={"items": [], "total": 1234, "limit": 0, "offset": 0})
+
+    c = make_client(handler)
+    assert c.document_count() == 1234


### PR DESCRIPTION
## Summary

User noticed during the in-flight Phase 4 sweep on MINI that research was running *while ingestion was still finishing*. That's a real bug — research against a partially-ingested corpus would produce low-recall citations and skew Phase 5 parity scores.

**Root cause:** `_ingest_corpus` calls `watch_folder_add` (which just registers the folder in HC's DB), then immediately enters `wait_for_quiet_pipeline()` polling every 30s. The watcher's actual filesystem-walk + per-file enqueue happens asynchronously in HC's watcher service. For fast corpora (CUAD's 80 PDFs), the queue can be genuinely empty on the first poll — *before the watcher has touched it*. The harness declares the corpus "ingested" and runs research against an empty (or partial) DB.

## Fix — three-phase wait

1. `wait_for_pipeline_activity()` — block up to 120s for the queue to become *non*-empty. Confirms the watcher actually started.
2. `wait_for_quiet_pipeline()` — existing behaviour, drain to zero.
3. `document_count()` sanity check — log ERROR if `actual < 0.5 × manifest.doc_count`, else INFO. Soft gate because synthetic corpus has JSON sidecars in the ingest dir whose ingestion is HC-config-dependent.

## Impact on the in-flight sweep

If you've already run Phase 4 cells before this fix, **citation_overlap will be suspiciously low for *every* model on the affected corpus** (because no model could find the missing docs). After pulling the fix, re-run any affected slices:

```bash
# nuclear option — re-run all Phase 4 (long but defensible)
sweep ... --rerun "phase=4"

# surgical — only the corpus where you saw the issue
sweep ... --rerun "phase=4,corpus=cuad"
```

## Test plan

- [x] 3 new tests for `wait_for_pipeline_activity` (busy / timeout) and `document_count`. 69 total pass.
- [x] ruff clean
- [ ] User pulls + restarts MINI sweep; first ingest log line should now be "waiting for watcher to begin enqueueing files for cuad" before the drain wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)
