### PR TITLE
fix(test-corpora): graceful handling of zombie llama and HC API restarts

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -26,6 +26,16 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 WATCHDOG_INTERVAL_SECONDS = 30
 WATCHDOG_THRESHOLD = 2
 
+# Maximum seconds of SSE-event silence before run_research's watchdog forces
+# the stream closed. HC's research_stream emits events frequently during
+# normal operation (round_started, search results, LLM call boundaries).
+# Sustained silence — while ``model_status`` keeps reporting ``ready`` —
+# means llama-server's HTTP server is alive but stuck mid-inference (the
+# "zombie llama" failure mode). 5 minutes is long enough to ride out a
+# slow search round on a Mac mini, short enough to bail before a 30-min
+# read timeout on a truly stuck research.
+SSE_EVENT_SILENCE_TIMEOUT_SECONDS = 5 * 60
+
 
 @dataclass
 class _WatchdogState:
@@ -100,18 +110,28 @@ def _evaluate_health(
     model_state: str | None,
     research_status: str | None,
     state: _WatchdogState,
+    silence_seconds: float = 0.0,
     threshold: int = WATCHDOG_THRESHOLD,
+    silence_threshold_seconds: float = SSE_EVENT_SILENCE_TIMEOUT_SECONDS,
 ) -> tuple[str | None, str | None]:
     """Update consecutive-bad counters and decide whether to abort an in-flight research.
 
     Returns ``(abort_kind, abort_detail)`` — both ``None`` when no abort.
 
-    A "bad" model reading is anything other than ``state == "ready"`` (including
-    ``model_state is None``, which means the status call itself failed). A "bad"
-    research reading is one of ``{interrupted, failed, error}``; anything else,
-    including ``None`` (no conv_id yet, or transient poll failure), resets that
-    counter. We require ``threshold`` consecutive bad readings before bailing —
-    one transient blip shouldn't kill a long-running research.
+    Three independent abort conditions:
+
+    - ``model_unhealthy``: model_status != "ready" for ``threshold`` consecutive
+      readings (or the status call itself raised, surfaced as ``model_state=None``).
+    - ``research_failed``: HC reports research status in {interrupted, failed, error}
+      for ``threshold`` consecutive readings.
+    - ``sse_silent``: ``silence_seconds`` since the last SSE event has met or
+      exceeded ``silence_threshold_seconds``. Catches the "zombie llama" case
+      where llama-server's HTTP server keeps answering /health 200 (so
+      model_state stays "ready") but inference is wedged and no events flow.
+
+    The two consecutive-bad checks fire only after ``threshold`` readings so
+    one transient blip doesn't kill a long-running research. The silence
+    check is single-shot — by definition it represents sustained inactivity.
     """
     if model_state == "ready":
         state.model_bad = 0
@@ -126,6 +146,9 @@ def _evaluate_health(
         state.research_bad = 0
     if state.research_bad >= threshold:
         return ("research_failed", f"research status={research_status}")
+
+    if silence_seconds >= silence_threshold_seconds:
+        return ("sse_silent", f"no SSE events for {silence_seconds:.0f}s")
 
     return (None, None)
 
@@ -373,6 +396,10 @@ class HarborClerkClient:
         abort_reason: dict[str, str] = {}
         conv_id_holder: list[str | None] = [None]
         response_holder: list[Any] = [None]
+        # Last-event timestamp; updated by the main loop on every parsed SSE
+        # event. The watchdog reads it to detect the "zombie llama" case where
+        # the model_status keeps reporting `ready` but no events flow.
+        last_event_at: list[float] = [time.time()]
 
         def _close_stream() -> None:
             r = response_holder[0]
@@ -396,7 +423,8 @@ class HarborClerkClient:
                         rs_status = self.poll_research(cid).get("status")
                     except Exception:
                         rs_status = None
-                kind, detail = _evaluate_health(ms_state, rs_status, wstate)
+                silence = time.time() - last_event_at[0]
+                kind, detail = _evaluate_health(ms_state, rs_status, wstate, silence_seconds=silence)
                 if kind is not None:
                     abort_reason["kind"] = kind
                     abort_reason["detail"] = detail or kind
@@ -428,6 +456,10 @@ class HarborClerkClient:
                         event = json.loads(payload)
                     except json.JSONDecodeError:
                         continue
+                    # Refresh silence timer on every successfully-parsed event,
+                    # so the watchdog only fires when the server actually goes
+                    # quiet (not just when we're slow to drain a buffer).
+                    last_event_at[0] = time.time()
                     etype = event.get("type")
                     if etype in ("done", "error"):
                         break

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -598,6 +598,18 @@ def main(argv: list[str] | None = None) -> int:
         current_corpus_in_db: str | None = None
         current_model: str | None = None
 
+        # HC-unreachability circuit breaker. When the sweep is running and HC
+        # restarts (e.g. menubar's granular restart on model switch), every
+        # in-flight request gets ConnectError until HC comes back. Without a
+        # limit, the loop burns through dozens of pending units marking each
+        # ERROR. Track consecutive ConnectErrors and bail cleanly once we're
+        # confident HC isn't coming back on its own. Units that hit
+        # ConnectError get flipped back to PENDING on bail so --resume
+        # picks them up after HC restarts.
+        hc_connect_errors = 0
+        hc_connect_error_units: list[Unit] = []
+        HC_UNREACHABLE_CONSECUTIVE_LIMIT = 3
+
         # Phase 1 MCP session — lazily opened the first time Phase 1 runs.
         # SyncMcpSession connects to Harbor Clerk's /mcp endpoint so that the
         # Sonnet 4.6 baseline generator has real KB tools available.
@@ -791,9 +803,55 @@ def main(argv: list[str] | None = None) -> int:
                             final_status.value,
                             error_msg,
                         )
+                except httpx.ConnectError as exc:
+                    # HC is refusing connections — likely restarting. Mark the
+                    # unit ERROR for now, but track it so we can flip it back
+                    # to PENDING if we end up bailing.
+                    hc_connect_errors += 1
+                    hc_connect_error_units.append(u)
+                    log.exception(
+                        "unit failed (HC unreachable, consecutive %d/%d): %s",
+                        hc_connect_errors,
+                        HC_UNREACHABLE_CONSECUTIVE_LIMIT,
+                        u,
+                    )
+                    sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.ERROR, error=str(exc))
+                    if hc_connect_errors >= HC_UNREACHABLE_CONSECUTIVE_LIMIT:
+                        # Flip every connect-error victim from this run back
+                        # to PENDING so a plain `--resume` after HC comes
+                        # back picks them up. Without this the user would
+                        # need an extra `--rerun status=error` step.
+                        for failed_u in hc_connect_error_units:
+                            cur = sf.get(
+                                failed_u.phase, failed_u.corpus, failed_u.model, failed_u.question_id, failed_u.depth
+                            )
+                            if cur is not None:
+                                cur.status = Status.PENDING
+                                cur.heartbeat = None
+                                cur.started_at = None
+                                cur.error = None
+                        sf.save()
+                        log.error(
+                            "HC API at %s unreachable for %d consecutive units; "
+                            "exiting cleanly. Restart HC and re-run with --resume.",
+                            args.api_base,
+                            hc_connect_errors,
+                        )
+                        raise SystemExit(
+                            f"HC API at {args.api_base} unreachable for {hc_connect_errors} consecutive units; "
+                            "exiting cleanly so --resume picks up where we left off."
+                        ) from exc
                 except (httpx.HTTPError, RuntimeError, KeyError) as exc:
                     log.exception("unit failed: %s", u)
                     sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.ERROR, error=str(exc))
+                    # Non-connect error: HC is reachable, just this unit failed.
+                    hc_connect_errors = 0
+                    hc_connect_error_units.clear()
+                else:
+                    # Successful unit (no exception in the try). Reset the
+                    # circuit-breaker counters; we just talked to HC, it's up.
+                    hc_connect_errors = 0
+                    hc_connect_error_units.clear()
                 finally:
                     # If the unit is still IN_PROGRESS — meaning an uncaught
                     # exception (KeyboardInterrupt, tenacity.RetryError, etc.)

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -542,6 +542,48 @@ def test_evaluate_health_research_bad_resets_on_running():
     assert state.research_bad == 0
 
 
+def test_evaluate_health_aborts_on_sse_silence():
+    """The 'zombie llama' case: model_status keeps reporting ready, research
+    keeps reporting running, but no SSE events have flowed for longer than
+    the silence threshold. Single-shot — sustained inactivity by definition."""
+    state = _WatchdogState()
+    kind, detail = _evaluate_health(
+        "ready",
+        "running",
+        state,
+        silence_seconds=301,
+        silence_threshold_seconds=300,
+    )
+    assert kind == "sse_silent"
+    assert "no SSE events for 301s" in (detail or "")
+
+
+def test_evaluate_health_does_not_trigger_silence_below_threshold():
+    """Silence below the threshold must NOT trigger — otherwise every slow
+    research round (notes phase 30-60s, planning phase ~30s) would bail."""
+    state = _WatchdogState()
+    kind, _ = _evaluate_health(
+        "ready",
+        "running",
+        state,
+        silence_seconds=299,
+        silence_threshold_seconds=300,
+    )
+    assert kind is None
+
+
+def test_evaluate_health_silence_check_does_not_eat_research_failure():
+    """A research that's both silent AND has flipped to status=failed should
+    surface as research_failed (the more specific signal) — silence is the
+    fallback for when nothing else fires."""
+    state = _WatchdogState()
+    # Two consecutive failed readings + long silence
+    _evaluate_health("ready", "failed", state, silence_seconds=999, silence_threshold_seconds=300)
+    kind, detail = _evaluate_health("ready", "failed", state, silence_seconds=999, silence_threshold_seconds=300)
+    assert kind == "research_failed"
+    assert "failed" in (detail or "")
+
+
 def test_run_research_returns_interrupted_when_server_interrupts():
     """If HC reports the task as interrupted (e.g. real disconnect for
     some other reason, or model-switch race), run_research must surface


### PR DESCRIPTION
## Summary

Two failure modes the harness has been blind to, both observed today:

| Scenario | Symptom | Watchdog reaction (today) | This PR |
|---|---|---|---|
| Zombie llama | inference wedged but `/health` still 200 | sees `ready` forever, never trips | bail on SSE silence ≥ 5 min |
| HC API restart | port 8100 refuses for ~4s during model switch | each unit gets `ConnectError`, marks ERROR, burns through pending queue | exit cleanly after 3 consecutive ConnectErrors, flip victims back to PENDING |

## 1. Zombie llama (SSE silence timeout)

User on MINI: research went 17 minutes with no events. `/api/chat/models/status` proxies llama-server's `/health` which kept returning 200 the whole time — model state stayed `ready`, our watchdog from [#299](https://github.com/r0shi/harborclerk/pull/299) never tripped. llama-server's HTTP server was alive but inference was wedged.

**Fix:** track time of last SSE event in `run_research`; the watchdog passes elapsed silence to `_evaluate_health`. New third bail condition `("sse_silent", ...)` fires when silence ≥ `SSE_EVENT_SILENCE_TIMEOUT_SECONDS` (default 5 min). Watchdog closes the stream; [#303](https://github.com/r0shi/harborclerk/pull/303)'s retry path does its job. The two consecutive-bad checks (model_unhealthy, research_failed) keep their threshold semantics — silence is single-shot since by definition it represents sustained inactivity.

## 2. HC API restart cascade

Today on BIG, switching from `gemma4-26b-a4b` to `qwen36-35b-a3b` triggered HC's menubar to restart the entire subprocess tree (API process PID changed from 21476 → 22321), not just llama-server. ~4 seconds where port 8100 actively refused. The sweep's per-unit `cleanup_orphan_research()` got `ConnectError`, the existing `except` clause marked the unit ERROR, and the loop burned through 14 pending units in 1.5 seconds before HC came back.

(The HC menubar's "restart everything on model switch" behavior is its own bug to file — model switch should only touch llama-server.)

**Fix:** split `httpx.ConnectError` out of the per-unit `except`. Track consecutive ConnectErrors and the units they hit. After `HC_UNREACHABLE_CONSECUTIVE_LIMIT = 3`, flip every connect-error victim from this run back to `PENDING` and `SystemExit` cleanly. A plain `--resume` after HC comes back picks them up — no `--rerun status=error` gymnastics needed.

```python
except httpx.ConnectError as exc:
    hc_connect_errors += 1
    hc_connect_error_units.append(u)
    sf.set_status(..., Status.ERROR, error=str(exc))
    if hc_connect_errors >= HC_UNREACHABLE_CONSECUTIVE_LIMIT:
        for failed_u in hc_connect_error_units:
            cur = sf.get(failed_u.phase, ...)
            cur.status = Status.PENDING  # cleared timestamps + error
        sf.save()
        raise SystemExit(...)
except (httpx.HTTPError, RuntimeError, KeyError) as exc:
    sf.set_status(..., Status.ERROR, error=str(exc))
    hc_connect_errors = 0  # HC was reachable, just this unit failed
else:
    hc_connect_errors = 0  # success path, reset
```

## Test plan

- [x] 3 new `_evaluate_health` tests:
  - silence ≥ threshold → `sse_silent`
  - silence < threshold → no abort
  - silence + research_failed both true → `research_failed` wins (more specific)
- [x] 105 tests pass; ruff clean + format clean
- [ ] On BIG/MINI: next time HC restarts mid-sweep, observe `HC API ... unreachable for 3 consecutive units; exiting cleanly` and the 3 victims back to PENDING for a clean `--resume`
- [ ] On a hung llama, observe `harness aborted research: no SSE events for 300s` after ~5 min instead of waiting the full read timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
