### PR TITLE
docs(test-corpora): split RUNBOOK by topology (single, parallel-twins, heterogeneous)

### DIFF
--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -1,16 +1,16 @@
 # Test Corpora Sweep Runbook
 
-How to run the full six-phase LLM evaluation sweep across two machines, mostly unattended.
+How to run the full six-phase LLM evaluation sweep against Harbor Clerk, mostly unattended.
 
-This runbook is the operations companion to:
+This is the operations companion to:
 - [README.md](README.md) — quickstart + dev orientation
 - [`docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md`](../../docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md) — the design
 
 ---
 
-## ⚠️  This sweep is destructive
+## ⚠️ This sweep is destructive
 
-The harness **wipes the Harbor Clerk instance it talks to**. Every Phase 4 / Phase 5 / Phase 6 corpus ingest calls:
+The harness **wipes the Harbor Clerk instance it talks to**. Every Phase 1 / Phase 4 / Phase 5 / Phase 6 corpus ingest calls:
 
 1. `DELETE` for every existing watch folder
 2. `POST /api/system/delete-all-documents` (drops all documents, chunks, entities, embeddings, ingestion jobs, uploads, and originals storage objects)
@@ -18,89 +18,72 @@ The harness **wipes the Harbor Clerk instance it talks to**. Every Phase 4 / Pha
 
 **If you have personal documents in this Harbor Clerk instance, they will be deleted.** Conversations, chat messages, users, and API keys are preserved — only document-shaped data is wiped.
 
-If you want to keep an existing corpus intact, run the sweep against a **separate Harbor Clerk instance**:
+If you want to keep an existing corpus intact, point the sweep at a **separate Harbor Clerk instance**:
 
 - spin up a second instance via Docker on a different port (e.g. `docker compose up` with a remapped 443→8443) and set `HC_API_BASE` accordingly, or
-- use the Mac mini's instance which is presumed clean (this is the natural fit for the split BIG/MINI flow below).
+- use a second Mac that's presumed clean.
 
 ---
 
-## Moving parts
+## Pick your topology
 
-```
-                                    ┌──────────────────────────┐
-                                    │  Anthropic API           │
-                                    │  (baselines + judge)     │
-                                    └────────────┬─────────────┘
-                                                 │
-   ┌─────────────────────────────┐               │              ┌──────────────────────────┐
-   │  BIG  (~36 GB+ Mac, current)│               │              │  MINI (32 GB M4 Pro)     │
-   │                             │               │              │                          │
-   │  Harbor Clerk (native app)  │◀─── REST ─────┤              │  Harbor Clerk (native)   │
-   │   ├ Postgres                │               │              │   ├ Postgres             │
-   │   ├ Tika                    │               │              │   ├ Tika                 │
-   │   ├ Embedder                │               │              │   ├ Embedder             │
-   │   └ llama-server            │               │              │   └ llama-server         │
-   │                             │               │              │                          │
-   │  sweep harness              │               │              │  sweep harness           │
-   │   ├ Phase 0,1,5,6           │◀──────────────┘              │   ├ Phase 0 (cached)     │
-   │   └ Phase 4 top 2 models    │                              │   └ Phase 4 6 small      │
-   │      (gemma4-26b, qwen36)   │                              │      (smollm3-3b...      │
-   │                             │                              │       gpt-oss-20b)       │
-   │  supervisor.py              │                              │  supervisor.py           │
-   │   └ tail log → notify       │                              │   └ tail log → notify    │
-   │                             │                              │                          │
-   │  tmux session "sweep-big"   │                              │  tmux session "sweep-mini"│
-   │  ~/sweep-logs/phase4-big.log│                              │  ~/sweep-logs/phase4-mini│
-   │                             │                              │   .log                   │
-   └────────────────┬────────────┘                              └──────────┬───────────────┘
-                    │                                                      │
-                    │           rsync results/<run-id>/                    │
-                    └──────────────────────────────────────────────────────┘
-                              ⇩  combined results live on BIG
-                                 metrics.csv + judge JSON + state.json
-```
+The sweep can be run on one machine or split across two. The shape of the deployment changes which commands you run and what gets rsynced; the universal pre-flight, recovery, and aggregation steps below are the same.
+
+| Topology | When to use it | Wall-clock | Runbook |
+| --- | --- | --- | --- |
+| **Single machine** | One reasonably-spec'd Mac (≥ 32 GB) with patience. | 60-80 h | [`runbooks/single.md`](runbooks/single.md) |
+| **Two similar machines** | Two Macs of comparable spec (e.g. both M2/M3/M4 with ≥ 32 GB) and **both** able to host Gemma 26B / Qwen 35B. Splits Phases 4 and 5. | 35-45 h | [`runbooks/parallel-twins.md`](runbooks/parallel-twins.md) |
+| **One big + one small** | A larger Mac (≥ 36 GB headroom for Gemma 26B / Qwen 35B) plus a smaller one that runs only the lighter models. Big runs the heavy models; small runs the rest in parallel. | 45-55 h | [`runbooks/heterogeneous.md`](runbooks/heterogeneous.md) |
+
+Each topology runbook has its own diagram and phase-by-phase commands, but inherits the pre-flight, recovery, and aggregation sections below.
+
+---
+
+## Components
 
 | Component | Where | Purpose | Lifetime |
 | --- | --- | --- | --- |
-| `runner/sweep.py` | both machines | the actual harness — runs the six-phase loop | per phase invocation, hours |
-| `runner/supervisor.py` | both machines | tails the harness log, posts macOS notifications, recommends skips | runs alongside the sweep |
-| `tmux` session | both machines | keeps the harness alive across SSH disconnects + Claude session ends | session lifetime |
-| Anthropic API key | both machines | Sonnet 4.6 baselines (Phase 1) and judge (Phase 5) | the sweep |
-| Harbor Clerk admin login (`HC_USERNAME`/`HC_PASSWORD`) | both machines | required for `delete_all_documents` between corpora | the sweep |
-| Claude subagent (Sonnet) | optional, on either machine's Claude session | reads supervisor stdout, decides what to do for ambiguous events | session lifetime |
-| `results/<run-id>/` directory | rsynced between machines | shared state — baselines from BIG, responses from both | through to the final report |
+| `runner/sweep.py` | every machine | the actual harness — runs the six-phase loop | per phase invocation, hours |
+| `runner/supervisor.py` | every machine | tails the harness log, posts macOS notifications, recommends skips | runs alongside the sweep |
+| `tmux` session | every machine | keeps the harness alive across SSH disconnects + Claude session ends | session lifetime |
+| Anthropic API key | every machine | Sonnet 4.6 baselines (Phase 1) and judge (Phase 5) | the sweep |
+| Harbor Clerk admin login (`HC_USERNAME`/`HC_PASSWORD`) | every machine | required for `delete_all_documents` between corpora | the sweep |
+| Claude subagent (Sonnet) | optional, on any session | reads supervisor stdout, decides what to do for ambiguous events | session lifetime |
+| `results/<run-id>/` directory | rsynced between machines (split topologies only) | shared state — baselines, responses, judge verdicts | through to the final report |
 
 ---
 
 ## Pre-flight (do once, before any sweep starts)
 
-### On both machines
+### On every machine
 
 ```bash
 cd /path/to/mcp-gateway/scripts/test_corpora
 uv sync --extra test
 uv run python -m spacy download en_core_web_sm
 
-# verify all 38+ unit tests pass
+# verify all unit tests pass
 uv run pytest -q
 ```
 
-### On `BIG` only
+### SSH alias for split topologies (optional)
 
-Generate an SSH alias to `MINI` so rsync is a one-liner:
+If you're running on two machines, set up an SSH alias on the *coordinator* machine (the one that does the rsyncs) so the rsync commands in the topology runbooks Just Work:
 
 ```bash
-# one-time: ssh-keygen + ssh-copy-id alex@mini.local
-echo "Host mini" >> ~/.ssh/config
-echo "  HostName mini.local" >> ~/.ssh/config
+# one-time on the coordinator:
+# ssh-keygen + ssh-copy-id alex@<other-machine>.local
+echo "Host other" >> ~/.ssh/config
+echo "  HostName <other-machine>.local" >> ~/.ssh/config
 echo "  User $USER" >> ~/.ssh/config
-ssh mini "echo ok"   # should print 'ok' without password prompt
+ssh other "echo ok"   # should print 'ok' without password prompt
 ```
 
-### On both machines
+The topology runbooks use `other` as the placeholder — substitute the real alias.
 
-Pick a stable run-id and shared workdir. **Use the same run-id on both machines.**
+### On every machine
+
+Pick a stable run-id and shared workdir. **Use the same run-id on every machine.**
 
 ```bash
 export RUN=2026-05-05-prod
@@ -108,7 +91,7 @@ export WORKDIR=~/Library/Application\ Support/Harbor\ Clerk/test-corpora
 mkdir -p ~/sweep-logs
 ```
 
-### On both machines
+### On every machine
 
 Harbor Clerk listens differently depending on how you run it:
 
@@ -123,7 +106,7 @@ Find your `api_port` if you've changed the default:
 jq .api_port "$HOME/Library/Application Support/Harbor Clerk/config.json"
 ```
 
-Set env vars for the sweep. Adjust `HC_API_BASE` to match your setup:
+Set env vars for the sweep:
 
 ```bash
 # macOS native (most common)
@@ -159,156 +142,7 @@ curl -sI -X POST "$HC_API_BASE/mcp/mcp" -H "Authorization: Bearer $JWT" | head -
 # A 405 means the path is wrong; 404 means the MCP app isn't mounted.
 ```
 
----
-
-## Phase 0 + 1: corpus acquisition + Claude baselines
-
-Phase 0 acquires all three corpora (cuad, enron, synthetic). Phase 1 generates 48 Claude baselines using Sonnet 4.6 + the Harbor Clerk MCP server. Both run on `BIG` so the `baselines/` dir is colocated with where Phase 5 will read it.
-
-```bash
-# on BIG
-cd /path/to/mcp-gateway
-
-tmux new -d -s sweep-prep "uv --project scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.sweep \
-    --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 0-1 \
-    2>&1 | tee ~/sweep-logs/phase01-big.log"
-
-# detach is automatic with -d. Reattach with: tmux attach -t sweep-prep
-```
-
-In a second terminal, start the supervisor:
-
-```bash
-# on BIG
-uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase01-big.log \
-    --workdir "$WORKDIR" --run-id "$RUN"
-# --workdir + --run-id let the heartbeat events include real progress
-# numbers (state.json summary, corpus/baseline file counts).
-# --heartbeat-seconds N changes the cadence (default 600s = 10 min,
-# 0 disables).
-```
-
-Expected wall-clock: ~10 min for Phase 0 (synthetic generation dominates) + ~30-60 min for Phase 1 (48 questions × ~30-60 s each, Sonnet tool-call rounds).
-
-When supervisor emits a `completion` event (and you get a macOS notification), proceed to sync.
-
-### Sync results to `MINI`
-
-```bash
-# on BIG
-rsync -av --progress \
-    "$WORKDIR/cuad" "$WORKDIR/enron" "$WORKDIR/synthetic" \
-    "$WORKDIR/results/" \
-    "mini:$WORKDIR/"
-```
-
-`MINI` now has the corpora pre-acquired (so its Phase 0 short-circuits) and the baselines (so it could run Phase 5 too, though Phase 5 is reserved for `BIG`).
-
----
-
-## Phase 4: split sweep across both machines
-
-These two commands run **at the same time** on the two machines. The harness state files don't conflict because each machine has its own `state.json` keyed by the same `run-id`.
-
-### On `MINI` (6 smaller models)
-
-```bash
-cd /path/to/mcp-gateway
-
-tmux new -d -s sweep-mini "uv --project scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.sweep \
-    --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 4 \
-    --models smollm3-3b,qwen3-4b,phi4-mini,qwen3-8b,deepseek-r1-0528-8b,gpt-oss-20b \
-    \
-    2>&1 | tee ~/sweep-logs/phase4-mini.log"
-
-uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase4-mini.log \
-    --workdir "$WORKDIR" --run-id "$RUN"
-```
-
-Wall-clock estimate: 6 models × 50 questions × ~5 min average = **~25 hours**. The corpus-outer loop ordering means only 3 DB wipes total (one per corpus), not 18.
-
-### On `BIG` (top 2 models)
-
-```bash
-cd /path/to/mcp-gateway
-
-tmux new -d -s sweep-big "uv --project scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.sweep \
-    --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 4 \
-    --models gemma4-26b-a4b,qwen36-35b-a3b \
-    \
-    2>&1 | tee ~/sweep-logs/phase4-big.log"
-
-uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase4-big.log \
-    --workdir "$WORKDIR" --run-id "$RUN"
-```
-
-Wall-clock estimate: 2 models × 50 questions × ~10-15 min average = **~17-25 hours** (the larger models are slower).
-
-### Sync `MINI`'s responses back
-
-When `MINI`'s supervisor signals completion:
-
-```bash
-# on BIG
-rsync -av --progress \
-    "mini:$WORKDIR/results/$RUN/responses/" \
-    "$WORKDIR/results/$RUN/responses/"
-
-# also pull MINI's metrics.csv rows
-ssh mini "tail -n +2 \"$WORKDIR/results/$RUN/metrics.csv\"" \
-    >> "$WORKDIR/results/$RUN/metrics.csv"
-```
-
-(The CSV append assumes both machines started from the header-only state file. Skip the `tail -n +2` step if you're doing it differently.)
-
----
-
-## Phase 5 (parity) on `BIG`
-
-```bash
-cd /path/to/mcp-gateway
-
-tmux new -d -s sweep-parity "uv --project scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.sweep \
-    --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 5 \
-    2>&1 | tee ~/sweep-logs/phase5-big.log"
-
-uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.supervisor \
-    --log-file ~/sweep-logs/phase5-big.log \
-    --workdir "$WORKDIR" --run-id "$RUN"
-```
-
-Wall-clock estimate: ~17-25 hours of model runs + ~$1-2 in Sonnet judge calls (100 calls × ~$0.01-0.02 each).
-
----
-
-## Phase 6 (unified) on `BIG`
-
-```bash
-cd /path/to/mcp-gateway
-
-tmux new -d -s sweep-unified "uv --project scripts/test_corpora run python -m \
-    scripts.test_corpora.runner.sweep \
-    --run-id $RUN --workdir \"$WORKDIR\" \
-    --phases 6 \
-    2>&1 | tee ~/sweep-logs/phase6-big.log"
-```
-
-Wall-clock: ~3-5 hours.
+Once these checks pass on every machine, pick your topology and follow its runbook.
 
 ---
 
@@ -318,7 +152,7 @@ Wall-clock: ~3-5 hours.
 
 In a Claude Code session on the relevant machine:
 
-> Watch `~/sweep-logs/phase4-mini.log` via `tail -f`. The `scripts/test_corpora/runner/supervisor.py` watcher prints structured JSON events to its stdout — you have access to that log file at the same path. Your job is to act on these events:
+> Watch `~/sweep-logs/<phase>-<machine>.log` via `tail -f`. The `scripts/test_corpora/runner/supervisor.py` watcher prints structured JSON events to its stdout — you have access to that log file at the same path. Your job is to act on these events:
 >
 > - **`phase_boundary`** — log it; no action needed
 > - **`completion`** — log it; tell me the sweep is done
@@ -343,10 +177,11 @@ The harness state file (`results/<run-id>/state.json`) tracks every cell. To res
 # add --resume to any sweep invocation
 uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
     --run-id $RUN --workdir "$WORKDIR" \
-    --phases 4 --models <same-list> --resume 2>&1 | tee -a ~/sweep-logs/phase4-mini.log
+    --phases <same-list> --models <same-list> --resume \
+    2>&1 | tee -a ~/sweep-logs/<phase>-<machine>.log
 ```
 
-The `--resume` flag is required when `state.json` already exists — without it, the sweep fails fast so a typo'd or re-used `--run-id` can't silently inherit a prior run's cells. Stale `IN_PROGRESS` rows older than 2× the time-budget revert to `PENDING` automatically.
+The `--resume` flag is required when `state.json` already exists — without it the sweep fails fast so a typo'd or re-used `--run-id` can't silently inherit a prior run's cells. Stale `IN_PROGRESS` rows older than 2× the time-budget revert to `PENDING` automatically at startup.
 
 ### Stale `state.lock`
 
@@ -370,7 +205,7 @@ Restart Harbor Clerk's LLM model via the UI or:
 curl -X PUT "$HC_API_BASE/api/chat/models/<model_id>/activate"
 ```
 
-Then re-run the sweep with `--resume`.
+Then re-run the sweep with `--resume`. The harness's per-unit ConnectError handling waits up to 120s for HC to come back before incrementing the outage counter, so a brief restart usually doesn't cause unit losses.
 
 ### Anthropic rate-limit storm
 
@@ -391,6 +226,15 @@ uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.swee
 
 This is exactly what the supervisor recommends after 3 consecutive errors. Re-run the sweep to skip the rest of that model's units.
 
+### Stale or empty corpus ingest dir
+
+If a Phase 4/5 unit fails with "watcher never enqueued any jobs for `<corpus>` within 120s", the sweep tries to auto-recover by re-acquiring the corpus on the spot. If that fails too, manually nuke the marker and re-run:
+
+```bash
+rm "$WORKDIR/<corpus>/ingest/.acquired"
+# then re-run with --rerun 'phase=0,corpus=<corpus>' and --resume
+```
+
 ---
 
 ## Final aggregation
@@ -398,7 +242,7 @@ This is exactly what the supervisor recommends after 3 consecutive errors. Re-ru
 When all phases are complete:
 
 ```bash
-# on BIG, summarize Phase 4 completion
+# summarize Phase 4 completion
 awk -F, 'NR>1 && $1==4 {key=$3"|"$2; total[key]++; if($6=="done")done[key]++} END {for(k in total) printf "%-30s %3d/%-3d\n", k, done[k], total[k]}' \
     "$WORKDIR/results/$RUN/metrics.csv" | sort
 
@@ -424,10 +268,10 @@ The full per-question detail lives in:
 | --- | --- |
 | Phase 0 synthetic generation | ~$3-5 (Sonnet 4.6, ~280 docs × ~4K tokens each) |
 | Phase 1 Claude baselines | ~$0.50-2 (48 questions × Sonnet tool-call rounds) |
-| Phase 4 (local) | $0 in API; 25-50 GPU-hours total across both machines |
-| Phase 5 model runs | $0 in API; 17-25 GPU-hours on BIG |
+| Phase 4 (local) | $0 in API; 25-50 GPU-hours total across all machines |
+| Phase 5 model runs | $0 in API; 17-25 GPU-hours |
 | Phase 5 judge | ~$1-2 (100 judge calls × ~$0.01-0.02) |
-| Phase 6 | $0 in API; 3-5 GPU-hours on BIG |
+| Phase 6 | $0 in API; 3-5 GPU-hours |
 | **Total Anthropic spend** | **~$5-10** |
 
 ---
@@ -437,9 +281,9 @@ The full per-question detail lives in:
 Wipe and start over:
 
 ```bash
-# Wipe the run dir on both machines
+# Wipe the run dir on every machine
 rm -rf "$WORKDIR/results/$RUN"
-ssh mini "rm -rf \"$WORKDIR/results/$RUN\""
+ssh other "rm -rf \"$WORKDIR/results/$RUN\""   # if multi-machine
 
 # Pick a new run-id
 export RUN=2026-05-06-retry
@@ -447,4 +291,4 @@ export RUN=2026-05-06-retry
 # Start from Phase 0 again
 ```
 
-Phase 0's `.acquired` markers stay, so the actual corpus downloads are cached — only the run-specific state (responses, baselines, metrics) is regenerated.
+Phase 0's `.acquired` markers and the `hf_enron/` HF download cache stay, so corpus acquisition is cheap on re-runs — only the run-specific state (responses, baselines, metrics) is regenerated. The expensive Phase 0 synthetic generation is preserved as long as `synthetic/ingest/.acquired` exists.

--- a/scripts/test_corpora/runbooks/heterogeneous.md
+++ b/scripts/test_corpora/runbooks/heterogeneous.md
@@ -1,0 +1,212 @@
+# Heterogeneous Runbook (one big, one small)
+
+> **Topology:** one larger Mac handling the heavy models, one smaller Mac handling the rest in parallel.
+
+Pick this if you have one Mac with comfortable headroom for the largest models (≥ 36 GB unified memory, or whatever it takes to run Gemma 4 26B-A4B and Qwen 3.6 35B-A3B without paging) plus a smaller second Mac (e.g. 32 GB M4 Pro). The big machine runs the two heaviest models in Phase 4 plus all of Phases 0/1/5/6; the smaller one runs the six lighter models in Phase 4 in parallel. Phase 5 (top-2 parity + judge) and Phase 6 (unified) stay on BIG so the gemma + qwen weights don't have to load again.
+
+This is the original two-machine flow the harness was built for. It's the fastest topology for an asymmetric pair because every minute the smaller machine runs is "free" — it'd otherwise be idle while BIG plodded through 8 models sequentially.
+
+Wall-clock estimate: **45-55 hours** end-to-end. Phase 4 finishes around the wall-clock of whichever side is slower (typically BIG's two large models at ~17-25 hours, vs. MINI's six smaller models at ~25 hours combined — close to balanced by design). Phase 5 is the next-largest chunk, running only on BIG; if both machines could host the largest models, [parallel-twins](parallel-twins.md) splits Phase 5 too and is the faster topology overall.
+
+Wall-clock comparison vs. single-machine:
+
+| Phase | Single-machine | Heterogeneous | Speedup |
+| --- | --- | --- | --- |
+| 0+1 | 40-70 min | 40-70 min (BIG only) | none |
+| 4 | 40-50 h | 25 h (parallel, MINI-bound) | ~1.7× |
+| 5 | 17-25 h | 17-25 h (BIG only) | none |
+| 6 | 3-5 h | 3-5 h (BIG only) | none |
+| **Total** | **60-80 h** | **45-55 h** | **~1.4×** |
+
+Before starting, complete the [universal pre-flight](../RUNBOOK.md#pre-flight-do-once-before-any-sweep-starts) on **both** machines, including the SSH-alias step on BIG. The placeholder name in this runbook is `mini` — substitute the alias you set up.
+
+```
+                                    ┌──────────────────────────┐
+                                    │  Anthropic API           │
+                                    │  (baselines + judge)     │
+                                    └────────────┬─────────────┘
+                                                 │
+   ┌─────────────────────────────┐               │              ┌──────────────────────────┐
+   │  BIG  (≥ 36 GB Mac)         │               │              │  MINI (32 GB M4 Pro)     │
+   │                             │               │              │                          │
+   │  Harbor Clerk (native app)  │◀─── REST ─────┤              │  Harbor Clerk (native)   │
+   │   ├ Postgres                │               │              │   ├ Postgres             │
+   │   ├ Tika                    │               │              │   ├ Tika                 │
+   │   ├ Embedder                │               │              │   ├ Embedder             │
+   │   └ llama-server            │               │              │   └ llama-server         │
+   │                             │               │              │                          │
+   │  sweep harness              │               │              │  sweep harness           │
+   │   ├ Phase 0,1,5,6           │◀──────────────┘              │   ├ Phase 0 (cached)     │
+   │   └ Phase 4 top 2 models    │                              │   └ Phase 4 6 small      │
+   │      (gemma4-26b, qwen36)   │                              │      (smollm3-3b...      │
+   │                             │                              │       gpt-oss-20b)       │
+   │  supervisor.py              │                              │  supervisor.py           │
+   │   └ tail log → notify       │                              │   └ tail log → notify    │
+   │                             │                              │                          │
+   │  tmux session "sweep-big"   │                              │  tmux session "sweep-mini"│
+   │  ~/sweep-logs/phase4-big.log│                              │  ~/sweep-logs/phase4-mini│
+   │                             │                              │   .log                   │
+   └────────────────┬────────────┘                              └──────────┬───────────────┘
+                    │                                                      │
+                    │           rsync results/<run-id>/                    │
+                    └──────────────────────────────────────────────────────┘
+                              ⇩  combined results live on BIG
+                                 metrics.csv + judge JSON + state.json
+```
+
+---
+
+## Phase 0 + 1: corpus acquisition + Claude baselines (BIG only)
+
+Phase 0 acquires all three corpora (cuad, enron, synthetic). Phase 1 generates 48 Claude baselines using Sonnet 4.6 + the Harbor Clerk MCP server. Both run on BIG so the `baselines/` dir is colocated with where Phase 5 will read it.
+
+```bash
+# on BIG
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-prep "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 0-1 \
+    2>&1 | tee ~/sweep-logs/phase01-big.log"
+
+# detach is automatic with -d. Reattach with: tmux attach -t sweep-prep
+```
+
+In a second terminal, start the supervisor:
+
+```bash
+# on BIG
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase01-big.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+# --workdir + --run-id let the heartbeat events include real progress
+# numbers (state.json summary, corpus/baseline file counts).
+# --heartbeat-seconds N changes the cadence (default 600s = 10 min,
+# 0 disables).
+```
+
+Expected wall-clock: ~10 min for Phase 0 (synthetic generation dominates) + ~30-60 min for Phase 1 (48 questions × ~30-60 s each, Sonnet tool-call rounds).
+
+When supervisor emits a `completion` event (and you get a macOS notification), proceed to sync.
+
+### Sync results to MINI
+
+```bash
+# on BIG
+rsync -av --progress \
+    "$WORKDIR/cuad" "$WORKDIR/enron" "$WORKDIR/synthetic" \
+    "$WORKDIR/results/" \
+    "mini:$WORKDIR/"
+```
+
+MINI now has the corpora pre-acquired (so its Phase 0 short-circuits) and the baselines (so it could run Phase 5 too, though Phase 5 is reserved for BIG).
+
+---
+
+## Phase 4: split sweep across both machines
+
+These two commands run **at the same time** on the two machines. The harness state files don't conflict because each machine has its own `state.json` keyed by the same `run-id`.
+
+### On MINI (6 smaller models)
+
+```bash
+# on MINI
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-mini "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    --models smollm3-3b,qwen3-4b,phi4-mini,qwen3-8b,deepseek-r1-0528-8b,gpt-oss-20b \
+    2>&1 | tee ~/sweep-logs/phase4-mini.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4-mini.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock estimate: 6 models × ~50 questions × ~5 min average = **~25 hours**. The corpus-outer loop ordering means only 3 DB wipes total (one per corpus), not 18.
+
+### On BIG (top 2 models)
+
+```bash
+# on BIG
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-big "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    --models gemma4-26b-a4b,qwen36-35b-a3b \
+    2>&1 | tee ~/sweep-logs/phase4-big.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4-big.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock estimate: 2 models × ~50 questions × ~10-15 min average = **~17-25 hours** (the larger models are slower).
+
+### Sync MINI's responses back
+
+When MINI's supervisor signals completion:
+
+```bash
+# on BIG
+rsync -av --progress \
+    "mini:$WORKDIR/results/$RUN/responses/" \
+    "$WORKDIR/results/$RUN/responses/"
+
+# also pull MINI's metrics.csv rows
+ssh mini "tail -n +2 \"$WORKDIR/results/$RUN/metrics.csv\"" \
+    >> "$WORKDIR/results/$RUN/metrics.csv"
+```
+
+(The CSV append assumes both machines started from the header-only state file. Skip the `tail -n +2` step if you're doing it differently.)
+
+---
+
+## Phase 5 (parity) on BIG
+
+```bash
+# on BIG
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-parity "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 5 \
+    2>&1 | tee ~/sweep-logs/phase5-big.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase5-big.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock estimate: ~17-25 hours of model runs + ~$1-2 in Sonnet judge calls (100 calls × ~$0.01-0.02 each).
+
+---
+
+## Phase 6 (unified) on BIG
+
+```bash
+# on BIG
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-unified "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 6 \
+    2>&1 | tee ~/sweep-logs/phase6-big.log"
+```
+
+Wall-clock: ~3-5 hours.
+
+---
+
+When this finishes, head back to [the parent runbook's final-aggregation section](../RUNBOOK.md#final-aggregation).

--- a/scripts/test_corpora/runbooks/parallel-twins.md
+++ b/scripts/test_corpora/runbooks/parallel-twins.md
@@ -1,0 +1,243 @@
+# Parallel-Twins Runbook
+
+> **Topology:** two similar Macs, Phase 4 split 4-and-4 across them.
+
+Pick this if you have two roughly comparable machines (both ≥ 32 GB unified memory, similar M-series generation) and want to roughly halve the wall-clock of Phases 4 and 5. Phase 0/1/6 stay on one designated **coordinator** machine; Phase 4 splits the eight models four-and-four; Phase 5's top-2 parity step splits one model per machine. Both machines need enough memory headroom to run a ~35B-class model (Qwen 3.6 35B-A3B on the coordinator, Gemma 4 26B-A4B on the other) — if one machine can't, use the [heterogeneous topology](heterogeneous.md) instead.
+
+Wall-clock estimate: **35-45 hours** end-to-end for the full sweep, vs. 60-80 hours on a single machine.
+
+Wall-clock comparison vs. single-machine:
+
+| Phase | Single-machine | Parallel-twins | Speedup |
+| --- | --- | --- | --- |
+| 0+1 | 40-70 min | 40-70 min (coordinator only) | none |
+| 4 | 40-50 h | 22-25 h (parallel) | ~2× |
+| 5 | 17-25 h | 9-13 h (parallel) | ~2× |
+| 6 | 3-5 h | 3-5 h (coordinator only) | none |
+| **Total** | **60-80 h** | **35-45 h** | **~1.7×** |
+
+Before starting, complete the [universal pre-flight](../RUNBOOK.md#pre-flight-do-once-before-any-sweep-starts) on **both** machines, including the SSH-alias step on the coordinator. The placeholder name in this runbook is `twin` — substitute the alias you set up.
+
+```
+                                ┌──────────────────────────┐
+                                │  Anthropic API           │
+                                │  (baselines + judge)     │
+                                └────────────┬─────────────┘
+                                             │
+   ┌─────────────────────────────┐           │           ┌──────────────────────────┐
+   │  TWIN-A (coordinator)       │           │           │  TWIN-B                  │
+   │  ≥ 32 GB Mac                │           │           │  ≥ 32 GB Mac             │
+   │                             │           │           │                          │
+   │  Harbor Clerk (native)      │◀── REST ──┤           │  Harbor Clerk (native)   │
+   │   ├ Postgres                │           │           │   ├ Postgres             │
+   │   ├ Tika                    │           │           │   ├ Tika                 │
+   │   ├ Embedder                │           │           │   ├ Embedder             │
+   │   └ llama-server            │           │           │   └ llama-server         │
+   │                             │           │           │                          │
+   │  sweep harness              │           │           │  sweep harness           │
+   │   ├ Phase 0,1               │◀──────────┘           │   ├ Phase 0 (cached)     │
+   │   ├ Phase 4 set A:          │                       │   └ Phase 4 set B:       │
+   │   │   qwen36-35b-a3b        │                       │       gemma4-26b-a4b     │
+   │   │   gpt-oss-20b           │                       │       deepseek-r1-0528-8b│
+   │   │   qwen3-8b              │                       │       qwen3-4b           │
+   │   │   smollm3-3b            │                       │       phi4-mini          │
+   │   ├ Phase 5: qwen36-35b-a3b │                       │   Phase 5: gemma4-26b-a4b│
+   │   └ Phase 6 (unified)       │                       │                          │
+   │                             │                       │                          │
+   │  supervisor.py              │                       │  supervisor.py           │
+   │  tmux "sweep-A"             │                       │  tmux "sweep-B"          │
+   │  ~/sweep-logs/<phase>-A.log │                       │  ~/sweep-logs/<phase>-B  │
+   │                             │                       │   .log                   │
+   └────────────────┬────────────┘                       └──────────┬───────────────┘
+                    │                                               │
+                    │           rsync results/<run-id>/             │
+                    └───────────────────────────────────────────────┘
+                              ⇩  combined results live on TWIN-A
+                                 metrics.csv + judge JSON + state.json
+```
+
+The split: each twin runs **one ~20-35B-class model** + **three smaller models** in Phase 4, so Phase 4 wall-clock is roughly balanced. For Phase 5 parity, the top-2 models split one-per-machine — keep each model on the twin that ran it in Phase 4 to avoid a second cold-load.
+
+---
+
+## Phase 0 + 1: corpus acquisition + Claude baselines (TWIN-A only)
+
+Phase 0 acquires all three corpora; Phase 1 generates 48 Claude baselines. Both run on TWIN-A so the `baselines/` dir is colocated with where Phase 5's TWIN-A side will read it.
+
+```bash
+# on TWIN-A
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-prep "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 0-1 \
+    2>&1 | tee ~/sweep-logs/phase01-A.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase01-A.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Expected wall-clock: ~10 min for Phase 0 + ~30-60 min for Phase 1.
+
+### Sync corpora and baselines to TWIN-B
+
+When supervisor emits `completion`:
+
+```bash
+# on TWIN-A
+rsync -av --progress \
+    "$WORKDIR/cuad" "$WORKDIR/enron" "$WORKDIR/synthetic" \
+    "$WORKDIR/results/" \
+    "twin:$WORKDIR/"
+```
+
+TWIN-B now has the corpora pre-acquired (Phase 0 short-circuits via `.acquired` markers) and the baselines (so Phase 5's TWIN-B side can run too).
+
+---
+
+## Phase 4: split sweep across both twins
+
+These two commands run **at the same time**. Each machine has its own `state.json` keyed by the same `run-id`; cells don't conflict because `(model, phase, corpus, question, depth)` is disjoint between the two model lists.
+
+### On TWIN-A (set A: 1 large + 3 small)
+
+```bash
+# on TWIN-A
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-A "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    --models qwen36-35b-a3b,gpt-oss-20b,qwen3-8b,smollm3-3b \
+    2>&1 | tee ~/sweep-logs/phase4-A.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4-A.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+### On TWIN-B (set B: 1 large + 3 small)
+
+```bash
+# on TWIN-B
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-B "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    --models gemma4-26b-a4b,deepseek-r1-0528-8b,qwen3-4b,phi4-mini \
+    2>&1 | tee ~/sweep-logs/phase4-B.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4-B.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock per twin: ~22-25 hours. The two heavy models (qwen36-35b-a3b on TWIN-A, gemma4-26b-a4b on TWIN-B) dominate at ~17-22 hours each; the three smaller models on each twin finish in single-digit hours combined.
+
+### Sync TWIN-B's responses back
+
+When TWIN-B's supervisor signals completion:
+
+```bash
+# on TWIN-A
+rsync -av --progress \
+    "twin:$WORKDIR/results/$RUN/responses/" \
+    "$WORKDIR/results/$RUN/responses/"
+
+# also pull TWIN-B's metrics.csv rows
+ssh twin "tail -n +2 \"$WORKDIR/results/$RUN/metrics.csv\"" \
+    >> "$WORKDIR/results/$RUN/metrics.csv"
+```
+
+---
+
+## Phase 5 (parity): split top-2 across both twins
+
+Phase 5 re-runs the top 2 models (gemma4-26b-a4b, qwen36-35b-a3b) at higher depth and runs the Sonnet judge against their responses. To avoid cold-loading either large model on the wrong machine, pair each with the twin that already ran it in Phase 4.
+
+### On TWIN-A (qwen36-35b-a3b)
+
+```bash
+# on TWIN-A
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-parity-A "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 5 \
+    --models qwen36-35b-a3b \
+    2>&1 | tee ~/sweep-logs/phase5-A.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase5-A.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+### On TWIN-B (gemma4-26b-a4b)
+
+```bash
+# on TWIN-B
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-parity-B "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 5 \
+    --models gemma4-26b-a4b \
+    2>&1 | tee ~/sweep-logs/phase5-B.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase5-B.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock per twin: ~9-13 hours.
+
+### Sync TWIN-B's parity results back
+
+```bash
+# on TWIN-A
+rsync -av --progress \
+    "twin:$WORKDIR/results/$RUN/responses/" \
+    "$WORKDIR/results/$RUN/responses/"
+
+rsync -av --progress \
+    "twin:$WORKDIR/results/$RUN/judge/" \
+    "$WORKDIR/results/$RUN/judge/"
+
+ssh twin "tail -n +2 \"$WORKDIR/results/$RUN/metrics.csv\"" \
+    >> "$WORKDIR/results/$RUN/metrics.csv"
+```
+
+---
+
+## Phase 6 (unified) on TWIN-A
+
+Phase 6 unifies all three corpora into one ingest dir and re-runs a small set of cross-corpus questions. It runs on the coordinator only — there's nothing to parallelise.
+
+```bash
+# on TWIN-A
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-unified "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 6 \
+    2>&1 | tee ~/sweep-logs/phase6-A.log"
+```
+
+Wall-clock: ~3-5 hours.
+
+---
+
+When this finishes, head back to [the parent runbook's final-aggregation section](../RUNBOOK.md#final-aggregation).

--- a/scripts/test_corpora/runbooks/single.md
+++ b/scripts/test_corpora/runbooks/single.md
@@ -1,0 +1,166 @@
+# Single-Machine Runbook
+
+> **Topology:** one Mac doing everything, sequentially.
+
+This is the simplest layout — pick this if you have one reasonably-spec'd Mac (≥ 32 GB unified memory, ideally an M-series with headroom for the larger models like Gemma 4 26B and Qwen 3.6 35B-A3B) and you don't mind waiting.
+
+Wall-clock estimate: **60-80 hours** for the full sweep (Phase 4 dominates — 8 models × ~50 questions × 5-15 min each, sequential, plus Phase 5 re-runs the top-2 at higher depth). You can split this over multiple sessions; `--resume` is reliable.
+
+Before starting, complete the [universal pre-flight](../RUNBOOK.md#pre-flight-do-once-before-any-sweep-starts) on this machine. The SSH-alias step is not needed.
+
+```
+                                ┌──────────────────────────┐
+                                │  Anthropic API           │
+                                │  (Phase 0 synth-gen,     │
+                                │   Phase 1 baselines,     │
+                                │   Phase 5 judge)         │
+                                └────────────┬─────────────┘
+                                             │
+                ┌────────────────────────────┴────────────────────────────┐
+                │                                                          │
+                │   Single Mac (≥ 32 GB)                                   │
+                │                                                          │
+                │   Harbor Clerk (native app)                              │
+                │    ├ Postgres                                            │
+                │    ├ Tika                                                │
+                │    ├ Embedder                                            │
+                │    └ llama-server                                        │
+                │                                                          │
+                │   sweep harness   (all phases, all models)               │
+                │    ├ Phase 0 corpus acquisition                          │
+                │    ├ Phase 1 Claude baselines (48 q × Sonnet)            │
+                │    ├ Phase 4 8 models × ~50 questions                    │
+                │    ├ Phase 5 top-2 parity + judge                        │
+                │    └ Phase 6 unified corpus                              │
+                │                                                          │
+                │   supervisor.py    (one per phase, watches the log)      │
+                │   tmux session "sweep"                                   │
+                │   ~/sweep-logs/<phase>.log                               │
+                │                                                          │
+                │   results live here. No rsync, no remote machines.       │
+                │                                                          │
+                └──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## The fast path: one command, all phases
+
+If you trust the harness and just want to start, this single invocation runs everything in order:
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    2>&1 | tee ~/sweep-logs/full.log"
+```
+
+Default `--phases` is 0,1,4,5,6 (everything). Default `--models` is all eight from the registry. The corpus-outer iteration order means each corpus is ingested exactly once (cuad → enron → synthetic → unified) and all relevant phases run for that corpus before the next ingest.
+
+Then start the supervisor in a second terminal:
+
+```bash
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/full.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+That's it. Skip to the [final aggregation](../RUNBOOK.md#final-aggregation) section when supervisor emits `completion`.
+
+The rest of this runbook walks through the same work split phase-by-phase, which is what you want if you'd rather run overnight in chunks, sanity-check between phases, or just see what each phase costs.
+
+---
+
+## Phase 0 + 1: corpus acquisition + Claude baselines
+
+Phase 0 acquires all three corpora (cuad, enron, synthetic). Phase 1 generates 48 Claude baselines using Sonnet 4.6 + the Harbor Clerk MCP server.
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-prep "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 0-1 \
+    2>&1 | tee ~/sweep-logs/phase01.log"
+
+# detach is automatic with -d. Reattach with: tmux attach -t sweep-prep
+```
+
+In a second terminal, start the supervisor:
+
+```bash
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase01.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock: ~10 min for Phase 0 (synthetic generation dominates) + ~30-60 min for Phase 1 (48 questions × ~30-60 s each, Sonnet tool-call rounds). When supervisor emits `completion`, proceed.
+
+---
+
+## Phase 4: local model sweep
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-local "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 4 \
+    2>&1 | tee ~/sweep-logs/phase4.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase4.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock: ~25 hours for the six smaller models + ~17-25 hours for the two larger ones ≈ **40-50 hours** sequentially. The corpus-outer loop ordering means each corpus is ingested exactly once.
+
+This is the longest phase; it's safe to detach, sleep, and reattach the next day. `--resume` will pick up wherever it stopped.
+
+---
+
+## Phase 5 (parity + judge)
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-parity "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 5 \
+    2>&1 | tee ~/sweep-logs/phase5.log"
+
+uv --project /path/to/mcp-gateway/scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.supervisor \
+    --log-file ~/sweep-logs/phase5.log \
+    --workdir "$WORKDIR" --run-id "$RUN"
+```
+
+Wall-clock: ~17-25 hours of model runs + a few minutes of Sonnet judge calls (~$1-2 in API spend).
+
+---
+
+## Phase 6 (unified)
+
+```bash
+cd /path/to/mcp-gateway
+
+tmux new -d -s sweep-unified "uv --project scripts/test_corpora run python -m \
+    scripts.test_corpora.runner.sweep \
+    --run-id $RUN --workdir \"$WORKDIR\" \
+    --phases 6 \
+    2>&1 | tee ~/sweep-logs/phase6.log"
+```
+
+Wall-clock: ~3-5 hours.
+
+---
+
+When this finishes, head back to [the parent runbook's final-aggregation section](../RUNBOOK.md#final-aggregation).


### PR DESCRIPTION
## Summary

User: *"Runbook is currently too specific to my case. I want to split it into 3 versions: Basic: run on 1 machine, parallel: split the work onto 2 machines of similar specs (new workflow - needs a new split strategy), big+small/heterogenous/some other name - the current one. These can be there as three example runbooks to explain how to use the harness. Each should have a preamble in the beginning explaining the layout (as well as the diagram, which is excellent)"*

The previous `RUNBOOK.md` described only the BIG+MINI workflow that fit alex's dev setup. That worked for one operator but presented the harness as if it required a heterogeneous two-machine deployment.

The harness actually supports three topologies cleanly. Restructure `RUNBOOK.md` into a top-level chooser + three flavor runbooks under `runbooks/`.

## Layout

| Topology | When | Wall-clock | File |
| --- | --- | --- | --- |
| **Single** | one Mac ≥ 32 GB | 60-80 h | `runbooks/single.md` |
| **Parallel twins** | two similar Macs, both can host Gemma 26B / Qwen 35B | 35-45 h | `runbooks/parallel-twins.md` |
| **Heterogeneous** | one large Mac + one smaller | 45-55 h | `runbooks/heterogeneous.md` |

Each flavor file owns its preamble, diagram, and phase-by-phase commands. `RUNBOOK.md` keeps the universal pre-flight, supervisor-subagent guidance, recovery procedures, final aggregation, and "what to do if it all goes wrong" — flavor files cross-reference back via anchors.

## Notable design choices

- **Parallel-twins introduces a new model split** for Phase 4 — each twin runs one ~25-35B-class model + three smaller ones, so wall-clocks stay balanced:
  - Set A: `qwen36-35b-a3b`, `gpt-oss-20b`, `qwen3-8b`, `smollm3-3b`
  - Set B: `gemma4-26b-a4b`, `deepseek-r1-0528-8b`, `qwen3-4b`, `phi4-mini`
- **Phase 5 in parallel-twins splits one model per twin**, pinning each top-2 model to whichever twin already ran it in Phase 4 — avoids a cold-load tax.
- **Heterogeneous keeps Phase 5/6 on BIG** because the smaller machine can't host gemma26 / qwen35.
- **Wall-clock numbers tightened** across all runbooks for self-consistency: single = sum-of-phases (no parallelism); heterogeneous = max(BIG, MINI) for Phase 4 only; parallel-twins = max(twin) for both Phase 4 and 5.

## What stayed in `RUNBOOK.md`

The pre-flight, supervisor instructions, recovery, aggregation, cost summary, and "if it all goes wrong" sections are universal — they're the same regardless of topology. Keeping them in the chooser avoids 3× duplication and prevents drift between copies.

## Test plan

- [x] `ruff check` passes
- [ ] Render the three flavor files in your markdown viewer of choice; verify all anchor cross-links resolve
- [ ] Pick a topology and follow the runbook end-to-end on a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
