### PR TITLE
fix(macos): Cancel in Preferences dismisses the restart banner

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
@@ -236,7 +236,30 @@ struct PreferencesWindow: View {
     // MARK: - State management
 
     private func markDirty() {
-        needsRestart = true
+        // Recompute against the initial snapshot rather than unconditionally
+        // setting true. Two reasons:
+        //   1. Cancel: revertToInitial() writes every @State back to its
+        //      initial value. Each write fires its .onChange handler, which
+        //      calls markDirty(). If markDirty just set true, those late
+        //      handlers would clobber the explicit `needsRestart = false`
+        //      revertToInitial set first, leaving the banner stuck open.
+        //   2. Manual revert: if the user toggles a setting and then
+        //      toggles it back, the banner correctly dismisses instead of
+        //      staying open over no actual change.
+        needsRestart = isDirty()
+    }
+
+    private func isDirty() -> Bool {
+        return allowRemoteWeb != initial.allowRemoteWeb
+            || allowRemoteMCP != initial.allowRemoteMCP
+            || workerPreset != initial.workerPreset
+            || apiPortText != initial.apiPort
+            || postgresPortText != initial.postgresPort
+            || tikaPortText != initial.tikaPort
+            || embedderPortText != initial.embedderPort
+            || llamaPortText != initial.llamaPort
+            || llmModelId != initial.llmModelId
+            || logLevel != initial.logLevel
     }
 
     /// Write all local @State values to AppSettings (single save).


### PR DESCRIPTION
## Summary

User: *"When making a change to a daemon setting in the menu bar prefs, you get a banner to restart or cancel — if you hit cancel, the value goes back but the banner doesn't dismiss."*

Cancel reverted the control values correctly, but the orange "Restart services" banner stayed stuck.

## Cause

[`revertToInitial()`](macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift:272) writes each `@State` back to its initial value, then sets `needsRestart = false`. Each `@State` write fires the field's `.onChange` handler, which called [`markDirty()`](macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift:238); `markDirty()` unconditionally set `needsRestart = true`.

SwiftUI dispatches `.onChange` handlers **after** the synchronous body of `revertToInitial` returns. So the explicit `needsRestart = false` ran first, then the `.onChange` cascade clobbered it back to `true`. The banner stayed open over an already-reverted form.

## Fix

`markDirty()` now recomputes the dirty state by comparing every `@State` against the initial snapshot:

```swift
private func markDirty() {
    needsRestart = isDirty()
}

private func isDirty() -> Bool {
    return allowRemoteWeb != initial.allowRemoteWeb
        || allowRemoteMCP != initial.allowRemoteMCP
        // ...one line per setting
        || logLevel != initial.logLevel
}
```

Cancel: revertToInitial sets every field back to initial → late `.onChange` handlers fire → `markDirty()` recomputes → all fields equal initial → `needsRestart = false`. Banner dismisses.

Bonus: also dismisses the banner if the user toggles a setting and then manually toggles it back. Previously that left the banner stuck over no actual change.

## Test plan

- [ ] User exercises: open Preferences, change a daemon setting, hit Cancel → value reverts AND banner dismisses.
- [ ] User exercises: change a setting, change it back manually → banner dismisses without needing Cancel.
- [ ] User exercises: change a setting, hit Restart Now → still works (uses `applyToSettings` + `captureInitial` path, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
