### PR TITLE
feat(test-corpora): substring-match selector for --rerun / --skip

### DIFF
--- a/scripts/test_corpora/runner/state.py
+++ b/scripts/test_corpora/runner/state.py
@@ -194,18 +194,29 @@ class StateFile:
         """Compare a unit field's value against a CLI selector value.
 
         Handles three field shapes the CLI plumbs through:
-          - ``str`` fields (``corpus``, ``model``, ``question_id``, ``depth``):
-            direct string compare.
+          - ``str`` fields (``corpus``, ``model``, ``question_id``, ``depth``,
+            ``error``): direct string compare, or substring-contains when the
+            value starts with ``~``.
           - ``int`` fields (``phase``): coerce wanted to int when comparing,
             so ``--rerun 'phase=4'`` matches ``Unit.phase = 4``.
           - ``Status(str, Enum)`` fields (``status``): compare against
             ``.value``. ``str(Status.ERROR)`` returns ``'Status.ERROR'`` (Enum
             default), not ``'error'``, so the previous string compare silently
             failed for every status selector.
+
+        Substring syntax: prefix the value with ``~`` to match if the actual
+        field contains that text. Useful for flipping just the units that
+        failed with a particular error message, e.g.
+        ``--rerun 'status=error,error=~no SSE events'`` to retry only the
+        watchdog-aborted research runs.
         """
         if isinstance(actual, enum.Enum):
-            return str(actual.value) == wanted
-        return str(actual) == wanted
+            actual_str = str(actual.value)
+        else:
+            actual_str = "" if actual is None else str(actual)
+        if wanted.startswith("~"):
+            return wanted[1:] in actual_str
+        return actual_str == wanted
 
     def rerun(self, selectors: dict[str, str]) -> int:
         """Flip units matching all selectors back to PENDING. Returns count."""

--- a/scripts/test_corpora/tests/test_state.py
+++ b/scripts/test_corpora/tests/test_state.py
@@ -223,6 +223,42 @@ def test_rerun_combines_status_and_other_selectors(tmp_path: Path):
     assert enron_unit is not None and enron_unit.status == Status.ERROR
 
 
+def test_rerun_substring_selector_matches_error_text(tmp_path: Path):
+    """A `~` prefix turns the selector into a substring-contains match. The
+    original case: retry only the units that aborted with the SSE-silence
+    watchdog message, leaving other failure modes alone."""
+    sf = StateFile(tmp_path / "state.json")
+    sf.register(
+        [
+            Unit(phase=4, corpus="cuad", model="m", question_id="q1", depth="standard"),
+            Unit(phase=4, corpus="cuad", model="m", question_id="q2", depth="standard"),
+            Unit(phase=4, corpus="cuad", model="m", question_id="q3", depth="standard"),
+        ]
+    )
+    sf.set_status(
+        4, "cuad", "m", "q1", "standard", Status.ERROR, error="harness aborted research: no SSE events for 311s"
+    )
+    sf.set_status(
+        4, "cuad", "m", "q2", "standard", Status.ERROR, error="harness aborted research: no SSE events for 240s"
+    )
+    sf.set_status(4, "cuad", "m", "q3", "standard", Status.ERROR, error="HC unreachable after 3 consecutive failures")
+
+    n = sf.rerun({"error": "~no SSE events"})
+    assert n == 2
+    assert sf.get(4, "cuad", "m", "q1", "standard").status == Status.PENDING
+    assert sf.get(4, "cuad", "m", "q2", "standard").status == Status.PENDING
+    assert sf.get(4, "cuad", "m", "q3", "standard").status == Status.ERROR
+
+
+def test_rerun_substring_selector_handles_none_error(tmp_path: Path):
+    """A None error field must not crash substring matching; just doesn't match."""
+    sf = StateFile(tmp_path / "state.json")
+    sf.register([Unit(phase=4, corpus="cuad", model="m", question_id="q1", depth="standard")])
+    # PENDING unit, error is None
+    n = sf.rerun({"error": "~no SSE events"})
+    assert n == 0
+
+
 def test_skip_status_selector_matches_enum_value(tmp_path: Path):
     """Same selector fix applies to --skip; verify it works end-to-end."""
     sf = StateFile(tmp_path / "state.json")


### PR DESCRIPTION
## Summary

User on MINI: *"On mini, how can I selectively retry failures like this: `harness aborted research: no SSE events for 311s` ... after the sweep is done (ie on the next run)"*

The existing `--rerun 'status=error'` is too coarse — it retries every errored unit, including unrelated chat-422 / HC-unreachable / model-warmup failures. Stacking `model=...` only narrows by metadata, not by failure mode. The error text itself wasn't selectable because `_selector_matches` did exact `==`.

Adds a `~` prefix that turns a selector value into a substring-contains test:

```bash
--rerun 'status=error,error=~no SSE events'
```

Flips just the watchdog-aborted units back to PENDING. Other ERROR rows untouched.

## Implementation

- [`_selector_matches`](scripts/test_corpora/runner/state.py:193) strips a leading `~` and switches to `wanted_text in actual_str`. None coerced to `""` so `error=None` doesn't crash — it just doesn't match.
- Backward compatible: no `~` → exact compare, identical behaviour to before.

## Tests

- `test_rerun_substring_selector_matches_error_text` — 3 ERROR units with different error messages; `error=~no SSE events` flips only the matching pair.
- `test_rerun_substring_selector_handles_none_error` — PENDING unit with `error=None`; substring selector returns 0 matches without raising.

All 17 state tests + 620 backend tests pass; ruff check + format clean.

## Test plan

- [x] unit tests + lint
- [ ] User uses `--rerun 'status=error,error=~no SSE events'` on the next MINI sweep run; only the SSE-watchdog failures flip back to PENDING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
