### PR TITLE
feat(harness): circuit breaker + tighter done predicate + bad-baseline rejection

### DIFF
--- a/scripts/test_corpora/runner/circuit_breaker.py
+++ b/scripts/test_corpora/runner/circuit_breaker.py
@@ -1,0 +1,160 @@
+"""Per-model circuit breaker for the sweep.
+
+Without this, a dead-LLM cascade (chat returns ``completed`` with no tokens
+in ~2 s) fires the next 9+ ask units back-to-back, all empty, all in 2 s
+each. The harness records 10+ ``degraded`` rows in 20 seconds while HC is
+silently broken. The 2026-05-05-prod sweep had 124 of 386 units (32%) in
+this state — overwhelmingly bursts of empty answers immediately after a
+model swap or LLM restart.
+
+The breaker tracks consecutive *operational* failures per model. Model
+quirks (refusal, tool-call roleplay) don't count — those are real signal
+about the model's capability. The breaker fires only for symptoms of an
+unhealthy LLM/HC: empty answers, HC-side research interrupts, watchdog
+aborts, ``status=failed``.
+
+On trip, it cools the loop down for a fixed period (no fancy recovery
+detection — model_status was reporting "ready" while chat returned empty,
+so a cooldown is more reliable than a probe). After ``max_trips`` cycles
+on the same model, it gives up on that model for the remainder of the
+run, leaving remaining units PENDING so ``--resume`` can pick them up
+once the operator has investigated.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import time
+
+# These signatures are matched substring-wise against ``error_msg`` strings
+# emitted by the sweep's per-unit status assignment. Anything in this list
+# implies "the LLM or HC is unhealthy" rather than "the model gave a bad
+# answer."
+_OPERATIONAL_FAILURE_SIGNATURES = (
+    "empty answer",
+    "interrupted by harbor clerk",
+    "harness aborted research",
+    "research finished with status=failed",
+    "research finished with status=timeout",
+    "unexpected result status",
+)
+
+
+def is_operational_failure(error_msg: str | None) -> bool:
+    """Whether ``error_msg`` looks like an LLM/HC fault vs a model fault.
+
+    Returns ``False`` for:
+
+    - ``None`` (clean DONE, no failure).
+    - ``"completed with refusal (...)"`` — model declined to engage, real
+      capability signal.
+    - ``"completed with tool roleplay (...)"`` — small-model tool-call
+      fingerprint, real capability signal.
+    - ``"unfilled placeholder: {{contract_a}}"`` — test-data problem,
+      neither LLM nor HC fault.
+
+    Returns ``True`` for the empty-answer cascades and HC-side interrupts
+    that overwhelmingly dominated the 2026-05-05-prod failure modes.
+    """
+    if not error_msg:
+        return False
+    low = error_msg.lower()
+    return any(sig in low for sig in _OPERATIONAL_FAILURE_SIGNATURES)
+
+
+@dataclasses.dataclass
+class CircuitBreaker:
+    """Per-model consecutive-operational-failure tracker with cooldown.
+
+    Default knobs:
+
+    - ``failure_threshold=3`` — after this many consecutive operational
+      failures for the same model, pause.
+    - ``max_trips=3`` — after this many trip+cooldown cycles for the same
+      model, give up and skip remaining units for that model.
+    - ``cooldown_seconds=60`` — how long to sleep when the breaker trips.
+
+    Usage in the sweep loop:
+
+    .. code-block:: python
+
+        breaker = CircuitBreaker()
+        for u in units:
+            if breaker.should_skip(u.model):
+                continue  # remaining units stay PENDING for --resume
+            if breaker.should_pause(u.model):
+                breaker.pause_and_reset(u.model, log)
+            # ... run unit, determine final_status + error_msg ...
+            breaker.note(
+                u.model,
+                operational_failure=is_operational_failure(error_msg)
+                    if final_status != Status.DONE
+                    else False,
+            )
+    """
+
+    failure_threshold: int = 3
+    max_trips: int = 3
+    cooldown_seconds: int = 60
+    _fail_count: dict[str, int] = dataclasses.field(default_factory=dict)
+    _trip_count: dict[str, int] = dataclasses.field(default_factory=dict)
+    # Sleep function — overridable for tests. Module-level ``time.sleep`` by
+    # default; tests pass a no-op or a recording callable.
+    sleep: object = time.sleep
+
+    def note(self, model: str, *, operational_failure: bool) -> None:
+        """Record one unit's outcome for this model.
+
+        ``operational_failure=True`` increments the consecutive-failure
+        counter; any other outcome (including DONE, refusal, roleplay)
+        resets it. The reset on non-operational-failure is important — a
+        single real DONE between two empty-answer cascades shouldn't trip
+        the breaker.
+        """
+        if operational_failure:
+            self._fail_count[model] = self._fail_count.get(model, 0) + 1
+        else:
+            self._fail_count[model] = 0
+
+    def should_pause(self, model: str) -> bool:
+        """True when ``model`` has hit the consecutive-failure threshold."""
+        return self._fail_count.get(model, 0) >= self.failure_threshold
+
+    def should_skip(self, model: str) -> bool:
+        """True when ``model`` has tripped+cooled down ``max_trips`` times.
+
+        At this point we've burned ``max_trips × cooldown_seconds`` waiting
+        for this model to recover and it hasn't. Remaining units for this
+        model are skipped (left PENDING so ``--resume`` can pick them up)
+        rather than retried — the operator should investigate.
+        """
+        return self._trip_count.get(model, 0) >= self.max_trips
+
+    def pause_and_reset(self, model: str, log: logging.Logger) -> None:
+        """Sleep for ``cooldown_seconds`` and reset the failure counter.
+
+        Bumps the trip count. Once the trip count reaches ``max_trips``,
+        subsequent ``should_skip`` calls return True. The reset is done
+        after the sleep so a recovery during the cooldown gets credit on
+        the next ``note`` call.
+        """
+        log.warning(
+            "circuit breaker tripped for model=%s after %d consecutive operational failures; sleeping %ds (trip %d/%d)",
+            model,
+            self._fail_count.get(model, 0),
+            self.cooldown_seconds,
+            self._trip_count.get(model, 0) + 1,
+            self.max_trips,
+        )
+        self.sleep(self.cooldown_seconds)  # type: ignore[operator]
+        self._trip_count[model] = self._trip_count.get(model, 0) + 1
+        self._fail_count[model] = 0
+
+    def fail_count(self, model: str) -> int:
+        """Read-only view of the current consecutive-failure count. Used by tests."""
+        return self._fail_count.get(model, 0)
+
+    def trip_count(self, model: str) -> int:
+        """Read-only view of how many times this model has tripped. Used by tests."""
+        return self._trip_count.get(model, 0)

--- a/scripts/test_corpora/runner/quality.py
+++ b/scripts/test_corpora/runner/quality.py
@@ -1,0 +1,214 @@
+"""Answer/baseline quality checks for the sweep.
+
+The sweep's old ``status == "completed" and answer != ""`` predicate was
+generous to a fault: it counted answers like *"I'm sorry, but I don't have
+the capability to search the specific documents"* as DONE, because the chat
+endpoint returned cleanly and the answer was non-empty. The result is a
+matrix in which a model's "100% pass" can really mean "100% punted."
+
+This module provides three independent quality probes:
+
+- ``classify_answer`` — buckets a model answer as real / refusal / roleplay /
+  empty so the sweep can demote DONE → DEGRADED with a specific reason.
+- ``find_unfilled_placeholder`` — flags a question that still contains a
+  ``{{contract_a}}``-style template marker (it should have been substituted
+  during sampling). Such questions cannot pass and must not be sent to the
+  LLM.
+- ``baseline_quality_problem`` — flags a baseline answer that is itself
+  unusable (corpus was empty at baseline-gen time, Claude saw a placeholder
+  and asked to clarify, etc.) so the sweep doesn't compute meaningless
+  citation/entity metrics against it.
+
+All three return ``None`` (or ``"real"``) on the happy path and a short
+human-readable string when something is off, so they're easy to log into
+``metrics.csv`` and ``log.txt`` without further wrapping.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+# ── classify_answer ──
+
+# Short, polite "I can't help" answers that signal the model didn't try to
+# engage with the corpus. Match case-insensitively. Each phrase is something
+# that appeared verbatim in the 2026-05-05-prod sweep across phi4-mini,
+# smollm3-3b, etc., so the list is empirically grounded — not preemptive.
+_REFUSAL_PHRASES = (
+    "i'm sorry, but i don't have",
+    "i don't have access to",
+    "i don't have the capability",
+    "i cannot access",
+    "i cannot retrieve",
+    "i haven't been trained on specific documents",
+    "i'm an ai language model",
+    "i'm an ai assistant",
+    "i don't have the ability to access",
+    "i am unable to access",
+    "i am not able to access",
+)
+
+# Tool-call syntax leaking into the answer body. Small models with weak
+# tool-calling fine-tunes sometimes narrate tool calls as text instead of
+# emitting them as structured calls. The bracketed-tool-name pattern is the
+# fingerprint: ``[search_documents: "..."]`` rather than an actual call.
+_TOOL_NAMES_FOR_ROLEPLAY = (
+    "search_documents",
+    "kb_search",
+    "kb_batch_search",
+    "batch_search",
+    "read_passages",
+    "kb_read_passages",
+    "expand_context",
+    "kb_expand_context",
+    "get_document",
+    "kb_get_document",
+    "list_documents",
+    "kb_list_recent",
+    "corpus_overview",
+    "kb_corpus_overview",
+    "entity_search",
+    "kb_entity_search",
+    "find_related",
+    "kb_find_related",
+    "document_outline",
+    "kb_document_outline",
+)
+_ROLEPLAY_RE = re.compile(
+    r"\[\s*(?:" + "|".join(_TOOL_NAMES_FOR_ROLEPLAY) + r")\b",
+    re.IGNORECASE,
+)
+
+# Cap on answer length for refusal detection. Above this we trust that any
+# refusal phrase appearing in a long answer is being quoted, not asserted.
+# 1500 chars is roughly two paragraphs of real content; refusals tend to be
+# under 800.
+_REFUSAL_MAX_LEN = 1500
+
+AnswerLabel = Literal["real", "refusal", "roleplay", "empty"]
+
+
+def classify_answer(answer: str | None) -> tuple[AnswerLabel, str | None]:
+    """Bucket a model answer into one of four labels.
+
+    Returns ``(label, reason)``. ``reason`` is a short human string when
+    ``label`` is not ``"real"`` — suitable for the metrics CSV ``status``
+    column or a log line.
+
+    Detection order matters:
+
+    1. Empty/whitespace → ``empty``. This is the dead-LLM cascade signature
+       (chat returns "completed" with no tokens in ~2s) and is already
+       captured as DEGRADED upstream; included here so the function totals
+       to a complete classification.
+    2. Roleplay → ``roleplay``. Checked before refusal because a model that
+       roleplays tool calls *and* hedges should be flagged as roleplay (the
+       more specific bucket).
+    3. Refusal → ``refusal``, but only when the answer is short. Long
+       answers that happen to quote a refusal phrase are real content.
+    4. Anything else → ``real``.
+    """
+    if not answer or not answer.strip():
+        return ("empty", "completed with empty answer")
+
+    if _ROLEPLAY_RE.search(answer):
+        return (
+            "roleplay",
+            "completed with tool roleplay (model emitted tool-call syntax as text)",
+        )
+
+    if len(answer) <= _REFUSAL_MAX_LEN:
+        low = answer.lower()
+        for phrase in _REFUSAL_PHRASES:
+            if phrase in low:
+                return ("refusal", f"completed with refusal (matched: {phrase!r})")
+
+    return ("real", None)
+
+
+# ── placeholder detection ──
+
+# Matches ``{{name}}``, ``{{ contract_a }}``, etc. Greedy is fine — we're
+# looking for the existence of a placeholder, not parsing nested ones.
+_PLACEHOLDER_RE = re.compile(r"\{\{[^{}]+\}\}")
+
+
+def find_unfilled_placeholder(text: str) -> str | None:
+    """Return the first ``{{...}}`` placeholder in ``text``, or ``None``.
+
+    Used to reject questions like ``"What is the governing law of the
+    {{contract_a}} agreement?"`` that should have been substituted during
+    sampling but weren't. Sending such a question to an LLM produces either
+    a clarification request or a literal-search attempt — neither is a
+    pass.
+    """
+    if not text:
+        return None
+    m = _PLACEHOLDER_RE.search(text)
+    return m.group(0) if m else None
+
+
+# ── baseline_quality_problem ──
+
+# Baseline-answer fingerprints that indicate the baseline itself is unusable
+# as a gold standard. These come from re-reading the 2026-05-05-prod
+# baselines: Claude saw either an empty corpus or an unfilled placeholder
+# and answered accordingly. Computing citation_overlap or entity_overlap
+# against such answers tells you nothing about the model under test.
+_BASELINE_EMPTY_CORPUS_SIGNATURES = (
+    "corpus appears to be",  # "the corpus appears to be completely empty"
+    "no documents have been uploaded",
+    "no documents have been ingested",
+    "knowledge base is empty",
+)
+_BASELINE_NOTHING_FOUND_SIGNATURES = (
+    "i was unable to find",
+    "i couldn't find any",
+    "all searches returned zero results",
+    "no information about",
+)
+_BASELINE_PLACEHOLDER_SIGNATURES = (
+    "unfilled template placeholder",
+    "i notice your message contains",
+    "looks like the specific contract name or identifier wasn't filled",
+)
+_BASELINE_REFUSAL_SIGNATURES = (
+    "i don't have the capability to search",
+    "i don't have access to external databases",
+)
+
+
+def baseline_quality_problem(baseline: dict) -> str | None:
+    """Return a reason if the baseline answer is unusable as a gold standard.
+
+    The sweep should still record the unit's operational status and write
+    the row to ``metrics.csv``, but with empty quality columns and a logged
+    skip — there's no point computing ``citation_overlap`` against an
+    "I can't find anything" baseline.
+
+    Returns ``None`` when the baseline looks usable.
+    """
+    if not isinstance(baseline, dict):
+        return "baseline payload is not a dict"
+
+    answer = (baseline.get("answer") or "").strip()
+    if not answer:
+        return "baseline answer is empty"
+
+    low = answer.lower()
+
+    for sig in _BASELINE_EMPTY_CORPUS_SIGNATURES:
+        if sig in low:
+            return "baseline says corpus is empty"
+    for sig in _BASELINE_PLACEHOLDER_SIGNATURES:
+        if sig in low:
+            return "baseline saw unfilled placeholder"
+    for sig in _BASELINE_NOTHING_FOUND_SIGNATURES:
+        if sig in low:
+            return "baseline found no matching documents"
+    for sig in _BASELINE_REFUSAL_SIGNATURES:
+        if sig in low:
+            return "baseline is a refusal"
+
+    return None

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -787,11 +787,10 @@ def main(argv: list[str] | None = None) -> int:
                 if phase in (2, 3, 4, 5, 6):
                     if breaker.should_skip(u.model):
                         log.warning(
-                            "skipping %s/%s/%s — circuit breaker is open for model=%s (left PENDING for --resume)",
+                            "skipping %s/%s/%s — circuit breaker is open (left PENDING for --resume)",
                             u.corpus,
                             u.model,
                             u.question_id,
-                            u.model,
                         )
                         continue
                     if breaker.should_pause(u.model):
@@ -983,10 +982,12 @@ def main(argv: list[str] | None = None) -> int:
                         if result.get("harness_aborted"):
                             final_status = Status.ERROR
                             error_msg = f"harness aborted research: {result.get('harness_abort_reason', 'unknown')}"
-                        elif result_status == "completed" and result_answer:
+                        elif result_status == "completed":
                             # Tighter DONE predicate: a non-empty answer is not
                             # automatically a real engagement with the corpus.
-                            # ``classify_answer`` separates real answers from
+                            # ``classify_answer`` is the single authority on
+                            # completed-status outcomes — it folds the
+                            # "empty/whitespace answer" case in alongside
                             # refusals ("I don't have the capability...") and
                             # roleplay (small models that emit ``[search_documents:
                             # "..."]`` as text instead of invoking the tool). Both
@@ -999,9 +1000,6 @@ def main(argv: list[str] | None = None) -> int:
                             else:
                                 final_status = Status.DEGRADED
                                 error_msg = reason
-                        elif result_status == "completed" and not result_answer:
-                            final_status = Status.DEGRADED
-                            error_msg = "completed with empty answer"
                         elif result_status == "interrupted":
                             final_status = Status.ERROR
                             error_msg = "research interrupted by Harbor Clerk"

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -36,10 +36,16 @@ import yaml
 from scripts.test_corpora import conftest as cfg
 from scripts.test_corpora.corpora import cuad, enron, synthetic
 from scripts.test_corpora.corpora.manifest import CorpusManifest
+from scripts.test_corpora.runner.circuit_breaker import CircuitBreaker, is_operational_failure
 from scripts.test_corpora.runner.claude_baseline import BaselineGenerator
 from scripts.test_corpora.runner.client import HarborClerkClient, SyncMcpSession
 from scripts.test_corpora.runner.judge import JudgeClient
 from scripts.test_corpora.runner.metrics import citation_extra, citation_overlap, entity_overlap
+from scripts.test_corpora.runner.quality import (
+    baseline_quality_problem,
+    classify_answer,
+    find_unfilled_placeholder,
+)
 from scripts.test_corpora.runner.sampler import CompletionEvent, Sampler
 from scripts.test_corpora.runner.state import StateFile, Status, Unit
 
@@ -638,6 +644,14 @@ def main(argv: list[str] | None = None) -> int:
         anthro = anthropic.Anthropic()
         judge = JudgeClient(client=anthro, model=cfg.JUDGE_MODEL)
 
+        # Per-model circuit breaker. Caps the damage from a dead-LLM cascade
+        # by sleeping after N consecutive operational failures, and skips
+        # remaining units for a model that's tripped too many times.
+        # State persists across the whole sweep (multiple corpora, multiple
+        # phases) since a model that's broken in one block typically stays
+        # broken until manual intervention.
+        breaker = CircuitBreaker()
+
         # CSV metrics
         metrics_path = run_dir / "metrics.csv"
         new_csv = not metrics_path.exists()
@@ -765,6 +779,24 @@ def main(argv: list[str] | None = None) -> int:
                     log.info("dry-run: skipping %s", u)
                     continue
 
+                # Circuit-breaker gate. Only meaningful for unit phases that
+                # actually run the local model (2-6). Phase 0/1 have their
+                # own failure modes (ingest, baseline-gen) that don't fit
+                # the per-model breaker pattern. Skipped units stay PENDING
+                # so ``--resume`` after manual intervention picks them up.
+                if phase in (2, 3, 4, 5, 6):
+                    if breaker.should_skip(u.model):
+                        log.warning(
+                            "skipping %s/%s/%s — circuit breaker is open for model=%s (left PENDING for --resume)",
+                            u.corpus,
+                            u.model,
+                            u.question_id,
+                            u.model,
+                        )
+                        continue
+                    if breaker.should_pause(u.model):
+                        breaker.pause_and_reset(u.model, log)
+
                 # Ensure correct corpus is in the DB for phases 1/4/5 (unified for 6).
                 # Phase 1 baselines call HC's MCP for KB tools — Sonnet's queries hit
                 # whatever is currently in HC's DB, so a fresh sweep that doesn't
@@ -832,6 +864,30 @@ def main(argv: list[str] | None = None) -> int:
                                 headers=mcp_headers,
                             )
                         text, _lang = _question_text(questions_by_corpus[u.corpus], u.question_id)
+                        placeholder = find_unfilled_placeholder(text)
+                        if placeholder:
+                            # The question template still contains a
+                            # ``{{contract_a}}``-style marker. Sampling should
+                            # have substituted it before the unit was planned;
+                            # sending it verbatim wastes a Claude baseline call
+                            # and produces a "please clarify" answer that taints
+                            # every downstream model run for the same question.
+                            log.error(
+                                "phase 1 baseline aborted for %s/%s: unfilled placeholder %s",
+                                u.corpus,
+                                u.question_id,
+                                placeholder,
+                            )
+                            sf.set_status(
+                                u.phase,
+                                u.corpus,
+                                u.model,
+                                u.question_id,
+                                u.depth,
+                                Status.ERROR,
+                                error=f"unfilled placeholder: {placeholder}",
+                            )
+                            continue
                         out = _phase1_baseline(anthro, mcp_session, u.corpus, u.question_id, text, run_dir)
                     elif phase in (2, 3, 4, 5, 6):
                         owning_corpus = (
@@ -840,6 +896,31 @@ def main(argv: list[str] | None = None) -> int:
                             else _find_owning_corpus(u.question_id, questions_by_corpus)
                         )
                         text, _lang = _question_text(questions_by_corpus[owning_corpus], u.question_id)
+                        placeholder = find_unfilled_placeholder(text)
+                        if placeholder:
+                            # Same reasoning as phase 1: don't ship a question
+                            # with an unfilled template marker. Mark ERROR so
+                            # the unit shows up in the matrix with a clear
+                            # reason rather than a 422 or a "please clarify"
+                            # answer that looks like an LLM failure.
+                            log.error(
+                                "phase %d aborted for %s/%s/%s: unfilled placeholder %s",
+                                phase,
+                                u.corpus,
+                                u.model,
+                                u.question_id,
+                                placeholder,
+                            )
+                            sf.set_status(
+                                u.phase,
+                                u.corpus,
+                                u.model,
+                                u.question_id,
+                                u.depth,
+                                Status.ERROR,
+                                error=f"unfilled placeholder: {placeholder}",
+                            )
+                            continue
                         out = _run_local(
                             hc=hc,
                             corpus=u.corpus,
@@ -903,7 +984,21 @@ def main(argv: list[str] | None = None) -> int:
                             final_status = Status.ERROR
                             error_msg = f"harness aborted research: {result.get('harness_abort_reason', 'unknown')}"
                         elif result_status == "completed" and result_answer:
-                            final_status = Status.DONE
+                            # Tighter DONE predicate: a non-empty answer is not
+                            # automatically a real engagement with the corpus.
+                            # ``classify_answer`` separates real answers from
+                            # refusals ("I don't have the capability...") and
+                            # roleplay (small models that emit ``[search_documents:
+                            # "..."]`` as text instead of invoking the tool). Both
+                            # the chat path and the research path get the same
+                            # treatment so the matrix consistently captures
+                            # "answer said something useful" vs "answer punted."
+                            label, reason = classify_answer(result_answer)
+                            if label == "real":
+                                final_status = Status.DONE
+                            else:
+                                final_status = Status.DEGRADED
+                                error_msg = reason
                         elif result_status == "completed" and not result_answer:
                             final_status = Status.DEGRADED
                             error_msg = "completed with empty answer"
@@ -934,6 +1029,14 @@ def main(argv: list[str] | None = None) -> int:
                             final_status.value,
                             error_msg,
                         )
+
+                    # Feed the circuit breaker. Only model-running phases
+                    # (2-6) count toward the per-model counter; phase 0/1
+                    # failures aren't symptoms of the model under test
+                    # being unhealthy.
+                    if phase in (2, 3, 4, 5, 6):
+                        op_fault = final_status != Status.DONE and is_operational_failure(error_msg)
+                        breaker.note(u.model, operational_failure=op_fault)
                 except httpx.ConnectError as exc:
                     # HC is refusing connections — likely restarting (e.g.
                     # menubar restarts the API process during a model switch).
@@ -1027,50 +1130,71 @@ def main(argv: list[str] | None = None) -> int:
                     if baseline_path.exists():
                         baseline = json.loads(baseline_path.read_text())
                         model_answer = out.get("result", {}).get("answer", "")
-                        model_doc_ids = [c.get("doc_id") for c in out.get("result", {}).get("citations", [])]
-                        co = citation_overlap(baseline.get("cited_doc_ids", []), model_doc_ids)
-                        ce = citation_extra(baseline.get("cited_doc_ids", []), model_doc_ids)
-                        eo = entity_overlap(baseline.get("answer", ""), model_answer, lang="en")
-
-                        # Run LLM-as-judge when ``_should_judge`` says so. Phase 4
-                        # (main matrix) and phase 5 (parity heavies) qualify;
-                        # earlier phases don't produce a model answer worth
-                        # comparing against the baseline.
-                        if _should_judge(
-                            phase=phase,
-                            status=final_status,
-                            model_answer=model_answer,
-                            no_judge=args.no_judge,
-                        ):
-                            owning_c = (
-                                u.corpus
-                                if u.corpus != "unified"
-                                else _find_owning_corpus(u.question_id, questions_by_corpus)
+                        # Refuse to grade against a baseline that's itself
+                        # unusable — Claude saw an empty corpus, an unfilled
+                        # placeholder, or punted with a refusal. Computing
+                        # citation_overlap or entity_overlap against such an
+                        # answer is noise: the row still gets written so the
+                        # operational status is preserved, but the quality
+                        # columns stay at their zero defaults and we don't
+                        # spend Sonnet credits judging it.
+                        baseline_problem = baseline_quality_problem(baseline)
+                        if baseline_problem:
+                            log.warning(
+                                "skipping metrics for %s/%s/%s: %s",
+                                u.corpus,
+                                u.model,
+                                u.question_id,
+                                baseline_problem,
                             )
-                            text_for_judge, _ = _question_text(questions_by_corpus[owning_c], u.question_id)
-                            try:
-                                v = judge.judge(
-                                    question=text_for_judge,
-                                    baseline=baseline.get("answer", ""),
-                                    model_answer=model_answer,
+                        else:
+                            model_doc_ids = [c.get("doc_id") for c in out.get("result", {}).get("citations", [])]
+                            co = citation_overlap(baseline.get("cited_doc_ids", []), model_doc_ids)
+                            ce = citation_extra(baseline.get("cited_doc_ids", []), model_doc_ids)
+                            eo = entity_overlap(baseline.get("answer", ""), model_answer, lang="en")
+
+                            # Run LLM-as-judge when ``_should_judge`` says so. Phase 4
+                            # (main matrix) and phase 5 (parity heavies) qualify;
+                            # earlier phases don't produce a model answer worth
+                            # comparing against the baseline. Nested under the
+                            # ``baseline_problem is None`` branch so we don't burn
+                            # Sonnet credits judging against a baseline we already
+                            # know is corrupt.
+                            if _should_judge(
+                                phase=phase,
+                                status=final_status,
+                                model_answer=model_answer,
+                                no_judge=args.no_judge,
+                            ):
+                                owning_c = (
+                                    u.corpus
+                                    if u.corpus != "unified"
+                                    else _find_owning_corpus(u.question_id, questions_by_corpus)
                                 )
-                            except Exception:
-                                # Judge failures must not poison the sweep — log
-                                # and carry on with empty verdict columns.
-                                log.warning(
-                                    "judge call failed for %s/%s/%s; continuing without verdict",
-                                    u.corpus,
-                                    u.model,
-                                    u.question_id,
-                                    exc_info=True,
-                                )
-                            else:
-                                (run_dir / "judge" / u.corpus / u.model).mkdir(parents=True, exist_ok=True)
-                                (
-                                    run_dir / "judge" / u.corpus / u.model / f"{u.question_id}__{u.depth}.json"
-                                ).write_text(json.dumps(dataclasses.asdict(v), indent=2))
-                                judge_verdict = v.verdict
-                                judge_completeness = v.completeness
+                                text_for_judge, _ = _question_text(questions_by_corpus[owning_c], u.question_id)
+                                try:
+                                    v = judge.judge(
+                                        question=text_for_judge,
+                                        baseline=baseline.get("answer", ""),
+                                        model_answer=model_answer,
+                                    )
+                                except Exception:
+                                    # Judge failures must not poison the sweep — log
+                                    # and carry on with empty verdict columns.
+                                    log.warning(
+                                        "judge call failed for %s/%s/%s; continuing without verdict",
+                                        u.corpus,
+                                        u.model,
+                                        u.question_id,
+                                        exc_info=True,
+                                    )
+                                else:
+                                    (run_dir / "judge" / u.corpus / u.model).mkdir(parents=True, exist_ok=True)
+                                    (
+                                        run_dir / "judge" / u.corpus / u.model / f"{u.question_id}__{u.depth}.json"
+                                    ).write_text(json.dumps(dataclasses.asdict(v), indent=2))
+                                    judge_verdict = v.verdict
+                                    judge_completeness = v.completeness
 
                         sampler.note(
                             CompletionEvent(

--- a/scripts/test_corpora/tests/test_circuit_breaker.py
+++ b/scripts/test_corpora/tests/test_circuit_breaker.py
@@ -1,0 +1,138 @@
+"""Tests for the per-model CircuitBreaker."""
+
+from __future__ import annotations
+
+import logging
+
+from scripts.test_corpora.runner.circuit_breaker import CircuitBreaker, is_operational_failure
+
+# ── is_operational_failure ──
+
+
+def test_none_is_not_operational() -> None:
+    assert not is_operational_failure(None)
+    assert not is_operational_failure("")
+
+
+def test_refusal_is_not_operational() -> None:
+    # Model declined to engage — real capability signal, not an LLM fault.
+    assert not is_operational_failure("completed with refusal (matched: 'i don't have the capability')")
+
+
+def test_roleplay_is_not_operational() -> None:
+    # Small-model fingerprint, real capability signal.
+    assert not is_operational_failure("completed with tool roleplay (model emitted tool-call syntax as text)")
+
+
+def test_unfilled_placeholder_is_not_operational() -> None:
+    # Test-data problem, not an LLM/HC fault.
+    assert not is_operational_failure("unfilled placeholder: {{contract_a}}")
+
+
+def test_empty_answer_is_operational() -> None:
+    # Dead-LLM cascade signature.
+    assert is_operational_failure("completed with empty answer")
+
+
+def test_interrupted_by_hc_is_operational() -> None:
+    assert is_operational_failure("research interrupted by Harbor Clerk")
+
+
+def test_harness_aborted_is_operational() -> None:
+    assert is_operational_failure("harness aborted research: no SSE events for 311s")
+    assert is_operational_failure("harness aborted research: research status=interrupted")
+
+
+def test_status_failed_is_operational() -> None:
+    assert is_operational_failure("research finished with status=failed")
+    assert is_operational_failure("research finished with status=timeout")
+
+
+def test_unexpected_result_status_is_operational() -> None:
+    assert is_operational_failure("unexpected result status: 'weird'")
+
+
+# ── CircuitBreaker counters ──
+
+
+def test_breaker_counters_start_at_zero() -> None:
+    b = CircuitBreaker()
+    assert b.fail_count("any-model") == 0
+    assert b.trip_count("any-model") == 0
+    assert not b.should_pause("any-model")
+    assert not b.should_skip("any-model")
+
+
+def test_breaker_increments_on_operational_failure() -> None:
+    b = CircuitBreaker(failure_threshold=3)
+    b.note("m1", operational_failure=True)
+    b.note("m1", operational_failure=True)
+    assert b.fail_count("m1") == 2
+    assert not b.should_pause("m1")
+    b.note("m1", operational_failure=True)
+    assert b.fail_count("m1") == 3
+    assert b.should_pause("m1")
+
+
+def test_breaker_resets_on_success() -> None:
+    b = CircuitBreaker(failure_threshold=3)
+    b.note("m1", operational_failure=True)
+    b.note("m1", operational_failure=True)
+    b.note("m1", operational_failure=False)  # one good unit
+    assert b.fail_count("m1") == 0
+    assert not b.should_pause("m1")
+
+
+def test_breaker_resets_on_non_operational_failure() -> None:
+    # A refusal or roleplay is a degraded outcome but the breaker should
+    # treat it like a success — it's model behavior, not LLM unhealth.
+    b = CircuitBreaker(failure_threshold=3)
+    b.note("m1", operational_failure=True)
+    b.note("m1", operational_failure=True)
+    b.note("m1", operational_failure=False)  # refusal/roleplay counts as reset
+    assert b.fail_count("m1") == 0
+
+
+def test_breaker_is_per_model() -> None:
+    b = CircuitBreaker(failure_threshold=3)
+    for _ in range(3):
+        b.note("m1", operational_failure=True)
+    assert b.should_pause("m1")
+    assert not b.should_pause("m2")
+
+
+def test_pause_and_reset_resets_fail_count_increments_trip_count() -> None:
+    sleeps: list[float] = []
+    b = CircuitBreaker(failure_threshold=3, cooldown_seconds=42, sleep=sleeps.append)
+    for _ in range(3):
+        b.note("m1", operational_failure=True)
+    b.pause_and_reset("m1", logging.getLogger("test"))
+    assert sleeps == [42]
+    assert b.fail_count("m1") == 0
+    assert b.trip_count("m1") == 1
+    assert not b.should_pause("m1")
+    assert not b.should_skip("m1")
+
+
+def test_breaker_skips_after_max_trips() -> None:
+    b = CircuitBreaker(failure_threshold=2, max_trips=3, cooldown_seconds=0, sleep=lambda _: None)
+    log = logging.getLogger("test")
+    for _ in range(3):
+        # Each trip: hit threshold then pause_and_reset.
+        b.note("m1", operational_failure=True)
+        b.note("m1", operational_failure=True)
+        assert b.should_pause("m1")
+        b.pause_and_reset("m1", log)
+    assert b.trip_count("m1") == 3
+    assert b.should_skip("m1")
+
+
+def test_breaker_default_knobs_match_design() -> None:
+    # 3 consecutive failures × 3 trips × 60s = 9 failures + 3min of cooldown
+    # before we shed remaining units for a model. Reasonable budget given
+    # the 2026-05-05-prod sweep where empty-answer cascades typically hit
+    # 10+ units in a row.
+    b = CircuitBreaker()
+    assert b.failure_threshold == 3
+    assert b.max_trips == 3
+    assert b.cooldown_seconds == 60

--- a/scripts/test_corpora/tests/test_quality.py
+++ b/scripts/test_corpora/tests/test_quality.py
@@ -1,0 +1,189 @@
+"""Tests for runner.quality — answer/baseline/placeholder validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.test_corpora.runner.quality import (
+    baseline_quality_problem,
+    classify_answer,
+    find_unfilled_placeholder,
+)
+
+# ── classify_answer ──
+
+
+def test_empty_string_is_empty() -> None:
+    label, reason = classify_answer("")
+    assert label == "empty"
+    assert reason == "completed with empty answer"
+
+
+@pytest.mark.parametrize("answer", [" ", "\n", "\t\n  \t"])
+def test_whitespace_only_is_empty(answer: str) -> None:
+    label, _ = classify_answer(answer)
+    assert label == "empty"
+
+
+def test_none_is_empty() -> None:
+    label, _ = classify_answer(None)
+    assert label == "empty"
+
+
+def test_refusal_short_answer() -> None:
+    # Verbatim from phi4-mini cuad-ask-1 in 2026-05-05-prod.
+    answer = (
+        "I'm sorry, but I don't have the capability to search the specific "
+        "documents or retrieve information from them. My responses are based "
+        "on a mixture of licensed data."
+    )
+    label, reason = classify_answer(answer)
+    assert label == "refusal"
+    assert reason is not None
+    assert "refusal" in reason
+
+
+def test_refusal_long_answer_treated_as_real() -> None:
+    # A genuine answer that happens to quote a refusal phrase shouldn't be
+    # flagged. We cap the refusal-detector to short answers (<= 1500 chars).
+    quoted = (
+        "The contract states the parties may terminate with 30 days notice. "
+        "Note: an earlier draft included the boilerplate clause "
+        "'I'm sorry, but I don't have access to external databases' which "
+        "was later struck. "
+    )
+    real_content = "More substantive content. " * 100  # push it past 1500 chars
+    label, _ = classify_answer(quoted + real_content)
+    assert label == "real"
+
+
+def test_roleplay_bracketed_search_documents() -> None:
+    # Verbatim from phi4-mini cuad-ask-4 in 2026-05-05-prod.
+    answer = '[search_documents: "California law contracts"]  [search_documents: "California contract law"]'
+    label, reason = classify_answer(answer)
+    assert label == "roleplay"
+    assert reason is not None
+    assert "roleplay" in reason
+
+
+def test_roleplay_bracketed_kb_search() -> None:
+    answer = "[kb_search: query='contracts']"
+    label, _ = classify_answer(answer)
+    assert label == "roleplay"
+
+
+def test_roleplay_with_whitespace_around_tool_name() -> None:
+    answer = "[ search_documents: 'foo' ]"
+    label, _ = classify_answer(answer)
+    assert label == "roleplay"
+
+
+def test_roleplay_beats_refusal_when_both_present() -> None:
+    # An answer that both roleplays AND apologizes should be classified as
+    # roleplay (the more specific failure mode).
+    answer = "I'm sorry, but I don't have the capability. [search_documents: 'foo']"
+    label, _ = classify_answer(answer)
+    assert label == "roleplay"
+
+
+def test_real_answer_passes() -> None:
+    answer = (
+        "The termination notice period in the Vendor Agreement is 30 days. "
+        "Page 4, section 9.1. [VendorAgreement.pdf, page 4]"
+    )
+    label, reason = classify_answer(answer)
+    assert label == "real"
+    assert reason is None
+
+
+def test_real_answer_with_brackets_but_no_tool_name() -> None:
+    # Quoting "[California law]" or similar must not match the roleplay
+    # regex — only known tool names with the bracket prefix do.
+    answer = "The contract was governed by [California law] and exclusively."
+    label, _ = classify_answer(answer)
+    assert label == "real"
+
+
+# ── find_unfilled_placeholder ──
+
+
+def test_unfilled_placeholder_found() -> None:
+    text = "What is the governing law of the {{contract_a}} agreement?"
+    assert find_unfilled_placeholder(text) == "{{contract_a}}"
+
+
+def test_unfilled_placeholder_with_spaces() -> None:
+    text = "List parties to the {{ contract_b }} agreement"
+    assert find_unfilled_placeholder(text) == "{{ contract_b }}"
+
+
+def test_no_placeholder_returns_none() -> None:
+    assert find_unfilled_placeholder("What is the governing law?") is None
+
+
+def test_empty_text_returns_none() -> None:
+    assert find_unfilled_placeholder("") is None
+    assert find_unfilled_placeholder(None) is None  # type: ignore[arg-type]
+
+
+def test_single_brace_does_not_match() -> None:
+    # A single brace like {foo} or }foo{ should not be treated as a
+    # placeholder — only the double-brace Jinja-style form.
+    assert find_unfilled_placeholder("Show {foo}") is None
+    assert find_unfilled_placeholder("Show }contract_a{") is None
+
+
+def test_only_first_placeholder_returned() -> None:
+    text = "Compare {{contract_a}} with {{contract_b}}"
+    assert find_unfilled_placeholder(text) == "{{contract_a}}"
+
+
+# ── baseline_quality_problem ──
+
+
+def test_baseline_empty_answer() -> None:
+    assert baseline_quality_problem({"answer": ""}) == "baseline answer is empty"
+    assert baseline_quality_problem({"answer": "   "}) == "baseline answer is empty"
+    assert baseline_quality_problem({}) == "baseline answer is empty"
+
+
+def test_baseline_not_a_dict() -> None:
+    assert baseline_quality_problem("not a dict") is not None  # type: ignore[arg-type]
+
+
+def test_baseline_says_corpus_empty() -> None:
+    # Verbatim from cuad-research-1 baseline in 2026-05-05-prod.
+    baseline = {
+        "answer": (
+            "The corpus appears to be **completely empty** — there are "
+            "currently **no documents** ingested into the knowledge base."
+        )
+    }
+    assert baseline_quality_problem(baseline) == "baseline says corpus is empty"
+
+
+def test_baseline_saw_placeholder() -> None:
+    # Verbatim from cuad-ask-1 baseline in 2026-05-05-prod.
+    baseline = {"answer": ("I notice your message contains an unfilled template placeholder: **`{{contract_a}}`**.")}
+    assert baseline_quality_problem(baseline) == "baseline saw unfilled placeholder"
+
+
+def test_baseline_found_nothing() -> None:
+    # Verbatim from synthetic-ask-1 baseline.
+    baseline = {
+        "answer": (
+            "I was unable to find any information about a Q3 vendor contract "
+            "with Globex Supplies in the knowledge base."
+        )
+    }
+    assert baseline_quality_problem(baseline) == "baseline found no matching documents"
+
+
+def test_baseline_real_answer_passes() -> None:
+    baseline = {
+        "answer": (
+            "The termination notice period in the Vendor Agreement is 30 days. "
+            "This is consistent with industry practice for service agreements."
+        )
+    }
+    assert baseline_quality_problem(baseline) is None


### PR DESCRIPTION
## Summary

Three robustness improvements to the test-corpora sweep, addressing the operational failure patterns visible in the 2026-05-05-prod analysis:

**1. Tighter `DONE` predicate (item 7)** — `classify_answer` separates real answers from refusals (*"I don't have the capability..."*) and tool roleplay (small models that emit `[search_documents: "..."]` as text instead of invoking the tool). DONE → DEGRADED with a specific reason in those cases. Phi4-mini's "100% pass" on `cuad-ask-*` in the last sweep was built entirely on refusal-style answers; the tighter predicate surfaces them so the matrix stops conflating "answered the question" with "responded with anything."

**2. Hard-fail unfilled `{{...}}` placeholders (item 4)** — questions that still contain a `{{contract_a}}`-style marker are refused before the LLM is touched. `cuad-ask-1/2/3` in the last sweep shipped placeholders verbatim because the sampler apparently didn't run; this stops that from costing baseline credits *or* producing "please clarify" answers across every model.

**3. Reject corrupt baselines for metric computation (item 4 cont.)** — `baseline_quality_problem` flags baseline answers that say *"corpus is empty"*, *"I was unable to find"*, *"I notice your message contains an unfilled placeholder"*, etc. When the baseline is unusable, the sweep still records the operational status but skips `citation_overlap` / `entity_overlap` / judge — there's no point computing them against a baseline Claude couldn't actually answer.

**4. Per-model circuit breaker (item 3)** — tracks consecutive *operational* failures per model (empty-answer cascades, HC-side interrupts, harness aborts, `status=failed`). Refusal and roleplay do **not** count — those are real capability signal, not LLM unhealth. After 3 consecutive op-faults, cooldown 60 s and reset. After 3 trip cycles for the same model, skip remaining units for it (left PENDING so `--resume` picks them up). Caps the damage from the 124-of-386 empty-answer cascade pattern in the last sweep, where 10+ asks burned through in 20 s while HC was silently broken.

## Expected impact

- Units now distinguish "responded with anything" from "actually engaged with the corpus." Refusals and roleplay land in `degraded` with explicit reasons.
- A dead-LLM cascade no longer torches 10+ units in 20 s. Worst case: 3 failures → 60 s sleep, 3 more → 60 s sleep, 3 more → skip the model. ~9 op-faults + 3 min wait before shedding instead of dozens of units.
- Corrupt baselines (cuad-research-1, several enron baselines) no longer produce noisy zero-value rows that look like the model failed.

## Test plan

- [x] 25 unit tests on `quality.py` (classify_answer, find_unfilled_placeholder, baseline_quality_problem)
- [x] 17 unit tests on `circuit_breaker.py` (per-model counters, threshold, cooldown, max-trips skip)
- [x] All 180 harness tests pass (was 138 — 42 new); 651 main repo tests still pass
- [x] Fresh-eyes review caught 2 findings ≥80 confidence, both addressed in [bf8d504](https://github.com/r0shi/harborclerk/commit/bf8d504): redundant `u.model` log arg removed, dead `elif` branch collapsed so `classify_answer` is the single authority on `completed`-status outcomes

## Out of scope (follow-ups still queued)

- Per-corpus canary chat before each phase
- Capture HC server logs into run dir
- Capture `messages[]` for ask responses
- Surface structured `interrupt_reason` from HC
- Regenerate the cuad-ask-1/2/3, cuad-research-1, enron-research-1 baselines (these are now identified as corrupt by `baseline_quality_problem`, so the next sweep will skip them gracefully; a follow-up will replace them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
