### PR TITLE
fix(test-corpora): wait for HC to come back instead of bailing fast

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -64,6 +64,39 @@ _LEGACY_MODEL_ID_RENAMES = {
 # the eventual ERROR.
 RESEARCH_RETRY_DELAY_SECONDS = 30
 
+# When the HC API itself goes unreachable (model-switch restart, manual stop,
+# etc.) we poll /api/system/health for up to this many seconds before giving
+# up on the current unit. Long enough for HC's typical 6-15s restart, plus
+# slack for slow llama warmup that can briefly wedge the API.
+HC_RECOVERY_WAIT_SECONDS = 120
+
+# How many sustained ConnectError outages we tolerate before bailing the
+# whole sweep. With HC_RECOVERY_WAIT_SECONDS=120 this is up to ~6 minutes
+# of total wait before exit — well-suited to multi-hour runs where a
+# clean exit + --resume costs less than re-running cells.
+HC_UNREACHABLE_CONSECUTIVE_LIMIT = 3
+
+
+def _wait_for_hc_reachable(hc: HarborClerkClient, max_wait_seconds: int = HC_RECOVERY_WAIT_SECONDS) -> bool:
+    """Poll ``/api/system/health`` until it responds or we time out.
+
+    Returns ``True`` as soon as ``hc.health()`` returns successfully, ``False``
+    if the deadline elapses with HC still unreachable. Used by the per-unit
+    ConnectError handler to ride out HC restarts (e.g. menubar's restart of
+    the API process during a model switch) without burning through pending
+    units in machine-time.
+    """
+    deadline = time.time() + max_wait_seconds
+    while time.time() < deadline:
+        try:
+            hc.health()
+            return True
+        except (httpx.HTTPError, RuntimeError):
+            pass
+        if time.time() < deadline:
+            time.sleep(3)
+    return False
+
 
 def _is_retryable_research_failure(out: dict) -> bool:
     """Whether ``out["result"]`` warrants a one-shot retry.
@@ -598,17 +631,16 @@ def main(argv: list[str] | None = None) -> int:
         current_corpus_in_db: str | None = None
         current_model: str | None = None
 
-        # HC-unreachability circuit breaker. When the sweep is running and HC
+        # HC-unreachability tolerance. When the sweep is running and HC
         # restarts (e.g. menubar's granular restart on model switch), every
-        # in-flight request gets ConnectError until HC comes back. Without a
-        # limit, the loop burns through dozens of pending units marking each
-        # ERROR. Track consecutive ConnectErrors and bail cleanly once we're
-        # confident HC isn't coming back on its own. Units that hit
-        # ConnectError get flipped back to PENDING on bail so --resume
-        # picks them up after HC restarts.
+        # in-flight request gets ConnectError until HC comes back — typically
+        # 6-15s of downtime. Per-unit ConnectError handler waits up to
+        # HC_RECOVERY_WAIT_SECONDS for HC to come back before counting the
+        # outage; only HC_UNREACHABLE_CONSECUTIVE_LIMIT sustained timeouts
+        # back-to-back trigger a clean exit. The unit is always flipped
+        # PENDING (not ERROR) so a `--resume` picks up exactly where we left
+        # off, no `--rerun status=error` needed.
         hc_connect_errors = 0
-        hc_connect_error_units: list[Unit] = []
-        HC_UNREACHABLE_CONSECUTIVE_LIMIT = 3
 
         # Phase 1 MCP session — lazily opened the first time Phase 1 runs.
         # SyncMcpSession connects to Harbor Clerk's /mcp endpoint so that the
@@ -804,54 +836,63 @@ def main(argv: list[str] | None = None) -> int:
                             error_msg,
                         )
                 except httpx.ConnectError as exc:
-                    # HC is refusing connections — likely restarting. Mark the
-                    # unit ERROR for now, but track it so we can flip it back
-                    # to PENDING if we end up bailing.
-                    hc_connect_errors += 1
-                    hc_connect_error_units.append(u)
-                    log.exception(
-                        "unit failed (HC unreachable, consecutive %d/%d): %s",
-                        hc_connect_errors,
-                        HC_UNREACHABLE_CONSECUTIVE_LIMIT,
-                        u,
+                    # HC is refusing connections — likely restarting (e.g.
+                    # menubar restarts the API process during a model switch).
+                    # Mark this unit PENDING (it didn't fail, HC was unreachable)
+                    # so --resume picks it up, then actively wait for HC to
+                    # come back rather than burning through pending units in
+                    # machine-time.
+                    log.warning(
+                        "ConnectError on unit %s/%s/%s — HC at %s may be restarting; "
+                        "waiting up to %ds for it to come back",
+                        u.corpus,
+                        u.model,
+                        u.question_id,
+                        args.api_base,
+                        HC_RECOVERY_WAIT_SECONDS,
                     )
-                    sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.ERROR, error=str(exc))
-                    if hc_connect_errors >= HC_UNREACHABLE_CONSECUTIVE_LIMIT:
-                        # Flip every connect-error victim from this run back
-                        # to PENDING so a plain `--resume` after HC comes
-                        # back picks them up. Without this the user would
-                        # need an extra `--rerun status=error` step.
-                        for failed_u in hc_connect_error_units:
-                            cur = sf.get(
-                                failed_u.phase, failed_u.corpus, failed_u.model, failed_u.question_id, failed_u.depth
-                            )
-                            if cur is not None:
-                                cur.status = Status.PENDING
-                                cur.heartbeat = None
-                                cur.started_at = None
-                                cur.error = None
-                        sf.save()
-                        log.error(
-                            "HC API at %s unreachable for %d consecutive units; "
-                            "exiting cleanly. Restart HC and re-run with --resume.",
-                            args.api_base,
+                    cur = sf.get(u.phase, u.corpus, u.model, u.question_id, u.depth)
+                    if cur is not None:
+                        cur.status = Status.PENDING
+                        cur.heartbeat = None
+                        cur.started_at = None
+                        cur.error = None
+                    sf.save()
+
+                    if _wait_for_hc_reachable(hc, max_wait_seconds=HC_RECOVERY_WAIT_SECONDS):
+                        log.info("HC reachable again; resetting outage counter and continuing")
+                        hc_connect_errors = 0
+                    else:
+                        hc_connect_errors += 1
+                        log.warning(
+                            "HC still unreachable after %ds (%d/%d sustained outages)",
+                            HC_RECOVERY_WAIT_SECONDS,
                             hc_connect_errors,
+                            HC_UNREACHABLE_CONSECUTIVE_LIMIT,
                         )
-                        raise SystemExit(
-                            f"HC API at {args.api_base} unreachable for {hc_connect_errors} consecutive units; "
-                            "exiting cleanly so --resume picks up where we left off."
-                        ) from exc
+                        if hc_connect_errors >= HC_UNREACHABLE_CONSECUTIVE_LIMIT:
+                            log.error(
+                                "HC API at %s never came back after %d × %ds attempts; "
+                                "exiting cleanly. Restart HC and re-run with --resume.",
+                                args.api_base,
+                                hc_connect_errors,
+                                HC_RECOVERY_WAIT_SECONDS,
+                            )
+                            raise SystemExit(
+                                f"HC API at {args.api_base} unreachable for "
+                                f"{hc_connect_errors} sustained outages "
+                                f"({HC_RECOVERY_WAIT_SECONDS}s each); exiting cleanly so "
+                                "--resume picks up where we left off."
+                            ) from exc
                 except (httpx.HTTPError, RuntimeError, KeyError) as exc:
                     log.exception("unit failed: %s", u)
                     sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.ERROR, error=str(exc))
                     # Non-connect error: HC is reachable, just this unit failed.
                     hc_connect_errors = 0
-                    hc_connect_error_units.clear()
                 else:
                     # Successful unit (no exception in the try). Reset the
-                    # circuit-breaker counters; we just talked to HC, it's up.
+                    # outage counter; we just talked to HC, it's up.
                     hc_connect_errors = 0
-                    hc_connect_error_units.clear()
                 finally:
                     # If the unit is still IN_PROGRESS — meaning an uncaught
                     # exception (KeyboardInterrupt, tenacity.RetryError, etc.)

--- a/scripts/test_corpora/tests/test_sweep_ingest.py
+++ b/scripts/test_corpora/tests/test_sweep_ingest.py
@@ -14,6 +14,7 @@ from scripts.test_corpora.runner.sweep import (
     _can_skip_ingest,
     _hc_corpus_matches,
     _is_retryable_research_failure,
+    _wait_for_hc_reachable,
 )
 
 
@@ -199,3 +200,52 @@ def test_not_retryable_when_no_result_block():
     assert _is_retryable_research_failure({}) is False
     assert _is_retryable_research_failure({"result": {}}) is False
     assert _is_retryable_research_failure({"result": None}) is False
+
+
+# ── HC unreachability wait ──
+
+
+def test_wait_for_hc_reachable_returns_true_on_first_success():
+    """Happy path: HC's /system/health returns 200, helper returns True."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/system/health":
+            return httpx.Response(200, json={"status": "healthy"})
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    assert _wait_for_hc_reachable(c, max_wait_seconds=5) is True
+
+
+def test_wait_for_hc_reachable_returns_true_after_recovery():
+    """HC was down, comes back during the wait — return True so the caller
+    knows to continue. The pattern this catches: model-switch restart of
+    the HC API that completes in 6-15s."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/system/health":
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                # First two probes fail with ConnectError-equivalent
+                raise httpx.ConnectError("Connection refused")
+            return httpx.Response(200, json={"status": "healthy"})
+        return httpx.Response(404)
+
+    c = _make_client(handler)
+    # Plenty of budget so the helper can ride out the first two failures
+    assert _wait_for_hc_reachable(c, max_wait_seconds=30) is True
+    assert calls["n"] >= 3
+
+
+def test_wait_for_hc_reachable_returns_false_on_persistent_outage():
+    """HC stays down past the deadline → return False so the caller
+    increments the outage counter (and eventually bails)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("Connection refused")
+
+    c = _make_client(handler)
+    # max_wait_seconds=0 means the deadline is already past — we exit
+    # the polling loop immediately without sleeping.
+    assert _wait_for_hc_reachable(c, max_wait_seconds=0) is False


### PR DESCRIPTION
## Summary

User on BIG hit the [#308](https://github.com/r0shi/harborclerk/pull/308) circuit breaker after **1.5 seconds**:

```
19:17:59,116  unit failed (HC unreachable, consecutive 3/3)
19:17:59,119  HC API at http://localhost:8100 unreachable for 3 consecutive units; exiting cleanly
```

Three ConnectErrors at machine-speed before HC's model-switch restart could finish (~6-15s). For a multi-hour run, exiting that fast is the wrong trade — better to wait a couple minutes than burn progress.

User: *"sleep for 2 minutes — in a multi hour run it's worth it not to blow up."*

## Fix

Replace the instant-bail counter with an active-wait loop. On each ConnectError:

1. **Flip the unit `PENDING`** (not ERROR) — this isn't a unit failure, it's an HC outage. A plain `--resume` picks it up.
2. **Poll `/api/system/health` every 3s** for up to `HC_RECOVERY_WAIT_SECONDS` (120s default). Returns the moment HC answers.
3. **If HC came back:** reset the outage counter, continue with the next unit.
4. **If the 120s wait timed out:** increment the counter. Bail only after `HC_UNREACHABLE_CONSECUTIVE_LIMIT` (3) sustained 120s outages back-to-back — total ~6 minutes of waiting before clean exit.

```python
except httpx.ConnectError as exc:
    # Mark unit PENDING (this is an HC outage, not a unit failure)
    cur = sf.get(...)
    cur.status = Status.PENDING
    cur.heartbeat = cur.started_at = None
    cur.error = None
    sf.save()

    if _wait_for_hc_reachable(hc, max_wait_seconds=HC_RECOVERY_WAIT_SECONDS):
        log.info("HC reachable again; resetting outage counter")
        hc_connect_errors = 0
    else:
        hc_connect_errors += 1
        if hc_connect_errors >= HC_UNREACHABLE_CONSECUTIVE_LIMIT:
            raise SystemExit(...)
```

## Asymmetric tolerance

| Scenario | Old behavior | New behavior |
|---|---|---|
| Model-switch restart (~10s) | Bail in 1.5s | Wait ~10s, continue |
| HC dead for 30s | Bail in 1.5s | Wait 30s, continue |
| HC dead for 90s | Bail in 1.5s | Wait 90s, continue |
| HC truly dead | Bail in 1.5s | Bail in ~6 min |

Brief outages cost roughly the actual downtime. Sustained outages still bail cleanly, just with much more patience.

## Test plan

- [x] 3 new `_wait_for_hc_reachable` tests:
  - Returns True on first successful probe
  - Returns True after a recovery (handler ConnectErrors twice then succeeds — exercises the 3s poll loop)
  - Returns False on persistent outage with `max_wait_seconds=0`
- [x] 108 tests pass total; ruff clean
- [ ] On BIG: next time HC restarts mid-sweep, observe `ConnectError on unit ... waiting up to 120s for it to come back` followed by `HC reachable again; resetting outage counter`. No exit, no lost units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
