### PR TITLE
fix(test-corpora): register units for any missing requested phase

### DIFF
--- a/scripts/test_corpora/README.md
+++ b/scripts/test_corpora/README.md
@@ -5,6 +5,11 @@ three structurally-different corpora (CUAD legal contracts, Enron email
 subset, synthetic bilingual small-business). Six sequential phases, fully
 restartable.
 
+> **⚠️  Destructive.** This sweep wipes the Harbor Clerk instance's documents,
+> watch folders, and storage objects between every corpus ingest. Use a
+> dedicated HC instance — never run it against one that holds documents you
+> care about. See [RUNBOOK.md](RUNBOOK.md#%EF%B8%8F--this-sweep-is-destructive) for the full impact list.
+
 See [`docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md`](../../docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md) for the full design.
 
 ## Quickstart

--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -8,6 +8,23 @@ This runbook is the operations companion to:
 
 ---
 
+## ⚠️  This sweep is destructive
+
+The harness **wipes the Harbor Clerk instance it talks to**. Every Phase 4 / Phase 5 / Phase 6 corpus ingest calls:
+
+1. `DELETE` for every existing watch folder
+2. `POST /api/system/delete-all-documents` (drops all documents, chunks, entities, embeddings, ingestion jobs, uploads, and originals storage objects)
+3. Adds the corpus's own watch folder
+
+**If you have personal documents in this Harbor Clerk instance, they will be deleted.** Conversations, chat messages, users, and API keys are preserved — only document-shaped data is wiped.
+
+If you want to keep an existing corpus intact, run the sweep against a **separate Harbor Clerk instance**:
+
+- spin up a second instance via Docker on a different port (e.g. `docker compose up` with a remapped 443→8443) and set `HC_API_BASE` accordingly, or
+- use the Mac mini's instance which is presumed clean (this is the natural fit for the split BIG/MINI flow below).
+
+---
+
 ## Moving parts
 
 ```

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -393,11 +393,30 @@ def main(argv: list[str] | None = None) -> int:
                 raise RuntimeError(f"--models has unknown values: {sorted(unknown_m)}. Known: {sorted(cfg.ALL_MODELS)}")
             log.info("--models filter: %s", sorted(models_filter))
 
-        # Plan units if state is empty
+        # Plan units for any requested phase that doesn't already have units
+        # registered in state.json. Earlier versions of this harness gated on
+        # ``if not sf.units()`` (state file completely empty), which silently
+        # skipped Phase 4 planning on a re-invocation that came after Phase
+        # 0/1 had already populated the state file. Register additively
+        # instead — never disturbs phases that already have units.
         phases = _phase_range(args.phases)
-        if not sf.units():
-            sf.register(_plan_units(questions_by_corpus, phases, args.depth, models_filter=models_filter))
+        existing_phases = {u.phase for u in sf.units()}
+        missing_phases = phases - existing_phases
+        if missing_phases:
+            new_units = _plan_units(
+                questions_by_corpus,
+                missing_phases,
+                args.depth,
+                models_filter=models_filter,
+            )
+            sf.register(new_units)
             sf.save()
+            log.info(
+                "registered %d new units for phases %s (existing: %s)",
+                len(new_units),
+                sorted(missing_phases),
+                sorted(existing_phases) or "none",
+            )
 
         # Apply --rerun / --skip
         if args.rerun:

--- a/scripts/test_corpora/tests/test_plan_units.py
+++ b/scripts/test_corpora/tests/test_plan_units.py
@@ -81,3 +81,49 @@ def test_phase4_corpus_then_model_ordering_minimizes_db_wipes():
     transitions = sum(1 for a, b in zip(units, units[1:]) if a.corpus != b.corpus)
     # 2 corpora → exactly 1 transition (cuad block, then enron block)
     assert transitions == 1
+
+
+def test_phase_planning_is_additive_after_prior_phase(tmp_path):
+    """Regression: invoking the harness with --phases 4 after --phases 0-1
+    has already populated state.json must still register phase 4 units.
+    The original gate was ``if not sf.units()`` which silently skipped
+    planning for every later phase. Now we register only the missing
+    phases additively."""
+    from scripts.test_corpora.runner.state import StateFile, Unit
+
+    sf = StateFile(tmp_path / "state.json")
+    # Simulate: phase 0/1 already done from a prior run
+    sf.register(
+        [
+            Unit(phase=0, corpus="cuad", model="-", question_id="-", depth="-"),
+            Unit(phase=1, corpus="cuad", model="claude-baseline", question_id="cuad-research-1", depth="n/a"),
+        ]
+    )
+    sf.save()
+
+    # Sanity check: state has phases {0, 1}, no phase 4
+    existing_phases = {u.phase for u in sf.units()}
+    assert existing_phases == {0, 1}
+
+    # The new gate: register units for any requested phase that's not present
+    requested = {4}
+    missing_phases = requested - existing_phases
+    assert missing_phases == {4}
+
+    new_units = _plan_units(
+        _qbc(["cuad"]),
+        missing_phases,
+        "standard",
+        models_filter={"qwen3.6-35b"},
+    )
+    assert len(new_units) > 0, "missing-phase planning produced zero units"
+    assert all(u.phase == 4 for u in new_units), "all new units must be phase 4"
+
+    sf.register(new_units)
+    sf.save()
+
+    # Reload and verify both phases coexist
+    sf2 = StateFile(tmp_path / "state.json")
+    sf2.load()
+    phases_seen = {u.phase for u in sf2.units()}
+    assert phases_seen == {0, 1, 4}, f"expected phases {{0,1,4}}, got {phases_seen}"


### PR DESCRIPTION
## Summary

The planning gate in `sweep.py` was `if not sf.units()` — only fired when state.json was *completely* empty. After Phase 0/1 populated state.json, every subsequent invocation with `--phases 4` (or 5, 6) found a non-empty state file, **skipped planning entirely**, and silently exited:

```
INFO sweep --models filter: ['gemma-26b', 'qwen3.6-35b']
INFO sweep flipped 0 units to PENDING via --rerun
INFO sweep === phase 4: 0 pending units ===
INFO sweep phase 4 already complete or empty
INFO sweep sweep complete after 0.0s
```

User's BIG hit this on both the original Phase 4 invocation AND the `--rerun "phase=4"` retry — Phase 4 units were never registered for the top-2 models. Pretty embarrassing miss; this gate has been broken since the harness was written, but nothing tripped it during smoke testing because PR #276's smoke ran with `--phases 0` from an empty state.

## Fix

Replace the gate with a missing-phases set:

```python
existing_phases = {u.phase for u in sf.units()}
missing_phases = phases - existing_phases
if missing_phases:
    new_units = _plan_units(questions_by_corpus, missing_phases, args.depth, models_filter=...)
    sf.register(new_units)
    sf.save()
    log.info("registered %d new units for phases %s (existing: %s)", ...)
```

Phase 0/1 stays untouched, phase 4 gets its 100 units (top-2 models on BIG, 6-model fan-out on MINI) on first phase-4 invocation.

## Test plan

- [x] New regression test `test_phase_planning_is_additive_after_prior_phase` pre-populates state with phase 0/1, asserts missing-phases is `{4}`, plans + registers, verifies phases `{0,1,4}` coexist after reload. 70 tests pass.
- [ ] User pulls + reruns the same `--rerun phase=4` command. The log should now show `registered 100 new units for phases [4] (existing: [0, 1])` followed by the actual Phase 4 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
