### PR TITLE
fix(test-corpora): drain research SSE so HC doesn't mark interrupted

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -194,18 +194,31 @@ class HarborClerkClient:
         return conv_id
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=15))
-    def start_research(
+    def poll_research(self, conv_id: str) -> dict[str, Any]:
+        """GET /api/research/{conv_id} — returns the JSON body."""
+        r = self._client.get(f"/api/research/{conv_id}")
+        r.raise_for_status()
+        return r.json()
+
+    def run_research(
         self,
         question: str,
         depth: str = "standard",
         time_limit_minutes: int = 30,
         strategy: str | None = None,
-    ) -> str:
-        """POST /api/research — returns the X-Research-Id header as conv_id.
+    ) -> tuple[str, dict[str, Any]]:
+        """POST /api/research and drain the SSE stream until the research
+        finishes server-side. Returns ``(conv_id, ResearchDetail)``.
 
-        The endpoint returns SSE. We open the stream, read the header, then
-        close immediately without draining the body. The server runs the
-        research regardless; we poll via GET to get the result.
+        Harbor Clerk's research handler runs as an SSE generator; if the
+        client disconnects mid-stream, the handler's finally block marks
+        the task ``interrupted``. So we MUST hold the connection open
+        for the duration. Trying to "fire and poll" by closing the
+        stream early — which an earlier version of this client did —
+        ends every research at round 0 with ``status="interrupted"``.
+
+        This call is NOT retried by ``tenacity`` because partial SSE
+        streams can't be safely re-opened against the same conv_id.
         """
         body: dict[str, Any] = {
             "question": question,
@@ -215,25 +228,44 @@ class HarborClerkClient:
         if strategy is not None:
             body["strategy"] = strategy
 
-        with self._client.stream("POST", "/api/research", json=body) as r:
+        # Read timeout must accommodate the full time_limit + slack for
+        # synthesis tail.
+        read_timeout = time_limit_minutes * 60 + 180
+        timeout = httpx.Timeout(connect=30, read=read_timeout, write=10, pool=10)
+
+        conv_id: str | None = None
+        with self._client.stream("POST", "/api/research", json=body, timeout=timeout) as r:
             r.raise_for_status()
             conv_id = r.headers.get("X-Research-Id")
             if not conv_id:
                 raise RuntimeError("research start did not return X-Research-Id")
-            return conv_id
+            # Drain the SSE stream until done/error. This is what keeps the
+            # research alive server-side.
+            for line in r.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if not payload.strip():
+                    continue
+                try:
+                    event = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                etype = event.get("type")
+                if etype in ("done", "error"):
+                    break
 
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=15))
-    def poll_research(self, conv_id: str) -> dict[str, Any]:
-        """GET /api/research/{conv_id} — returns the JSON body."""
-        r = self._client.get(f"/api/research/{conv_id}")
-        r.raise_for_status()
-        return r.json()
+        # Fetch the final state (status, report, citations, messages).
+        return conv_id, self.poll_research(conv_id)
 
     def wait_for_research(self, conv_id: str, max_wait_seconds: int, poll_seconds: int = 5) -> dict[str, Any]:
-        """Poll until status is completed/failed/interrupted or deadline.
+        """[Deprecated] Poll until status is completed/failed/interrupted or deadline.
 
-        Harbor Clerk returns a ``ResearchDetail`` object whose terminal values
-        are ``completed``, ``failed``, and ``interrupted`` (not ``done`` / ``error``).
+        Kept for backward-compat in tests but no longer used by the sweep —
+        ``run_research`` now blocks on the SSE stream itself, which is the
+        only safe way (closing the stream early triggers HC's
+        interrupted-on-disconnect handler).
+
         When poll_seconds=0 the sleep is skipped (test mode).
         """
         deadline = time.time() + max_wait_seconds

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -233,8 +233,10 @@ def _run_local(
         orphan = hc.cleanup_orphan_research()
         if orphan:
             log.warning("cleaned up orphan research task %s before starting new one", orphan)
-        conv_id = hc.start_research(question_text, depth=depth, time_limit_minutes=time_limit_minutes)
-        result = hc.wait_for_research(conv_id, max_wait_seconds=time_limit_minutes * 60 + 120)
+        # run_research drains the SSE stream until the research finishes
+        # server-side. Closing the stream early would trigger HC's
+        # "interrupted-on-disconnect" handler and produce empty results.
+        conv_id, result = hc.run_research(question_text, depth=depth, time_limit_minutes=time_limit_minutes)
         # Normalize: ResearchDetail returns "report", chat returns "answer".
         # Store under "answer" so all downstream metrics code uses a uniform key.
         normalized_answer = result.get("report") or result.get("answer", "")
@@ -573,7 +575,51 @@ def main(argv: list[str] | None = None) -> int:
                             results_dir=run_dir,
                         )
 
-                    sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.DONE)
+                    # For local-model questions (phases 2-6), inspect the
+                    # ResearchDetail / chat result and downgrade the unit
+                    # status when the result is not a clean completion.
+                    # Without this, the harness used to mark "interrupted"
+                    # research tasks as DONE — leaving cells with empty
+                    # answers in metrics.csv that looked like real
+                    # completions.
+                    final_status = Status.DONE
+                    error_msg: str | None = None
+                    if phase in (2, 3, 4, 5, 6):
+                        result = out.get("result", {}) or {}
+                        result_status = result.get("status")
+                        result_answer = result.get("answer") or ""
+                        if result_status == "completed" and result_answer:
+                            final_status = Status.DONE
+                        elif result_status == "completed" and not result_answer:
+                            final_status = Status.DEGRADED
+                            error_msg = "completed with empty answer"
+                        elif result_status == "interrupted":
+                            final_status = Status.ERROR
+                            error_msg = "research interrupted by Harbor Clerk"
+                        elif result_status in ("failed", "timeout"):
+                            final_status = Status.ERROR
+                            error_msg = f"research finished with status={result_status}"
+                        else:
+                            final_status = Status.ERROR
+                            error_msg = f"unexpected result status: {result_status!r}"
+                    sf.set_status(
+                        u.phase,
+                        u.corpus,
+                        u.model,
+                        u.question_id,
+                        u.depth,
+                        final_status,
+                        error=error_msg,
+                    )
+                    if final_status != Status.DONE:
+                        log.warning(
+                            "unit %s/%s/%s ended with %s: %s",
+                            u.corpus,
+                            u.model,
+                            u.question_id,
+                            final_status.value,
+                            error_msg,
+                        )
                 except (httpx.HTTPError, RuntimeError, KeyError) as exc:
                     log.exception("unit failed: %s", u)
                     sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.ERROR, error=str(exc))

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -64,25 +64,6 @@ def test_wait_for_model_ready_returns_false_on_wrong_model():
     assert c.wait_for_model_ready("qwen3-8b", max_wait_seconds=1, poll_seconds=0) is False
 
 
-def test_start_research_extracts_x_research_id_header():
-    def handler(request):
-        assert request.url.path == "/api/research"
-        body = json.loads(request.content)
-        assert body["question"] == "What?"
-        assert body["depth"] == "standard"
-        assert body["time_limit_minutes"] == 30
-        # Return SSE stream with the conv_id in headers
-        return httpx.Response(
-            200,
-            headers={"X-Research-Id": "conv-abc", "Content-Type": "text/event-stream"},
-            content=b'data: {"type":"started"}\n\n',
-        )
-
-    c = make_client(handler)
-    conv_id = c.start_research("What?", depth="standard", time_limit_minutes=30)
-    assert conv_id == "conv-abc"
-
-
 def test_poll_research_returns_completed():
     """poll_research should pass through whatever the server returns — the terminal
     value check lives in wait_for_research."""
@@ -359,3 +340,64 @@ def test_document_count_uses_total_field():
 
     c = make_client(handler)
     assert c.document_count() == 1234
+
+
+def test_run_research_drains_sse_stream_until_done():
+    """Regression test for the interrupted-on-disconnect bug. The harness
+    MUST hold the SSE stream open until the server emits ``done``;
+    closing early triggers HC's research_stream finally-block which
+    marks the task ``interrupted`` and yields empty answers."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/api/research":
+            # Simulate an SSE response with several events ending in 'done'
+            body = (
+                'data: {"type":"started"}\n\n'
+                'data: {"type":"token","content":"hello "}\n\n'
+                'data: {"type":"token","content":"world"}\n\n'
+                'data: {"type":"done","conversation_id":"conv-abc"}\n\n'
+            )
+            return httpx.Response(
+                200,
+                headers={"X-Research-Id": "conv-abc", "Content-Type": "text/event-stream"},
+                content=body,
+            )
+        # Final poll for ResearchDetail
+        if request.method == "GET" and request.url.path == "/api/research/conv-abc":
+            return httpx.Response(
+                200,
+                json={"status": "completed", "report": "hello world", "conversation_id": "conv-abc"},
+            )
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    conv_id, result = c.run_research("Q?", depth="standard", time_limit_minutes=1)
+    assert conv_id == "conv-abc"
+    assert result["status"] == "completed"
+    assert result["report"] == "hello world"
+
+
+def test_run_research_returns_interrupted_when_server_interrupts():
+    """If HC reports the task as interrupted (e.g. real disconnect for
+    some other reason, or model-switch race), run_research must surface
+    that status faithfully so the caller can downgrade the unit."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/api/research":
+            body = 'data: {"type":"error","message":"llm error"}\n\n'
+            return httpx.Response(
+                200,
+                headers={"X-Research-Id": "conv-int", "Content-Type": "text/event-stream"},
+                content=body,
+            )
+        if request.method == "GET" and request.url.path == "/api/research/conv-int":
+            return httpx.Response(
+                200,
+                json={"status": "interrupted", "report": None, "error": "llm error"},
+            )
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    conv_id, result = c.run_research("Q?", depth="standard", time_limit_minutes=1)
+    assert result["status"] == "interrupted"
+    assert result.get("report") is None


### PR DESCRIPTION
## Summary

Every Phase 4 research task on MINI was finishing with `status="interrupted"`, `current_round=0`, empty report — and the harness was marking them all `done`. Discovered when the user pasted one such response file: the conv started, got interrupted before any rounds executed, and the harness wrote it to disk as if successful.

**Root cause:** HC's `research_stream` is an SSE async generator. Its `finally` block catches client disconnect:

```python
# src/harbor_clerk/llm/research.py:1391-1400
if state.status == "running":
    logger.info("Research stream disconnected, marking interrupted (...)", ...)
    state.status = "interrupted"
```

The harness's `start_research()` opened the SSE stream solely to capture the `X-Research-Id` response header, then exited the `with` block. The disconnect tripped HC's `finally` before the research even reached round 0. Pseudo-code of the broken pattern:

```python
with self._client.stream("POST", "/api/research", ...) as r:
    conv_id = r.headers.get("X-Research-Id")
    return conv_id  # ← stream closes here → HC fires interrupted-on-disconnect
```

## Fix

**Two parts in one PR:**

### 1. Drain the SSE stream

Replace `start_research` + `wait_for_research` with a single `run_research()` that holds the connection open until the server emits `done` or `error`. Read timeout = `time_limit_minutes × 60 + 180s` slack. This keeps the research alive server-side for its full duration.

### 2. Stop marking non-completed results as DONE

`sweep.py`'s phase 2-6 path now inspects `result['status']` after `_run_local`:

| Result | Status |
| --- | --- |
| `completed` + non-empty answer | `DONE` |
| `completed` + empty answer | `DEGRADED` (logged) |
| `interrupted` | `ERROR` (logged) |
| `failed` / `timeout` | `ERROR` (logged) |
| anything else | `ERROR` (logged) |

Previously *every* result was unconditionally `DONE`, which is why the user's MINI metrics.csv looked full of completions despite zero actual research output.

## Test plan

- [x] 2 new SSE-drain tests cover the happy path (`run_research_drains_sse_stream_until_done`) and the interrupted path (`run_research_returns_interrupted_when_server_interrupts`)
- [x] Removed the obsolete `test_start_research_extracts_x_research_id_header` (the API it tested is the buggy one)
- [x] 71 tests pass; ruff check + format clean
- [ ] User pulls + reruns Phase 4 via `--rerun "phase=4"`. The new "registered N new units" log should be followed by the actual SSE drain, with `result.status == "completed"` and non-empty `report`/`answer` per response file.

## Impact on existing data

**Every Phase 4 cell that completed before this fix is suspect** — if you grep for `"answer": ""` or `"status": "interrupted"` in `responses/*/standard.json`, you'll see it everywhere. After pulling:

```bash
sweep ... --rerun "phase=4"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
