### PR TITLE
fix(test-corpora): auto-recover empty ingest dir before phase 4/5 ingest

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -663,6 +663,19 @@ def main(argv: list[str] | None = None) -> int:
                 if phase in (4, 5) and u.corpus != current_corpus_in_db:
                     if u.corpus not in manifests:
                         manifests[u.corpus] = _phase0_acquire(u.corpus, workdir)
+                    # Belt-and-suspenders: if Phase 0's ingest dir got cleaned up
+                    # between runs (manual cleanup, fs eviction, lost mount), the
+                    # ingest below would hit the 120s "watcher never enqueued any
+                    # jobs" timeout. Re-acquire on the spot so the user doesn't
+                    # have to chase a --rerun 'phase=0,corpus=...' workaround.
+                    ingest_dir = manifests[u.corpus].ingest_dir
+                    if not ingest_dir.exists() or not any(ingest_dir.iterdir()):
+                        log.warning(
+                            "ingest dir for %s is missing or empty (%s) — re-acquiring",
+                            u.corpus,
+                            ingest_dir,
+                        )
+                        manifests[u.corpus] = _phase0_acquire(u.corpus, workdir)
                     if current_corpus_in_db is None and _can_skip_ingest(hc, manifests[u.corpus]):
                         log.info("HC already has %s loaded — skipping re-ingest", u.corpus)
                         current_corpus_in_db = u.corpus


### PR DESCRIPTION
## Summary

User on MINI hit:

```
RuntimeError: watcher never enqueued any jobs for enron within 120s —
verify the ingest dir contains supported files:
/Users/alex/Library/Application Support/Harbor Clerk/test-corpora/enron/ingest
```

Enron's ingest dir was empty. Phase 0 had populated it earlier in a prior run, but the files got cleaned up between runs (manual cleanup, fs eviction, lost mount — root cause unclear). The harness errored out and made the user chase a `--rerun 'phase=0,corpus=enron'` workaround.

## Fix

Right after the per-unit Phase 0 manifest fetch, check whether `ingest_dir` exists and contains files. If not, log a warning and re-acquire on the spot:

```python
ingest_dir = manifests[u.corpus].ingest_dir
if not ingest_dir.exists() or not any(ingest_dir.iterdir()):
    log.warning("ingest dir for %s is missing or empty (%s) - re-acquiring", u.corpus, ingest_dir)
    manifests[u.corpus] = _phase0_acquire(u.corpus, workdir)
```

Phase 0's `acquire()` functions are idempotent: cuad/enron skip the HF snapshot download if cached, synthetic regenerates from a fixed seed (RANDOM_SEED=42). So re-acquiring is fast for the common "files lost from disk" case and still works for "we never finished Phase 0."

The 120s `wait_for_pipeline_activity` timeout still fires for the pathological case where `acquire()` itself produces zero files (e.g. an HF download that succeeds but filters down to empty). That's a real bug worth surfacing, not a silent retry.

## Test plan

- [x] 105 tests pass; ruff clean
- [ ] User reruns MINI without `--rerun phase=0`. Sweep logs `ingest dir for enron is missing or empty - re-acquiring`, then proceeds normally

Generated with Claude Code
