### PR TITLE
fix(test-corpora): align sweep model ids with HC's actual registry

### DIFF
--- a/scripts/test_corpora/README.md
+++ b/scripts/test_corpora/README.md
@@ -76,7 +76,7 @@ uv run python -m scripts.test_corpora.runner.sweep \
 
 ```bash
 uv run python -m scripts.test_corpora.runner.sweep \
-    --run-id 2026-05-05-full --rerun "phase=5,model=qwen3.6-35b,corpus=cuad"
+    --run-id 2026-05-05-full --rerun "phase=5,model=qwen36-35b-a3b,corpus=cuad"
 ```
 
 ## Output layout

--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -45,7 +45,7 @@ If you want to keep an existing corpus intact, run the sweep against a **separat
    │  sweep harness              │               │              │  sweep harness           │
    │   ├ Phase 0,1,5,6           │◀──────────────┘              │   ├ Phase 0 (cached)     │
    │   └ Phase 4 top 2 models    │                              │   └ Phase 4 6 small      │
-   │      (gemma-26b, qwen3.6)   │                              │      (smollm3-3b...      │
+   │      (gemma4-26b, qwen36)   │                              │      (smollm3-3b...      │
    │                             │                              │       gpt-oss-20b)       │
    │  supervisor.py              │                              │  supervisor.py           │
    │   └ tail log → notify       │                              │   └ tail log → notify    │
@@ -223,7 +223,7 @@ tmux new -d -s sweep-mini "uv --project scripts/test_corpora run python -m \
     scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir \"$WORKDIR\" \
     --phases 4 \
-    --models smollm3-3b,qwen3-4b,phi-4-mini,qwen3-8b,deepseek-r1-8b,gpt-oss-20b \
+    --models smollm3-3b,qwen3-4b,phi4-mini,qwen3-8b,deepseek-r1-0528-8b,gpt-oss-20b \
     \
     2>&1 | tee ~/sweep-logs/phase4-mini.log"
 
@@ -244,7 +244,7 @@ tmux new -d -s sweep-big "uv --project scripts/test_corpora run python -m \
     scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir \"$WORKDIR\" \
     --phases 4 \
-    --models gemma-26b,qwen3.6-35b \
+    --models gemma4-26b-a4b,qwen36-35b-a3b \
     \
     2>&1 | tee ~/sweep-logs/phase4-big.log"
 
@@ -322,7 +322,7 @@ In a Claude Code session on the relevant machine:
 >
 > - **`phase_boundary`** — log it; no action needed
 > - **`completion`** — log it; tell me the sweep is done
-> - **`skip_recommendation`** — investigate the last 50 lines of the harness log around the failure. If the model is `deepseek-r1-8b` (known research-mode flake), accept the recommendation and run `uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep --run-id $RUN --skip "model=<model>"` to mark its remaining units SKIPPED. For any other model, page me with the failure context and don't auto-skip.
+> - **`skip_recommendation`** — investigate the last 50 lines of the harness log around the failure. If the model is `deepseek-r1-0528-8b` (known research-mode flake), accept the recommendation and run `uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep --run-id $RUN --skip "model=<model>"` to mark its remaining units SKIPPED. For any other model, page me with the failure context and don't auto-skip.
 > - **`stuck`** — investigate the last 100 lines of the harness log. If you see `llama-server` errors or `Connection refused`, ask me whether to restart Harbor Clerk's LLM service. If you see only Anthropic 429/503, just wait.
 > - **`rate_limit`** — log and wait; the harness retries with exponential backoff
 > - **any unhandled event type** — page me
@@ -386,7 +386,7 @@ Skip it:
 ```bash
 uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir "$WORKDIR" \
-    --skip "model=deepseek-r1-8b"
+    --skip "model=deepseek-r1-0528-8b"
 ```
 
 This is exactly what the supervisor recommends after 3 consecutive errors. Re-run the sweep to skip the rest of that model's units.

--- a/scripts/test_corpora/conftest.py
+++ b/scripts/test_corpora/conftest.py
@@ -17,21 +17,23 @@ from pathlib import Path
 API_BASE = os.environ.get("HC_API_BASE", "http://localhost:8100")
 ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
 
-# All eight downloaded models, by Harbor Clerk model_id. Phase 4 sweeps over
-# this list. Phase 5 uses TOP_MODELS only.
+# All eight downloaded models, by Harbor Clerk model_id. These MUST match the
+# canonical ids in src/harbor_clerk/llm/models.py — anything else 404s on
+# PUT /api/chat/models/<id>/activate. Phase 4 sweeps over this list. Phase 5
+# uses TOP_MODELS only.
 ALL_MODELS = [
     "qwen3-8b",
     "qwen3-4b",
-    "phi-4-mini",
-    "deepseek-r1-8b",
-    "gemma-26b",
+    "phi4-mini",
+    "deepseek-r1-0528-8b",
+    "gemma4-26b-a4b",
     "smollm3-3b",
     "gpt-oss-20b",
-    "qwen3.6-35b",
+    "qwen36-35b-a3b",
 ]
 
 # Two largest by parameter count. Used for Phases 5 and 6 parity comparison.
-TOP_MODELS = ["qwen3.6-35b", "gemma-26b"]
+TOP_MODELS = ["qwen36-35b-a3b", "gemma4-26b-a4b"]
 
 DEPTHS = ["light", "standard", "thorough"]
 DEFAULT_DEPTH = "standard"

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -155,18 +155,18 @@ def _plan_units(
                 for q in _question_ids(qs):
                     units.append(Unit(phase=1, corpus=c, model="claude-baseline", question_id=q, depth="n/a"))
         elif phase == 2:
-            # smoke — one model, one corpus. Skipped if cuad or qwen3.6-35b isn't in scope.
-            if "cuad" in questions_by_corpus and (models_filter is None or "qwen3.6-35b" in models_filter):
+            # smoke — one model, one corpus. Skipped if cuad or qwen36-35b-a3b isn't in scope.
+            if "cuad" in questions_by_corpus and (models_filter is None or "qwen36-35b-a3b" in models_filter):
                 units.append(
-                    Unit(phase=2, corpus="cuad", model="qwen3.6-35b", question_id="cuad-research-1", depth=depth)
+                    Unit(phase=2, corpus="cuad", model="qwen36-35b-a3b", question_id="cuad-research-1", depth=depth)
                 )
         elif phase == 3:
             # depth coverage — same model × all three depths on cuad. Skipped if cuad or
-            # qwen3.6-35b isn't in scope.
-            if "cuad" in questions_by_corpus and (models_filter is None or "qwen3.6-35b" in models_filter):
+            # qwen36-35b-a3b isn't in scope.
+            if "cuad" in questions_by_corpus and (models_filter is None or "qwen36-35b-a3b" in models_filter):
                 for d in cfg.DEPTHS:
                     for q in _question_ids(questions_by_corpus["cuad"]):
-                        units.append(Unit(phase=3, corpus="cuad", model="qwen3.6-35b", question_id=q, depth=d))
+                        units.append(Unit(phase=3, corpus="cuad", model="qwen36-35b-a3b", question_id=q, depth=d))
         elif phase == 4:
             # Corpus is outer loop so each corpus change (= full re-ingest) happens only
             # once per corpus rather than once per (model, corpus) pair.

--- a/scripts/test_corpora/tests/test_plan_units.py
+++ b/scripts/test_corpora/tests/test_plan_units.py
@@ -23,33 +23,33 @@ def test_models_filter_restricts_phase4_loop():
         _qbc(["cuad"]),
         phases={4},
         depth="standard",
-        models_filter={"qwen3-8b", "phi-4-mini"},
+        models_filter={"qwen3-8b", "phi4-mini"},
     )
     models = {u.model for u in units}
-    assert models == {"qwen3-8b", "phi-4-mini"}
+    assert models == {"qwen3-8b", "phi4-mini"}
 
 
 def test_models_filter_restricts_phase5_to_top_subset():
     """Phase 5 normally includes both TOP_MODELS. A filter that excludes
-    qwen3.6-35b should leave only gemma-26b in Phase 5."""
+    qwen36-35b-a3b should leave only gemma4-26b-a4b in Phase 5."""
     units = _plan_units(
         _qbc(["cuad"]),
         phases={5},
         depth="standard",
-        models_filter={"gemma-26b"},
+        models_filter={"gemma4-26b-a4b"},
     )
     models = {u.model for u in units}
-    assert models == {"gemma-26b"}
+    assert models == {"gemma4-26b-a4b"}
 
 
 def test_models_filter_excludes_phase2_smoke_when_qwen35_filtered_out():
-    """Phase 2 hard-codes qwen3.6-35b. If that model isn't in the filter, no
+    """Phase 2 hard-codes qwen36-35b-a3b. If that model isn't in the filter, no
     Phase 2 unit should be planned."""
     units = _plan_units(
         _qbc(["cuad"]),
         phases={2},
         depth="standard",
-        models_filter={"phi-4-mini"},
+        models_filter={"phi4-mini"},
     )
     assert units == []
 
@@ -75,7 +75,7 @@ def test_phase4_corpus_then_model_ordering_minimizes_db_wipes():
         _qbc(["cuad", "enron"]),
         phases={4},
         depth="standard",
-        models_filter={"qwen3-8b", "phi-4-mini"},
+        models_filter={"qwen3-8b", "phi4-mini"},
     )
     # Walk the unit list and count corpus transitions
     transitions = sum(1 for a, b in zip(units, units[1:]) if a.corpus != b.corpus)
@@ -114,7 +114,7 @@ def test_phase_planning_is_additive_after_prior_phase(tmp_path):
         _qbc(["cuad"]),
         missing_phases,
         "standard",
-        models_filter={"qwen3.6-35b"},
+        models_filter={"qwen36-35b-a3b"},
     )
     assert len(new_units) > 0, "missing-phase planning produced zero units"
     assert all(u.phase == 4 for u in new_units), "all new units must be phase 4"


### PR DESCRIPTION
## Summary

On BIG, the sweep died with:

```
2026-05-06 12:00:50,286 INFO sweep activating model gemma-26b (was None)
2026-05-06 12:00:50,290 INFO httpx HTTP Request: PUT http://localhost:8100/api/chat/models/gemma-26b/activate "HTTP/1.1 404 Not Found"
(processed exited after that)
```

Same bug latent on MINI for `phi-4-mini` and `deepseek-r1-8b` — just further down the loop.

## Root cause

`ALL_MODELS` in [conftest.py](scripts/test_corpora/conftest.py:22) used informal labels. The canonical ids live in [src/harbor_clerk/llm/models.py](src/harbor_clerk/llm/models.py:51) and `PUT /api/chat/models/{id}/activate` 404s on anything else. Four of eight were wrong:

| `conftest.py` (was) | `models.py` (canonical) |
| --- | --- |
| `phi-4-mini` | `phi4-mini` |
| `deepseek-r1-8b` | `deepseek-r1-0528-8b` |
| `gemma-26b` | `gemma4-26b-a4b` |
| `qwen3.6-35b` | `qwen36-35b-a3b` |

The other four (`qwen3-8b`, `qwen3-4b`, `smollm3-3b`, `gpt-oss-20b`) happened to match by luck.

## Fix

Source-of-truth update in `conftest.py` (`ALL_MODELS` + `TOP_MODELS`), plus the four downstream references in `sweep.py`'s hardcoded Phase 2/3 smoke-test loops, the example commands in `README.md` and `RUNBOOK.md` (MINI + BIG --models lists, deepseek skip example), and the `test_plan_units` fixtures.

`test_state` / `test_sampler` / `test_supervisor` pass model ids as opaque strings — state-file keys, log-line regex captures — so those aren't tied to HC's registry. Left as-is.

## Test plan

- [x] 59 tests pass; ruff check + format clean
- [ ] On BIG: rerun produces `activating model gemma4-26b-a4b` instead of `gemma-26b`, returns 200
- [ ] On MINI: full smaller-6 loop activates `phi4-mini` and `deepseek-r1-0528-8b` without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
