### PR TITLE
fix(test-corpora): create_conversation: drop null title + nonexistent mode

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -390,12 +390,16 @@ class HarborClerkClient:
 
     # ── ask (chat SSE) ──
 
-    def create_conversation(self, title: str | None = None, mode: str = "chat") -> str:
-        """POST /api/chat/conversations — returns conversation_id."""
-        r = self._client.post(
-            "/api/chat/conversations",
-            json={"title": title, "mode": mode},
-        )
+    def create_conversation(self, title: str = "test-corpora") -> str:
+        """POST /api/chat/conversations — returns conversation_id.
+
+        HC's ``CreateConversationRequest`` schema is ``title: str`` (no longer
+        optional), and there is no ``mode`` field. Earlier versions of the
+        harness sent ``{"title": null, "mode": "chat"}`` which Pydantic
+        rejects with 422 ("Input should be a valid string"). We now always
+        pass a non-empty title and never send ``mode``.
+        """
+        r = self._client.post("/api/chat/conversations", json={"title": title})
         r.raise_for_status()
         return r.json()["conversation_id"]
 

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -262,7 +262,7 @@ def _run_local(
         result["answer"] = normalized_answer
     else:
         # Ask flow: create a chat conversation, then send the question, drain SSE
-        conv_id = hc.create_conversation(mode="chat")
+        conv_id = hc.create_conversation(title=f"test-corpora/{corpus}/{model}/{question_id}")
         events = list(hc.stream_ask(conv_id, question_text))
         # Harbor Clerk chat SSE emits {type: "token", content: "<text>"} for tokens.
         # Citations are in the final {type: "done"} event's rag_context.citations field.

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -154,10 +154,41 @@ def test_delete_all_documents_sends_literal_confirmation():
 def test_create_conversation_returns_id():
     def handler(request):
         assert request.url.path == "/api/chat/conversations"
-        return httpx.Response(200, json={"conversation_id": "conv-xyz", "mode": "chat"})
+        return httpx.Response(200, json={"conversation_id": "conv-xyz"})
 
     c = make_client(handler)
-    assert c.create_conversation(mode="chat") == "conv-xyz"
+    assert c.create_conversation(title="my-test") == "conv-xyz"
+
+
+def test_create_conversation_sends_only_title_no_null_no_mode():
+    """Regression for the 422 bug: HC's CreateConversationRequest is
+    ``title: str`` (no None default, no ``mode`` field). The harness used
+    to send ``{"title": null, "mode": "chat"}`` which Pydantic rejects.
+    Body must be exactly ``{"title": "<string>"}``."""
+    seen_bodies: list[dict] = []
+
+    def handler(request):
+        seen_bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"conversation_id": "conv-xyz"})
+
+    c = make_client(handler)
+    c.create_conversation(title="cuad-ask-1")
+    assert seen_bodies == [{"title": "cuad-ask-1"}]
+
+
+def test_create_conversation_default_title_is_string():
+    """When no title is passed, the harness must still send a non-null
+    string — never ``{"title": null}``."""
+    seen_bodies: list[dict] = []
+
+    def handler(request):
+        seen_bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"conversation_id": "conv-xyz"})
+
+    c = make_client(handler)
+    c.create_conversation()  # no title arg
+    assert isinstance(seen_bodies[0].get("title"), str)
+    assert seen_bodies[0]["title"]  # non-empty
 
 
 def test_stream_ask_aggregates_token_events():


### PR DESCRIPTION
## Summary

User on BIG hit 10 consecutive failures, all on the cuad-ask-N units of gemma4-26b-a4b:

```
POST /api/chat/conversations -> 422 Unprocessable Entity
```

The research units on the same model worked fine (they hit `/api/research`, not `/api/chat/conversations`). It was only the chat (`-ask-`) cells that 422'd.

Latent bug from sweep day 1, only surfaced now because [#300](https://github.com/r0shi/harborclerk/pull/300)'s model-id mismatches were preventing the sweep from ever reaching chat units in the first place.

## Root cause

HC's [CreateConversationRequest](src/harbor_clerk/api/schemas/chat.py:11) is:

```python
class CreateConversationRequest(BaseModel):
    title: str = "New conversation"
```

`title: str` — required, with a string default, **not** `Optional[str]`. The harness was sending:

```python
self._client.post("/api/chat/conversations", json={"title": None, "mode": "chat"})
```

Both fields wrong:
- `title: null` fails Pydantic's str validator → 422
- `mode` isn't in the schema at all (chat conversations don't have modes anymore — that's an old design that got dropped)

## Fix

In [client.py](scripts/test_corpora/runner/client.py:393): drop the `mode` parameter, default `title` to a non-null string. In [sweep.py](scripts/test_corpora/runner/sweep.py:265): pass a meaningful `test-corpora/{corpus}/{model}/{question_id}` title so HC's conversation list is actually useful when debugging a sweep run.

## Test plan

- [x] 2 new tests pin the request-body shape:
  - `test_create_conversation_sends_only_title_no_null_no_mode` — body must be exactly `{"title": "<string>"}`, no `mode`, no nulls
  - `test_create_conversation_default_title_is_string` — even with no title arg, never sends `null`
- [x] 33 client tests pass; ruff check + format clean
- [ ] On BIG: rerun produces 200s on `/api/chat/conversations` with `{"title": "test-corpora/cuad/.../cuad-ask-1"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
