### PR TITLE
feat(pipeline): decouple summarize from finalize gate; yield-to-interactive

### DIFF
--- a/src/harbor_clerk/llm/summarize.py
+++ b/src/harbor_clerk/llm/summarize.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import random
 import time
+from collections.abc import Callable
 from enum import Enum
 
 import httpx
@@ -488,14 +489,26 @@ def _summarize_medium(chunks: list[str], max_input_chars: int) -> str | None:
     )
 
 
-def _summarize_long(chunks: list[str], max_input_chars: int) -> str | None:
-    """Long docs: map-reduce — group summaries then final summary."""
+def _summarize_long(
+    chunks: list[str],
+    max_input_chars: int,
+    *,
+    yield_check: Callable[[], None] | None = None,
+) -> str | None:
+    """Long docs: map-reduce — group summaries then final summary.
+
+    `yield_check`, if provided, is called before each LLM sub-call so the
+    summarize worker can yield to interactive chat/research workloads
+    between map iterations and before the reduce step.
+    """
     groups = _group_chunks_for_mapreduce(chunks, max_input_chars)
     logger.info("Map-reduce summarization: %d groups from %d chunks", len(groups), len(chunks))
 
     # Map step: summarize each group (fewer retries to stay within stage timeout)
     section_summaries: list[str] = []
     for idx, group in enumerate(groups):
+        if yield_check is not None:
+            yield_check()
         result = _call_llm(
             _PROMPT_MAP,
             group,
@@ -518,6 +531,8 @@ def _summarize_long(chunks: list[str], max_input_chars: int) -> str | None:
         return None
 
     # Reduce step: combine section summaries into final
+    if yield_check is not None:
+        yield_check()
     numbered = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(section_summaries))
     reduce_input = numbered[:max_input_chars]
     return _call_llm(
@@ -604,7 +619,12 @@ def classify_doc_type(chunks: list[str], mime_type: str = "") -> str:
     return _mime_to_doc_type(mime_type)
 
 
-def generate_summary(chunks: list[str], max_chars: int | None = None) -> tuple[str, str]:
+def generate_summary(
+    chunks: list[str],
+    max_chars: int | None = None,
+    *,
+    yield_check: Callable[[], None] | None = None,
+) -> tuple[str, str]:
     """Generate a summary for a document from its chunks.
 
     Uses an adaptive strategy based on document length:
@@ -614,6 +634,9 @@ def generate_summary(chunks: list[str], max_chars: int | None = None) -> tuple[s
 
     Falls back to extractive heuristic when no LLM is available.
     Never raises — returns best-effort summary.
+
+    `yield_check`, if provided, is called between map-reduce sub-calls in
+    the long tier so the caller can yield to interactive workloads.
 
     Returns (summary_text, model_used) where model_used is the LLM model id
     or "extractive" for the heuristic fallback.
@@ -660,7 +683,7 @@ def generate_summary(chunks: list[str], max_chars: int | None = None) -> tuple[s
         elif tier == _Tier.MEDIUM:
             result = _summarize_medium(chunks, max_input_chars)
         else:
-            result = _summarize_long(chunks, max_input_chars)
+            result = _summarize_long(chunks, max_input_chars, yield_check=yield_check)
         stage_elapsed = time.perf_counter() - stage_started
 
         # One-line per-doc summary so a `tail -f` of worker-llm.log yields

--- a/src/harbor_clerk/worker/pipeline.py
+++ b/src/harbor_clerk/worker/pipeline.py
@@ -82,8 +82,23 @@ STAGE_ORDER = [
 # Sequential prefix: these stages run one after another
 _SEQUENTIAL_STAGES = [JobStage.extract, JobStage.ocr, JobStage.chunk]
 
-# Parallel stages: fan out after chunk, fan in before finalize
-_PARALLEL_STAGES = frozenset({JobStage.entities, JobStage.embed, JobStage.summarize})
+# Parallel stages: fan out after chunk, fan in before finalize.
+# Summarize used to live here, but it's NOT a retrieval prerequisite — chunks'
+# FTS columns are populated by Postgres on insert, embeddings come from embed,
+# entity search comes from entities. Summary is decoration consumed only by
+# kb_get_document / kb_list_recent / kb_corpus_overview / kb_find_related and
+# the frontend display. Keeping summarize in the fan-in gated docs from
+# becoming retrievable on `pipeline_status = ready` until the (often slow)
+# LLM call returned. Now summarize is enqueued in parallel with the fan-in
+# trio but does NOT gate finalize.
+_PARALLEL_STAGES = frozenset({JobStage.entities, JobStage.embed})
+
+# Background side-channel: enqueued at the same time as the fan-in trio but
+# never blocks finalize. Doc reaches `ready` once {entities, embed} land plus
+# finalize; summarize runs whenever the dedicated `llm` queue worker is free
+# and yields to interactive chat/research workloads (see worker/stages/
+# summarize.py:_user_llm_active).
+_BACKGROUND_STAGES = frozenset({JobStage.summarize})
 
 # Status after stage completes
 STAGE_DONE_STATUS: dict[JobStage, PipelineStatus] = {
@@ -132,9 +147,13 @@ def enqueue_stage(doc_id: uuid.UUID, stage: JobStage, *, priority: int = 0) -> N
             )
             session.add(job)
 
-        # Update doc pipeline_status
+        # Update doc pipeline_status — background stages (summarize) don't
+        # touch it. The doc may already be `ready` when summarize is
+        # enqueued, and we don't want the badge to regress. See the
+        # matching guard in mark_stage_done.
         doc = session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one()
-        doc.pipeline_status = running_status
+        if stage not in _BACKGROUND_STAGES:
+            doc.pipeline_status = running_status
         doc.error = None
 
         session.commit()
@@ -218,8 +237,9 @@ def advance_pipeline(doc_id: uuid.UUID) -> None:
 
     Three phases:
       1. Sequential prefix: extract → [ocr] → chunk (linear, same as before)
-      2. Fan-out: entities + embed + summarize (all enqueued at once after chunk)
-      3. Fan-in: finalize (only when all parallel stages are done)
+      2. Fan-out: entities + embed enqueued after chunk; summarize enqueued
+         alongside as a background stage (does NOT gate finalize)
+      3. Fan-in: finalize (only when entities + embed are done)
     """
     session = get_sync_session()
     try:
@@ -253,7 +273,7 @@ def advance_pipeline(doc_id: uuid.UUID) -> None:
             enqueue_stage(doc_id, stage, priority=priority)
             return
 
-        # --- Phase 2: Fan-out (entities + embed + summarize) ---
+        # --- Phase 2: Fan-out (entities + embed) + background (summarize) ---
         to_enqueue: list[JobStage] = []
         for stage in _PARALLEL_STAGES:
             if stage in completed or stage in in_flight:
@@ -273,26 +293,37 @@ def advance_pipeline(doc_id: uuid.UUID) -> None:
                 continue
             to_enqueue.append(stage)
 
-        if to_enqueue:
+        # Background stages run alongside but never gate finalize. Enqueued
+        # the first time we see chunk done so they aren't repeatedly
+        # re-queued on each advance_pipeline tick.
+        background_to_enqueue: list[JobStage] = []
+        if JobStage.chunk in completed:
+            for stage in _BACKGROUND_STAGES:
+                if stage in completed or stage in in_flight:
+                    continue
+                background_to_enqueue.append(stage)
+
+        all_new = to_enqueue + background_to_enqueue
+        if all_new:
             session.commit()
             session.close()
-            for stage in to_enqueue:
+            for stage in all_new:
                 enqueue_stage(doc_id, stage, priority=priority)
             return
 
-        # --- Phase 3: Fan-in (finalize) ---
+        # --- Phase 3: Fan-in (finalize) — gates only on _PARALLEL_STAGES ---
         if completed >= _PARALLEL_STAGES and JobStage.finalize not in completed and JobStage.finalize not in in_flight:
             session.commit()
             session.close()
             enqueue_stage(doc_id, JobStage.finalize, priority=priority)
             return
 
-        # Only restore to ready if ALL stages are actually done (not just nothing to enqueue).
-        # Phase 2 falls through when something is in_flight but nothing new to enqueue — we
-        # must NOT publish finalize-done in that case, it's still processing.
+        # Only restore to ready if the gating stages are actually done (not
+        # just nothing to enqueue). Background stages (summarize) are NOT
+        # in the gate — a still-pending summary is normal post-finalize.
         all_stages_done = (
             JobStage.finalize in completed
-            and not in_flight
+            and not (in_flight - _BACKGROUND_STAGES)
             and completed >= _PARALLEL_STAGES | {JobStage.extract, JobStage.chunk}
         )
         if all_stages_done and doc.pipeline_status != PipelineStatus.ready:
@@ -372,7 +403,13 @@ def mark_stage_done(
         job.finished_at = datetime.now(UTC)
 
         doc = session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one()
-        doc.pipeline_status = done_status
+        # Background stages (summarize) never touch pipeline_status — that
+        # field reflects the gating-stage progression only. A summarize-
+        # before-finalize finish would otherwise prematurely set
+        # pipeline_status = summarized; a summarize-after-finalize finish
+        # would regress it from ready back to summarized. Either is wrong.
+        if stage not in _BACKGROUND_STAGES:
+            doc.pipeline_status = done_status
         filename = _doc_filename(doc)
 
         session.commit()

--- a/src/harbor_clerk/worker/stages/summarize.py
+++ b/src/harbor_clerk/worker/stages/summarize.py
@@ -1,22 +1,78 @@
 """Summarize stage — generate adaptive document summary from all chunks."""
 
 import logging
+import time
 import uuid
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
 
 from harbor_clerk.config import refresh_llm_settings
 from harbor_clerk.db_sync import get_sync_session
 from harbor_clerk.llm.summarize import classify_doc_type, generate_summary
-from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models import ChatMessage, Chunk, Document
 from harbor_clerk.models.enums import JobStage
+from harbor_clerk.models.research_state import ResearchState
 from harbor_clerk.worker.pipeline import check_pipeline_seq, mark_stage_done, mark_stage_running
 
 logger = logging.getLogger(__name__)
 
+# Yield-to-interactive: when a user-driven LLM workload is active, summarize
+# stops before claiming the LLM slot and waits up to YIELD_BUDGET_SEC for
+# the slot to free. Avoids long summary jobs starving chat/research with
+# `-np 1` on llama-server. After the budget expires, summarize proceeds
+# anyway so it isn't starved indefinitely.
+_USER_ACTIVITY_WINDOW_SEC = 60  # last user-message age that counts as "active"
+_YIELD_POLL_SEC = 15  # how often to re-check while yielding
+_YIELD_BUDGET_SEC = 60  # total time we'll wait before proceeding anyway
+
+
+def _user_llm_active() -> bool:
+    """Return True if a chat or research is using (or just used) the local LLM.
+
+    Two signals:
+      - A chat user-message was created in the last _USER_ACTIVITY_WINDOW_SEC.
+        Chat saves the user message at the start of chat_stream(), so a
+        recent user message means a chat assistant turn is likely streaming.
+      - A research_state row exists with status='running'. Research holds
+        the LLM for minutes at a time across many calls.
+    """
+    cutoff = datetime.now(UTC) - timedelta(seconds=_USER_ACTIVITY_WINDOW_SEC)
+    session = get_sync_session()
+    try:
+        recent_chat = session.execute(
+            select(ChatMessage.id).where(ChatMessage.role == "user").where(ChatMessage.created_at > cutoff).limit(1)
+        ).first()
+        if recent_chat:
+            return True
+        running_research = session.execute(
+            select(ResearchState.conversation_id).where(ResearchState.status == "running").limit(1)
+        ).first()
+        return running_research is not None
+    finally:
+        session.close()
+
+
+def _wait_for_idle_llm(budget_sec: int = _YIELD_BUDGET_SEC) -> None:
+    """Block up to budget_sec while a user is using the LLM, polling every
+    _YIELD_POLL_SEC. Returns either when the LLM is idle or the budget
+    expires (so summarize is never starved indefinitely)."""
+    elapsed = 0
+    while elapsed < budget_sec and _user_llm_active():
+        logger.info("summarize: yielding to interactive LLM workload (%ds elapsed)", elapsed)
+        time.sleep(_YIELD_POLL_SEC)
+        elapsed += _YIELD_POLL_SEC
+
 
 def run_summarize(doc_id: uuid.UUID) -> None:
     """Generate a summary for the document from all its chunks."""
+    # Yield-to-interactive: if the user is chatting or researching right
+    # now, wait up to _YIELD_BUDGET_SEC before claiming the LLM slot. This
+    # makes interactive workloads feel snappy without preempting in-flight
+    # summary work — between map-reduce sub-calls we also yield (see the
+    # yield_check passed to generate_summary).
+    _wait_for_idle_llm()
+
     if not mark_stage_running(doc_id, JobStage.summarize):
         return
 
@@ -37,7 +93,7 @@ def run_summarize(doc_id: uuid.UUID) -> None:
         if chunks:
             # Generate summary (compute before race check)
             try:
-                summary, model_used = generate_summary(list(chunks))
+                summary, model_used = generate_summary(list(chunks), yield_check=_wait_for_idle_llm)
             except Exception:
                 logger.warning("Summary generation failed for %s", doc_id, exc_info=True)
                 summary, model_used = None, None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -336,3 +336,101 @@ async def test_run_finalize_aborts_when_seq_bumped_mid_stage(db_session):
         assert refreshed_job.status == JobStatus.done
     finally:
         sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_summarize_done_after_finalize_does_not_regress_status(db_session):
+    """Background stages (summarize) must not regress pipeline_status from
+    `ready` back to their own done-status. Doc reaches `ready` once finalize
+    fires on the {entities, embed} gate; a later-completing summarize used
+    to flip the user-visible badge from Ready → summarized."""
+    doc = Document(
+        title="Background regress check",
+        canonical_filename="bg.pdf",
+        status="active",
+        sha256=b"b" * 32,
+        needs_ocr=False,
+        pipeline_status=PipelineStatus.ready,  # finalize already ran
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+
+    # Realistic post-finalize state: every gate stage is done, summarize
+    # lingers in queued because it's slow.
+    sync_session = get_sync_session()
+    try:
+        for stage in (
+            JobStage.extract,
+            JobStage.chunk,
+            JobStage.entities,
+            JobStage.embed,
+            JobStage.finalize,
+        ):
+            sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=stage, status=JobStatus.done))
+        sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.summarize, status=JobStatus.queued))
+        sync_session.commit()
+    finally:
+        sync_session.close()
+
+    assert mark_stage_running(doc.doc_id, JobStage.summarize) is True
+    mark_stage_done(doc.doc_id, JobStage.summarize)
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc.doc_id)).scalar_one()
+        # KEY assertion: still ready, NOT regressed to summarized.
+        assert refreshed.pipeline_status == PipelineStatus.ready
+        # Job row marked done independently of pipeline_status.
+        job = sync_session.execute(
+            select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.summarize)
+        ).scalar_one()
+        assert job.status == JobStatus.done
+    finally:
+        sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_summarize_not_in_finalize_gate(db_session):
+    """advance_pipeline must enqueue finalize once {entities, embed} are done,
+    even if summarize is still running. This is the core fan-in change —
+    summarize is a background stage now."""
+    from harbor_clerk.worker.pipeline import advance_pipeline
+
+    doc = Document(
+        title="Fan-in gate",
+        canonical_filename="gate.pdf",
+        status="active",
+        sha256=b"g" * 32,
+        pipeline_status=PipelineStatus.embedded,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+
+    sync_session = get_sync_session()
+    try:
+        # Sequential prefix done
+        for stage in (JobStage.extract, JobStage.chunk):
+            sync_session.add(
+                IngestionJob(doc_id=doc.doc_id, stage=stage, status=JobStatus.done)
+            )
+        # Fan-in trio: entities + embed done, summarize still running
+        sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.entities, status=JobStatus.done))
+        sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.embed, status=JobStatus.done))
+        sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.summarize, status=JobStatus.running))
+        sync_session.commit()
+    finally:
+        sync_session.close()
+
+    advance_pipeline(doc.doc_id)
+
+    # Finalize should now be queued — gate ignores in-flight summarize.
+    sync_session = get_sync_session()
+    try:
+        finalize_job = sync_session.execute(
+            select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.finalize)
+        ).scalar_one()
+        assert finalize_job.status == JobStatus.queued
+    finally:
+        sync_session.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -412,9 +412,7 @@ async def test_summarize_not_in_finalize_gate(db_session):
     try:
         # Sequential prefix done
         for stage in (JobStage.extract, JobStage.chunk):
-            sync_session.add(
-                IngestionJob(doc_id=doc.doc_id, stage=stage, status=JobStatus.done)
-            )
+            sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=stage, status=JobStatus.done))
         # Fan-in trio: entities + embed done, summarize still running
         sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.entities, status=JobStatus.done))
         sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.embed, status=JobStatus.done))


### PR DESCRIPTION
## Summary

User: *"Yeah, make a branch and do it. No need for actual preemption; your middle ground sounds good."*

Backend half of the summarize-as-background-stage refactor we discussed. Documents reach `ready` once `{entities, embed} → finalize` complete; summarize keeps running on the dedicated `llm` queue and writes `Document.summary` when it finishes. The user-visible "Done" badge no longer waits on the often-slow LLM summary call.

Frontend changes (queue tray UI split + per-doc summary chip + Observatory adjustments) are intentionally **out of scope for this PR** — the backend is independent and ships first.

## Changes

### 1. Drop `summarize` from the fan-in gate

| Before | After |
| --- | --- |
| `_PARALLEL_STAGES = {entities, embed, summarize}` | `_PARALLEL_STAGES = {entities, embed}` |
| Finalize waits on all three | Finalize waits on `{entities, embed}` only |
| Doc reaches `ready` after summarize completes | Doc reaches `ready` immediately after finalize |
| | New `_BACKGROUND_STAGES = {summarize}` — enqueued in the same tick, never gating finalize |

### 2. Background stages don't touch `pipeline_status`

`enqueue_stage` and `mark_stage_done` used to set `pipeline_status` unconditionally. With summarize now able to start before finalize OR finish after finalize, that would either prematurely flip the badge to `summarizing`/`summarized` (before retrieval is ready) or regress it from `ready` back to `summarized` (after the doc was already presented as Done). `pipeline_status` now reflects the gating-stage progression only; summary state lives on the `IngestionJob` row.

### 3. Yield-to-interactive in summarize

llama-server runs `-np 1`. Without yield, a chat send arriving while summary is mid-call waits up to one chunk-summary (10-90 s). Added in `worker/stages/summarize.py`:

```python
def _user_llm_active() -> bool:
    # True if a chat user-message was created in the last 60s OR a
    # research_state row has status='running'.

def _wait_for_idle_llm(budget_sec: int = 60) -> None:
    # Sleep up to budget_sec in 15s polls before claiming the LLM slot.
    # Bounded so summary isn't starved indefinitely.
```

Hooked in two places:
- **Before claiming the slot**: `run_summarize` calls `_wait_for_idle_llm()` before `mark_stage_running`. Avoids the hot-claim race where summarize takes the slot a chat was about to use.
- **Between map-reduce sub-calls**: `generate_summary` and `_summarize_long` accept a `yield_check` callable, called before each LLM call. Long-doc summaries yield mid-flight so the user gets the slot back without waiting for the entire map-reduce sweep.

This is "yield, not preempt" — once an LLM call is in flight, the summary completes that one call, then yields if the user is now active. Bounded latency ≤ one chunk-summary for chat senders.

## Tests

- `test_summarize_done_after_finalize_does_not_regress_status`: late summarize-completion does NOT flip `pipeline_status` from `ready` back to `summarized`.
- `test_summarize_not_in_finalize_gate`: `advance_pipeline` enqueues finalize once `{entities, embed}` are done, even if summarize is still running.
- 622 tests pass; ruff check + format clean.

## Out of scope (planned follow-up)

UI changes worth a brainstorm pass with the visual companion:
- Pipeline pill caps at "Ready" once finalize completes; small secondary "📝 Summary cooking / Summarized" chip beside it.
- Queue tray gets a soft-glowing "✨ Summarizing N docs" footer chip — your "off in the corner" idea.
- Observatory: drop summarize from "Avg Pipeline Timing", add a separate "Summary Backlog" line.
- Pipeline diagram: main flow ends at finalize/Ready; summarize branches off as a faded sidebar lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
