### PR TITLE
fix(test-corpora): retry research once on transient failure + harden ready-wait

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -200,17 +200,33 @@ class HarborClerkClient:
         model_id: str,
         max_wait_seconds: int = 600,
         poll_seconds: int = 2,
+        consecutive_ready_required: int = 3,
     ) -> bool:
-        """Poll model_status() until state=='ready' and model_id matches.
+        """Poll model_status() until state=='ready' and model_id matches for
+        ``consecutive_ready_required`` consecutive polls.
+
+        HC's ``/api/chat/models/status`` reports ``ready`` as soon as
+        llama-server's ``/health`` returns 200 — but llama-server's HTTP
+        server can come up slightly before the model is actually warm
+        enough to generate, so a single ready reading sometimes leads to
+        an immediate research failure on the first generation. Requiring
+        3 consecutive readings (with default poll_seconds=2 → ~4-6s of
+        stable ``ready``) closes that race without forcing a fixed
+        post-load sleep.
 
         Returns True on success, False on timeout or persistent mismatch.
         When poll_seconds=0 (test mode) the sleep is skipped.
         """
         deadline = time.time() + max_wait_seconds
+        consecutive = 0
         while time.time() < deadline:
             status = self.model_status()
             if status.get("state") == "ready" and status.get("model_id") == model_id:
-                return True
+                consecutive += 1
+                if consecutive >= consecutive_ready_required:
+                    return True
+            else:
+                consecutive = 0
             if poll_seconds > 0:
                 time.sleep(poll_seconds)
         return False

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -58,6 +58,36 @@ _LEGACY_MODEL_ID_RENAMES = {
 }
 
 
+# How long to wait between the original research and a one-shot retry on
+# transient failure (failed / interrupted / harness_aborted). 30s lets a
+# briefly wedged llama-server recover; longer doesn't help and just delays
+# the eventual ERROR.
+RESEARCH_RETRY_DELAY_SECONDS = 30
+
+
+def _is_retryable_research_failure(out: dict) -> bool:
+    """Whether ``out["result"]`` warrants a one-shot retry.
+
+    Retryable:
+      - ``status == "failed"`` — HC's research raised an error mid-stream.
+        Most often a llama-server hiccup, sometimes a model that wasn't
+        actually warm yet despite ``model_status == "ready"``.
+      - ``status == "interrupted"`` — HC's SSE stream closed before
+        completion. Could be a real disconnect or a watchdog catch.
+      - ``harness_aborted`` — our watchdog forced the stream closed
+        because the model went unhealthy. The retry covers the case
+        where the model recovers (auto-restart, transient glitch).
+
+    Not retryable: ``status == "completed"`` (even with an empty answer —
+    same query against same model won't suddenly succeed), or non-research
+    output (chat questions don't go through this path).
+    """
+    result = out.get("result", {}) or {}
+    if result.get("harness_aborted"):
+        return True
+    return result.get("status") in ("failed", "interrupted")
+
+
 # ── argparse ──
 
 
@@ -664,6 +694,40 @@ def main(argv: list[str] | None = None) -> int:
                             is_research=_is_research(u.question_id),
                             results_dir=run_dir,
                         )
+
+                        # One-shot retry on transient research failures. The most
+                        # common cause is the model wasn't actually warm despite
+                        # HC reporting state=ready; second-most-common is
+                        # llama-server hiccup mid-run that recovered. Wait, verify
+                        # the model is still ready, then re-run the same question
+                        # at the same depth. If the retry also fails the unit gets
+                        # the normal status downgrade (ERROR) below.
+                        if _is_research(u.question_id) and _is_retryable_research_failure(out):
+                            res = out.get("result", {}) or {}
+                            log.warning(
+                                "research %s/%s/%s failed (status=%s, harness_aborted=%s); retrying once after %ds",
+                                u.corpus,
+                                u.model,
+                                u.question_id,
+                                res.get("status"),
+                                bool(res.get("harness_aborted")),
+                                RESEARCH_RETRY_DELAY_SECONDS,
+                            )
+                            time.sleep(RESEARCH_RETRY_DELAY_SECONDS)
+                            if not hc.wait_for_model_ready(u.model, max_wait_seconds=600):
+                                log.warning("model %s not ready before retry — accepting failure", u.model)
+                            else:
+                                out = _run_local(
+                                    hc=hc,
+                                    corpus=u.corpus,
+                                    model=u.model,
+                                    question_id=u.question_id,
+                                    question_text=text,
+                                    depth=u.depth,
+                                    time_limit_minutes=args.time_limit_minutes,
+                                    is_research=True,
+                                    results_dir=run_dir,
+                                )
 
                     # For local-model questions (phases 2-6), inspect the
                     # ResearchDetail / chat result and downgrade the unit

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -47,12 +47,26 @@ def test_wait_for_model_ready_returns_true_when_ready():
 
     def handler(request):
         calls["n"] += 1
-        # First call: loading. Second call: ready.
+        # First call: loading. Subsequent: ready.
         state = "loading" if calls["n"] == 1 else "ready"
         return httpx.Response(200, json={"state": state, "model_id": "qwen3-8b"})
 
     c = make_client(handler)
-    assert c.wait_for_model_ready("qwen3-8b", max_wait_seconds=5, poll_seconds=0) is True
+    assert c.wait_for_model_ready("qwen3-8b", max_wait_seconds=5, poll_seconds=0, consecutive_ready_required=3) is True
+
+
+def test_wait_for_model_ready_requires_consecutive_ready_polls():
+    """Single 'ready' flicker between 'loading' readings must NOT satisfy
+    the wait. HC reports ready as soon as llama-server's /health returns 200,
+    but llama-server can briefly answer 200 before the model is generation-
+    ready. We require 3 consecutive ready readings to ride that out."""
+    states = iter(["loading", "ready", "loading", "ready", "ready", "ready"])
+
+    def handler(request):
+        return httpx.Response(200, json={"state": next(states), "model_id": "qwen3-8b"})
+
+    c = make_client(handler)
+    assert c.wait_for_model_ready("qwen3-8b", max_wait_seconds=10, poll_seconds=0, consecutive_ready_required=3) is True
 
 
 def test_wait_for_model_ready_returns_false_on_wrong_model():
@@ -61,7 +75,7 @@ def test_wait_for_model_ready_returns_false_on_wrong_model():
 
     c = make_client(handler)
     # Wants qwen3-8b but the active is qwen3-4b — should time out and return False
-    assert c.wait_for_model_ready("qwen3-8b", max_wait_seconds=1, poll_seconds=0) is False
+    assert c.wait_for_model_ready("qwen3-8b", max_wait_seconds=1, poll_seconds=0, consecutive_ready_required=3) is False
 
 
 def test_poll_research_returns_completed():

--- a/scripts/test_corpora/tests/test_sweep_ingest.py
+++ b/scripts/test_corpora/tests/test_sweep_ingest.py
@@ -10,7 +10,11 @@ import httpx
 
 from scripts.test_corpora.corpora.manifest import CorpusManifest
 from scripts.test_corpora.runner.client import HarborClerkClient
-from scripts.test_corpora.runner.sweep import _can_skip_ingest, _hc_corpus_matches
+from scripts.test_corpora.runner.sweep import (
+    _can_skip_ingest,
+    _hc_corpus_matches,
+    _is_retryable_research_failure,
+)
 
 
 def _make_client(handler) -> HarborClerkClient:
@@ -143,3 +147,55 @@ def test_hc_corpus_matches_handles_tiny_corpus_floor():
     c = _make_client(handler)
     m = CorpusManifest(corpus_id="x", ingest_dir=Path("/tmp/x"), doc_count=1, total_size_bytes=1, license="ignored")
     assert _hc_corpus_matches(c, m) is False
+
+
+# ── retry decision logic ──
+
+
+def test_is_retryable_when_research_failed():
+    """status=failed → retry. Most common case: llama-server hiccup or
+    model-not-warm-yet despite HC reporting ready."""
+    assert _is_retryable_research_failure({"result": {"status": "failed"}}) is True
+
+
+def test_is_retryable_when_research_interrupted():
+    """status=interrupted → retry. SSE stream closed mid-run."""
+    assert _is_retryable_research_failure({"result": {"status": "interrupted"}}) is True
+
+
+def test_is_retryable_when_harness_aborted():
+    """harness_aborted=True → retry. Watchdog forced the stream closed
+    because the model went unhealthy. Retry covers auto-recovery."""
+    assert (
+        _is_retryable_research_failure(
+            {
+                "result": {
+                    "status": "interrupted",
+                    "harness_aborted": True,
+                    "harness_abort_reason": "model state=loading",
+                }
+            }
+        )
+        is True
+    )
+
+
+def test_not_retryable_when_completed_with_answer():
+    """Successful research must NEVER retry, even on flaky-looking results."""
+    assert _is_retryable_research_failure({"result": {"status": "completed", "answer": "yes"}}) is False
+
+
+def test_not_retryable_when_completed_empty_answer():
+    """Completed-with-empty-answer is a model behaviour, not a transient.
+    Same query against same model won't suddenly succeed — don't waste
+    a retry slot."""
+    assert _is_retryable_research_failure({"result": {"status": "completed", "answer": ""}}) is False
+
+
+def test_not_retryable_when_no_result_block():
+    """Phase 0/1 outputs don't have a result block; never retry those.
+    (The caller already gates retry on _is_research, but the helper itself
+    should be safe to call with anything.)"""
+    assert _is_retryable_research_failure({}) is False
+    assert _is_retryable_research_failure({"result": {}}) is False
+    assert _is_retryable_research_failure({"result": None}) is False


### PR DESCRIPTION
## Summary

User hit on BIG:

```
2026-05-06 13:44:10,091 INFO httpx HTTP Request: GET .../api/research/...
2026-05-06 13:44:10,097 WARNING sweep unit cuad/gemma4-26b-a4b/cuad-research-1 ended with error: research finished with status=failed
```

Research died right after activation, harness moved on to ERROR. They asked: fix the cause + add retry.

## Two-part fix

### 1. Harden `wait_for_model_ready`

HC's `GET /api/chat/models/status` flips to `"ready"` the instant llama-server's `/health` returns 200 ([api/routes/chat.py:407](src/harbor_clerk/api/routes/chat.py:407)). But llama-server can briefly answer 200 before the model is generation-ready — so a single ready reading was enough to fool us into starting research too soon.

New `consecutive_ready_required` parameter (default 3). With the default 2s poll, that's ~4-6s of stable `ready` before returning True. No fixed post-load sleep, just a stability requirement.

### 2. One-shot retry on transient failure

After `_run_local` for phases 2-6, if the research ended with `status in {failed, interrupted}` or `harness_aborted=True`:

1. Log a warning with the failure mode
2. Sleep 30s
3. Re-call `wait_for_model_ready` (in case the model crashed mid-research)
4. Re-run the same question

If the retry also fails, the existing status-downgrade marks ERROR — same as today, just one extra attempt before giving up.

**Not retried:** `status == "completed"` even with empty answer. Same query against same model won't suddenly succeed; that's a model behaviour, not a transient.

Decision logic factored as `_is_retryable_research_failure(out) -> bool`:

```python
def _is_retryable_research_failure(out: dict) -> bool:
    result = out.get("result", {}) or {}
    if result.get("harness_aborted"):
        return True
    return result.get("status") in ("failed", "interrupted")
```

## Test plan

- [x] 1 new client test asserting a single ready flicker between two loading readings does NOT satisfy the wait
- [x] 6 new sweep tests covering retry decision: failed / interrupted / harness_aborted → True; completed-with-and-without-answer → False; None/empty `result` → False
- [x] 90 tests pass; ruff check + format clean
- [ ] On BIG: rerun should show `research ... failed (status=failed, harness_aborted=False); retrying once after 30s` and ideally succeed on the second attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
