### PR TITLE
fix(test-corpora): skip re-ingest on --resume when HC already has corpus

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -276,14 +276,13 @@ def _run_local(
 def _hc_corpus_matches(hc: HarborClerkClient, manifest: CorpusManifest) -> bool:
     """Return True iff HC already has the given corpus loaded.
 
-    Used at sweep startup (before the first per-unit ingest decision) to
-    skip the wipe-and-re-ingest cycle when the user is resuming a sweep
-    that was killed mid-run with the right corpus still in the DB.
-
     Two checks: a watch folder whose ``path`` equals ``manifest.ingest_dir``,
     AND ``document_count() >= 50% of manifest.doc_count``. The doc-count
     floor matches ``_ingest_corpus``'s "ingest looks incomplete" sanity
     check, so anything we'd accept fresh we also accept on resume.
+
+    Pure point-in-time check — the caller is responsible for ensuring HC's
+    queue is drained before trusting the doc count (see ``_can_skip_ingest``).
     """
     target = str(manifest.ingest_dir)
     folders = hc.watch_folder_list()
@@ -291,6 +290,27 @@ def _hc_corpus_matches(hc: HarborClerkClient, manifest: CorpusManifest) -> bool:
         return False
     threshold = max(1, int(manifest.doc_count * 0.5))
     return hc.document_count() >= threshold
+
+
+def _can_skip_ingest(
+    hc: HarborClerkClient,
+    manifest: CorpusManifest,
+    max_drain_wait: int = 4 * 3600,
+) -> bool:
+    """Decide whether to skip ``_ingest_corpus``'s wipe-and-re-ingest cycle.
+
+    Used at sweep startup, before the first per-unit ingest decision in
+    phases 4/5/6. If a previous sweep died mid-ingest, HC may still have
+    pending jobs in the queue — trusting ``document_count`` while the
+    queue is draining could let research start against a partial corpus.
+    So we drain first (up to ``max_drain_wait``), then ask whether HC's
+    state matches the manifest.
+    """
+    if not hc.pipeline_quiet():
+        log.info("pipeline still draining at startup — waiting before checking corpus state")
+        if not hc.wait_for_quiet_pipeline(max_wait_seconds=max_drain_wait):
+            return False
+    return _hc_corpus_matches(hc, manifest)
 
 
 def _ingest_corpus(hc: HarborClerkClient, manifest: CorpusManifest) -> None:
@@ -529,7 +549,7 @@ def main(argv: list[str] | None = None) -> int:
                     notes="unified pass",
                 )
                 if not args.dry_run:
-                    if current_corpus_in_db is None and _hc_corpus_matches(hc, unified_manifest):
+                    if current_corpus_in_db is None and _can_skip_ingest(hc, unified_manifest):
                         log.info("HC already has unified corpus loaded — skipping re-ingest")
                         current_corpus_in_db = "unified"
                     elif current_corpus_in_db != "unified":
@@ -543,12 +563,13 @@ def main(argv: list[str] | None = None) -> int:
 
                 # Ensure correct corpus is in the DB for phases 4/5 (unified for 6).
                 # On a fresh process (current_corpus_in_db is None) we first ask HC
-                # whether it already has u.corpus loaded — if so, skip the wipe so
-                # `--resume` after a mid-corpus crash doesn't lose the existing ingest.
+                # whether it already has u.corpus loaded AND its queue has drained —
+                # if so, skip the wipe so `--resume` after a mid-corpus crash doesn't
+                # lose the existing ingest.
                 if phase in (4, 5) and u.corpus != current_corpus_in_db:
                     if u.corpus not in manifests:
                         manifests[u.corpus] = _phase0_acquire(u.corpus, workdir)
-                    if current_corpus_in_db is None and _hc_corpus_matches(hc, manifests[u.corpus]):
+                    if current_corpus_in_db is None and _can_skip_ingest(hc, manifests[u.corpus]):
                         log.info("HC already has %s loaded — skipping re-ingest", u.corpus)
                         current_corpus_in_db = u.corpus
                     elif u.corpus != current_corpus_in_db:

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -273,6 +273,26 @@ def _run_local(
 # ── ingestion helper ──
 
 
+def _hc_corpus_matches(hc: HarborClerkClient, manifest: CorpusManifest) -> bool:
+    """Return True iff HC already has the given corpus loaded.
+
+    Used at sweep startup (before the first per-unit ingest decision) to
+    skip the wipe-and-re-ingest cycle when the user is resuming a sweep
+    that was killed mid-run with the right corpus still in the DB.
+
+    Two checks: a watch folder whose ``path`` equals ``manifest.ingest_dir``,
+    AND ``document_count() >= 50% of manifest.doc_count``. The doc-count
+    floor matches ``_ingest_corpus``'s "ingest looks incomplete" sanity
+    check, so anything we'd accept fresh we also accept on resume.
+    """
+    target = str(manifest.ingest_dir)
+    folders = hc.watch_folder_list()
+    if not any(f.get("path") == target for f in folders):
+        return False
+    threshold = max(1, int(manifest.doc_count * 0.5))
+    return hc.document_count() >= threshold
+
+
 def _ingest_corpus(hc: HarborClerkClient, manifest: CorpusManifest) -> None:
     """Wipe the DB, register the corpus's ingest dir, wait for ingestion to
     fully complete before returning.
@@ -509,20 +529,31 @@ def main(argv: list[str] | None = None) -> int:
                     notes="unified pass",
                 )
                 if not args.dry_run:
-                    _ingest_corpus(hc, unified_manifest)
-                    current_corpus_in_db = "unified"
+                    if current_corpus_in_db is None and _hc_corpus_matches(hc, unified_manifest):
+                        log.info("HC already has unified corpus loaded — skipping re-ingest")
+                        current_corpus_in_db = "unified"
+                    elif current_corpus_in_db != "unified":
+                        _ingest_corpus(hc, unified_manifest)
+                        current_corpus_in_db = "unified"
 
             for u in phase_units:
                 if args.dry_run and phase > 0:
                     log.info("dry-run: skipping %s", u)
                     continue
 
-                # Ensure correct corpus is in the DB for phases 4/5 (unified for 6)
+                # Ensure correct corpus is in the DB for phases 4/5 (unified for 6).
+                # On a fresh process (current_corpus_in_db is None) we first ask HC
+                # whether it already has u.corpus loaded — if so, skip the wipe so
+                # `--resume` after a mid-corpus crash doesn't lose the existing ingest.
                 if phase in (4, 5) and u.corpus != current_corpus_in_db:
                     if u.corpus not in manifests:
                         manifests[u.corpus] = _phase0_acquire(u.corpus, workdir)
-                    _ingest_corpus(hc, manifests[u.corpus])
-                    current_corpus_in_db = u.corpus
+                    if current_corpus_in_db is None and _hc_corpus_matches(hc, manifests[u.corpus]):
+                        log.info("HC already has %s loaded — skipping re-ingest", u.corpus)
+                        current_corpus_in_db = u.corpus
+                    elif u.corpus != current_corpus_in_db:
+                        _ingest_corpus(hc, manifests[u.corpus])
+                        current_corpus_in_db = u.corpus
 
                 # Ensure correct model is active for phases 2-6
                 if phase in (2, 3, 4, 5, 6) and u.model not in (None, "-", "claude-baseline"):

--- a/scripts/test_corpora/tests/test_sweep_ingest.py
+++ b/scripts/test_corpora/tests/test_sweep_ingest.py
@@ -10,7 +10,7 @@ import httpx
 
 from scripts.test_corpora.corpora.manifest import CorpusManifest
 from scripts.test_corpora.runner.client import HarborClerkClient
-from scripts.test_corpora.runner.sweep import _hc_corpus_matches
+from scripts.test_corpora.runner.sweep import _can_skip_ingest, _hc_corpus_matches
 
 
 def _make_client(handler) -> HarborClerkClient:
@@ -84,6 +84,48 @@ def test_hc_corpus_matches_false_when_doc_count_below_threshold():
 
     c = _make_client(handler)
     assert _hc_corpus_matches(c, _manifest(doc_count=80)) is False
+
+
+def test_can_skip_ingest_true_when_quiet_and_loaded():
+    """Happy path for --resume: queue is quiet, folder + count match → True."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/jobs/snapshot":
+            return httpx.Response(
+                200, json={"queues": {"io": {"queued": 0, "running": 0}, "cpu": {"queued": 0, "running": 0}}}
+            )
+        if request.url.path == "/api/watch/folders":
+            return httpx.Response(200, json=[{"folder_id": "f1", "path": "/tmp/cuad-ingest"}])
+        if request.url.path == "/api/docs":
+            return httpx.Response(200, json={"items": [], "total": 80, "limit": 0})
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _can_skip_ingest(c, _manifest(), max_drain_wait=0) is True
+
+
+def test_can_skip_ingest_false_when_queue_busy_and_no_drain_budget():
+    """Mid-ingest case the user flagged: HC has 51% of expected docs but
+    the queue is still draining. With max_drain_wait=0 the helper bails
+    out and returns False, forcing _ingest_corpus to wipe + re-ingest
+    rather than letting research start against a partial corpus."""
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/api/jobs/snapshot":
+            return httpx.Response(
+                200, json={"queues": {"io": {"queued": 5, "running": 1}, "cpu": {"queued": 0, "running": 0}}}
+            )
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _can_skip_ingest(c, _manifest(), max_drain_wait=0) is False
+    # Critical: with the queue busy we must NEVER read document_count and decide
+    # based on a moving number. Verify the helper short-circuited before
+    # calling /api/docs or /api/watch/folders.
+    assert "/api/docs" not in seen_paths
+    assert "/api/watch/folders" not in seen_paths
 
 
 def test_hc_corpus_matches_handles_tiny_corpus_floor():

--- a/scripts/test_corpora/tests/test_sweep_ingest.py
+++ b/scripts/test_corpora/tests/test_sweep_ingest.py
@@ -1,0 +1,103 @@
+"""Tests for sweep.py's ingest-detection helpers — particularly the
+`_hc_corpus_matches` shortcut that lets `--resume` skip a re-ingest when
+HC already has the right corpus loaded."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+from scripts.test_corpora.corpora.manifest import CorpusManifest
+from scripts.test_corpora.runner.client import HarborClerkClient
+from scripts.test_corpora.runner.sweep import _hc_corpus_matches
+
+
+def _make_client(handler) -> HarborClerkClient:
+    transport = httpx.MockTransport(handler)
+    return HarborClerkClient(base_url="https://localhost", transport=transport, verify=False)
+
+
+def _manifest(ingest_dir: str = "/tmp/cuad-ingest", doc_count: int = 80) -> CorpusManifest:
+    return CorpusManifest(
+        corpus_id="cuad",
+        ingest_dir=Path(ingest_dir),
+        doc_count=doc_count,
+        total_size_bytes=1,
+        license="ignored",
+    )
+
+
+def test_hc_corpus_matches_true_when_folder_and_count_align():
+    """Happy-path: HC has the right watch folder AND a plausible doc count.
+    Returns True so the caller skips the wipe-and-re-ingest cycle."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/watch/folders":
+            return httpx.Response(200, json=[{"folder_id": "f1", "path": "/tmp/cuad-ingest"}])
+        if request.url.path == "/api/docs":
+            assert request.url.params.get("limit") == "0"
+            return httpx.Response(200, json={"items": [], "total": 80, "limit": 0, "offset": 0})
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _hc_corpus_matches(c, _manifest()) is True
+
+
+def test_hc_corpus_matches_false_when_no_watch_folders():
+    """Empty watch folder list → no corpus loaded, fall through to re-ingest."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/watch/folders":
+            return httpx.Response(200, json=[])
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _hc_corpus_matches(c, _manifest()) is False
+
+
+def test_hc_corpus_matches_false_when_folder_path_differs():
+    """HC has a watch folder but for a different corpus → don't skip ingest.
+    Important: prevents a previous corpus's stale ingest from masquerading
+    as this corpus's data."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/watch/folders":
+            return httpx.Response(200, json=[{"folder_id": "f1", "path": "/tmp/enron-ingest"}])
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _hc_corpus_matches(c, _manifest("/tmp/cuad-ingest")) is False
+
+
+def test_hc_corpus_matches_false_when_doc_count_below_threshold():
+    """Folder matches but HC has nowhere near the expected doc count —
+    likely a partial / interrupted ingest. Re-ingest from scratch."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/watch/folders":
+            return httpx.Response(200, json=[{"folder_id": "f1", "path": "/tmp/cuad-ingest"}])
+        if request.url.path == "/api/docs":
+            # 39 < 80 * 0.5 = 40, so below the threshold
+            return httpx.Response(200, json={"items": [], "total": 39, "limit": 0, "offset": 0})
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _hc_corpus_matches(c, _manifest(doc_count=80)) is False
+
+
+def test_hc_corpus_matches_handles_tiny_corpus_floor():
+    """A 1-document corpus's threshold floors at 1 (50% of 1 = 0 by int()).
+    Without the `max(1, ...)` floor, an empty DB would falsely match every
+    1-doc manifest."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/watch/folders":
+            return httpx.Response(200, json=[{"folder_id": "f1", "path": "/tmp/x"}])
+        if request.url.path == "/api/docs":
+            return httpx.Response(200, json={"items": [], "total": 0, "limit": 0, "offset": 0})
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    m = CorpusManifest(corpus_id="x", ingest_dir=Path("/tmp/x"), doc_count=1, total_size_bytes=1, license="ignored")
+    assert _hc_corpus_matches(c, m) is False


### PR DESCRIPTION
## Summary

`--resume` after a killed sweep was wiping the DB and re-ingesting the same corpus from scratch (~15 min for CUAD on a Mac mini). Root cause: `current_corpus_in_db` starts at `None` on every fresh process, so the first per-unit ingest decision in the phase 4/5 loop always took the `u.corpus != None` branch.

```python
# scripts/test_corpora/runner/sweep.py — before
current_corpus_in_db: str | None = None
...
if phase in (4, 5) and u.corpus != current_corpus_in_db:
    _ingest_corpus(hc, manifests[u.corpus])  # ← always fires on first unit
    current_corpus_in_db = u.corpus
```

## Fix

Add a one-time detection at the first ingest decision: if HC already has a watch folder whose `path` equals `manifest.ingest_dir` AND the document count is at least 50% of expected (same threshold as `_ingest_corpus`'s post-ingest sanity check), set `current_corpus_in_db` without calling `_ingest_corpus`. Same logic in the Phase 6 unified branch.

```python
if current_corpus_in_db is None and _hc_corpus_matches(hc, manifests[u.corpus]):
    log.info("HC already has %s loaded — skipping re-ingest", u.corpus)
    current_corpus_in_db = u.corpus
elif u.corpus != current_corpus_in_db:
    _ingest_corpus(hc, manifests[u.corpus])
    current_corpus_in_db = u.corpus
```

The threshold floors at 1 — without that, a 1-doc corpus could falsely match an empty DB (50% of 1 = 0 by integer truncation).

The detection only runs ONCE per process (when `current_corpus_in_db is None`). After that the existing logic takes over: a corpus *change* still always wipes + re-ingests, because the harness needs the right corpus loaded for the current unit.

## Test plan

- [x] 5 new tests in `test_sweep_ingest.py` cover: matching folder + sufficient docs (True), no folders (False), mismatched folder path (False), sufficient folder but doc count below threshold (False), 1-doc floor (False)
- [x] 50 tests pass; ruff check + format clean
- [ ] Kill a sweep mid-Phase-4 with cuad already ingested; rerun with `--resume` and observe `HC already has cuad loaded — skipping re-ingest` instead of `delete_all_documents before ingesting cuad`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
