### PR TITLE
docs(test-corpora): loud destructive-sweep warning

### DIFF
--- a/scripts/test_corpora/README.md
+++ b/scripts/test_corpora/README.md
@@ -5,6 +5,11 @@ three structurally-different corpora (CUAD legal contracts, Enron email
 subset, synthetic bilingual small-business). Six sequential phases, fully
 restartable.
 
+> **⚠️  Destructive.** This sweep wipes the Harbor Clerk instance's documents,
+> watch folders, and storage objects between every corpus ingest. Use a
+> dedicated HC instance — never run it against one that holds documents you
+> care about. See [RUNBOOK.md](RUNBOOK.md#%EF%B8%8F--this-sweep-is-destructive) for the full impact list.
+
 See [`docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md`](../../docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md) for the full design.
 
 ## Quickstart

--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -8,6 +8,23 @@ This runbook is the operations companion to:
 
 ---
 
+## ⚠️  This sweep is destructive
+
+The harness **wipes the Harbor Clerk instance it talks to**. Every Phase 4 / Phase 5 / Phase 6 corpus ingest calls:
+
+1. `DELETE` for every existing watch folder
+2. `POST /api/system/delete-all-documents` (drops all documents, chunks, entities, embeddings, ingestion jobs, uploads, and originals storage objects)
+3. Adds the corpus's own watch folder
+
+**If you have personal documents in this Harbor Clerk instance, they will be deleted.** Conversations, chat messages, users, and API keys are preserved — only document-shaped data is wiped.
+
+If you want to keep an existing corpus intact, run the sweep against a **separate Harbor Clerk instance**:
+
+- spin up a second instance via Docker on a different port (e.g. `docker compose up` with a remapped 443→8443) and set `HC_API_BASE` accordingly, or
+- use the Mac mini's instance which is presumed clean (this is the natural fit for the split BIG/MINI flow below).
+
+---
+
 ## Moving parts
 
 ```


### PR DESCRIPTION
## Summary

User asked "is it the expectation that I'm starting with no documents and no watched folders?" while a sweep was already underway against their Harbor Clerk instance. Yes — the harness wipes everything between corpus ingests by design. But that wasn't called out anywhere prominent enough.

This PR adds:

- A top-of-README warning callout with a link into the new RUNBOOK section
- A dedicated `## ⚠️  This sweep is destructive` section at the top of RUNBOOK.md, listing exactly what gets deleted (documents, watch folders, originals storage) vs preserved (users, API keys, conversations, chat messages)
- Concrete recommendation: run against a separate HC instance (Docker on a remapped port, or the dedicated MINI in the split flow)

Docs-only — 69 tests still pass; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
