### PR TITLE
feat(harness): emit citations + enable judge in phase 4

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -98,6 +98,35 @@ def _wait_for_hc_reachable(hc: HarborClerkClient, max_wait_seconds: int = HC_REC
     return False
 
 
+def _should_judge(*, phase: int, status: Status, model_answer: str, no_judge: bool) -> bool:
+    """Whether to call the LLM-as-judge for one finished unit.
+
+    Phase 4 (main matrix) and phase 5 (parity heavies) are the phases that
+    produce model answers worth judging — earlier phases either don't run
+    the model (0, 1) or use cached baselines.
+
+    We gate the call on three things beyond phase:
+
+    1. ``--no-judge`` is the opt-out for cheap local runs (no Anthropic spend).
+    2. ``final_status`` must be ``DONE``. Degraded/error units have no
+       meaningful answer to compare against — judging them produces a
+       junk verdict and wastes a Sonnet call.
+    3. The model answer must be non-whitespace. An empty answer is the
+       fingerprint of the dead-LLM cascade (chat returns "completed" with
+       no tokens in ~2s) and is captured by the ``degraded`` status anyway.
+
+    Pulled out as a helper so the gate is unit-testable and so the
+    docstring lives next to the predicate.
+    """
+    if no_judge:
+        return False
+    if phase not in (4, 5):
+        return False
+    if status != Status.DONE:
+        return False
+    return bool(model_answer and model_answer.strip())
+
+
 def _is_retryable_research_failure(out: dict) -> bool:
     """Whether ``out["result"]`` warrants a one-shot retry.
 
@@ -146,6 +175,14 @@ def make_parser() -> argparse.ArgumentParser:
     p.add_argument("--time-limit-minutes", type=int, default=30)
     p.add_argument("--insecure", action="store_true", help="disable TLS verify (self-signed)")
     p.add_argument("--dry-run", action="store_true", help="run Phase 0 only, no API calls beyond acquire")
+    p.add_argument(
+        "--no-judge",
+        action="store_true",
+        help=(
+            "skip the LLM-as-judge call in phases 4 and 5. Use for cheap local-only "
+            "runs when you don't want to spend Anthropic credits on Sonnet judgments."
+        ),
+    )
     return p
 
 
@@ -995,22 +1032,45 @@ def main(argv: list[str] | None = None) -> int:
                         ce = citation_extra(baseline.get("cited_doc_ids", []), model_doc_ids)
                         eo = entity_overlap(baseline.get("answer", ""), model_answer, lang="en")
 
-                        if phase == 5:
+                        # Run LLM-as-judge when ``_should_judge`` says so. Phase 4
+                        # (main matrix) and phase 5 (parity heavies) qualify;
+                        # earlier phases don't produce a model answer worth
+                        # comparing against the baseline.
+                        if _should_judge(
+                            phase=phase,
+                            status=final_status,
+                            model_answer=model_answer,
+                            no_judge=args.no_judge,
+                        ):
                             owning_c = (
                                 u.corpus
                                 if u.corpus != "unified"
                                 else _find_owning_corpus(u.question_id, questions_by_corpus)
                             )
                             text_for_judge, _ = _question_text(questions_by_corpus[owning_c], u.question_id)
-                            v = judge.judge(
-                                question=text_for_judge, baseline=baseline.get("answer", ""), model_answer=model_answer
-                            )
-                            (run_dir / "judge" / u.corpus / u.model).mkdir(parents=True, exist_ok=True)
-                            (run_dir / "judge" / u.corpus / u.model / f"{u.question_id}__{u.depth}.json").write_text(
-                                json.dumps(dataclasses.asdict(v), indent=2)
-                            )
-                            judge_verdict = v.verdict
-                            judge_completeness = v.completeness
+                            try:
+                                v = judge.judge(
+                                    question=text_for_judge,
+                                    baseline=baseline.get("answer", ""),
+                                    model_answer=model_answer,
+                                )
+                            except Exception:
+                                # Judge failures must not poison the sweep — log
+                                # and carry on with empty verdict columns.
+                                log.warning(
+                                    "judge call failed for %s/%s/%s; continuing without verdict",
+                                    u.corpus,
+                                    u.model,
+                                    u.question_id,
+                                    exc_info=True,
+                                )
+                            else:
+                                (run_dir / "judge" / u.corpus / u.model).mkdir(parents=True, exist_ok=True)
+                                (
+                                    run_dir / "judge" / u.corpus / u.model / f"{u.question_id}__{u.depth}.json"
+                                ).write_text(json.dumps(dataclasses.asdict(v), indent=2))
+                                judge_verdict = v.verdict
+                                judge_completeness = v.completeness
 
                         sampler.note(
                             CompletionEvent(

--- a/scripts/test_corpora/tests/test_should_judge.py
+++ b/scripts/test_corpora/tests/test_should_judge.py
@@ -1,0 +1,98 @@
+"""Tests for the ``_should_judge`` predicate in sweep.py.
+
+The judge decision is one of the few branches in the sweep that directly
+controls Anthropic spend (Sonnet 4.6 is the judge model). Bugs here are
+costly in two directions — silently dropping judgments leaves the matrix
+quality-blind, silently judging too much burns credits — so the predicate
+gets its own unit tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.test_corpora.runner.state import Status
+from scripts.test_corpora.runner.sweep import _should_judge
+
+# ── phase gating ──
+
+
+@pytest.mark.parametrize("phase", [0, 1, 2, 3, 6])
+def test_judge_skipped_for_non_target_phases(phase: int) -> None:
+    assert not _should_judge(
+        phase=phase,
+        status=Status.DONE,
+        model_answer="A real answer.",
+        no_judge=False,
+    )
+
+
+@pytest.mark.parametrize("phase", [4, 5])
+def test_judge_runs_for_phase_4_and_5(phase: int) -> None:
+    assert _should_judge(
+        phase=phase,
+        status=Status.DONE,
+        model_answer="A real answer.",
+        no_judge=False,
+    )
+
+
+# ── status gating ──
+
+
+@pytest.mark.parametrize("status", [Status.PENDING, Status.IN_PROGRESS, Status.DEGRADED, Status.ERROR])
+def test_judge_skipped_for_non_done_status(status: Status) -> None:
+    assert not _should_judge(
+        phase=4,
+        status=status,
+        model_answer="A real answer.",
+        no_judge=False,
+    )
+
+
+# ── empty answer ──
+
+
+@pytest.mark.parametrize("answer", ["", "   ", "\n\n", "\t"])
+def test_judge_skipped_for_empty_or_whitespace_answer(answer: str) -> None:
+    # The dead-LLM cascade signature: chat returns "completed" with no tokens
+    # in 2 seconds. We don't want to burn Sonnet calls on these.
+    assert not _should_judge(
+        phase=4,
+        status=Status.DONE,
+        model_answer=answer,
+        no_judge=False,
+    )
+
+
+# ── opt-out ──
+
+
+def test_judge_skipped_when_no_judge_flag_set() -> None:
+    assert not _should_judge(
+        phase=4,
+        status=Status.DONE,
+        model_answer="A real answer.",
+        no_judge=True,
+    )
+
+
+def test_judge_skipped_when_no_judge_flag_set_phase_5() -> None:
+    assert not _should_judge(
+        phase=5,
+        status=Status.DONE,
+        model_answer="A real answer.",
+        no_judge=True,
+    )
+
+
+# ── happy path ──
+
+
+def test_judge_runs_when_all_conditions_met() -> None:
+    assert _should_judge(
+        phase=4,
+        status=Status.DONE,
+        model_answer="Real answer with content.",
+        no_judge=False,
+    )

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -144,12 +144,21 @@ async def get_research(
 
     # Build tool result lookup for enrichment
     from harbor_clerk.api.routes.chat import _enrich_tool_calls
+    from harbor_clerk.llm.citations import dedupe_citations, extract_citations_from_tool_result
     from harbor_clerk.llm.tools import summarize_tool_result as _summarize_tool_result
 
     tool_results_by_id: dict[str, tuple[str, str]] = {}
+    # Citations derived from every tool result emitted during the research
+    # turn. Computed at read-time so research detail surfaces citations
+    # without needing a new persisted column. ``dedupe_citations`` collapses
+    # the same (doc_id, chunk_id) seen across multiple searches and keeps
+    # the highest score.
+    citations_acc: list[dict] = []
     for m in all_msgs:
         if m.role == "tool" and m.tool_call_id and m.content:
             tool_results_by_id[m.tool_call_id] = (_summarize_tool_result(m.content), m.content)
+            citations_acc.extend(extract_citations_from_tool_result(m.content))
+    citations = dedupe_citations(citations_acc)
 
     # Build message dicts
     messages: list[dict] = []
@@ -186,6 +195,7 @@ async def get_research(
         report=report,
         model_id=report_model_id or (get_settings().llm_model_id or None),
         messages=messages,
+        citations=citations,
         created_at=conv.created_at,
         completed_at=state.completed_at,
     )

--- a/src/harbor_clerk/api/schemas/research.py
+++ b/src/harbor_clerk/api/schemas/research.py
@@ -60,6 +60,12 @@ class ResearchDetail(BaseModel):
     report: str | None = None
     model_id: str | None = None
     messages: list[dict]
+    # Deduped citation records derived from the tool-result messages of the
+    # research turn. Each entry has at minimum ``doc_id`` (when the underlying
+    # tool exposed it); additional fields include ``doc_title``, ``chunk_id``,
+    # ``pages``, ``score``. Computed at read-time from persisted tool messages
+    # so historical research surfaces citations too.
+    citations: list[dict] = []
     created_at: datetime
     completed_at: datetime | None = None
 

--- a/src/harbor_clerk/llm/chat.py
+++ b/src/harbor_clerk/llm/chat.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 
 from harbor_clerk.config import get_settings, refresh_llm_settings
 from harbor_clerk.db import async_session_factory
+from harbor_clerk.llm.citations import dedupe_citations, extract_citations_from_tool_result
 from harbor_clerk.llm.health import report_llm_error, report_llm_success
 from harbor_clerk.llm.models import get_model
 from harbor_clerk.llm.tools import execute_tool, get_chat_tools, summarize_tool_result
@@ -270,6 +271,12 @@ async def chat_stream(
         total_tokens = 0
         budget_exhausted = False
 
+        # Accumulated citations parsed from each tool result. Deduped+attached
+        # to the assistant ChatMessage row (``rag_context`` column) and emitted
+        # on the ``done`` SSE event so the UI and the test harness can surface
+        # what the model cited without re-parsing the prose.
+        citations_accumulated: list[dict] = []
+
         for _round in range(_MAX_TOOL_ROUNDS):
             # Check context budget before each LLM call
             usage_frac = _context_usage(messages, context_tokens)
@@ -359,9 +366,11 @@ async def chat_stream(
                         if detail:
                             error_event["detail"] = detail
                         yield f"data: {json.dumps(error_event)}\n\n"
+                        early_cites = dedupe_citations(citations_accumulated)
                         done_payload: dict = {
                             "type": "done",
                             "context_pct": 100 if is_context_overflow else None,
+                            "rag_context": {"citations": early_cites} if early_cites else None,
                         }
                         if conv and conv.title != "New conversation":
                             done_payload["title"] = conv.title
@@ -438,7 +447,10 @@ async def chat_stream(
                     conv.title = _generate_title(user_message)
                 await session.commit()
                 yield f"data: {json.dumps({'type': 'error', 'message': error_summary})}\n\n"
+                early_cites = dedupe_citations(citations_accumulated)
                 done_payload: dict = {"type": "done"}
+                if early_cites:
+                    done_payload["rag_context"] = {"citations": early_cites}
                 if conv and conv.title != "New conversation":
                     done_payload["title"] = conv.title
                 if active_model_id:
@@ -474,6 +486,12 @@ async def chat_stream(
                     yield f"data: {json.dumps({'type': 'tool_call', 'name': fn_name, 'arguments': fn_args})}\n\n"
 
                     result_str = await execute_tool(fn_name, fn_args, user_id)
+
+                    # Capture citations parsed from this tool result. Best-effort:
+                    # tools that don't return citation-shaped JSON contribute nothing.
+                    # Dedup happens later, after the whole tool loop, so the same
+                    # chunk surfacing in two searches collapses to one cite.
+                    citations_accumulated.extend(extract_citations_from_tool_result(result_str))
 
                     yield f"data: {json.dumps({'type': 'tool_result', 'name': fn_name, 'summary': summarize_tool_result(result_str), 'raw_result': result_str})}\n\n"
 
@@ -554,6 +572,8 @@ async def chat_stream(
         context_pct = round(min(used_tokens / context_tokens, 1.0) * 100) if context_tokens > 0 else 0
 
         # Save assistant response
+        final_citations = dedupe_citations(citations_accumulated)
+        rag_context_payload = {"citations": final_citations} if final_citations else None
         assistant_msg = None
         if assistant_content:
             assistant_msg = ChatMessage(
@@ -561,7 +581,7 @@ async def chat_stream(
                 role="assistant",
                 content=assistant_content,
                 tokens_used=total_tokens or None,
-                rag_context=None,
+                rag_context=rag_context_payload,
                 model_id=active_model_id,
                 context_pct=context_pct,
             )
@@ -578,6 +598,7 @@ async def chat_stream(
             "type": "done",
             "message_id": str(assistant_msg.message_id) if assistant_msg else None,
             "context_pct": context_pct,
+            "rag_context": rag_context_payload,
         }
         if conv and conv.title != "New conversation":
             done_payload["title"] = conv.title

--- a/src/harbor_clerk/llm/citations.py
+++ b/src/harbor_clerk/llm/citations.py
@@ -1,0 +1,148 @@
+"""Citation extraction from MCP tool results.
+
+The chat and research loops execute tools whose JSON output contains
+references back to corpus chunks and documents. This module pulls those
+references into a uniform ``{doc_id, doc_title?, chunk_id?, pages?, score?}``
+shape so that the chat ``done`` SSE event and ``ResearchDetail`` can expose a
+``citations`` list to clients (UI badges, test-harness ``citation_overlap``,
+etc.).
+
+The extractor is best-effort: tool results that don't look like citations
+(errors, status responses, free-form summaries) return an empty list. It
+intentionally never raises on malformed input — citation metadata is
+auxiliary; a parse failure must not break a chat turn.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def extract_citations_from_tool_result(raw_result: str) -> list[dict]:
+    """Pull citation-shaped records out of one tool-result JSON string.
+
+    Recognised shapes (the seven that any HC ``kb_*`` tool can emit):
+
+    - ``kb_search`` → ``{"hits": [{"doc_id", "chunk_id", "doc_title", "pages", "score", ...}]}``
+    - ``kb_batch_search`` → ``{"results": [{"hits": [...]}]}``
+    - ``kb_read_passages`` → ``{"passages": [{"chunk_id", "doc_title", "pages", ...}]}``
+      (no top-level ``doc_id``; passages carry chunk_id only)
+    - ``kb_expand_context`` → ``{"doc_id", "doc_title", "chunks": [{"chunk_id", "pages", ...}]}``
+    - ``kb_list_recent`` / ``kb_corpus_overview`` → ``{"documents": [{"doc_id", "title", ...}]}``
+    - ``kb_find_related`` → ``{"doc_id", "related": [{"doc_id", "title", ...}]}``
+    - ``kb_get_document`` / ``kb_document_outline`` → ``{"doc_id", "title", ...}`` (top-level)
+
+    Anything else (e.g. ``{"error": ...}``, ``kb_system_health``,
+    ``kb_entity_overview``, ``kb_corpus_topics``) returns ``[]``.
+
+    Returns a list of fresh dicts; the caller owns dedup and ordering.
+    """
+    try:
+        data: Any = json.loads(raw_result)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    if not isinstance(data, dict) or "error" in data:
+        return []
+
+    out: list[dict] = []
+
+    parent_doc_id = data.get("doc_id")
+    parent_doc_title = data.get("doc_title") or data.get("title")
+
+    def _record(d: dict, *, fallback_doc_id: Any = None, fallback_doc_title: Any = None) -> None:
+        doc_id = d.get("doc_id") or fallback_doc_id
+        if doc_id is None:
+            # passages-only case: chunk_id present, no doc_id. Capture the
+            # chunk so a chunk→doc join later can still resolve it; the
+            # test harness will ignore entries with no doc_id when computing
+            # citation_overlap.
+            if not d.get("chunk_id"):
+                return
+            cite: dict = {}
+        else:
+            cite = {"doc_id": str(doc_id)}
+
+        title = d.get("doc_title") or d.get("title") or fallback_doc_title
+        if title:
+            cite["doc_title"] = title
+        chunk_id = d.get("chunk_id")
+        if chunk_id:
+            cite["chunk_id"] = str(chunk_id)
+        pages = d.get("pages")
+        if pages:
+            cite["pages"] = pages
+        score = d.get("score")
+        if isinstance(score, (int, float)):
+            cite["score"] = score
+        out.append(cite)
+
+    # kb_search: top-level "hits"
+    for h in data.get("hits") or []:
+        if isinstance(h, dict):
+            _record(h)
+
+    # kb_batch_search: {"results": [{"hits": [...]}]}
+    for r in data.get("results") or []:
+        if isinstance(r, dict):
+            for h in r.get("hits") or []:
+                if isinstance(h, dict):
+                    _record(h)
+
+    # kb_read_passages: {"passages": [{chunk_id, doc_title, pages, ...}]}
+    for p in data.get("passages") or []:
+        if isinstance(p, dict):
+            _record(p)
+
+    # kb_expand_context: {"doc_id", "chunks": [...]} — chunks inherit parent doc_id
+    for c in data.get("chunks") or []:
+        if isinstance(c, dict):
+            _record(c, fallback_doc_id=parent_doc_id, fallback_doc_title=parent_doc_title)
+
+    # kb_list_recent / kb_corpus_overview: {"documents": [{doc_id, title, ...}]}
+    for d in data.get("documents") or []:
+        if isinstance(d, dict):
+            _record(d)
+
+    # kb_find_related: {"doc_id", "related": [{doc_id, title, ...}]}
+    for r in data.get("related") or []:
+        if isinstance(r, dict):
+            _record(r)
+
+    # kb_get_document / kb_document_outline / single-doc responses:
+    # doc_id at top level with no nested list we already handled.
+    has_nested = any(data.get(k) for k in ("hits", "results", "passages", "chunks", "documents", "related"))
+    if parent_doc_id and not has_nested:
+        _record({"doc_id": parent_doc_id, "doc_title": parent_doc_title})
+
+    return out
+
+
+def dedupe_citations(cites: list[dict]) -> list[dict]:
+    """Dedupe by (doc_id, chunk_id), preserving first-seen order.
+
+    When the same (doc_id, chunk_id) appears more than once, keep the entry
+    with the highest score (search calls report scores; ``kb_read_passages``
+    does not). Entries with no doc_id and no chunk_id are dropped — they
+    can't be deduplicated meaningfully and aren't useful as citations.
+    """
+    seen: dict[tuple, dict] = {}
+    order: list[tuple] = []
+    for c in cites:
+        if not isinstance(c, dict):
+            continue
+        key = (c.get("doc_id"), c.get("chunk_id"))
+        if key == (None, None):
+            continue
+        if key in seen:
+            prev = seen[key]
+            cur_score = c.get("score")
+            prev_score = prev.get("score")
+            if isinstance(cur_score, (int, float)) and (
+                not isinstance(prev_score, (int, float)) or cur_score > prev_score
+            ):
+                seen[key] = c
+        else:
+            seen[key] = c
+            order.append(key)
+    return [seen[k] for k in order]

--- a/tests/test_api_research_citations.py
+++ b/tests/test_api_research_citations.py
@@ -1,0 +1,190 @@
+"""Tests for ResearchDetail.citations on GET /api/research/{conv_id}.
+
+The research route computes citations at read-time from the persisted
+``ChatMessage(role='tool')`` rows of the turn — the same data the
+``citations_extract`` module knows how to parse. These tests verify the
+wire-up: seed a finished research with tool messages, fetch detail, expect
+deduped citations on the response.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from harbor_clerk.models import ChatMessage, Conversation
+from harbor_clerk.models.research_state import ResearchState
+from tests.conftest import auth_header
+
+
+async def _seed_research(
+    db_session,
+    admin_user,
+    *,
+    status: str = "completed",
+    tool_messages: list[tuple[str, str]] | None = None,
+) -> uuid.UUID:
+    """Insert a conversation + research_state + (optionally) tool messages.
+
+    ``tool_messages`` is a list of (tool_call_id, raw_result_json_str). The
+    helper creates one assistant message with matching tool_calls plus one
+    tool result message per entry.
+    """
+    conv_id = uuid.uuid4()
+    conv = Conversation(
+        conversation_id=conv_id,
+        user_id=admin_user.user_id,
+        title="test research",
+        mode="research",
+    )
+    db_session.add(conv)
+    await db_session.flush()  # make FK visible to subsequent inserts
+    state = ResearchState(
+        conversation_id=conv_id,
+        strategy="search",
+        status=status,
+        current_round=2,
+        max_rounds=4,
+    )
+    db_session.add(state)
+
+    # User question
+    db_session.add(
+        ChatMessage(
+            conversation_id=conv_id,
+            role="user",
+            content="What's in the corpus?",
+        )
+    )
+
+    if tool_messages:
+        for tc_id, raw in tool_messages:
+            db_session.add(
+                ChatMessage(
+                    conversation_id=conv_id,
+                    role="tool",
+                    tool_call_id=tc_id,
+                    content=raw,
+                )
+            )
+
+    if status == "completed":
+        db_session.add(
+            ChatMessage(
+                conversation_id=conv_id,
+                role="assistant",
+                content="The report.",
+                model_id="test-model",
+            )
+        )
+
+    await db_session.flush()
+    return conv_id
+
+
+async def test_research_detail_citations_empty_when_no_tools(client, admin_user, admin_token, db_session):
+    conv_id = await _seed_research(db_session, admin_user, tool_messages=None)
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["citations"] == []
+
+
+async def test_research_detail_citations_from_kb_search(client, admin_user, admin_token, db_session):
+    raw = json.dumps(
+        {
+            "hits": [
+                {
+                    "doc_id": "11111111-1111-1111-1111-111111111111",
+                    "chunk_id": "aaa",
+                    "doc_title": "Doc A",
+                    "score": 0.9,
+                    "pages": "1-2",
+                },
+                {
+                    "doc_id": "22222222-2222-2222-2222-222222222222",
+                    "chunk_id": "bbb",
+                    "doc_title": "Doc B",
+                    "score": 0.7,
+                },
+            ]
+        }
+    )
+    conv_id = await _seed_research(db_session, admin_user, tool_messages=[("call_1", raw)])
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    cites = resp.json()["citations"]
+    assert {c["doc_id"] for c in cites} == {
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    }
+    a = next(c for c in cites if c["doc_id"] == "11111111-1111-1111-1111-111111111111")
+    assert a["chunk_id"] == "aaa"
+    assert a["doc_title"] == "Doc A"
+    assert a["score"] == 0.9
+    assert a["pages"] == "1-2"
+
+
+async def test_research_detail_citations_deduped_across_tool_results(client, admin_user, admin_token, db_session):
+    # Same chunk surfaces in two searches → dedupe to one entry, with the
+    # higher score winning (matches the dedupe_citations contract).
+    r1 = json.dumps({"hits": [{"doc_id": "D1", "chunk_id": "C1", "score": 0.5}]})
+    r2 = json.dumps(
+        {
+            "hits": [
+                {"doc_id": "D1", "chunk_id": "C1", "score": 0.85},
+                {"doc_id": "D2", "chunk_id": "C2", "score": 0.6},
+            ]
+        }
+    )
+    conv_id = await _seed_research(
+        db_session,
+        admin_user,
+        tool_messages=[("call_1", r1), ("call_2", r2)],
+    )
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    cites = resp.json()["citations"]
+    assert len(cites) == 2
+    by_chunk = {c["chunk_id"]: c for c in cites}
+    assert by_chunk["C1"]["score"] == 0.85
+    assert by_chunk["C2"]["score"] == 0.6
+
+
+async def test_research_detail_citations_skips_error_payloads(client, admin_user, admin_token, db_session):
+    # A failed tool call returns {"error": ...}. Those must not produce
+    # citations — the extractor is best-effort and treats errors as no-ops.
+    err = json.dumps({"error": "no such doc_id"})
+    ok = json.dumps({"hits": [{"doc_id": "D1", "chunk_id": "C1"}]})
+    conv_id = await _seed_research(
+        db_session,
+        admin_user,
+        tool_messages=[("call_err", err), ("call_ok", ok)],
+    )
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    cites = resp.json()["citations"]
+    assert len(cites) == 1
+    assert cites[0]["doc_id"] == "D1"
+
+
+async def test_research_detail_citations_from_read_passages_keeps_chunk_only(
+    client, admin_user, admin_token, db_session
+):
+    # kb_read_passages doesn't include doc_id. Those chunk-only entries still
+    # appear in citations so the UI can show them; the test harness ignores
+    # entries without doc_id for citation_overlap.
+    raw = json.dumps(
+        {
+            "passages": [
+                {"chunk_id": "C1", "doc_title": "X", "pages": "5", "text": "..."},
+            ]
+        }
+    )
+    conv_id = await _seed_research(db_session, admin_user, tool_messages=[("call_1", raw)])
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    cites = resp.json()["citations"]
+    assert len(cites) == 1
+    assert "doc_id" not in cites[0]
+    assert cites[0]["chunk_id"] == "C1"
+    assert cites[0]["doc_title"] == "X"

--- a/tests/test_llm_citations.py
+++ b/tests/test_llm_citations.py
@@ -1,0 +1,232 @@
+"""Tests for harbor_clerk.llm.citations — extractor + dedup."""
+
+from __future__ import annotations
+
+import json
+
+from harbor_clerk.llm.citations import dedupe_citations, extract_citations_from_tool_result
+
+# ── shape coverage ──
+
+
+def test_extract_from_kb_search_hits() -> None:
+    raw = json.dumps(
+        {
+            "hits": [
+                {
+                    "chunk_id": "11111111-1111-1111-1111-111111111111",
+                    "doc_id": "22222222-2222-2222-2222-222222222222",
+                    "doc_title": "Vendor Agreement v3",
+                    "score": 0.82,
+                    "pages": "3-4",
+                },
+                {
+                    "chunk_id": "33333333-3333-3333-3333-333333333333",
+                    "doc_id": "44444444-4444-4444-4444-444444444444",
+                    "doc_title": "Master Service Agreement",
+                    "score": 0.71,
+                },
+            ],
+            "total_candidates": 12,
+            "has_more": True,
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert len(cites) == 2
+    assert cites[0]["doc_id"] == "22222222-2222-2222-2222-222222222222"
+    assert cites[0]["doc_title"] == "Vendor Agreement v3"
+    assert cites[0]["chunk_id"] == "11111111-1111-1111-1111-111111111111"
+    assert cites[0]["pages"] == "3-4"
+    assert cites[0]["score"] == 0.82
+    # Second hit has no pages — must not crash and must not invent the field.
+    assert "pages" not in cites[1]
+
+
+def test_extract_from_kb_batch_search() -> None:
+    raw = json.dumps(
+        {
+            "results": [
+                {"query": "X", "hits": [{"doc_id": "aa", "chunk_id": "c1"}]},
+                {"query": "Y", "hits": [{"doc_id": "bb", "chunk_id": "c2"}]},
+            ]
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert [c["doc_id"] for c in cites] == ["aa", "bb"]
+    assert [c["chunk_id"] for c in cites] == ["c1", "c2"]
+
+
+def test_extract_from_kb_read_passages_keeps_chunk_only() -> None:
+    # kb_read_passages does NOT include doc_id — passages carry chunk_id +
+    # doc_title only. We still capture them so the UI can render the passage
+    # and a chunk→doc join later can resolve doc_id.
+    raw = json.dumps(
+        {
+            "passages": [
+                {"chunk_id": "c1", "doc_title": "X", "pages": "5", "text": "..."},
+                {"chunk_id": "c2", "doc_title": "Y", "text": "..."},
+            ]
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert len(cites) == 2
+    assert cites[0]["chunk_id"] == "c1"
+    assert cites[0]["doc_title"] == "X"
+    assert "doc_id" not in cites[0]
+
+
+def test_extract_from_kb_expand_context_inherits_doc_id() -> None:
+    raw = json.dumps(
+        {
+            "doc_id": "DOC1",
+            "doc_title": "Title A",
+            "chunks": [
+                {"chunk_id": "c1", "chunk_num": 4, "pages": "2"},
+                {"chunk_id": "c2", "chunk_num": 5, "is_target": True},
+            ],
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert len(cites) == 2
+    assert all(c["doc_id"] == "DOC1" for c in cites)
+    assert all(c["doc_title"] == "Title A" for c in cites)
+
+
+def test_extract_from_kb_list_recent_documents() -> None:
+    raw = json.dumps(
+        {
+            "total_count": 2,
+            "documents": [
+                {"doc_id": "d1", "title": "Doc 1"},
+                {"doc_id": "d2", "title": "Doc 2"},
+            ],
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert {c["doc_id"] for c in cites} == {"d1", "d2"}
+    assert cites[0]["doc_title"] == "Doc 1"
+
+
+def test_extract_from_kb_find_related() -> None:
+    raw = json.dumps(
+        {
+            "doc_id": "ROOT",
+            "related": [
+                {"doc_id": "r1", "title": "Related 1"},
+                {"doc_id": "r2", "title": "Related 2"},
+            ],
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    # The root doc plus two related docs would over-count what the user is
+    # citing; ``related`` callers are using it to follow leads, so only the
+    # related list is treated as citations.
+    assert [c["doc_id"] for c in cites] == ["r1", "r2"]
+
+
+def test_extract_from_kb_get_document() -> None:
+    raw = json.dumps(
+        {
+            "doc_id": "D1",
+            "title": "Single Doc",
+            "mime_type": "application/pdf",
+            "size_bytes": 12345,
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert cites == [{"doc_id": "D1", "doc_title": "Single Doc"}]
+
+
+# ── error/edge cases ──
+
+
+def test_error_payload_returns_empty() -> None:
+    assert extract_citations_from_tool_result(json.dumps({"error": "oh no"})) == []
+
+
+def test_non_json_returns_empty() -> None:
+    assert extract_citations_from_tool_result("not json at all") == []
+
+
+def test_non_object_json_returns_empty() -> None:
+    assert extract_citations_from_tool_result("[]") == []
+    assert extract_citations_from_tool_result("null") == []
+    assert extract_citations_from_tool_result('"hello"') == []
+
+
+def test_empty_hits_returns_empty() -> None:
+    assert extract_citations_from_tool_result(json.dumps({"hits": []})) == []
+
+
+def test_unrelated_tool_shape_returns_empty() -> None:
+    # kb_entity_overview, kb_system_health, etc. — no citation shape.
+    assert extract_citations_from_tool_result(json.dumps({"total_entities": 42})) == []
+    assert extract_citations_from_tool_result(json.dumps({"status": "healthy"})) == []
+
+
+def test_hit_without_doc_id_or_chunk_id_skipped() -> None:
+    raw = json.dumps({"hits": [{"score": 0.9}, {"doc_id": "d1"}]})
+    cites = extract_citations_from_tool_result(raw)
+    assert len(cites) == 1
+    assert cites[0]["doc_id"] == "d1"
+
+
+def test_score_must_be_numeric() -> None:
+    raw = json.dumps({"hits": [{"doc_id": "d1", "score": "high"}]})
+    cites = extract_citations_from_tool_result(raw)
+    assert "score" not in cites[0]
+
+
+# ── dedup ──
+
+
+def test_dedupe_keeps_first_order() -> None:
+    cites = [
+        {"doc_id": "a", "chunk_id": "x"},
+        {"doc_id": "b", "chunk_id": "y"},
+        {"doc_id": "a", "chunk_id": "x"},
+    ]
+    out = dedupe_citations(cites)
+    assert [(c["doc_id"], c["chunk_id"]) for c in out] == [("a", "x"), ("b", "y")]
+
+
+def test_dedupe_keeps_highest_score() -> None:
+    cites = [
+        {"doc_id": "a", "chunk_id": "x", "score": 0.5},
+        {"doc_id": "a", "chunk_id": "x", "score": 0.9},
+        {"doc_id": "a", "chunk_id": "x", "score": 0.3},
+    ]
+    out = dedupe_citations(cites)
+    assert len(out) == 1
+    assert out[0]["score"] == 0.9
+
+
+def test_dedupe_doc_only_vs_chunk() -> None:
+    # Same doc, different chunks → kept separate. Same doc, no chunk → its
+    # own dedup bucket.
+    cites = [
+        {"doc_id": "a", "chunk_id": "x"},
+        {"doc_id": "a", "chunk_id": "y"},
+        {"doc_id": "a"},
+        {"doc_id": "a"},
+    ]
+    out = dedupe_citations(cites)
+    assert len(out) == 3
+
+
+def test_dedupe_drops_empty_records() -> None:
+    cites: list[dict] = [{"doc_id": "a"}, {}, "not a dict"]  # type: ignore[list-item]
+    out = dedupe_citations(cites)
+    assert out == [{"doc_id": "a"}]
+
+
+def test_dedupe_chunk_only_records_kept() -> None:
+    # kb_read_passages produces chunk-only records — dedupe must keep them
+    # rather than dropping for missing doc_id.
+    cites = [
+        {"chunk_id": "c1", "doc_title": "X"},
+        {"chunk_id": "c1", "doc_title": "X"},
+    ]
+    out = dedupe_citations(cites)
+    assert len(out) == 1
+    assert out[0]["chunk_id"] == "c1"


### PR DESCRIPTION
## Summary

The test-corpora sweep was effectively quality-blind:

- `citation_overlap` was 0 in every one of 386 phase-4 rows in the last sweep because HC's chat SSE `done` event never included citations and `ResearchDetail` had no `citations` field. The harness was reading from a key that didn't exist.
- The LLM-as-judge (Sonnet 4.6) only ran in phase 5 (the parity heavies, ~32 units), not phase 4 (the main matrix, ~386 units). So `judge_verdict` was empty in every phase-4 row.

Together these meant the only "quality" signal on the main matrix was `entity_overlap` from spaCy NER on the prose — noisy on domain-specific corpora and useless for citation-grounding judgments.

## What changed

**Citations passthrough (HC)**

- New `harbor_clerk.llm.citations` module with `extract_citations_from_tool_result` + `dedupe_citations`. Handles the 7 citation-shaped responses HC tools emit: `kb_search`, `kb_batch_search`, `kb_read_passages`, `kb_expand_context`, `kb_list_recent`/`kb_corpus_overview`, `kb_find_related`, `kb_get_document`/`kb_document_outline`. Best-effort — error payloads / unrelated shapes contribute nothing rather than raising.
- `chat_stream` accumulates citations after each tool result, dedupes at exit, and emits `rag_context: {"citations": [...]}` on the `done` SSE event (all 3 exit paths: context overflow, LLM error, normal success). Also persists to `ChatMessage.rag_context`.
- `ResearchDetail` gains `citations: list[dict]`, computed at read time from the persisted `role="tool"` messages of the turn. No migration needed; historical research becomes citable too.

**Judge in phase 4 (harness)**

- New `_should_judge` predicate extracted as a testable helper. Gates on phase ∈ {4, 5}, `Status.DONE`, non-empty answer, and `--no-judge`.
- New `--no-judge` CLI flag to opt out of Anthropic spend on cheap local-only runs.
- Judge failures are caught and logged so a single bad call doesn't poison the sweep.

## Expected impact

- `citation_overlap`, `citation_extra` go from all-zero to real numbers on every phase-4 unit that has cited docs.
- `judge_verdict` and `judge_completeness` populate for every phase-4 done-status unit with a non-empty answer (~290 of 386 in the last sweep).
- Cost: ~$5 in Sonnet credits per full phase-4 run (~360 judgments × ~$0.012 each).
- Backward-compatible: harness reads citations the same way it always did (`event["rag_context"]["citations"]` + `result.citations[]`); HC just starts populating them.

## Test plan

- [x] 19 unit tests on `extract_citations_from_tool_result` + `dedupe_citations` (all 7 tool shapes, error/edge cases, dedup invariants)
- [x] 5 integration tests on the `GET /api/research/{id}` route end-to-end (citation propagation, dedupe across multiple tool calls, error-payload skipping, chunk-only entries from `kb_read_passages`)
- [x] 18 unit tests on `_should_judge` (phase gating, status gating, empty-answer gating, `--no-judge` flag)
- [x] Full unit suite passes: 651 main + 138 harness tests, no regressions

## Out of scope (follow-ups)

These are queued for subsequent PRs in this arc:

- Health-aware circuit breaker in the harness (stop firing units after N consecutive degraded/empty-answer cascades)
- Hard-fail unfilled `{{contract_a}}` placeholders + reject "corpus is empty" / refusal baselines
- Tighten the "done" predicate beyond `status==completed && answer != ""` (detect refusals, require tool use)
- Per-corpus canary chat before each phase
- Capture HC server logs into the run dir
- Capture `messages[]` for ask responses
- Surface a structured `interrupt_reason` from HC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
