### PR TITLE
fix(test-corpora): auto-refresh JWT on 401 so long sweeps don't crash

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -33,6 +33,69 @@ class _WatchdogState:
     research_bad: int = 0
 
 
+class _JWTRefreshAuth(httpx.Auth):
+    """``httpx.Auth`` that injects a Bearer token and re-logs in on 401.
+
+    HC's JWT access token TTL defaults to 30 minutes
+    (``settings.jwt_access_token_expire_minutes``). Phase 4 research cells
+    regularly run longer than that, after which every request returns 401
+    and the harness used to crash. This Auth catches 401, re-issues
+    ``POST /api/auth/login`` with the saved credentials, and retries the
+    original request with the fresh token.
+
+    Lazy initial login: the first authenticated request triggers the
+    initial login. So bad credentials surface on the first real call,
+    not at ``HarborClerkClient.login`` time.
+    """
+
+    def __init__(self, email: str, password: str, login_path: str = "/api/auth/login") -> None:
+        self._email = email
+        self._password = password
+        self._login_path = login_path
+        self._token: str | None = None
+
+    def auth_flow(self, request: httpx.Request):
+        # Login itself MUST NOT trigger a 401-retry — that would loop forever
+        # if credentials are wrong.
+        if request.url.path == self._login_path:
+            yield request
+            return
+
+        if self._token is None:
+            yield from self._do_login(request)
+
+        if self._token is not None:
+            request.headers["Authorization"] = f"Bearer {self._token}"
+        response = yield request
+
+        if response.status_code == 401:
+            # Read the body so the connection can be released back to the pool
+            # before we issue another request through it.
+            response.read()
+            yield from self._do_login(request)
+            if self._token is not None:
+                request.headers["Authorization"] = f"Bearer {self._token}"
+                yield request
+
+    def _do_login(self, base_request: httpx.Request):
+        login_url = base_request.url.copy_with(
+            path=self._login_path,
+            raw_path=self._login_path.encode(),
+            query=b"",
+        )
+        login_req = httpx.Request(
+            "POST",
+            login_url,
+            json={"email": self._email, "password": self._password},
+        )
+        login_resp = yield login_req
+        login_resp.read()
+        if login_resp.status_code == 200:
+            self._token = login_resp.json().get("access_token")
+        # If login failed (bad creds, server down), leave _token unchanged
+        # and let the caller's original 401 surface to the user.
+
+
 def _evaluate_health(
     model_state: str | None,
     research_status: str | None,
@@ -171,11 +234,14 @@ class HarborClerkClient:
     # ── auth ──
 
     def login(self, email: str, password: str) -> None:
-        """POST /api/auth/login — stores the access token as a Bearer header."""
-        r = self._client.post("/api/auth/login", json={"email": email, "password": password})
-        r.raise_for_status()
-        token = r.json()["access_token"]
-        self._client.headers["Authorization"] = f"Bearer {token}"
+        """Install JWT auth that handles initial login + auto-refresh on 401.
+
+        Credentials are saved on the auth object so that long-running
+        sweeps don't crash when HC's 30-minute access token expires
+        mid-research. The initial login is lazy — the first authenticated
+        request triggers it, and bad credentials surface there as 401.
+        """
+        self._client.auth = _JWTRefreshAuth(email, password)
 
     # ── model management ──
 

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -30,6 +30,62 @@ def test_login_stores_bearer_token():
     assert c.pipeline_quiet() is True
 
 
+def test_jwt_refresh_on_401_relogins_and_retries():
+    """When a request returns 401 with an expired token, the client must
+    transparently re-login and retry. Without this, long-running phase 4
+    cells crash when HC's 30-minute access token TTL elapses mid-research."""
+    bearers_seen: list[str | None] = []
+    login_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            login_count["n"] += 1
+            return httpx.Response(200, json={"access_token": "tok-fresh", "token_type": "bearer"})
+
+        if request.url.path == "/api/jobs/snapshot":
+            bearer = request.headers.get("Authorization")
+            bearers_seen.append(bearer)
+            # The "stale" pre-seeded token returns 401; the freshly-issued
+            # token returns 200. This is exactly what HC does when the JWT
+            # passes its TTL.
+            if bearer == "Bearer tok-stale":
+                return httpx.Response(401, json={"detail": "Token expired"})
+            return httpx.Response(
+                200, json={"queues": {"io": {"queued": 0, "running": 0}, "cpu": {"queued": 0, "running": 0}}}
+            )
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    c.login("a@b.c", "pw")
+    # Pre-seed a stale token to simulate "logged in 30 min ago, now expired"
+    # without having to wait through tokens lifecycle.
+    c._client.auth._token = "tok-stale"
+    assert c.pipeline_quiet() is True
+
+    # Exactly one login: the refresh after 401. (Pre-seed bypasses lazy login.)
+    assert login_count["n"] == 1
+    # The first attempt sent the stale token; the retry must carry the fresh one.
+    assert bearers_seen == ["Bearer tok-stale", "Bearer tok-fresh"]
+
+
+def test_jwt_refresh_does_not_loop_when_login_itself_401s():
+    """If credentials are wrong, login() returns 401. We must NOT retry the
+    login forever — the /api/auth/login path is skipped in auth_flow's
+    401-retry. The original request's 401 still surfaces."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            return httpx.Response(401, json={"detail": "Invalid credentials"})
+        return httpx.Response(401, json={"detail": "Token expired"})
+
+    c = make_client(handler)
+    c.login("wrong@b.c", "pw")
+    # Use model_status (no tenacity retry wrapper) so we see the underlying
+    # HTTPStatusError directly without it being wrapped in RetryError.
+    with pytest.raises(httpx.HTTPStatusError):
+        c.model_status()
+
+
 def test_activate_model_calls_put():
     seen: list[tuple[str, str]] = []
 


### PR DESCRIPTION
## Summary

Both BIG and MINI hit this mid-Phase-4:

```
GET /api/research/<id> "HTTP/1.1 401 Unauthorized"
GET /api/chat/models/status "HTTP/1.1 401 Unauthorized"
... tenacity.RetryError → process exits
```

[HC's `jwt_access_token_expire_minutes` defaults to 30 min](src/harbor_clerk/config.py:55). Phase 4 cells regularly run 30+ min. The harness logs in once at startup and never refreshes — eventually every request 401s.

Worse: the watchdog from [#299](https://github.com/r0shi/harborclerk/pull/299) is running parallel poll_research / model_status calls. Those also start 401'ing, and `_evaluate_health` treats `model_state=None` (from the failed status call) as "model unhealthy" → would abort the research mid-run if it got that far.

## Fix

Replace the one-shot login pattern with an `httpx.Auth` subclass that:

1. **Lazily logs in** on the first authenticated request. Existing callers (`login()` then immediately call methods) see no behavior change because the first method call triggers the login.
2. **Catches 401** on any response, re-issues `POST /api/auth/login` with saved credentials, and retries the original request once with the fresh token.
3. **Skips the 401 retry for `/api/auth/login` itself** — without that, wrong creds would loop forever inside the auth flow.

```python
def auth_flow(self, request):
    if request.url.path == self._login_path:
        yield request
        return  # never retry login itself

    if self._token is None:
        yield from self._do_login(request)

    request.headers["Authorization"] = f"Bearer {self._token}"
    response = yield request

    if response.status_code == 401:
        response.read()
        yield from self._do_login(request)
        request.headers["Authorization"] = f"Bearer {self._token}"
        yield request
```

Token lives on the auth object (not `client.headers`) so the watchdog thread sees the refresh too — both threads share the same auth instance.

## Test plan

- [x] `test_jwt_refresh_on_401_relogins_and_retries` — pre-seeds a stale token, asserts a single re-login fires, and the retry carries the fresh bearer
- [x] `test_jwt_refresh_does_not_loop_when_login_itself_401s` — bad creds don't infinite-loop
- [x] All 33 pre-existing client tests still pass; 97 total tests; ruff clean
- [ ] On BIG/MINI: rerun should keep grinding through Phase 4 past the 30-min mark with a periodic `POST /api/auth/login` showing up in the log every time HC's TTL elapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
