### PR TITLE
fix(macos+api): keep menubar Preferences and web System Settings in sync on the active model

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -208,15 +208,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func showPreferences() {
-        if preferencesWindowController == nil {
-            let view = PreferencesWindow()
-            let hostingController = NSHostingController(rootView: view)
-            let window = NSWindow(contentViewController: hostingController)
-            window.title = "Preferences"
-            window.styleMask = [.titled, .closable, .fullSizeContentView]
-            configureGlassWindow(window, size: NSSize(width: 480, height: 590))
-            preferencesWindowController = NSWindowController(window: window)
+        // If the window is already on screen, just bring it forward — don't
+        // disturb anything the user might be editing.
+        if let controller = preferencesWindowController, controller.window?.isVisible == true {
+            controller.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
         }
+
+        // Otherwise, build a fresh window. PreferencesWindow's @State props
+        // are initialized from AppSettings.shared at view-struct creation
+        // time — if we reused an existing controller after the web app (or
+        // anything else) wrote to config.json, the picker would still show
+        // the previous selection. AppSettings.reload() pulls in the latest
+        // file contents so the freshly-built View captures them.
+        AppSettings.shared.reload()
+        let view = PreferencesWindow()
+        let hostingController = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: hostingController)
+        window.title = "Preferences"
+        window.styleMask = [.titled, .closable, .fullSizeContentView]
+        configureGlassWindow(window, size: NSSize(width: 480, height: 590))
+        preferencesWindowController = NSWindowController(window: window)
         preferencesWindowController?.showWindow(nil)
         preferencesWindowController?.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -189,8 +189,19 @@ final class AppSettings: @unchecked Sendable {
         let jsonData = lock.withLock {
             try? JSONSerialization.data(withJSONObject: data, options: .prettyPrinted)
         }
-        if let jsonData {
-            try? jsonData.write(to: configURL)
+        guard let jsonData else { return }
+        // Atomic write — write to a sibling temp file and rename. Without
+        // this, Python's refresh_llm_settings() can briefly observe a
+        // truncated file mid-write, fail to parse, and silently keep its
+        // stale in-memory value for one more poll cycle. Mirrors the
+        // temp+rename pattern in Python's sync_native_config().
+        let dir = configURL.deletingLastPathComponent()
+        let tmpURL = dir.appendingPathComponent(".\(configURL.lastPathComponent).tmp")
+        do {
+            try jsonData.write(to: tmpURL)
+            _ = try FileManager.default.replaceItemAt(configURL, withItemAt: tmpURL)
+        } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
         }
     }
 

--- a/src/harbor_clerk/api/routes/chat.py
+++ b/src/harbor_clerk/api/routes/chat.py
@@ -20,7 +20,7 @@ from harbor_clerk.api.schemas.chat import (
     ModelOut,
     SendMessageRequest,
 )
-from harbor_clerk.config import get_settings, sync_native_config
+from harbor_clerk.config import get_settings, refresh_llm_settings, sync_native_config
 from harbor_clerk.db import get_session
 from harbor_clerk.llm.chat import chat_stream
 from harbor_clerk.llm.download import (
@@ -258,6 +258,10 @@ async def send_message(
             detail="Research task in progress — chat unavailable until complete",
         )
 
+    # Refresh from config.json so a menubar-side model change between the
+    # user clicking Send and this handler running doesn't yield a 503 even
+    # though a model is now configured.
+    refresh_llm_settings()
     settings = get_settings()
     if not settings.llm_model_id:
         raise HTTPException(
@@ -286,6 +290,12 @@ async def send_message(
 async def list_available_models(
     principal: Principal = Depends(require_user),
 ):
+    # Pick up changes that happened outside this process — most often
+    # the menubar Preferences window writing config.json directly. Without
+    # this, the in-memory settings stays at whatever the last activate/
+    # deactivate handler set, and the web app's "active" badge sticks to
+    # the previous model after a menubar-side switch.
+    refresh_llm_settings()
     settings = get_settings()
     downloaded = set(list_downloaded())
     return [
@@ -394,6 +404,9 @@ async def llm_status(
     llama-server is wedged. The frontend polls it every second or
     two during a model switch.
     """
+    # See list_available_models — refresh to catch menubar-side writes
+    # to config.json that bypass this process.
+    refresh_llm_settings()
     settings = get_settings()
     model_id = settings.llm_model_id or None
 
@@ -429,6 +442,7 @@ async def toggle_yarn(
 async def get_yarn_status(
     principal: Principal = Depends(require_user),
 ):
+    refresh_llm_settings()
     settings = get_settings()
     return {"yarn_enabled": settings.llm_yarn_enabled}
 
@@ -455,6 +469,7 @@ async def toggle_summary_force_afm(
 async def get_summary_force_afm(
     principal: Principal = Depends(require_user),
 ):
+    refresh_llm_settings()
     settings = get_settings()
     return {"summary_force_apple_intelligence": settings.summary_force_apple_intelligence}
 

--- a/src/harbor_clerk/llm/chat.py
+++ b/src/harbor_clerk/llm/chat.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncGenerator
 import httpx
 from sqlalchemy import select
 
-from harbor_clerk.config import get_settings
+from harbor_clerk.config import get_settings, refresh_llm_settings
 from harbor_clerk.db import async_session_factory
 from harbor_clerk.llm.health import report_llm_error, report_llm_success
 from harbor_clerk.llm.models import get_model
@@ -200,6 +200,11 @@ async def chat_stream(
     (the DI session closes when the endpoint returns, before the SSE generator
     has finished streaming).
     """
+    # Pick up model changes that happened outside this process (typically
+    # the menubar Preferences window writing config.json directly). Without
+    # this, chat would stream against whatever model the API server cached
+    # at startup — possibly a model llama-server is no longer hosting.
+    refresh_llm_settings()
     settings = get_settings()
     active_model_id = settings.llm_model_id or None
 


### PR DESCRIPTION
## Summary

User: *"The selected model in the menu bar preferences and inside the app in System Settings don't match. It's not clear which one wins."*

Both surfaces share the same `~/Library/Application Support/Harbor Clerk/config.json` file, so in principle they shouldn't drift — but two stale-cache bugs (one in each direction) made them drift in practice. The actual answer to "which one wins" is: **whichever wrote to `config.json` last** (and that's also what `llama-server` will use after its next restart). The mismatch was purely stale display.

## Bug 1 — menubar change → web app stays stale

The Python API server caches its `Settings` object in-memory at startup. When the menubar Preferences writes `config.json` directly via Swift's `AppSettings.save()`, the API server never re-reads. `GET /api/chat/models` reports `active=true` for whichever model the in-process `activate`/`deactivate` handler last touched.

**Fix:** call the existing `refresh_llm_settings()` helper at the top of the four GET handlers that report model state to the web app:
- `list_available_models` (`/chat/models`)
- `llm_status` (`/chat/models/status`)
- `get_yarn_status` (`/chat/models/yarn`)
- `get_summary_force_afm` (`/chat/models/summary-afm`)

Same call also fixes the same drift for `llm_yarn_enabled` and `summary_force_apple_intelligence` since both keys are writable from the menubar. Hot-path cost is sub-100 µs (sub-1 KB JSON file, OS page cache).

Also added `refresh_llm_settings()` at the top of `send_message` and `chat_stream` so chat can't be launched against a model llama-server is no longer hosting.

## Bug 2 — web app change → menubar Preferences stays stale

`PreferencesWindow`'s `@State` props (`@State llmModelId = AppSettings.shared.llmModelId`, etc.) capture the value at View-struct creation time. `AppDelegate.showPreferences()` cached `preferencesWindowController` across opens, so the same View struct (with frozen `@State`) was reused — the picker kept showing the value from when the window first opened, even after the web app had since changed the model and Swift's mtime poller had updated `AppSettings.shared`.

**Fix:** in `showPreferences()`, only reuse the controller while the window is currently visible. Otherwise call `AppSettings.shared.reload()` and build a fresh `PreferencesWindow` + `NSWindowController` so `@State` captures the current `config.json` values.

## Bug 3 — non-atomic save (uncovered during review)

`AppSettings.save()` did `jsonData.write(to: configURL)` directly, which truncates before re-filling. Python's `refresh_llm_settings()` reads with `open(path)`; on a partial read, `json.loads()` raises and the helper silently swallows the exception, keeping the stale in-memory value for one more poll cycle. With the new refresh-on-every-GET strategy this race becomes more visible.

**Fix:** write to a sibling temp file under the same directory and atomically replace via `FileManager.replaceItemAt` — the same temp+rename pattern Python's `sync_native_config()` already uses.

## Test plan

- [x] `uv run pytest tests/` — 620 pass, 15 skip
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] Code review against branch tip: 2 important findings, both addressed in this PR
- [ ] User validates end-to-end: switch model from menubar → refresh web System Settings → active badge moves to new model. Same in reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
