### PR TITLE
fix(test-corpora): rewrite enron.acquire to read parquet, materialize .eml

### DIFF
--- a/scripts/test_corpora/corpora/enron.py
+++ b/scripts/test_corpora/corpora/enron.py
@@ -1,22 +1,27 @@
 """Enron Email Corpus subset acquisition.
 
-Downloads a HuggingFace-hosted Enron dataset, filters to target custodian
-inboxes (Skilling, Lay, Fastow by default) plus a deterministic random
-sample for noise. Outputs ``.eml`` files into ``ingest_dir``.
+Downloads the HuggingFace-hosted ``corbt/enron-emails`` dataset, which is
+a parquet-format collection of ~517k emails (3 parquet files, ~493 MB).
+Filters to target custodian inboxes (Skilling, Lay, Fastow by default)
+plus a deterministic random sample for noise. Materializes each
+selected row as an RFC 822-style ``.eml`` file in ``ingest_dir`` so the
+HC watcher (which is filename-based) can pick them up.
 
 This module supports two acquisition paths:
-1. ``_download_corpus`` (production) — fetches from HuggingFace.
-2. Tests inject a path directly via the patched ``_download_corpus``.
+1. ``_download_corpus`` (production) — fetches the parquet dataset from
+   HuggingFace.
+2. Tests inject a path directly via the patched ``_download_corpus``
+   pointing at a hand-crafted parquet fixture.
 
-The "filter to custodians" predicate is name-prefix based: filenames must
-start with one of the configured custodian tokens (case-insensitive) to
-count.
+The "filter to custodians" predicate is name-prefix based: each parquet
+row's ``file_name`` field (e.g. ``skilling-j/_sent_mail/1.``) must start
+with one of the configured custodian tokens (case-insensitive).
 """
 
 from __future__ import annotations
 
 import random
-import shutil
+from collections.abc import Iterator
 from pathlib import Path
 
 from .manifest import CorpusManifest
@@ -28,8 +33,6 @@ RANDOM_SEED = 42
 
 def _download_corpus(workdir: Path) -> Path:
     """Production path: download the Enron HuggingFace dataset."""
-    # Implementation note: the harness depends on huggingface_hub which is
-    # already in the harbor-clerk venv. Tests patch this whole function.
     from huggingface_hub import snapshot_download  # local import for testability
 
     workdir.mkdir(parents=True, exist_ok=True)
@@ -38,6 +41,44 @@ def _download_corpus(workdir: Path) -> Path:
         return out
     snapshot_download(repo_id="corbt/enron-emails", repo_type="dataset", local_dir=str(out))
     return out
+
+
+def _iter_parquet_rows(dataset_root: Path) -> Iterator[dict]:
+    """Yield each email row from every parquet file under ``dataset_root``.
+
+    HuggingFace lays the dataset out as ``data/train-NNNNN-of-MMMMM.parquet``;
+    we look there first and fall back to a recursive glob so callers can
+    point at non-standard layouts (used by tests).
+    """
+    import pyarrow.parquet as pq
+
+    candidates = sorted((dataset_root / "data").glob("*.parquet"))
+    if not candidates:
+        candidates = sorted(dataset_root.rglob("*.parquet"))
+    for pq_file in candidates:
+        yield from pq.read_table(pq_file).to_pylist()
+
+
+def _safe_filename(file_name: str | None, idx: int) -> str:
+    """Convert the dataset's ``file_name`` (e.g. ``skilling-j/_sent_mail/1.``)
+    into a filesystem-safe basename. Trailing index disambiguates duplicates."""
+    fn = file_name or f"unknown_{idx:06d}"
+    return fn.replace("/", "_").replace(".", "_") or f"unknown_{idx:06d}"
+
+
+def _row_to_eml(row: dict) -> str:
+    """Format a parquet row as an RFC 822-ish ``.eml`` string. Apache Tika
+    (HC's text extractor) parses this layout reliably for headers + body."""
+    headers = [
+        f"From: {row.get('from') or ''}",
+        f"To: {', '.join(row.get('to') or [])}",
+        f"Cc: {', '.join(row.get('cc') or [])}",
+        f"Subject: {row.get('subject') or ''}",
+        f"Date: {row.get('date')}",
+        f"Message-ID: {row.get('message_id') or ''}",
+    ]
+    body = row.get("body") or ""
+    return "\n".join(headers) + "\n\n" + body
 
 
 def acquire(
@@ -52,9 +93,9 @@ def acquire(
 
     if marker.exists():
         emls = sorted(ingest_dir.glob("*.eml"))
-        # Marker without files is a stale-cache sentinel — fall through to
-        # the download/filter/copy path so the marker doesn't trick the
-        # caller into thinking a corpus exists when its files are gone.
+        # Marker without files is a stale-cache sentinel — fall through to the
+        # download/filter/copy path so the marker doesn't trick the caller into
+        # thinking a corpus exists when its files are gone.
         if emls:
             return CorpusManifest(
                 corpus_id="enron",
@@ -67,31 +108,38 @@ def acquire(
         marker.unlink()  # remove stale marker so future runs don't keep tripping it
 
     src = _download_corpus(workdir)
-    all_eml = sorted(src.rglob("*.eml"))
 
-    target: list[Path] = []
-    others: list[Path] = []
-    for p in all_eml:
-        name = p.name.lower()
-        if any(name.startswith(c) for c in custodians):
-            target.append(p)
+    target: list[dict] = []
+    others: list[dict] = []
+    for row in _iter_parquet_rows(src):
+        fn = (row.get("file_name") or "").lower()
+        if any(fn.startswith(c) for c in custodians):
+            target.append(row)
         else:
-            others.append(p)
+            others.append(row)
 
     rng = random.Random(RANDOM_SEED)
     sampled_others = rng.sample(others, min(random_count, len(others)))
     selected = target + sampled_others
 
     ingest_dir.mkdir(parents=True, exist_ok=True)
-    for src_path in selected:
-        shutil.copy2(src_path, ingest_dir / src_path.name)
+    seen: set[str] = set()
+    for i, row in enumerate(selected):
+        base = _safe_filename(row.get("file_name"), i)
+        # Different rows can share file_name in some Enron layouts (forwarded
+        # threads, etc.); disambiguate with the running index.
+        if base in seen:
+            base = f"{base}_{i:06d}"
+        seen.add(base)
+        (ingest_dir / f"{base}.eml").write_text(_row_to_eml(row), encoding="utf-8")
 
     marker.write_text("acquired")
+    total_size = sum(p.stat().st_size for p in ingest_dir.glob("*.eml"))
     return CorpusManifest(
         corpus_id="enron",
         ingest_dir=ingest_dir,
         doc_count=len(selected),
-        total_size_bytes=sum(p.stat().st_size for p in selected),
+        total_size_bytes=total_size,
         license="public domain",
-        notes=f"Enron subset: {len(target)} custodian + {len(sampled_others)} random emails",
+        notes=f"Enron subset: {len(target)} custodian + {len(sampled_others)} random emails (from parquet)",
     )

--- a/scripts/test_corpora/pyproject.toml
+++ b/scripts/test_corpora/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "Pillow>=12",
     "spacy>=3.7",
     "huggingface_hub>=0.25",
+    "pyarrow>=21",
 ]
 
 [project.optional-dependencies]

--- a/scripts/test_corpora/tests/fixtures/enron_sample/lay_001.eml
+++ b/scripts/test_corpora/tests/fixtures/enron_sample/lay_001.eml
@@ -1,6 +1,0 @@
-From: kenneth.lay@enron.com
-To: jeff.skilling@enron.com
-Subject: Re: Q3 numbers
-Date: Mon, 1 Oct 2001 09:30:00 -0500
-
-Agreed. 4pm today.

--- a/scripts/test_corpora/tests/fixtures/enron_sample/random_001.eml
+++ b/scripts/test_corpora/tests/fixtures/enron_sample/random_001.eml
@@ -1,6 +1,0 @@
-From: random.employee@enron.com
-To: jeff.skilling@enron.com
-Subject: Lunch
-Date: Mon, 1 Oct 2001 11:00:00 -0500
-
-Want to grab lunch?

--- a/scripts/test_corpora/tests/fixtures/enron_sample/skilling_001.eml
+++ b/scripts/test_corpora/tests/fixtures/enron_sample/skilling_001.eml
@@ -1,6 +1,0 @@
-From: jeff.skilling@enron.com
-To: kenneth.lay@enron.com
-Subject: Q3 numbers
-Date: Mon, 1 Oct 2001 09:00:00 -0500
-
-We need to discuss the California position before the call tomorrow.

--- a/scripts/test_corpora/tests/test_enron.py
+++ b/scripts/test_corpora/tests/test_enron.py
@@ -1,50 +1,116 @@
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from scripts.test_corpora.corpora import enron
 
 
-def test_enron_filter_keeps_only_target_custodians(tmp_path: Path, fixtures_dir: Path):
-    src = fixtures_dir / "enron_sample"
+def _write_parquet_fixture(out_dir: Path, rows: list[dict]) -> None:
+    """Materialize an HF-style parquet dataset under ``out_dir/data/``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = out_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, data_dir / "train-00000-of-00001.parquet")
 
-    # Pretend the "downloaded" corpus is just our fixture dir
-    with patch.object(enron, "_download_corpus", return_value=src):
+
+def _make_row(file_name: str, *, body: str = "hi", subject: str = "x") -> dict:
+    return {
+        "message_id": f"<{file_name}@enron.com>",
+        "subject": subject,
+        "from": "alice@enron.com",
+        "to": ["bob@enron.com"],
+        "cc": [],
+        "bcc": [],
+        "date": datetime(2001, 5, 14, 23, 39, tzinfo=UTC),
+        "body": body,
+        "file_name": file_name,
+    }
+
+
+def test_enron_filter_keeps_only_target_custodians(tmp_path: Path):
+    """Custodian filter is name-prefix on ``file_name``; non-custodian rows
+    feed the random sample."""
+    rows = [
+        _make_row("skilling-j/_sent_mail/1."),
+        _make_row("skilling-j/inbox/2."),
+        _make_row("lay-k/_sent_mail/1."),
+        _make_row("fastow-a/inbox/1."),
+        _make_row("allen-p/_sent_mail/1."),
+        _make_row("germany-c/inbox/1."),
+        _make_row("dasovich-j/inbox/1."),
+    ]
+    fake_hf = tmp_path / "hf_enron"
+    _write_parquet_fixture(fake_hf, rows)
+
+    with patch.object(enron, "_download_corpus", return_value=fake_hf):
         m = enron.acquire(workdir=tmp_path / "work", custodians=["skilling", "lay"], random_count=1)
-        assert m.doc_count == 3  # 1 skilling + 1 lay + 1 random
-        names = sorted(p.name for p in m.ingest_dir.glob("*.eml"))
-        assert "skilling_001.eml" in names
-        assert "lay_001.eml" in names
+
+    # 2 skilling + 1 lay = 3 custodian, plus 1 random non-custodian = 4
+    assert m.doc_count == 4
+    names = sorted(p.name for p in m.ingest_dir.glob("*.eml"))
+    assert any(n.startswith("skilling-j_") for n in names)
+    assert any(n.startswith("lay-k_") for n in names)
 
 
-def test_enron_marker_without_files_re_acquires(tmp_path: Path, fixtures_dir: Path):
-    """Regression for the stale-marker bug: if the .acquired marker exists
-    but the .eml files are gone (manual cleanup, fs eviction, lost mount),
-    acquire() must re-download instead of trusting the marker. Without
-    this guard, Phase 0 marks the unit DONE in 4ms and Phase 4 hits a
-    120s 'watcher never enqueued' timeout."""
-    src = fixtures_dir / "enron_sample"
+def test_enron_eml_format_is_rfc822_like(tmp_path: Path):
+    """The materialized .eml should have standard headers + blank line + body
+    so Tika can parse it cleanly during HC ingest."""
+    fake_hf = tmp_path / "hf_enron"
+    _write_parquet_fixture(
+        fake_hf,
+        [
+            {
+                "message_id": "<m1@enron.com>",
+                "subject": "Q4 forecast",
+                "from": "phillip.allen@enron.com",
+                "to": ["tim.belden@enron.com"],
+                "cc": ["alice@enron.com"],
+                "bcc": [],
+                "date": datetime(2001, 5, 14, 23, 39, tzinfo=UTC),
+                "body": "Here is our forecast",
+                "file_name": "skilling-j/_sent_mail/1.",
+            }
+        ],
+    )
+
+    with patch.object(enron, "_download_corpus", return_value=fake_hf):
+        m = enron.acquire(workdir=tmp_path / "work", custodians=["skilling"], random_count=0)
+
+    eml = (m.ingest_dir / "skilling-j__sent_mail_1_.eml").read_text()
+    assert "From: phillip.allen@enron.com" in eml
+    assert "To: tim.belden@enron.com" in eml
+    assert "Cc: alice@enron.com" in eml
+    assert "Subject: Q4 forecast" in eml
+    assert "Message-ID: <m1@enron.com>" in eml
+    # Headers ↔ body separator
+    assert "\n\nHere is our forecast" in eml
+
+
+def test_enron_marker_without_files_re_acquires(tmp_path: Path):
+    """Regression for the stale-marker bug: marker present but ingest_dir
+    empty → re-acquire instead of returning a 0-doc manifest."""
+    fake_hf = tmp_path / "hf_enron"
+    _write_parquet_fixture(fake_hf, [_make_row("skilling-j/inbox/1.")])
 
     workdir = tmp_path / "work"
     ingest_dir = workdir / "ingest"
     ingest_dir.mkdir(parents=True)
-    # Pre-create the marker but leave ingest_dir empty
     (ingest_dir / ".acquired").write_text("acquired")
     assert list(ingest_dir.glob("*.eml")) == []
 
-    with patch.object(enron, "_download_corpus", return_value=src):
-        m = enron.acquire(workdir=workdir, custodians=["skilling", "lay"], random_count=1)
+    with patch.object(enron, "_download_corpus", return_value=fake_hf):
+        m = enron.acquire(workdir=workdir, custodians=["skilling"], random_count=0)
 
-    # Should have re-acquired despite the marker
-    assert m.doc_count == 3
-    assert sorted(p.name for p in m.ingest_dir.glob("*.eml"))
-    # Fresh marker should be in place after re-acquire
+    assert m.doc_count == 1
     assert (ingest_dir / ".acquired").exists()
 
 
 def test_enron_marker_with_files_short_circuits(tmp_path: Path):
-    """The fast path still works: marker + files present → return manifest
-    without re-downloading. Asserted by patching _download_corpus to raise
-    if it's called."""
+    """Fast path: marker + files present → return immediately, no download."""
     workdir = tmp_path / "work"
     ingest_dir = workdir / "ingest"
     ingest_dir.mkdir(parents=True)
@@ -56,4 +122,5 @@ def test_enron_marker_with_files_short_circuits(tmp_path: Path):
 
     with patch.object(enron, "_download_corpus", side_effect=_no_download):
         m = enron.acquire(workdir=workdir)
-        assert m.doc_count == 1
+
+    assert m.doc_count == 1


### PR DESCRIPTION
## Summary

User on BIG: Phase 0's enron unit completed in 67ms while the ingest dir stayed empty. Even after [#314](https://github.com/r0shi/harborclerk/pull/314)'s marker-empty re-acquire fix, the slow path itself is broken — it produces zero documents.

## Root cause

The HF dataset `corbt/enron-emails` is **parquet**, not loose `.eml` files:

```
hf_enron/
├── README.md
└── data/
    ├── train-00000-of-00003.parquet  (185 MB)
    ├── train-00001-of-00003.parquet  (167 MB)
    └── train-00002-of-00003.parquet  (141 MB)
```

517,401 emails across 3 files (~493 MB total). Schema: `message_id, subject, from, to[], cc[], bcc[], date, body, file_name`.

The harness's `acquire()` did `src.rglob("*.eml")` → matches nothing → empty result → marker written, ingest_dir empty, manifest reports `doc_count=0`. The dataset has been parquet the whole time; the harness was apparently written assuming `.eml` files.

## Fix

Replace the entire acquisition path with a parquet reader:

- `_iter_parquet_rows(dataset_root)` — yields rows from `data/*.parquet` (with rglob fallback for non-standard layouts).
- `_row_to_eml(row)` — formats each row as RFC 822-ish text (From, To, Cc, Subject, Date, Message-ID, blank line, body) which Tika parses cleanly.
- `_safe_filename(file_name, idx)` — converts the dataset's `file_name` field (e.g. `skilling-j/_sent_mail/1.`) into a filesystem-safe basename; numeric-suffix collision-protection.
- Custodian filter still uses `startswith` on `file_name`, just reading from parquet rows instead of stat'd Path objects.
- `pyarrow>=21` added to `scripts/test_corpora/pyproject.toml`.
- Marker-without-files re-acquire path preserved (carried from #314 which landed earlier).

## Tests

Fully rewritten on a parquet fixture built inline with pyarrow (removed the obsolete `.eml` fixtures under `tests/fixtures/enron_sample/`):

- `test_enron_filter_keeps_only_target_custodians` — 7-row mixed-custodian parquet, filter to skilling+lay, expect 3 custodian + 1 random
- `test_enron_eml_format_is_rfc822_like` — single row, verify all expected headers and the blank-line/body separator
- `test_enron_marker_without_files_re_acquires` — stale-marker regression
- `test_enron_marker_with_files_short_circuits` — positive control (patches `_download_corpus` to raise)

## Workaround for users blocked right now

If you've already cached `hf_enron/` from a previous run, you can materialize the .eml files manually before this lands:

```bash
uv run --with pyarrow python <<'PY'
# ... see chat for the inline script ...
PY
```

After this PR merges, `acquire()` does this for you on the slow path.

## Test plan

- [x] 4 enron tests pass; ruff clean; format clean
- [ ] On BIG/MINI after pulling: `--rerun 'phase=0,corpus=enron' --phases 0,1,4` should download (or use cached) parquet → write ~500 .eml files → Phase 4 ingests cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
