### PR TITLE
fix(test-corpora): bail run_research early when llama-server dies

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -12,12 +12,59 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 import time
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
 from tenacity import retry, stop_after_attempt, wait_exponential
+
+# Watchdog tunables for run_research. Two consecutive bad readings (~60s by
+# default) force the SSE stream closed so we don't sit on a hung llama-server.
+WATCHDOG_INTERVAL_SECONDS = 30
+WATCHDOG_THRESHOLD = 2
+
+
+@dataclass
+class _WatchdogState:
+    model_bad: int = 0
+    research_bad: int = 0
+
+
+def _evaluate_health(
+    model_state: str | None,
+    research_status: str | None,
+    state: _WatchdogState,
+    threshold: int = WATCHDOG_THRESHOLD,
+) -> tuple[str | None, str | None]:
+    """Update consecutive-bad counters and decide whether to abort an in-flight research.
+
+    Returns ``(abort_kind, abort_detail)`` — both ``None`` when no abort.
+
+    A "bad" model reading is anything other than ``state == "ready"`` (including
+    ``model_state is None``, which means the status call itself failed). A "bad"
+    research reading is one of ``{interrupted, failed, error}``; anything else,
+    including ``None`` (no conv_id yet, or transient poll failure), resets that
+    counter. We require ``threshold`` consecutive bad readings before bailing —
+    one transient blip shouldn't kill a long-running research.
+    """
+    if model_state == "ready":
+        state.model_bad = 0
+    else:
+        state.model_bad += 1
+    if state.model_bad >= threshold:
+        return ("model_unhealthy", f"model state={model_state}")
+
+    if research_status in ("interrupted", "failed", "error"):
+        state.research_bad += 1
+    else:
+        state.research_bad = 0
+    if state.research_bad >= threshold:
+        return ("research_failed", f"research status={research_status}")
+
+    return (None, None)
 
 
 class SyncMcpSession:
@@ -217,6 +264,13 @@ class HarborClerkClient:
         stream early — which an earlier version of this client did —
         ends every research at round 0 with ``status="interrupted"``.
 
+        A watchdog thread polls model + research status every
+        ``WATCHDOG_INTERVAL_SECONDS``. Two consecutive bad readings
+        (model not ``ready``, or research already ``interrupted``/``failed``)
+        forces the SSE stream closed so we don't sit on a hung llama-server.
+        When that happens the returned dict carries ``harness_aborted=True``
+        plus ``harness_abort_reason``.
+
         This call is NOT retried by ``tenacity`` because partial SSE
         streams can't be safely re-opened against the same conv_id.
         """
@@ -233,30 +287,87 @@ class HarborClerkClient:
         read_timeout = time_limit_minutes * 60 + 180
         timeout = httpx.Timeout(connect=30, read=read_timeout, write=10, pool=10)
 
-        conv_id: str | None = None
+        abort_event = threading.Event()
+        abort_reason: dict[str, str] = {}
+        conv_id_holder: list[str | None] = [None]
+        response_holder: list[Any] = [None]
+
+        def _close_stream() -> None:
+            r = response_holder[0]
+            if r is not None:
+                try:
+                    r.close()
+                except Exception:
+                    pass
+
+        def _watchdog() -> None:
+            wstate = _WatchdogState()
+            while not abort_event.wait(WATCHDOG_INTERVAL_SECONDS):
+                try:
+                    ms_state = self.model_status().get("state")
+                except Exception:
+                    ms_state = None
+                rs_status: str | None = None
+                cid = conv_id_holder[0]
+                if cid:
+                    try:
+                        rs_status = self.poll_research(cid).get("status")
+                    except Exception:
+                        rs_status = None
+                kind, detail = _evaluate_health(ms_state, rs_status, wstate)
+                if kind is not None:
+                    abort_reason["kind"] = kind
+                    abort_reason["detail"] = detail or kind
+                    _close_stream()
+                    return
+
+        watchdog: threading.Thread | None = None
         with self._client.stream("POST", "/api/research", json=body, timeout=timeout) as r:
             r.raise_for_status()
             conv_id = r.headers.get("X-Research-Id")
             if not conv_id:
                 raise RuntimeError("research start did not return X-Research-Id")
-            # Drain the SSE stream until done/error. This is what keeps the
-            # research alive server-side.
-            for line in r.iter_lines():
-                if not line.startswith("data: "):
-                    continue
-                payload = line[6:]
-                if not payload.strip():
-                    continue
-                try:
-                    event = json.loads(payload)
-                except json.JSONDecodeError:
-                    continue
-                etype = event.get("type")
-                if etype in ("done", "error"):
-                    break
+            conv_id_holder[0] = conv_id
+            response_holder[0] = r
+
+            watchdog = threading.Thread(target=_watchdog, daemon=True)
+            watchdog.start()
+
+            try:
+                for line in r.iter_lines():
+                    if abort_event.is_set():
+                        break
+                    if not line.startswith("data: "):
+                        continue
+                    payload = line[6:]
+                    if not payload.strip():
+                        continue
+                    try:
+                        event = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    etype = event.get("type")
+                    if etype in ("done", "error"):
+                        break
+            except Exception:
+                # Watchdog forced the stream closed → expected. Anything else
+                # is a real error worth surfacing.
+                if not abort_reason:
+                    raise
+            finally:
+                abort_event.set()
+                if watchdog is not None:
+                    watchdog.join(timeout=5)
 
         # Fetch the final state (status, report, citations, messages).
-        return conv_id, self.poll_research(conv_id)
+        final = self.poll_research(conv_id)
+        if abort_reason:
+            final = {
+                **final,
+                "harness_aborted": True,
+                "harness_abort_reason": abort_reason.get("detail", "unknown"),
+            }
+        return conv_id, final
 
     def wait_for_research(self, conv_id: str, max_wait_seconds: int, poll_seconds: int = 5) -> dict[str, Any]:
         """[Deprecated] Poll until status is completed/failed/interrupted or deadline.

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -588,7 +588,10 @@ def main(argv: list[str] | None = None) -> int:
                         result = out.get("result", {}) or {}
                         result_status = result.get("status")
                         result_answer = result.get("answer") or ""
-                        if result_status == "completed" and result_answer:
+                        if result.get("harness_aborted"):
+                            final_status = Status.ERROR
+                            error_msg = f"harness aborted research: {result.get('harness_abort_reason', 'unknown')}"
+                        elif result_status == "completed" and result_answer:
                             final_status = Status.DONE
                         elif result_status == "completed" and not result_answer:
                             final_status = Status.DEGRADED

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -3,7 +3,7 @@ import json
 import httpx
 import pytest
 
-from scripts.test_corpora.runner.client import HarborClerkClient
+from scripts.test_corpora.runner.client import HarborClerkClient, _evaluate_health, _WatchdogState
 
 
 def make_client(handler) -> HarborClerkClient:
@@ -375,6 +375,70 @@ def test_run_research_drains_sse_stream_until_done():
     assert conv_id == "conv-abc"
     assert result["status"] == "completed"
     assert result["report"] == "hello world"
+
+
+def test_evaluate_health_no_abort_when_model_ready_and_research_running():
+    state = _WatchdogState()
+    kind, detail = _evaluate_health("ready", "running", state)
+    assert kind is None and detail is None
+    assert state.model_bad == 0
+    assert state.research_bad == 0
+
+
+def test_evaluate_health_aborts_after_two_consecutive_model_bad():
+    """Two consecutive non-ready model readings must trigger model_unhealthy.
+    This is the case we're trying to catch: llama-server crashes, HC's
+    /api/chat/models/status flips from 'ready' to 'loading'/'errored'/etc.,
+    and the harness needs to bail rather than wait for HC's read timeout."""
+    state = _WatchdogState()
+    kind, _ = _evaluate_health("loading", None, state)
+    assert kind is None  # one bad reading isn't enough
+    assert state.model_bad == 1
+    kind, detail = _evaluate_health("loading", None, state)
+    assert kind == "model_unhealthy"
+    assert "loading" in (detail or "")
+
+
+def test_evaluate_health_treats_status_call_failure_as_bad():
+    """If GET /api/chat/models/status itself raises, the watchdog passes
+    None for model_state. Two such failures count as bad — HC API death
+    is just as much a stopper as model death."""
+    state = _WatchdogState()
+    _evaluate_health(None, None, state)
+    kind, _ = _evaluate_health(None, None, state)
+    assert kind == "model_unhealthy"
+
+
+def test_evaluate_health_resets_on_recovery():
+    """A transient blip ('loading' once, then 'ready') must NOT trigger
+    a bail — otherwise model warm-up races would kill every research."""
+    state = _WatchdogState()
+    _evaluate_health("loading", None, state)
+    assert state.model_bad == 1
+    kind, _ = _evaluate_health("ready", None, state)
+    assert kind is None
+    assert state.model_bad == 0
+
+
+def test_evaluate_health_aborts_after_two_consecutive_research_failed():
+    """If HC has marked the research interrupted/failed but somehow the SSE
+    stream is still open, the watchdog should bail. Same threshold so a
+    transient poll error doesn't masquerade as a state transition."""
+    state = _WatchdogState()
+    _evaluate_health("ready", "interrupted", state)
+    kind, detail = _evaluate_health("ready", "interrupted", state)
+    assert kind == "research_failed"
+    assert "interrupted" in (detail or "")
+
+
+def test_evaluate_health_research_bad_resets_on_running():
+    """Research status flipping to 'running' between bad readings resets
+    the counter — only a sustained bad state triggers a bail."""
+    state = _WatchdogState()
+    _evaluate_health("ready", "interrupted", state)
+    assert state.research_bad == 1
+    _evaluate_health("ready", "running", state)
+    assert state.research_bad == 0
 
 
 def test_run_research_returns_interrupted_when_server_interrupts():


### PR DESCRIPTION
## Summary

On MINI, a research POST sits in `iter_lines` for ~10 minutes per question with no events, eventually returns `status="interrupted"`, harness marks ERROR. Root cause is upstream — llama-server is crashing under sustained load on a 32 GB host — but the harness was happily waiting the full `read_timeout` (`time_limit_minutes*60 + 180s`) before giving up. It should detect this within ~60 seconds.

User: *"Looks like LLM is crashing, I will diagnose that separately, but it should still catch this."*

## Mechanism

A watchdog thread inside `run_research` polls two HC endpoints every `WATCHDOG_INTERVAL_SECONDS` (30s):

| Endpoint | Bad reading |
|---|---|
| `GET /api/chat/models/status` | `state` is anything other than `"ready"`, OR the call itself raises |
| `GET /api/research/{conv_id}` | `status` is one of `interrupted` / `failed` / `error` |

Two consecutive bad readings (`WATCHDOG_THRESHOLD = 2`, ~60s) → watchdog calls `r.close()` on the streaming response → main thread exits `iter_lines` → final `poll_research()` → returns with `harness_aborted=True` and a descriptive `harness_abort_reason`.

The "two consecutive" rule prevents a transient blip (single failed status call, brief loading-state during model warm-up) from killing a long-running research.

## Why this works

HC's `research_stream` makes a long-running httpx call to llama-server inside its handler. When llama-server dies, HC's call hangs without emitting SSE events. The client's `iter_lines` blocks for the entire `read_timeout`. By polling a *separate* endpoint (`/api/chat/models/status`) from a watchdog thread, we get an out-of-band signal that the LLM is dead even when the SSE stream is silent.

`r.close()` from the watchdog thread is httpx-safe — closing a streaming response while another thread iterates it just unblocks `iter_lines` cleanly.

## Decision logic factored for testing

The state-machine bit is extracted as `_evaluate_health(model_state, research_status, _WatchdogState)` — a pure function on a tiny dataclass. Six unit tests cover: no-abort happy path, model bail after threshold, status-call-failure-counts-as-bad, recovery resets counter, research-status bail, research-running resets.

Threading wiring inside `run_research` is glue around that helper.

## Sweep status downgrade

`sweep.py`'s phase 2-6 status logic learned a new branch:

```python
if result.get("harness_aborted"):
    final_status = Status.ERROR
    error_msg = f"harness aborted research: {result.get('harness_abort_reason', 'unknown')}"
```

So metrics.csv now shows `harness aborted research: model state=loading` instead of the generic `research interrupted by Harbor Clerk` — easier to grep for the LLM-crash failure mode separately from real HC interrupts.

## Test plan

- [x] 6 new `_evaluate_health` tests pass; existing 25 client tests still pass; ruff clean + format clean
- [ ] On MINI: observe a unit fail with `harness aborted research: model state=...` within ~60s of llama-server crash, instead of waiting 10 minutes per unit
- [ ] After abort, the next `_run_local` cycle's `cleanup_orphan_research()` cleans up any HC-side leftover state and the sweep continues to the next unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
