### PR TITLE
fix(test-corpora): clarify state-exists error — --rerun needs --resume

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -460,8 +460,11 @@ def main(argv: list[str] | None = None) -> int:
         if sf.units() and not args.resume:
             raise SystemExit(
                 f"state.json at {state_path} already has {len(sf.units())} units. "
-                "Pass --resume to continue from it, --rerun '<selectors>' to flip "
-                "specific cells back to PENDING, or pick a fresh --run-id."
+                "To proceed, either:\n"
+                "  - add --resume to continue from this state (combine with "
+                "--rerun '<selectors>' or --skip '<selectors>' to adjust which "
+                "cells run)\n"
+                "  - or pick a fresh --run-id to start a new run"
             )
 
         # Migrate legacy model ids in state.json before any other logic


### PR DESCRIPTION
## Summary

The error message I added in [#302](https://github.com/r0shi/harborclerk/pull/302) implied `--resume` and `--rerun` were alternatives:

```
state.json at /path/state.json already has 153 units.
Pass --resume to continue from it, --rerun '<selectors>' to flip specific
cells back to PENDING, or pick a fresh --run-id.
```

User tried just `--rerun 'phase=4'` and hit the gate. They were right to expect that to work — the message reads as three independent options. But `--rerun` operates on the loaded state file, so it needs `--resume` to load it.

## Fix

Reword as two clear options:

```
state.json at /path/state.json already has 153 units. To proceed, either:
  - add --resume to continue from this state (combine with --rerun
    '<selectors>' or --skip '<selectors>' to adjust which cells run)
  - or pick a fresh --run-id to start a new run
```

Trivial change to one f-string. 95 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)