### PR TITLE
fix(test-corpora): re-acquire when marker exists but ingest dir is empty

### DIFF
--- a/scripts/test_corpora/corpora/cuad.py
+++ b/scripts/test_corpora/corpora/cuad.py
@@ -64,14 +64,19 @@ def acquire(workdir: Path, sample_size: int = SAMPLE_SIZE_DEFAULT) -> CorpusMani
 
     if marker.exists():
         pdfs = sorted(ingest_dir.glob("*.pdf"))
-        return CorpusManifest(
-            corpus_id="cuad",
-            ingest_dir=ingest_dir,
-            doc_count=len(pdfs),
-            total_size_bytes=sum(p.stat().st_size for p in pdfs),
-            license="CC-BY 4.0",
-            notes=f"CUAD sample of {len(pdfs)} contracts",
-        )
+        # Marker without files is a stale-cache sentinel — fall through to
+        # the download/extract/copy path so the marker doesn't trick the
+        # caller into thinking a corpus exists when its files are gone.
+        if pdfs:
+            return CorpusManifest(
+                corpus_id="cuad",
+                ingest_dir=ingest_dir,
+                doc_count=len(pdfs),
+                total_size_bytes=sum(p.stat().st_size for p in pdfs),
+                license="CC-BY 4.0",
+                notes=f"CUAD sample of {len(pdfs)} contracts",
+            )
+        marker.unlink()  # remove stale marker so future runs don't keep tripping it
 
     archive = _download_release(workdir)
     extracted = _extract(archive, workdir)

--- a/scripts/test_corpora/corpora/enron.py
+++ b/scripts/test_corpora/corpora/enron.py
@@ -52,14 +52,19 @@ def acquire(
 
     if marker.exists():
         emls = sorted(ingest_dir.glob("*.eml"))
-        return CorpusManifest(
-            corpus_id="enron",
-            ingest_dir=ingest_dir,
-            doc_count=len(emls),
-            total_size_bytes=sum(p.stat().st_size for p in emls),
-            license="public domain",
-            notes=f"Enron subset: {len(emls)} emails",
-        )
+        # Marker without files is a stale-cache sentinel — fall through to
+        # the download/filter/copy path so the marker doesn't trick the
+        # caller into thinking a corpus exists when its files are gone.
+        if emls:
+            return CorpusManifest(
+                corpus_id="enron",
+                ingest_dir=ingest_dir,
+                doc_count=len(emls),
+                total_size_bytes=sum(p.stat().st_size for p in emls),
+                license="public domain",
+                notes=f"Enron subset: {len(emls)} emails",
+            )
+        marker.unlink()  # remove stale marker so future runs don't keep tripping it
 
     src = _download_corpus(workdir)
     all_eml = sorted(src.rglob("*.eml"))

--- a/scripts/test_corpora/corpora/synthetic.py
+++ b/scripts/test_corpora/corpora/synthetic.py
@@ -173,14 +173,20 @@ def acquire(
 
     if marker.exists():
         docs = sorted(ingest_dir.glob("*"))
-        return CorpusManifest(
-            corpus_id="synthetic",
-            ingest_dir=ingest_dir,
-            doc_count=sum(1 for d in docs if d.suffix in {".txt", ".pdf"}),
-            total_size_bytes=sum(d.stat().st_size for d in docs if d.is_file()),
-            license="generated",
-            notes="synthetic bilingual small-business",
-        )
+        doc_count = sum(1 for d in docs if d.suffix in {".txt", ".pdf"})
+        # Marker without files is a stale-cache sentinel — fall through to
+        # the generate path so the marker doesn't trick the caller into
+        # thinking a corpus exists when its files are gone.
+        if doc_count > 0:
+            return CorpusManifest(
+                corpus_id="synthetic",
+                ingest_dir=ingest_dir,
+                doc_count=doc_count,
+                total_size_bytes=sum(d.stat().st_size for d in docs if d.is_file()),
+                license="generated",
+                notes="synthetic bilingual small-business",
+            )
+        marker.unlink()  # remove stale marker so future runs don't keep tripping it
 
     ingest_dir.mkdir(parents=True, exist_ok=True)
     rng = random.Random(42)

--- a/scripts/test_corpora/tests/test_cuad.py
+++ b/scripts/test_corpora/tests/test_cuad.py
@@ -26,3 +26,26 @@ def test_cuad_acquire_idempotent(tmp_path: Path):
         with patch.object(cuad, "_download_release", side_effect=AssertionError("re-downloaded")):
             m2 = cuad.acquire(workdir=tmp_path / "work", sample_size=3)
             assert m2.ingest_dir == m1.ingest_dir
+
+
+def test_cuad_marker_without_files_re_acquires(tmp_path: Path):
+    """Regression for the stale-marker bug: marker present but ingest_dir
+    empty → must re-download. Without this guard, Phase 0 returns a
+    manifest with doc_count=0 and Phase 4 hits a 120s ingest-watcher
+    timeout."""
+    archive = tmp_path / "cuad-fake.zip"
+    _make_fake_release(archive)
+
+    workdir = tmp_path / "work"
+    ingest_dir = workdir / "ingest"
+    ingest_dir.mkdir(parents=True)
+    # Pre-create the marker but leave ingest_dir empty
+    (ingest_dir / ".acquired").write_text("acquired")
+    assert list(ingest_dir.glob("*.pdf")) == []
+
+    with patch.object(cuad, "_download_release", return_value=archive):
+        m = cuad.acquire(workdir=workdir, sample_size=3)
+
+    # Should have re-acquired despite the marker
+    assert m.doc_count == 3
+    assert (m.ingest_dir / "contract_000.pdf").exists()

--- a/scripts/test_corpora/tests/test_enron.py
+++ b/scripts/test_corpora/tests/test_enron.py
@@ -14,3 +14,46 @@ def test_enron_filter_keeps_only_target_custodians(tmp_path: Path, fixtures_dir:
         names = sorted(p.name for p in m.ingest_dir.glob("*.eml"))
         assert "skilling_001.eml" in names
         assert "lay_001.eml" in names
+
+
+def test_enron_marker_without_files_re_acquires(tmp_path: Path, fixtures_dir: Path):
+    """Regression for the stale-marker bug: if the .acquired marker exists
+    but the .eml files are gone (manual cleanup, fs eviction, lost mount),
+    acquire() must re-download instead of trusting the marker. Without
+    this guard, Phase 0 marks the unit DONE in 4ms and Phase 4 hits a
+    120s 'watcher never enqueued' timeout."""
+    src = fixtures_dir / "enron_sample"
+
+    workdir = tmp_path / "work"
+    ingest_dir = workdir / "ingest"
+    ingest_dir.mkdir(parents=True)
+    # Pre-create the marker but leave ingest_dir empty
+    (ingest_dir / ".acquired").write_text("acquired")
+    assert list(ingest_dir.glob("*.eml")) == []
+
+    with patch.object(enron, "_download_corpus", return_value=src):
+        m = enron.acquire(workdir=workdir, custodians=["skilling", "lay"], random_count=1)
+
+    # Should have re-acquired despite the marker
+    assert m.doc_count == 3
+    assert sorted(p.name for p in m.ingest_dir.glob("*.eml"))
+    # Fresh marker should be in place after re-acquire
+    assert (ingest_dir / ".acquired").exists()
+
+
+def test_enron_marker_with_files_short_circuits(tmp_path: Path):
+    """The fast path still works: marker + files present → return manifest
+    without re-downloading. Asserted by patching _download_corpus to raise
+    if it's called."""
+    workdir = tmp_path / "work"
+    ingest_dir = workdir / "ingest"
+    ingest_dir.mkdir(parents=True)
+    (ingest_dir / "skilling_x.eml").write_text("From: skilling@enron.com\n\nbody")
+    (ingest_dir / ".acquired").write_text("acquired")
+
+    def _no_download(_workdir):
+        raise AssertionError("must not download when marker + files exist")
+
+    with patch.object(enron, "_download_corpus", side_effect=_no_download):
+        m = enron.acquire(workdir=workdir)
+        assert m.doc_count == 1

--- a/scripts/test_corpora/tests/test_synthetic.py
+++ b/scripts/test_corpora/tests/test_synthetic.py
@@ -28,3 +28,30 @@ def test_synthetic_acquire_writes_doc_and_sidecar(tmp_path: Path):
     assert len(sidecars) == 2
     facts = json.loads(sidecars[0].read_text())
     assert facts["vendor"] == "Acme"
+
+
+def test_synthetic_marker_without_files_re_acquires(tmp_path: Path):
+    """Regression for the stale-marker bug: marker present but ingest_dir
+    has no .txt/.pdf docs → must regenerate. Without this guard, Phase 0
+    returns a manifest with doc_count=0 and Phase 4 hits a 120s
+    ingest-watcher timeout."""
+    fake_anthropic = MagicMock()
+    fake_anthropic.messages.create.return_value.content = [
+        MagicMock(text='{"text": "INVOICE\\nVendor: Acme", "facts": {"vendor": "Acme", "total_usd": 100}}')
+    ]
+
+    workdir = tmp_path / "synth"
+    ingest_dir = workdir / "ingest"
+    ingest_dir.mkdir(parents=True)
+    (ingest_dir / ".acquired").write_text("acquired")
+    # No .txt/.pdf files — only the marker. Stale-cache scenario.
+
+    with patch.object(synthetic, "_make_client", return_value=fake_anthropic):
+        m = synthetic.acquire(
+            workdir=workdir,
+            doc_counts={"invoice": 2},
+            ocr_subset_count=0,
+        )
+
+    assert m.doc_count == 2
+    assert sorted(m.ingest_dir.glob("*.txt"))


### PR DESCRIPTION
## Summary

User on BIG: Phase 0 marked the enron unit DONE in **4ms** while the ingest dir stayed empty. Phase 4 then hit the long ingest-watcher wait. Same pattern was the root cause of MINI's earlier "watcher never enqueued any jobs for enron within 120s" failure.

## Root cause

All three corpus modules use a `.acquired` marker file in `ingest_dir` to short-circuit re-acquisition. From [enron.py:53](scripts/test_corpora/corpora/enron.py:53):

```python
if marker.exists():
    emls = sorted(ingest_dir.glob("*.eml"))
    return CorpusManifest(
        ...
        doc_count=len(emls),  # ← could be 0!
        ...
    )
```

**Marker without files** is treated as "already acquired." If the corpus files vanish (manual cleanup, fs eviction, lost mount, rsync misadventure), the function trusts the marker and returns a `doc_count=0` manifest. The user's machines hit this twice.

## Fix

In all three modules, short-circuit only when the marker exists **and** the ingest_dir actually contains files. If marker is present but files are gone, unlink the stale marker and fall through to the download/filter/copy (or generate) path:

```python
if marker.exists():
    emls = sorted(ingest_dir.glob("*.eml"))
    if emls:
        return CorpusManifest(...)  # fast path
    marker.unlink()  # stale marker — re-acquire
```

## Test plan

- [x] 4 new regression tests — one per corpus testing "marker + empty dir → re-acquires", plus a positive control on enron asserting "marker + files → no download" (patches `_download_corpus` to raise)
- [x] All 7 corpus tests pass; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
