### PR TITLE
fix(test-corpora): Phase 1 baselines must also gate on corpus-loaded

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -687,12 +687,15 @@ def main(argv: list[str] | None = None) -> int:
                     log.info("dry-run: skipping %s", u)
                     continue
 
-                # Ensure correct corpus is in the DB for phases 4/5 (unified for 6).
-                # On a fresh process (current_corpus_in_db is None) we first ask HC
-                # whether it already has u.corpus loaded AND its queue has drained —
-                # if so, skip the wipe so `--resume` after a mid-corpus crash doesn't
-                # lose the existing ingest.
-                if phase in (4, 5) and u.corpus != current_corpus_in_db:
+                # Ensure correct corpus is in the DB for phases 1/4/5 (unified for 6).
+                # Phase 1 baselines call HC's MCP for KB tools — Sonnet's queries hit
+                # whatever is currently in HC's DB, so a fresh sweep that doesn't
+                # ingest first generates baselines against the wrong corpus (or no
+                # corpus at all). On a fresh process (current_corpus_in_db is None)
+                # we first ask HC whether it already has u.corpus loaded AND its
+                # queue has drained — if so, skip the wipe so `--resume` after a
+                # mid-corpus crash doesn't lose the existing ingest.
+                if phase in (1, 4, 5) and u.corpus != current_corpus_in_db:
                     if u.corpus not in manifests:
                         manifests[u.corpus] = _phase0_acquire(u.corpus, workdir)
                     # Belt-and-suspenders: if Phase 0's ingest dir got cleaned up


### PR DESCRIPTION
## Summary

User reported Phase 1 baselines started running while the corpus was still ingesting. Sonnet's MCP queries against HC's KB then hit whatever HC happened to have loaded (or nothing), producing baselines that reference the wrong corpus.

## Root cause

The ingest gate in the per-unit loop ([sweep.py:695](scripts/test_corpora/runner/sweep.py:695)) fires only for phases 4/5/6:

```python
if phase in (4, 5) and u.corpus != current_corpus_in_db:
    ... wipe and re-ingest ...
```

Phase 1 is the path that needs this **most** — the whole point of Phase 1 baselines is that Sonnet sees the same KB the local-model phases see. Without the gate, Phase 1 baselines are generated against an arbitrary corpus state.

## Fix

One-line change: extend the tuple to `(1, 4, 5)`. Phase 1 units are planned in corpus order, so the ingest happens once per corpus transition — 3 ingests total (cuad → enron → synthetic), same cadence as Phase 4/5.

## Test plan

- [x] 116 tests pass; ruff clean (the spaCy failure is the pre-existing env issue)
- [ ] User reruns Phase 1 after this lands; observes 3 ingest blocks in the log, each followed by ~17 baselines, no MCP calls before the matching corpus is loaded

## After this lands

User must rerun all Phase 1 baselines — the previous batch is unreliable. Synthetic corpus regeneration is NOT needed (Phase 0 synthetic output is on disk and intact: 260 .txt + 20 .pdf + 280 .json sidecars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)