### PR TITLE
fix(frontend): render DeepSeek-R1 thinking correctly in chat

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -617,14 +617,41 @@ function EmptyState() {
 
 /* ---- Thinking/reasoning parser ---- */
 
-function parseThinking(content: string): { thinking: string | null; response: string } {
-  // Handle streaming: <think> opened but not closed yet
+// Models whose chat template appends "<think>" to the assistant prompt — the
+// streamed content starts INSIDE the thinking block with no opening tag, just
+// reasoning text, and only emits the closing </think> at the answer boundary.
+// Mid-stream we treat early text as thinking until </think> arrives, instead
+// of leaking chain-of-thought into the visible reply. Update when adding new
+// thinking-by-default models.
+const IMPLICIT_THINKING_MODELS = new Set(['deepseek-r1-0528-8b'])
+
+function parseThinking(
+  content: string,
+  modelId?: string | null,
+  isStreaming?: boolean,
+): { thinking: string | null; response: string } {
+  // Explicit-opening cases: Qwen3 / older patterns that emit <think> inline.
   if (content.startsWith('<think>') && !content.includes('</think>')) {
     return { thinking: content.slice(7), response: '' }
   }
   const match = content.match(/^<think>([\s\S]*?)<\/think>\s*/)
   if (match) {
     return { thinking: match[1].trim(), response: content.slice(match[0].length) }
+  }
+  // Implicit-opening case: closing </think> arrived but no opening tag was
+  // ever emitted. Everything before </think> was reasoning.
+  const closeIdx = content.indexOf('</think>')
+  if (closeIdx >= 0) {
+    return {
+      thinking: content.slice(0, closeIdx).trim(),
+      response: content.slice(closeIdx + '</think>'.length).trim(),
+    }
+  }
+  // Streaming with a known implicit-thinking model: no </think> yet, so we're
+  // still inside the implicit thinking block. Surface the running text in the
+  // reasoning section, leaving response empty until the closing tag arrives.
+  if (isStreaming && modelId && IMPLICIT_THINKING_MODELS.has(modelId) && content) {
+    return { thinking: content, response: '' }
   }
   return { thinking: null, response: content }
 }
@@ -694,7 +721,7 @@ function MessageBubble({ message, modelNames }: { message: ChatMessage; modelNam
 
   const isError = !isUser && message.content.startsWith('Error:')
   const { thinking, response } = !isUser
-    ? parseThinking(message.content)
+    ? parseThinking(message.content, message.model_id, message.isStreaming)
     : { thinking: null, response: message.content }
 
   const modelLabel = !isUser && message.model_id ? modelNames[message.model_id] || message.model_id : null


### PR DESCRIPTION
## Summary

User: *"Looks like the thinking handling for deepseek isn't working. ... I think this is going to have to be per model or per model-family ... Nearly all (but not all) the deepseek research items failed. but the ones that succeeded look ok, so maybe the thinking handling is better in the research loop than in straight chat."*

Pages of chain-of-thought were leaking into the visible chat reply for `deepseek-r1-0528-8b`, with a stray `</think>` mid-message and the actual answer at the end.

## Diagnosis

[`parseThinking()`](frontend/src/pages/ChatPage.tsx:620) required the content to start with `<think>`. DeepSeek-R1's chat template appends `<think>` to the **assistant prompt itself**, so the model continues from inside the thinking block — its first generated token is reasoning text, not the opening tag. Only `</think>` eventually appears at the boundary. The leading-anchored regex missed, the no-thinking fallback fired, and the user saw the raw reasoning trace.

Research handles this correctly because [`research.py:252`](src/harbor_clerk/llm/research.py:252) explicitly strips `<think>...</think>` and falls back to `reasoning_content` when `content` is empty. Chat had neither path.

## Fix

Two branches added to `parseThinking()`:

1. **Implicit-opening (post-stream / history)**: if `</think>` appears anywhere, split there. Everything before is reasoning, everything after is the answer.
2. **Streaming**: while a message is still streaming AND the model is in `IMPLICIT_THINKING_MODELS` AND no `</think>` has arrived yet, treat the running content as reasoning (rendered in the collapsible section). Without this, deepseek's reasoning streams into the response bubble for 30+ seconds and then snaps when `</think>` lands.

`IMPLICIT_THINKING_MODELS` starts as a single-element set (`deepseek-r1-0528-8b`) per the user's "per-model or per-model-family" suggestion. Other models keep using the existing explicit-opening branch.

## Out of scope (architectural option for later)

A cleaner fix would be `--reasoning-format deepseek` on llama-server (Swift `LlamaService.swift`) plus reading `delta.reasoning_content` in `chat.py`. That routes thinking out of `delta.content` server-side and is symmetrical with the research engine's path. Not done here because it's three-component (Swift + Python + frontend) and the user is mid-sweep — wanted the smallest change that fixes the visible symptom.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean (only the pre-existing `useCallback` deps warning unrelated to this change)
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds
- [ ] Exercise chat with deepseek-r1-0528-8b: reasoning lives in the collapsible Reasoning section both during streaming and after; the answer renders cleanly in the bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
