### PR TITLE
fix(test-corpora): forward bearer to MCP session after JWT refactor

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -266,6 +266,37 @@ class HarborClerkClient:
         """
         self._client.auth = _JWTRefreshAuth(email, password)
 
+    def get_bearer_token(self) -> str | None:
+        """Return the current Bearer token (without the ``Bearer `` prefix), or
+        None if no auth is configured.
+
+        Used by callers that need to forward auth to a separate httpx client
+        managed outside ``HarborClerkClient`` — for example, the MCP session
+        that the Phase 1 baseline generator opens against ``/mcp/mcp``.
+
+        Triggers the lazy login if it hasn't fired yet. Without this, the
+        first call to ``get_bearer_token()`` after ``login()`` would return
+        an empty token because ``_JWTRefreshAuth`` only does the initial
+        POST on the first authenticated request through the wrapped client.
+        """
+        auth = self._client.auth
+        if isinstance(auth, _JWTRefreshAuth):
+            if auth._token is None:
+                # Force lazy login by making any authenticated request. health()
+                # is the cheapest endpoint that goes through the auth flow.
+                try:
+                    self.health()
+                except Exception:
+                    # If health fails for any reason (e.g. HC down), let the
+                    # caller decide how to handle a missing token.
+                    return None
+            return auth._token
+        # Legacy path: token may have been set directly on client headers.
+        h = self._client.headers.get("Authorization", "")
+        if h.startswith("Bearer "):
+            return h[len("Bearer ") :]
+        return None
+
     # ── model management ──
 
     def activate_model(self, model_id: str) -> None:

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -739,8 +739,13 @@ def main(argv: list[str] | None = None) -> int:
                         if mcp_session is None:
                             mcp_url = os.environ.get("HC_MCP_URL") or f"{args.api_base}/mcp/mcp"
                             log.info("opening MCP session at %s for Phase 1 baselines", mcp_url)
-                            bearer = hc._client.headers.get("Authorization")
-                            mcp_headers: dict[str, str] = {"Authorization": bearer} if bearer else {}
+                            # Forward HC's bearer to the separate MCP httpx client.
+                            # After PR #306 the token lives inside hc._client.auth, not
+                            # in client.headers — `get_bearer_token` triggers the lazy
+                            # login if needed and returns the active token. Without
+                            # this, the MCP session goes out unauthenticated and 401s.
+                            token = hc.get_bearer_token()
+                            mcp_headers: dict[str, str] = {"Authorization": f"Bearer {token}"} if token else {}
                             mcp_session = SyncMcpSession(
                                 url=mcp_url,
                                 headers=mcp_headers,

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -30,6 +30,59 @@ def test_login_stores_bearer_token():
     assert c.pipeline_quiet() is True
 
 
+def test_get_bearer_token_triggers_lazy_login():
+    """Regression for the Phase 1 MCP-session 401: after PR #306 the JWT
+    lives inside the auth class, populated lazily on the first
+    authenticated request. ``get_bearer_token`` must trigger that login
+    so callers (Phase 1 baselines forwarding auth to a separate MCP
+    httpx client) get a real token, not None."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            return httpx.Response(200, json={"access_token": "tok-fresh"})
+        if request.url.path == "/api/system/health":
+            return httpx.Response(200, json={"status": "healthy"})
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    c.login("a@b.c", "pw")
+    # Token has NOT been fetched yet — login() is lazy.
+    assert c._client.auth._token is None
+    # First call to get_bearer_token forces the lazy login and returns the token.
+    assert c.get_bearer_token() == "tok-fresh"
+    assert c._client.auth._token == "tok-fresh"
+
+
+def test_get_bearer_token_returns_existing_token_without_relogin():
+    """Subsequent calls return the cached token without triggering another login."""
+    login_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            login_count["n"] += 1
+            return httpx.Response(200, json={"access_token": "tok-existing"})
+        if request.url.path == "/api/system/health":
+            return httpx.Response(200, json={"status": "healthy"})
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    c.login("a@b.c", "pw")
+    # Pre-seed the token so get_bearer_token doesn't need to login again.
+    c._client.auth._token = "tok-existing"
+    assert c.get_bearer_token() == "tok-existing"
+    assert login_count["n"] == 0  # No login fired
+
+
+def test_get_bearer_token_returns_none_when_no_auth_configured():
+    """Without ``login()`` first, return None — caller decides what to do."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    assert c.get_bearer_token() is None
+
+
 def test_jwt_refresh_on_401_relogins_and_retries():
     """When a request returns 401 with an expired token, the client must
     transparently re-login and retry. Without this, long-running phase 4


### PR DESCRIPTION
## Summary

Regression from [#306](https://github.com/r0shi/harborclerk/pull/306) (JWT auto-refresh).

User on MINI hit this trying to rerun Phase 0+1 for enron after a state-file mishap:

```
POST http://localhost:8100/mcp/mcp "HTTP/1.1 401 Unauthorized"
... ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception) ...
```

Phase 1 baselines forward HC's bearer to a separate MCP `httpx` client (the streamable-HTTP transport that gives Sonnet access to KB tools). The forwarding code reads:

```python
bearer = hc._client.headers.get("Authorization")  # ← None after #306
mcp_headers = {"Authorization": bearer} if bearer else {}
```

Before #306, `hc.login()` wrote `Bearer <tok>` directly into `client.headers["Authorization"]`. After #306, the token lives inside `client.auth._token` and only populates lazily on the first authenticated request through the wrapped client. So `client.headers` stays empty, the MCP session goes out unauthenticated, HC 401s, the whole Phase 1 unit dies.

## Fix

New `HarborClerkClient.get_bearer_token()` method returns the active token (without `Bearer ` prefix), triggering the lazy login via a `health()` probe if the token hasn't been fetched yet. Falls back to reading `client.headers` for any legacy callers, returns `None` if no auth configured.

```python
def get_bearer_token(self) -> str | None:
    auth = self._client.auth
    if isinstance(auth, _JWTRefreshAuth):
        if auth._token is None:
            try:
                self.health()  # forces lazy login
            except Exception:
                return None
        return auth._token
    h = self._client.headers.get("Authorization", "")
    return h[len("Bearer ") :] if h.startswith("Bearer ") else None
```

`sweep.py` now forwards the token via `f"Bearer {token}"` instead of reading `client.headers`.

## Test plan

- [x] 3 new client tests: lazy login triggers + token returned, cached token returned without re-login, None when no auth configured
- [x] 43 client tests pass; ruff clean
- [ ] User reruns Phase 0+1 on MINI: MCP session opens with valid bearer, baselines proceed without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
