### PR TITLE
feat(harness): canary + log capture + interrupt_reason + tool_events

### DIFF
--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -133,6 +133,125 @@ def _should_judge(*, phase: int, status: Status, model_answer: str, no_judge: bo
     return bool(model_answer and model_answer.strip())
 
 
+_CANARY_QUESTION = "List up to three documents you can see in the corpus and tell me their titles."
+
+
+def _capture_hc_logs(run_dir: Path, log: logging.Logger) -> None:
+    """Copy Harbor Clerk's server-side log files into the run directory.
+
+    Without this, when the harness records ``"research interrupted by Harbor
+    Clerk"`` there's no easy way to tell *why* — the only log written into
+    the run directory is the harness side. HC's own log (api.log,
+    worker-*.log, postgres.log, llm.log, etc.) lives in
+    ``~/Library/Application Support/Harbor Clerk/logs/`` on macOS native.
+
+    Honours the ``HC_LOG_DIR`` env var. Best-effort: a missing source
+    directory or unreadable file is logged at warning level and skipped,
+    never raised — the sweep must not fail at finalize because logs
+    couldn't be copied.
+
+    Called once at sweep finalize. Captures a snapshot, not a tail —
+    operators interpret the timeline by cross-referencing with the
+    harness ``log.txt`` and ``metrics.csv`` timestamps.
+    """
+    import shutil
+
+    default_log_dir = Path.home() / "Library" / "Application Support" / "Harbor Clerk" / "logs"
+    src_dir = Path(os.environ.get("HC_LOG_DIR") or default_log_dir)
+    if not src_dir.exists():
+        log.info("HC log capture skipped: source dir %s does not exist", src_dir)
+        return
+
+    dst_dir = run_dir / "hc_logs"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    skipped = 0
+    for src in src_dir.glob("*.log"):
+        if not src.is_file():
+            continue
+        try:
+            shutil.copy2(src, dst_dir / src.name)
+            copied += 1
+        except OSError as exc:
+            log.warning("HC log capture: failed to copy %s: %r", src, exc)
+            skipped += 1
+
+    log.info(
+        "HC log capture: copied %d files from %s to %s (skipped %d)",
+        copied,
+        src_dir,
+        dst_dir,
+        skipped,
+    )
+
+
+def _run_canary(hc: HarborClerkClient, corpus: str, log: logging.Logger) -> dict[str, object]:
+    """Send one trivial chat question to verify HC + the active LLM can produce
+    a non-empty, non-refusal response against the just-ingested corpus.
+
+    Used as a pre-flight diagnostic before the per-unit loop chews through
+    20+ units against a structurally broken HC (the synthetic-block 100%
+    failure pattern in 2026-05-05-prod: 280 docs ingested, model_status
+    ready, every chat returns empty in 2s). The canary catches that state
+    in ~3s instead of burning hours of sweep time.
+
+    Returns a result dict with keys:
+      - ``passed`` (bool): True if the answer classified as "real"
+      - ``label`` (str): classify_answer's label (real/refusal/roleplay/empty)
+      - ``elapsed_seconds`` (float): wall clock of the chat call
+      - ``answer_chars`` (int): length of the streamed answer
+      - ``reason`` (str | None): the reason from classify_answer when failed
+
+    This function NEVER raises; on exception the result records ``passed=False``
+    with a stringified error in ``reason``. The canary must not be a source
+    of new failure modes.
+    """
+    t0 = time.time()
+    try:
+        conv_id = hc.create_conversation(title=f"test-corpora/canary/{corpus}")
+        events = list(hc.stream_ask(conv_id, _CANARY_QUESTION))
+    except Exception as exc:
+        log.warning("canary failed for corpus=%s: exception during chat: %r", corpus, exc)
+        return {
+            "passed": False,
+            "label": "exception",
+            "elapsed_seconds": time.time() - t0,
+            "answer_chars": 0,
+            "reason": f"exception: {exc!r}",
+        }
+
+    final_text = "".join(e.get("content", "") for e in events if e.get("type") == "token")
+    elapsed = time.time() - t0
+    label, reason = classify_answer(final_text)
+    passed = label == "real"
+
+    if passed:
+        log.info(
+            "canary OK for corpus=%s: %d chars in %.1fs",
+            corpus,
+            len(final_text),
+            elapsed,
+        )
+    else:
+        log.warning(
+            "canary failed for corpus=%s: label=%s reason=%s (elapsed %.1fs, %d chars)",
+            corpus,
+            label,
+            reason,
+            elapsed,
+            len(final_text),
+        )
+
+    return {
+        "passed": passed,
+        "label": label,
+        "elapsed_seconds": elapsed,
+        "answer_chars": len(final_text),
+        "reason": reason,
+    }
+
+
 def _is_retryable_research_failure(out: dict) -> bool:
     """Whether ``out["result"]`` warrants a one-shot retry.
 
@@ -187,6 +306,28 @@ def make_parser() -> argparse.ArgumentParser:
         help=(
             "skip the LLM-as-judge call in phases 4 and 5. Use for cheap local-only "
             "runs when you don't want to spend Anthropic credits on Sonnet judgments."
+        ),
+    )
+    p.add_argument(
+        "--skip-canary",
+        action="store_true",
+        help=(
+            "skip the per-corpus canary pre-flight chat. The canary catches the "
+            "structurally-broken-corpus pattern (all units degrade in 2s) in ~3s "
+            "instead of letting the circuit breaker chew through 9+ units first. "
+            "Pass this flag to disable on local runs where the diagnostic noise "
+            "isn't worth the extra chat call."
+        ),
+    )
+    p.add_argument(
+        "--no-hc-logs",
+        action="store_true",
+        help=(
+            "skip the HC log capture at sweep finalize. By default the harness "
+            "copies $HC_LOG_DIR (or ~/Library/Application Support/Harbor Clerk/"
+            "logs on macOS) into <run_dir>/hc_logs/ so post-hoc analysis can "
+            "cross-reference HC's own logs against metrics.csv timestamps. "
+            "Pass this flag on machines where the path doesn't apply."
         ),
     )
     return p
@@ -379,7 +520,21 @@ def _run_local(
                 rc = e.get("rag_context") or {}
                 for c in rc.get("citations", []) or e.get("citations", []):
                     citations.append(c if isinstance(c, dict) else {"doc_id": c})
-        result = {"status": "completed", "answer": final_text, "citations": citations, "conversation_id": conv_id}
+        # Preserve the raw SSE event stream so post-hoc analysis can tell
+        # ``model invoked the tool`` from ``model narrated a tool call as
+        # text.`` ``tool_call`` and ``tool_result`` events carry the
+        # function name + arguments + raw result; ``tool_call_count`` is
+        # the cheap summary the matrix can group by.
+        tool_events = [e for e in events if e.get("type") in ("tool_call", "tool_result")]
+        tool_call_count = sum(1 for e in events if e.get("type") == "tool_call")
+        result = {
+            "status": "completed",
+            "answer": final_text,
+            "citations": citations,
+            "conversation_id": conv_id,
+            "tool_events": tool_events,
+            "tool_call_count": tool_call_count,
+        }
 
     out = {
         "corpus": corpus,
@@ -652,6 +807,13 @@ def main(argv: list[str] | None = None) -> int:
         # broken until manual intervention.
         breaker = CircuitBreaker()
 
+        # Per-corpus canary outcomes. Run once per corpus before the first
+        # phase-2-6 unit, write to ``canary.json`` in the run dir for
+        # post-hoc analysis. Advisory only — the circuit breaker handles
+        # cascade prevention; this just gives operators a heads-up when a
+        # whole corpus block is structurally broken.
+        canary_results: dict[str, dict[str, object]] = {}
+
         # CSV metrics
         metrics_path = run_dir / "metrics.csv"
         new_csv = not metrics_path.exists()
@@ -795,6 +957,17 @@ def main(argv: list[str] | None = None) -> int:
                         continue
                     if breaker.should_pause(u.model):
                         breaker.pause_and_reset(u.model, log)
+
+                # Per-corpus canary. Runs once per corpus the first time we
+                # hit a phase-2-6 unit for it, after the model is set. Advisory
+                # only — purely a diagnostic so operators can tell at a glance
+                # whether a (corpus, configured-model) combo is healthy before
+                # the breaker has to catch up. ``--skip-canary`` opts out.
+                if phase in (2, 3, 4, 5, 6) and not args.skip_canary and u.corpus not in canary_results:
+                    canary_results[u.corpus] = _run_canary(hc, u.corpus, log)
+                    # Persist after each canary so a crash mid-sweep doesn't
+                    # lose the diagnostic.
+                    (run_dir / "canary.json").write_text(json.dumps(canary_results, indent=2))
 
                 # Ensure correct corpus is in the DB for phases 1/4/5 (unified for 6).
                 # Phase 1 baselines call HC's MCP for KB tools — Sonnet's queries hit
@@ -1002,10 +1175,26 @@ def main(argv: list[str] | None = None) -> int:
                                 error_msg = reason
                         elif result_status == "interrupted":
                             final_status = Status.ERROR
-                            error_msg = "research interrupted by Harbor Clerk"
+                            # ``result["error"]`` carries the structured reason
+                            # HC set on the ResearchState row (synthesis HTTP
+                            # error, reaper timeout, stream disconnect). Falls
+                            # back to the generic label only when the field is
+                            # absent — older snapshots before the schema field
+                            # was added still parse cleanly.
+                            hc_error = result.get("error")
+                            error_msg = (
+                                f"research interrupted by Harbor Clerk: {hc_error}"
+                                if hc_error
+                                else "research interrupted by Harbor Clerk"
+                            )
                         elif result_status in ("failed", "timeout"):
                             final_status = Status.ERROR
-                            error_msg = f"research finished with status={result_status}"
+                            hc_error = result.get("error")
+                            error_msg = (
+                                f"research finished with status={result_status}: {hc_error}"
+                                if hc_error
+                                else f"research finished with status={result_status}"
+                            )
                         else:
                             final_status = Status.ERROR
                             error_msg = f"unexpected result status: {result_status!r}"
@@ -1232,6 +1421,8 @@ def main(argv: list[str] | None = None) -> int:
             sampler.print_summary_table(phase=phase)
 
         metrics_f.close()
+        if not args.no_hc_logs:
+            _capture_hc_logs(run_dir, log)
         log.info("sweep complete after %.1fs", time.time() - sweep_started)
         return 0
     finally:

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -958,17 +958,6 @@ def main(argv: list[str] | None = None) -> int:
                     if breaker.should_pause(u.model):
                         breaker.pause_and_reset(u.model, log)
 
-                # Per-corpus canary. Runs once per corpus the first time we
-                # hit a phase-2-6 unit for it, after the model is set. Advisory
-                # only — purely a diagnostic so operators can tell at a glance
-                # whether a (corpus, configured-model) combo is healthy before
-                # the breaker has to catch up. ``--skip-canary`` opts out.
-                if phase in (2, 3, 4, 5, 6) and not args.skip_canary and u.corpus not in canary_results:
-                    canary_results[u.corpus] = _run_canary(hc, u.corpus, log)
-                    # Persist after each canary so a crash mid-sweep doesn't
-                    # lose the diagnostic.
-                    (run_dir / "canary.json").write_text(json.dumps(canary_results, indent=2))
-
                 # Ensure correct corpus is in the DB for phases 1/4/5 (unified for 6).
                 # Phase 1 baselines call HC's MCP for KB tools — Sonnet's queries hit
                 # whatever is currently in HC's DB, so a fresh sweep that doesn't
@@ -1003,6 +992,21 @@ def main(argv: list[str] | None = None) -> int:
                 # Ensure correct model is active for phases 2-6
                 if phase in (2, 3, 4, 5, 6) and u.model not in (None, "-", "claude-baseline"):
                     current_model = _ensure_model(hc, current_model, u.model)
+
+                # Per-corpus canary. Runs once per corpus the first time we
+                # hit a phase-2-6 unit for it, AFTER both corpus ingest and
+                # model activation — otherwise the canary tests against
+                # whatever HC happened to have loaded (often nothing on a
+                # fresh run), producing a misleading "empty" diagnostic
+                # unrelated to the structurally-broken-corpus pattern the
+                # canary is meant to catch. Advisory only: the circuit
+                # breaker handles cascade prevention; this just gives
+                # operators an early signal. ``--skip-canary`` opts out.
+                if phase in (2, 3, 4, 5, 6) and not args.skip_canary and u.corpus not in canary_results:
+                    canary_results[u.corpus] = _run_canary(hc, u.corpus, log)
+                    # Persist after each canary so a crash mid-sweep doesn't
+                    # lose the diagnostic.
+                    (run_dir / "canary.json").write_text(json.dumps(canary_results, indent=2))
 
                 sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.IN_PROGRESS)
                 sf.save()

--- a/scripts/test_corpora/tests/test_canary_and_logs.py
+++ b/scripts/test_corpora/tests/test_canary_and_logs.py
@@ -1,0 +1,168 @@
+"""Tests for the canary + HC log capture helpers in sweep.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.test_corpora.runner.sweep import _capture_hc_logs, _run_canary
+
+# ── _run_canary ──
+
+
+def _fake_hc(events: Iterable[dict], *, raise_on_create: bool = False, raise_on_stream: bool = False):
+    """Construct a MagicMock HC client that returns ``events`` from stream_ask."""
+    hc = MagicMock()
+    if raise_on_create:
+        hc.create_conversation.side_effect = RuntimeError("simulated HC down")
+    else:
+        hc.create_conversation.return_value = "conv-1"
+    if raise_on_stream:
+        hc.stream_ask.side_effect = RuntimeError("simulated stream failure")
+    else:
+        hc.stream_ask.return_value = events
+    return hc
+
+
+def test_canary_passes_on_real_answer() -> None:
+    events = [
+        {"type": "token", "content": "I found three documents: "},
+        {"type": "token", "content": "Vendor Agreement, Master Services, and HR Policy."},
+        {"type": "done"},
+    ]
+    hc = _fake_hc(events)
+    out = _run_canary(hc, "cuad", logging.getLogger("test"))
+    assert out["passed"] is True
+    assert out["label"] == "real"
+    assert out["answer_chars"] > 0
+    assert out["reason"] is None
+    hc.create_conversation.assert_called_once()
+    hc.stream_ask.assert_called_once()
+
+
+def test_canary_fails_on_empty_stream() -> None:
+    # Verbatim signature of the dead-LLM cascade: chat returns "completed"
+    # with no token events in ~2s.
+    events = [{"type": "done"}]
+    hc = _fake_hc(events)
+    out = _run_canary(hc, "cuad", logging.getLogger("test"))
+    assert out["passed"] is False
+    assert out["label"] == "empty"
+    assert out["answer_chars"] == 0
+
+
+def test_canary_fails_on_refusal() -> None:
+    events = [
+        {"type": "token", "content": "I'm sorry, but I don't have the capability to search the documents."},
+        {"type": "done"},
+    ]
+    hc = _fake_hc(events)
+    out = _run_canary(hc, "cuad", logging.getLogger("test"))
+    assert out["passed"] is False
+    assert out["label"] == "refusal"
+
+
+def test_canary_fails_on_create_conversation_exception() -> None:
+    hc = _fake_hc(events=[], raise_on_create=True)
+    out = _run_canary(hc, "cuad", logging.getLogger("test"))
+    assert out["passed"] is False
+    assert out["label"] == "exception"
+    assert "simulated HC down" in str(out["reason"])
+
+
+def test_canary_fails_on_stream_exception() -> None:
+    hc = _fake_hc(events=[], raise_on_stream=True)
+    out = _run_canary(hc, "cuad", logging.getLogger("test"))
+    assert out["passed"] is False
+    assert out["label"] == "exception"
+    assert "simulated stream failure" in str(out["reason"])
+
+
+def test_canary_result_is_json_serialisable() -> None:
+    # The result dict is persisted to ``canary.json`` in the run dir.
+    # If anything in the dict isn't JSON-serialisable, the persistence
+    # crashes the sweep at unit time, which is exactly the failure mode
+    # the canary is supposed to head off.
+    events = [{"type": "token", "content": "Hello."}, {"type": "done"}]
+    hc = _fake_hc(events)
+    out = _run_canary(hc, "cuad", logging.getLogger("test"))
+    json.dumps(out)  # must not raise
+
+
+# ── _capture_hc_logs ──
+
+
+def test_capture_hc_logs_copies_log_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src_dir = tmp_path / "src_logs"
+    src_dir.mkdir()
+    (src_dir / "api.log").write_text("api line 1\n")
+    (src_dir / "worker-io.log").write_text("worker line 1\n")
+    (src_dir / "not-a-log.txt").write_text("ignored\n")
+
+    monkeypatch.setenv("HC_LOG_DIR", str(src_dir))
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    _capture_hc_logs(run_dir, logging.getLogger("test"))
+
+    dst = run_dir / "hc_logs"
+    assert dst.exists()
+    assert (dst / "api.log").read_text() == "api line 1\n"
+    assert (dst / "worker-io.log").read_text() == "worker line 1\n"
+    # Only *.log files should be copied; .txt should be skipped.
+    assert not (dst / "not-a-log.txt").exists()
+
+
+def test_capture_hc_logs_handles_missing_source_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HC_LOG_DIR", str(tmp_path / "does_not_exist"))
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    # Must not raise — best-effort behavior is documented.
+    _capture_hc_logs(run_dir, logging.getLogger("test"))
+    assert not (run_dir / "hc_logs").exists()
+
+
+def test_capture_hc_logs_respects_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # When HC_LOG_DIR is set, it overrides the default macOS path.
+    custom_src = tmp_path / "custom"
+    custom_src.mkdir()
+    (custom_src / "test.log").write_text("custom\n")
+
+    monkeypatch.setenv("HC_LOG_DIR", str(custom_src))
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    _capture_hc_logs(run_dir, logging.getLogger("test"))
+    assert (run_dir / "hc_logs" / "test.log").read_text() == "custom\n"
+
+
+def test_capture_hc_logs_creates_destination_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.log").write_text("data\n")
+    monkeypatch.setenv("HC_LOG_DIR", str(src))
+
+    # run_dir exists but no hc_logs subdir yet
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    assert not (run_dir / "hc_logs").exists()
+
+    _capture_hc_logs(run_dir, logging.getLogger("test"))
+    assert (run_dir / "hc_logs").is_dir()
+
+
+def test_capture_hc_logs_no_env_var_uses_macos_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # When HC_LOG_DIR is absent, the function should fall through to the
+    # macOS default. We can't test that path actually works (the directory
+    # may or may not exist on the test machine), but we can verify the
+    # absence-of-env-var branch doesn't crash.
+    monkeypatch.delenv("HC_LOG_DIR", raising=False)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    # Must not raise regardless of default-path existence.
+    _capture_hc_logs(run_dir, logging.getLogger("test"))

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -196,6 +196,7 @@ async def get_research(
         model_id=report_model_id or (get_settings().llm_model_id or None),
         messages=messages,
         citations=citations,
+        error=state.error,
         created_at=conv.created_at,
         completed_at=state.completed_at,
     )

--- a/src/harbor_clerk/api/schemas/research.py
+++ b/src/harbor_clerk/api/schemas/research.py
@@ -66,6 +66,14 @@ class ResearchDetail(BaseModel):
     # ``pages``, ``score``. Computed at read-time from persisted tool messages
     # so historical research surfaces citations too.
     citations: list[dict] = []
+    # Free-text reason set when the research moved to ``interrupted`` or
+    # ``failed``. Examples: ``"Synthesis failed: LLM error (502)"``,
+    # ``"Research task stalled — no progress for 5+ minutes"`` (reaper),
+    # ``"Stream disconnected before completion"``. Used by the test harness
+    # to attribute interrupts to a specific cause (synthesis failure vs.
+    # reaper vs. client disconnect) rather than collapsing them all into
+    # the generic ``"research interrupted by Harbor Clerk"`` label.
+    error: str | None = None
     created_at: datetime
     completed_at: datetime | None = None
 

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -1395,6 +1395,12 @@ async def research_stream(
                     logger.info("Research stream disconnected, marking interrupted (conversation=%s)", conversation_id)
                     state.status = "interrupted"
                     state.current_round = step_count
+                    # Default reason so the API surfaces *something* on the
+                    # ``error`` field rather than ``null``. The other two
+                    # interrupt paths (synthesis HTTP error, synthesis
+                    # connect/timeout) already set a specific reason above.
+                    if not state.error:
+                        state.error = "Research stream disconnected before completion"
                     await session.commit()
             except Exception:
                 logger.exception("Failed to mark research as interrupted on disconnect")

--- a/tests/test_api_research_citations.py
+++ b/tests/test_api_research_citations.py
@@ -22,6 +22,7 @@ async def _seed_research(
     admin_user,
     *,
     status: str = "completed",
+    error: str | None = None,
     tool_messages: list[tuple[str, str]] | None = None,
 ) -> uuid.UUID:
     """Insert a conversation + research_state + (optionally) tool messages.
@@ -43,6 +44,7 @@ async def _seed_research(
         conversation_id=conv_id,
         strategy="search",
         status=status,
+        error=error,
         current_round=2,
         max_rounds=4,
     )
@@ -188,3 +190,40 @@ async def test_research_detail_citations_from_read_passages_keeps_chunk_only(
     assert "doc_id" not in cites[0]
     assert cites[0]["chunk_id"] == "C1"
     assert cites[0]["doc_title"] == "X"
+
+
+# ── error field ──
+
+
+async def test_research_detail_error_field_null_on_success(client, admin_user, admin_token, db_session):
+    conv_id = await _seed_research(db_session, admin_user, status="completed")
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["error"] is None
+
+
+async def test_research_detail_error_field_surfaces_reaper_reason(client, admin_user, admin_token, db_session):
+    # The reaper at app.py:154 sets this exact string when heartbeat goes stale.
+    conv_id = await _seed_research(
+        db_session,
+        admin_user,
+        status="interrupted",
+        error="Research task stalled — no progress for 5+ minutes",
+    )
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["error"] == "Research task stalled — no progress for 5+ minutes"
+
+
+async def test_research_detail_error_field_surfaces_synthesis_failure(client, admin_user, admin_token, db_session):
+    # research.py:1342 sets this when llama-server returns an HTTP error during
+    # the final synthesis pass.
+    conv_id = await _seed_research(
+        db_session,
+        admin_user,
+        status="interrupted",
+        error="Synthesis failed: LLM error (502)",
+    )
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["error"] == "Synthesis failed: LLM error (502)"


### PR DESCRIPTION
## Summary

Four instrumentation improvements addressing the remaining items from the test-corpora improvement punch list — `#6` (per-corpus canary), `#8` (HC log capture), `#9` (interrupt_reason), `#10` (tool_events).

**Per-corpus canary (#6)** — `_run_canary` sends one trivial chat (*"List up to three documents you can see in the corpus and tell me their titles"*) at the first phase-2-6 unit for each corpus. Result classified via `classify_answer` and persisted to `<run_dir>/canary.json`. Advisory only — the circuit breaker handles cascade prevention; this catches the structurally-broken-corpus pattern (synthetic block: 280 docs ingested, model_status ready, every chat returns empty in 2 s) in ~3 s so the operator gets early visibility. `--skip-canary` opts out.

**HC log capture (#8)** — `_capture_hc_logs` copies HC's `*.log` files into `<run_dir>/hc_logs/` at sweep finalize. Without this, when the harness records *"research interrupted by Harbor Clerk"* there's no way to cross-reference with HC's own logs (api, worker, llm). Honours `HC_LOG_DIR` env var with a macOS default. `--no-hc-logs` opts out. Best-effort: missing source dir or copy errors are logged and skipped, never raised.

**Interrupt reason (#9)** — `ResearchDetail` gains an `error: str | None` field carrying the structured reason HC set on the `ResearchState` row. The harness can now distinguish reaper timeout (*"Research task stalled — no progress for 5+ minutes"*) from synthesis failure (*"Synthesis failed: LLM error (502)"*) from stream disconnect (*"Research stream disconnected before completion"*). The stream-disconnect path in `research.py` now sets a default reason so the field is never null for an interrupted task. The harness's status-assignment elif chain reads `result.error` and appends it to `error_msg` so `metrics.csv` carries the structured reason.

**tool_events for asks (#10)** — the chat ask flow's result dict now includes `tool_events` (the raw SSE events for `tool_call` + `tool_result`) and `tool_call_count`. Previously the collapsed `final_text` alone couldn't distinguish *"model invoked the tool"* from *"model narrated a tool call as text"* — the phi4-mini roleplay fingerprint — so post-hoc analysis lacked the data to confirm the `classify_answer` roleplay heuristic. Now it has it.

## Expected impact

Together with PRs #337 and #338, the sweep now produces honest, actionable signal:

| Signal | Before | After this 3-PR arc |
|---|---|---|
| `citation_overlap` | 0 in every row | populated from real model citations |
| `judge_verdict` | empty in every phase-4 row | populated for every DONE row with a non-empty answer |
| `status=done` predicate | "answered with anything" | refusals/roleplay/empty all routed to DEGRADED |
| Empty-answer cascades | 10+ units burn through in 20s | breaker pauses after 3, skips model after 9 |
| Corrupt baselines | computed against anyway | flagged, metrics skipped |
| Structurally broken corpus | discovered 50+ units in | canary diagnostic in ~3s |
| "Why was research interrupted?" | always generic label | structured HC reason in `metrics.csv` |
| "Did the model use the tool?" | unknowable | `tool_events` + `tool_call_count` |
| "What was HC doing?" | only harness logs | HC's logs copied into run dir |

## Test plan

- [x] 11 new harness tests on `_run_canary` and `_capture_hc_logs` (happy path, empty/refusal/exception, JSON-serializability, env var override, missing source dir)
- [x] 3 new main-suite tests on `ResearchDetail.error` field (null on success, reaper reason, synthesis failure reason)
- [x] 191 harness + 654 main tests pass; no regressions
- [x] Fresh-eyes review caught 1 finding ≥80 confidence — canary fired before corpus ingest and model activation, addressed in [18f6c0a](https://github.com/r0shi/harborclerk/commit/18f6c0a) by re-ordering the per-unit body so canary runs after both gates

## Out of scope (follow-up)

- Item 5: regenerate the corrupt baselines (cuad-ask-1/2/3, cuad-research-1, enron-research-1). PR #338 already makes them harmless — `baseline_quality_problem` flags them and the sweep skips their metric computation — but they should be replaced for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
