### PR TITLE
refactor(test-corpora): iterate sweep corpus-outer to collapse 10 ingests to 4

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -647,17 +647,51 @@ def main(argv: list[str] | None = None) -> int:
         # Sonnet 4.6 baseline generator has real KB tools available.
         mcp_session: SyncMcpSession | None = None
 
-        # Process units in phase order
-        for phase in sorted(phases):
-            phase_units = [u for u in sf.units() if u.phase == phase and u.status == Status.PENDING]
-            if not phase_units:
-                log.info("phase %d already complete or empty", phase)
+        # Iterate corpus-outer / phase-inner so each corpus is ingested at most
+        # once per sweep run. The previous phase-outer / corpus-inner ordering
+        # forced the corpus to be wiped + re-ingested between phases (e.g.
+        # cuad ingested once for Phase 1 baselines, then again for Phase 4
+        # research, then again for Phase 5 parity) — 10 ingests across a full
+        # sweep, with each ~5-15 min on a Mac mini. Corpus-outer collapses
+        # that to 4 ingests (cuad + enron + synthetic + unified).
+        #
+        # Within a corpus block, units are sorted by (phase, model, question_id)
+        # so Phase 0 acquire runs before Phase 1 ingest, baselines before
+        # research, etc. The unified Phase 6 is special-cased to run LAST
+        # because its ingest dir has to be built from the other three corpora
+        # first.
+        by_corpus: dict[str, list[Unit]] = {}
+        for u in sf.units():
+            if u.status != Status.PENDING:
                 continue
-            log.info("=== phase %d: %d pending units ===", phase, len(phase_units))
+            if u.phase not in phases:
+                continue
+            by_corpus.setdefault(u.corpus, []).append(u)
+        for units_in in by_corpus.values():
+            units_in.sort(key=lambda u: (u.phase, u.model, u.question_id))
+        # Process non-unified corpora first, in stable order, then unified last.
+        ordered_corpora = sorted(c for c in by_corpus if c != "unified")
+        if "unified" in by_corpus:
+            ordered_corpora.append("unified")
 
-            # Phase-specific setup
-            if phase == 6:
-                # unified: build a combined ingest dir
+        if not ordered_corpora:
+            log.info("no pending units in scope")
+
+        for corpus in ordered_corpora:
+            corpus_units = by_corpus[corpus]
+            phases_in_block = sorted(set(u.phase for u in corpus_units))
+            log.info(
+                "=== corpus %s: %d pending units (phases %s) ===",
+                corpus,
+                len(corpus_units),
+                phases_in_block,
+            )
+
+            # Special setup for the unified corpus: build the combined ingest
+            # dir from cuad+enron+synthetic, then ingest. The non-unified
+            # ingest gate inside the per-unit body wouldn't trigger because
+            # phase 6 isn't in (1, 4, 5).
+            if corpus == "unified" and not args.dry_run:
                 unified_dir = workdir / "unified" / "ingest"
                 unified_dir.mkdir(parents=True, exist_ok=True)
                 for c in ("cuad", "enron", "synthetic"):
@@ -669,20 +703,27 @@ def main(argv: list[str] | None = None) -> int:
                 unified_manifest = CorpusManifest(
                     corpus_id="unified",
                     ingest_dir=unified_dir,
-                    doc_count=sum(m.doc_count for m in manifests.values()),
-                    total_size_bytes=sum(m.total_size_bytes for m in manifests.values()),
+                    doc_count=sum(m.doc_count for m in manifests.values() if m.corpus_id != "unified"),
+                    total_size_bytes=sum(m.total_size_bytes for m in manifests.values() if m.corpus_id != "unified"),
                     license="various",
                     notes="unified pass",
                 )
-                if not args.dry_run:
-                    if current_corpus_in_db is None and _can_skip_ingest(hc, unified_manifest):
-                        log.info("HC already has unified corpus loaded — skipping re-ingest")
-                        current_corpus_in_db = "unified"
-                    elif current_corpus_in_db != "unified":
-                        _ingest_corpus(hc, unified_manifest)
-                        current_corpus_in_db = "unified"
+                manifests["unified"] = unified_manifest
+                if current_corpus_in_db is None and _can_skip_ingest(hc, unified_manifest):
+                    log.info("HC already has unified corpus loaded — skipping re-ingest")
+                    current_corpus_in_db = "unified"
+                elif current_corpus_in_db != "unified":
+                    _ingest_corpus(hc, unified_manifest)
+                    current_corpus_in_db = "unified"
 
-            for u in phase_units:
+            last_phase_logged: int | None = None
+            for u in corpus_units:
+                # Phase boundary log within a corpus block, helps eyeball
+                # progress when a corpus contains units across multiple phases.
+                if u.phase != last_phase_logged:
+                    log.info("--- phase %d for %s ---", u.phase, corpus)
+                    last_phase_logged = u.phase
+                phase = u.phase  # rest of the body uses `phase` as a free var
                 if args.dry_run and phase > 0:
                     log.info("dry-run: skipping %s", u)
                     continue


### PR DESCRIPTION
## Summary

User: *"The ingest is one of the most time intensive parts of the pipeline. It would be better to do it once, do the baseline, do the actual queries, then load another corpus."*

A full sweep of phases 0/1/4/5/6 across cuad+enron+synthetic on the old **phase-outer / corpus-inner** ordering forced the corpus to be wiped and re-ingested every time the phase changed:

| Phase | Ingests |
| --- | --- |
| Phase 1 | cuad, enron, synthetic |
| Phase 4 | cuad, enron, synthetic |
| Phase 5 | cuad, enron, synthetic |
| Phase 6 | unified |
| **Total** | **10** |

Each ingest is 5-15 min on a Mac mini, so this was **1-3 hours of pure Tika+embedder overhead** per sweep.

## Fix

Refactor `main()`'s outer loop to **corpus-outer / phase-inner**:

| Corpus block | Phases | Ingests |
| --- | --- | --- |
| cuad | 0, 1 (baselines), 2-3 (smoke+depth), 4 (8 models × N), 5 (top 2 × N) | 1 |
| enron | 0, 1 (baselines), 4-5 | 1 |
| synthetic | 0, 1 (baselines), 4-5 | 1 |
| unified | 6 | 1 |
| **Total** | | **4** |

Saves **6 ingests per full sweep — ~30 min to 1.5 hours**.

## Implementation

- Replace the outer `for phase in sorted(phases)` with `for corpus in ordered_corpora`.
- Group pending units by corpus once at the start; sort each block by `(phase, model, question_id)` so phase 0 acquire runs before phase 1 ingest, baselines before research, etc.
- Process non-unified corpora alphabetically; **unified runs last** (its ingest dir is built from the other three corpora's output).
- Phase 6 setup (build combined dir + ingest) moves from a `phase == 6` branch in the old phase loop into a `corpus == "unified"` branch in the new corpus loop, kept BEFORE the per-unit body so the ingest happens before the unified units execute.
- Per-unit body unchanged — added `phase = u.phase` shim at the top so existing `if phase in (...)` checks, status-downgrade logic, and metrics row writes work without rewriting hundreds of lines.
- `sampler.print_summary_table(phase=phase)` now fires once per corpus block instead of once per phase. Different cadence but still meaningful — shows progress per corpus.

## Compatibility

- State.json is unchanged. Same units, same fields. Existing state files migrate forward; no flip-to-PENDING required.
- All existing per-unit logic preserved: ingest gate (phases 1/4/5), HC-unreachable circuit breaker, JWT auto-refresh, research retry, IN_PROGRESS recovery on uncaught exception, etc.
- The only thing that moves is the OUTER iteration order.

## Test plan

- [x] 81 unrelated tests still pass; ruff clean + format clean
- [x] `from sweep import main` imports without error
- [ ] User reruns full sweep (or `--phases 0,1,4,5,6` if subsetting); observes 4 corpus blocks in the log, each with a single ingest line followed by all phases for that corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
