### PR TITLE
fix(test-corpora): cleanup_orphan_research read the wrong response field

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -323,8 +323,9 @@ class HarborClerkClient:
     # ── research ──
 
     def active_research(self) -> dict[str, Any]:
-        """GET /api/research/active — returns ``{conversation_id, status}`` or
-        a falsy ``conversation_id`` when nothing is running."""
+        """GET /api/research/active — returns
+        ``{"active": bool, "research_id": str | None}``. ``research_id`` is
+        only set when ``active`` is True."""
         r = self._client.get("/api/research/active")
         r.raise_for_status()
         return r.json()
@@ -338,9 +339,15 @@ class HarborClerkClient:
 
     def cleanup_orphan_research(self) -> str | None:
         """If a research task is currently active, delete it. Returns the
-        conv_id that was deleted (or None). Idempotent."""
+        conv_id that was deleted (or None). Idempotent.
+
+        HC's `/research/active` schema is ``{active, research_id}`` — NOT
+        ``{conversation_id, status}``. An earlier version of this method
+        read the wrong field, so cleanup silently no-op'd and the next
+        ``POST /research`` 409'd until the user manually purged state.
+        """
         active = self.active_research()
-        conv_id = active.get("conversation_id")
+        conv_id = active.get("research_id") if active.get("active") else None
         if conv_id:
             self.delete_research(conv_id)
         return conv_id

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -349,27 +349,29 @@ def test_sync_mcp_session_uses_correct_streamable_function():
 
 
 def test_active_research_returns_state():
-    """Light coverage for the GET /api/research/active happy path."""
+    """Light coverage for the GET /api/research/active happy path.
+    HC's response schema is ``{active: bool, research_id: str|None}``."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/api/research/active"
-        return httpx.Response(200, json={"conversation_id": "conv-orphan", "status": "running"})
+        return httpx.Response(200, json={"active": True, "research_id": "conv-orphan"})
 
     c = make_client(handler)
     res = c.active_research()
-    assert res["conversation_id"] == "conv-orphan"
+    assert res["research_id"] == "conv-orphan"
 
 
 def test_cleanup_orphan_research_deletes_when_active():
-    """If GET /research/active returns a conv_id, cleanup_orphan_research
-    must DELETE it. This prevents the 409 Conflict on the very next
-    start_research after a killed sweep."""
+    """If GET /research/active reports an active research, cleanup_orphan_research
+    must DELETE it. Regression: an earlier version read the wrong field
+    (``conversation_id`` instead of ``research_id``), so cleanup silently
+    no-op'd and the next POST /research 409'd until manual purge."""
     seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(f"{request.method} {request.url.path}")
         if request.method == "GET" and request.url.path == "/api/research/active":
-            return httpx.Response(200, json={"conversation_id": "conv-orphan", "status": "running"})
+            return httpx.Response(200, json={"active": True, "research_id": "conv-orphan"})
         if request.method == "DELETE" and request.url.path == "/api/research/conv-orphan":
             return httpx.Response(200, json={"ok": True})
         return httpx.Response(404)
@@ -382,17 +384,33 @@ def test_cleanup_orphan_research_deletes_when_active():
 
 
 def test_cleanup_orphan_research_no_op_when_idle():
+    """When HC reports no active research, don't call DELETE."""
     seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(f"{request.method} {request.url.path}")
-        return httpx.Response(200, json={"conversation_id": None, "status": None})
+        return httpx.Response(200, json={"active": False, "research_id": None})
 
     c = make_client(handler)
     deleted = c.cleanup_orphan_research()
     assert deleted is None
     # Should have called GET but NOT DELETE
     assert any("GET" in s for s in seen)
+    assert not any("DELETE" in s for s in seen)
+
+
+def test_cleanup_orphan_research_ignores_research_id_when_active_false():
+    """Defensive: even if HC returns a stale research_id with active=False
+    (shouldn't happen, but the schema allows it), don't try to DELETE."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        return httpx.Response(200, json={"active": False, "research_id": "ghost-id"})
+
+    c = make_client(handler)
+    deleted = c.cleanup_orphan_research()
+    assert deleted is None
     assert not any("DELETE" in s for s in seen)
 
 


### PR DESCRIPTION
## Summary

User on BIG hit a 409 cascade after `RemoteProtocolError` mid-research:

```
21:49:35 POST /api/research "HTTP/1.1 200 OK"             ← first attempt starts
21:49:48 ... peer closed connection ... RemoteProtocolError ← HC drops mid-stream
21:49:54 GET  /api/research/active "HTTP/1.1 200 OK"       ← cleanup checks
21:49:54 POST /api/research "HTTP/1.1 409 Conflict"        ← but new POST 409s
... 14 more units fail the same way ...
```

`cleanup_orphan_research()` ran, called `/research/active`, got 200 — and silently no-op'd. Every subsequent POST /research returned 409.

## Root cause

HC's `/research/active` schema (see [api/schemas/research.py:67](src/harbor_clerk/api/schemas/research.py:67)):

```python
class ResearchActiveCheck(BaseModel):
    active: bool
    research_id: str | None = None
```

Our harness was reading the wrong field:

```python
def cleanup_orphan_research(self) -> str | None:
    active = self.active_research()
    conv_id = active.get("conversation_id")  # ← always None
    if conv_id:
        self.delete_research(conv_id)
    return conv_id
```

`conversation_id` is never in the response, so `conv_id` was always None → cleanup never deleted, the orphan stuck around, every subsequent POST 409'd.

The bug was invisible in the happy path because each unit's POST → drain → completion left HC in a clean state. Only when `run_research` raised mid-stream (RemoteProtocolError, LLM crash, anything that prevents a clean SSE close) did the stale `ResearchState` row block subsequent POSTs.

## Fix

Read `research_id`, gated on `active=True`:

```python
conv_id = active.get("research_id") if active.get("active") else None
```

Three updated tests now match HC's actual schema, plus a new defensive test that asserts we don't DELETE when `active=False` even if `research_id` is non-null.

## Test plan

- [x] 40 client tests pass; ruff clean
- [ ] On BIG: next time `RemoteProtocolError` fires mid-research, the next unit's `cleanup_orphan_research` actually DELETEs the orphan and POST /research returns 200, not 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
