### PR TITLE
fix(menubar): bound shutdown to 30s; defuse Pipe+waitUntilExit deadlock

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
+++ b/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A100000017 /* LlamaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000017; };
 		A100000028 /* WatcherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000028; };
 		A100000050 /* MasterKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000050; };
+		A100000060 /* ProcessExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000060; };
 		AT10000001 /* WorkerCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000001; };
 		AT10000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000002; };
 		AT10000003 /* OverallStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000003; };
@@ -33,6 +34,7 @@
 		AT10000006 /* ServiceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000006; };
 		AT10000007 /* BundleResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000007; };
 		AT10000010 /* MasterKeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000010; };
+		AT10000011 /* ProcessExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000011; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +68,7 @@
 		B100000017 /* LlamaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaService.swift; sourceTree = "<group>"; };
 		B100000028 /* WatcherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatcherService.swift; sourceTree = "<group>"; };
 		B100000050 /* MasterKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyManager.swift; sourceTree = "<group>"; };
+		B100000060 /* ProcessExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensions.swift; sourceTree = "<group>"; };
 		D100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D100000002 /* HarborClerkServer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HarborClerkServer.entitlements; sourceTree = "<group>"; };
 		CT10000001 /* HarborClerkServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HarborClerkServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -76,6 +79,7 @@
 		BT10000006 /* ServiceConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceConfigTests.swift; sourceTree = "<group>"; };
 		BT10000007 /* BundleResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleResourceTests.swift; sourceTree = "<group>"; };
 		BT10000010 /* MasterKeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyManagerTests.swift; sourceTree = "<group>"; };
+		BT10000011 /* ProcessExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +123,7 @@
 				B100000014 /* Settings.swift */,
 				B100000015 /* PreferencesWindow.swift */,
 				B100000050 /* MasterKeyManager.swift */,
+				B100000060 /* ProcessExtensions.swift */,
 				B100000016 /* Assets.xcassets */,
 				D100000001 /* Info.plist */,
 				D100000002 /* HarborClerkServer.entitlements */,
@@ -160,6 +165,7 @@
 				BT10000006 /* ServiceConfigTests.swift */,
 				BT10000007 /* BundleResourceTests.swift */,
 				BT10000010 /* MasterKeyManagerTests.swift */,
+				BT10000011 /* ProcessExtensionsTests.swift */,
 			);
 			path = HarborClerkServerTests;
 			sourceTree = "<group>";
@@ -294,6 +300,7 @@
 				A100000017 /* LlamaService.swift in Sources */,
 				A100000028 /* WatcherService.swift in Sources */,
 				A100000050 /* MasterKeyManager.swift in Sources */,
+				A100000060 /* ProcessExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -308,6 +315,7 @@
 				AT10000006 /* ServiceConfigTests.swift in Sources */,
 				AT10000007 /* BundleResourceTests.swift in Sources */,
 				AT10000010 /* MasterKeyManagerTests.swift in Sources */,
+				AT10000011 /* ProcessExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -52,8 +52,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard !isQuitting else { return .terminateNow }
         isQuitting = true
         healthChecker.stopPolling()
+
+        // 30-second hard deadline. The audit memo
+        // (project_menubar_process_management_audit.md) traced multiple
+        // ways the shutdown path can hang indefinitely — workers stuck on
+        // SIGTERM, Pipe+waitUntilExit deadlock, etc. Tier A fixes
+        // (this PR) make the hangs much less likely, but the deadline is
+        // the absolute guarantee: if stopAll() hasn't completed in 30s,
+        // SIGKILL everything we know about and exit. Better an unclean
+        // shutdown than a menubar app the user can't quit without
+        // Terminal — which is exactly the failure mode the user
+        // reported.
+        let deadlineSeconds: UInt64 = 30
+        let deadlineTask: Task<Void, Never> = Task {
+            try? await Task.sleep(for: .seconds(deadlineSeconds))
+            // If we reach here, Task.sleep ran to completion — the
+            // shutdown task hasn't called deadlineTask.cancel() yet, so
+            // stopAll() is still running. Force-kill and exit hard.
+            Log.logger("lifecycle").error(
+                "Shutdown exceeded \(deadlineSeconds, privacy: .public)s deadline — force-killing tracked children and exiting"
+            )
+            await self.serviceManager.forceKillEverything()
+            // exit(0) bypasses any further AppKit teardown. We've signalled
+            // every child we know about; the kernel will reparent any
+            // survivors to launchd. Reaching this line means stopAll() was
+            // wedged anyway — there's no graceful path forward.
+            exit(0)
+        }
+
         Task {
-            await serviceManager.stopAll()
+            await self.serviceManager.stopAll()
+            // stopAll() completed cleanly — cancel the deadline before it
+            // fires, then signal AppKit that termination can proceed.
+            deadlineTask.cancel()
             NSApp.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater

--- a/macos/HarborClerkServer/HarborClerkServer/ProcessExtensions.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ProcessExtensions.swift
@@ -1,0 +1,125 @@
+import Foundation
+import os
+
+/// Shared helpers for the shutdown path.
+///
+/// Two known fragilities of `Foundation.Process` + `Pipe` get addressed
+/// here in one place rather than re-implemented in every service:
+///
+/// 1. **Pipe + `waitUntilExit` deadlock.** Apple's `waitUntilExit`
+///    documents that it waits for *both* process termination *and* all
+///    Pipe references to release. `Log.createPipe()` attaches a
+///    `readabilityHandler` that nils itself on EOF (empty data), which
+///    is the documented cleanly-exiting fix — but a hung child never
+///    sends EOF, so the handler never runs the nil-out branch, so the
+///    pipe stays open, so `waitUntilExit` blocks indefinitely. The
+///    `detachPipesForShutdown()` helper proactively nils the handler,
+///    closes the read end, and replaces `standardOutput`/`standardError`
+///    with `/dev/null` so the wait only blocks on process termination.
+///    See `project_menubar_process_management_audit.md` for the audit
+///    that caught this.
+///
+/// 2. **No bounded wait.** Every service's stop path currently does
+///    `await withCheckedContinuation { proc.waitUntilExit() }` with no
+///    deadline beyond the per-service `DispatchQueue.asyncAfter` SIGKILL
+///    fallback. That fallback works in isolation but `stopAll()` is
+///    sequential; one hung worker stalls the whole shutdown. The
+///    `waitForExitWithDeadline()` helper folds SIGTERM-grace,
+///    SIGKILL-on-deadline, and the actual wait into a single call so
+///    callers can compose timeouts predictably.
+extension Process {
+    /// Defuse this Process's stdout/stderr Pipes so `waitUntilExit()` no
+    /// longer blocks on pipe-close even when the child is hung.
+    ///
+    /// What we do:
+    ///   1. Nil the `readabilityHandler` on each unique attached Pipe's
+    ///      read end. Releases the closure (no more handler invocations).
+    ///   2. Close the read-end FileHandle. This causes the kernel to
+    ///      report EOF on the pipe, and (more importantly) makes any
+    ///      blocked child write return EPIPE / receive SIGPIPE — which
+    ///      unwedges a child that was hung in a `write(2)` because the
+    ///      pipe buffer was full and our readabilityHandler had fallen
+    ///      behind.
+    ///
+    /// What we deliberately don't do:
+    ///   ~~Reassign `self.standardOutput = FileHandle.nullDevice`~~.
+    ///   `Foundation.Process` raises `NSInvalidArgumentException: task
+    ///   already launched` if you set `standardOutput`/`standardError`
+    ///   after `run()`. Closing the read-end fd is sufficient to defuse
+    ///   the wait — we don't need to replace the entire stream.
+    ///
+    /// Safe to call multiple times. Order relative to `terminate()`
+    /// doesn't matter.
+    func detachPipesForShutdown() {
+        let stdoutPipe = self.standardOutput as? Pipe
+        let stderrPipe = self.standardError as? Pipe
+
+        // Many of our services (Log.createPipe in PythonService) attach
+        // the SAME Pipe instance to both stdout and stderr. Identity
+        // check skips a redundant close — closing twice would just throw
+        // on the second call.
+        if let pipe = stdoutPipe {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            try? pipe.fileHandleForReading.close()
+        }
+        if let pipe = stderrPipe, pipe !== stdoutPipe {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            try? pipe.fileHandleForReading.close()
+        }
+    }
+
+    /// Wait for this Process to exit, with a bounded grace period.
+    ///
+    /// Behaviour:
+    ///   1. If the process is not running, returns immediately.
+    ///   2. Otherwise schedules a `SIGKILL` at `now + graceSeconds`. The
+    ///      schedule is fire-and-forget — if the process exits before the
+    ///      deadline, the SIGKILL closure short-circuits via
+    ///      `proc.isRunning` check.
+    ///   3. Blocks (asynchronously) on `waitUntilExit()` until the
+    ///      process actually exits.
+    ///
+    /// This is the standard pattern from `PythonService.stop()` (it had it
+    /// before this audit) lifted out so `stopAll()` can use it too without
+    /// reimplementing — that reimplementation was the bug.
+    ///
+    /// Always detaches Pipes first via `detachPipesForShutdown()`. Without
+    /// that, `waitUntilExit` could still hang waiting for the pipe to
+    /// close even after `SIGKILL` arrives.
+    ///
+    /// - Parameters:
+    ///   - graceSeconds: how long after `terminate()` to wait before
+    ///     escalating to `SIGKILL`. The caller is expected to have
+    ///     already sent `SIGTERM` via `terminate()` before invoking
+    ///     this helper.
+    ///   - serviceName: included in log messages so the "had to SIGKILL
+    ///     foo" line is informative.
+    func waitForExitWithDeadline(
+        graceSeconds: TimeInterval,
+        serviceName: String,
+    ) async {
+        guard self.isRunning else { return }
+
+        detachPipesForShutdown()
+
+        // Schedule SIGKILL escalation. Fire-and-forget; if the process is
+        // already gone by the deadline, kill(0) is harmless.
+        let proc = self
+        let name = serviceName
+        let grace = graceSeconds
+        DispatchQueue.global().asyncAfter(deadline: .now() + grace) {
+            guard proc.isRunning else { return }
+            Log.logger("lifecycle").warning(
+                "[\(name, privacy: .public)] Still running after \(Int(grace), privacy: .public)s — sending SIGKILL"
+            )
+            kill(proc.processIdentifier, SIGKILL)
+        }
+
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                proc.waitUntilExit()
+                c.resume()
+            }
+        }
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -343,27 +343,48 @@ final class ServiceManager: ObservableObject {
         }
         notifyStateChanged()
 
-        // Stop workers in parallel (SIGTERM all, then wait) — same as restartForChangedSettings
+        // Stop workers in parallel: SIGTERM all → wait-with-deadline all
+        // concurrently. Pre-audit (2026-05-11) this loop reimplemented the
+        // wait inline WITHOUT a SIGKILL fallback, so a single Python worker
+        // stuck in a blocking syscall (or behind a Pipe+waitUntilExit
+        // deadlock) would stall the entire shutdown indefinitely. The
+        // rewrite uses the shared `Process.waitForExitWithDeadline` helper,
+        // which detaches pipes and escalates to SIGKILL after the grace
+        // period — bounded at ~12s regardless of how many workers are hung.
         for worker in allWorkers {
             worker.state = .stopping
             worker.process?.terminate()
         }
         notifyStateChanged()
-        for worker in allWorkers {
-            if let proc = worker.process, proc.isRunning {
-                await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                    DispatchQueue.global().async {
-                        proc.waitUntilExit()
-                        c.resume()
+
+        await withTaskGroup(of: Void.self) { group in
+            for worker in allWorkers {
+                let proc = worker.process
+                let grace = worker.shutdownGracePeriod
+                let workerName = worker.name
+                group.addTask {
+                    if let proc, proc.isRunning {
+                        await proc.waitForExitWithDeadline(
+                            graceSeconds: grace,
+                            serviceName: workerName,
+                        )
+                    }
+                    await MainActor.run {
+                        worker.process = nil
+                        worker.state = .stopped
+                        self.notifyStateChanged()
                     }
                 }
             }
-            worker.process = nil
-            worker.state = .stopped
         }
-        notifyStateChanged()
 
-        // Stop remaining services in reverse order, notifying after each
+        // Stop remaining services in reverse order, notifying after each.
+        // Sequential here is intentional: shutdown ordering matters
+        // (api → llama → embedder → tika → postgres) because dependents
+        // need their backends alive long enough to close cleanly. Each
+        // service's own stop() uses the shared deadline helper so a hung
+        // service still can't stall the next one for more than its grace
+        // period.
         let nonWorkers = services.filter { svc in
             !allWorkers.contains(where: { ObjectIdentifier($0) == ObjectIdentifier(svc) })
         }.reversed()
@@ -373,6 +394,84 @@ final class ServiceManager: ObservableObject {
         }
 
         // All children stopped — remove PID file
+        removePidFile()
+    }
+
+    /// Send SIGKILL to every child we know about. Used by the
+    /// `applicationShouldTerminate` deadline path — when `stopAll()` has
+    /// failed to complete in time and we'd rather have a noisy unclean
+    /// shutdown than a menubar app the user can't quit without Terminal.
+    ///
+    /// Three sources for child PIDs:
+    ///   1. Every `ManagedService.process` we currently hold a strong
+    ///      reference to.
+    ///   2. The `PostgresService` postmaster PID (read from
+    ///      `postmaster.pid` inside the data dir).
+    ///   3. `child-pids.txt` written by `savePidFile()` — catches any
+    ///      child whose state we may have lost track of mid-shutdown.
+    ///
+    /// Synchronous and best-effort. We do *not* wait for the SIGKILLed
+    /// processes to actually die — the caller (`AppDelegate`) will call
+    /// `exit(0)` immediately after, and at that point the kernel will
+    /// reparent any survivors to launchd.
+    ///
+    /// Note (Tier B follow-up): without process groups (see audit memo),
+    /// this only catches the tracked PIDs, not their descendants. Tika's
+    /// child JVMs and worker-spawned utilities can survive. Adding
+    /// `posix_spawn` + `setpgid` + `killpg` is the durable fix.
+    func forceKillEverything() {
+        let logger = Log.logger("lifecycle")
+        var killed: Set<Int32> = []
+
+        // 1) Every Process we currently hold.
+        for service in services {
+            if let pySvc = service as? PythonService, let proc = pySvc.process {
+                let pid = proc.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGKILL)
+                    killed.insert(pid)
+                }
+            } else if let tika = service as? TikaService, let pid = tika.processIdentifier {
+                kill(pid, SIGKILL)
+                killed.insert(pid)
+            } else if let llama = service as? LlamaService, let pid = llama.processIdentifier {
+                kill(pid, SIGKILL)
+                killed.insert(pid)
+            }
+        }
+
+        // 2) Postgres — pg_ctl forks a postmaster we don't directly hold;
+        //    read its PID from the data dir so it doesn't survive as an
+        //    orphan still holding port 5433.
+        let pgPidFile = AppSettings.shared.postgresDataDir.appendingPathComponent("postmaster.pid")
+        if let contents = try? String(contentsOf: pgPidFile, encoding: .utf8),
+           let pidLine = contents.components(separatedBy: "\n").first,
+           let pid = Int32(pidLine), pid > 0, !killed.contains(pid)
+        {
+            kill(pid, SIGKILL)
+            killed.insert(pid)
+        }
+
+        // 3) child-pids.txt — anything our in-memory state lost track of
+        //    (e.g. an auto-restart that swapped the Process ref after the
+        //    last savePidFile call).
+        if let contents = try? String(contentsOf: Self.pidFileURL, encoding: .utf8) {
+            for line in contents.components(separatedBy: "\n") {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard let pid = Int32(trimmed), pid > 0, !killed.contains(pid) else { continue }
+                // kill(pid, 0) confirms the PID still belongs to a live
+                // process before we SIGKILL — a recycled PID belonging to
+                // someone else's process would be a serious bug.
+                guard kill(pid, 0) == 0 else { continue }
+                kill(pid, SIGKILL)
+                killed.insert(pid)
+            }
+        }
+
+        logger.warning("forceKillEverything sent SIGKILL to \(killed.count, privacy: .public) tracked PIDs")
+
+        // Don't leave the PID file behind — next launch's orphan cleanup
+        // shouldn't re-try to kill processes we already SIGKILLed.
         removePidFile()
     }
 

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -707,25 +707,38 @@ final class ServiceManager: ObservableObject {
 
         // 1. Stop python services (dependents first: workers → api/embedder)
         // Send SIGTERM to all workers in parallel, then wait for all to exit.
-        // This reduces total stop time from N×30s to ~30s.
+        // Parallel SIGTERM then parallel wait-with-deadline. Pre-audit
+        // (2026-05-11) this path had the same bug as stopAll()'s worker
+        // block: sequential unbounded waits with no SIGKILL fallback, so
+        // a single hung worker stalled the entire preferences-restart
+        // flow indefinitely. The rewrite uses the same helper, so a
+        // settings change that triggers a worker restart is now bounded
+        // at ~12s regardless of how many are hung.
         for worker in workersToStop {
             worker.state = .stopping
             worker.process?.terminate()
         }
         notifyStateChanged()
-        for worker in workersToStop {
-            if let proc = worker.process, proc.isRunning {
-                await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                    DispatchQueue.global().async {
-                        proc.waitUntilExit()
-                        c.resume()
+        await withTaskGroup(of: Void.self) { group in
+            for worker in workersToStop {
+                let proc = worker.process
+                let grace = worker.shutdownGracePeriod
+                let workerName = worker.name
+                group.addTask {
+                    if let proc, proc.isRunning {
+                        await proc.waitForExitWithDeadline(
+                            graceSeconds: grace,
+                            serviceName: workerName,
+                        )
+                    }
+                    await MainActor.run {
+                        worker.process = nil
+                        worker.state = .stopped
+                        self.notifyStateChanged()
                     }
                 }
             }
-            worker.process = nil
-            worker.state = .stopped
         }
-        notifyStateChanged()
         for svc in nonWorkerPython {
             await svc.stop()
         }

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -85,18 +85,11 @@ final class LlamaService: ManagedService {
 
         if let proc = process, proc.isRunning {
             proc.terminate() // SIGTERM
-            // Model unload can be slow — 10s grace, then SIGKILL
-            DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
-                guard proc.isRunning else { return }
-                Log.logger("lifecycle").warning("LLM still running after 10s, sending SIGKILL")
-                kill(proc.processIdentifier, SIGKILL)
-            }
-            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                DispatchQueue.global().async {
-                    proc.waitUntilExit()
-                    c.resume()
-                }
-            }
+            // Model unload can be slow — 10s grace, then SIGKILL. Uses the
+            // shared helper so the Pipe+waitUntilExit deadlock pattern
+            // (audit memo: project_menubar_process_management_audit.md)
+            // can't make this stall the rest of stopAll().
+            await proc.waitForExitWithDeadline(graceSeconds: 10, serviceName: name)
         }
         process = nil
 

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PythonService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PythonService.swift
@@ -81,20 +81,14 @@ class PythonService: ManagedService {
             return
         }
         proc.terminate() // SIGTERM
-        let grace = shutdownGracePeriod
-        let svcName = name
-        DispatchQueue.global().asyncAfter(deadline: .now() + grace) {
-            guard proc.isRunning else { return }
-            Log.logger("lifecycle").warning(
-                "\(svcName, privacy: .public) still running after \(Int(grace), privacy: .public)s, sending SIGKILL")
-            kill(proc.processIdentifier, SIGKILL)
-        }
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                c.resume()
-            }
-        }
+        // Use the shared deadline helper — detaches pipes (defusing the
+        // Pipe+waitUntilExit deadlock described in
+        // project_menubar_process_management_audit.md), schedules SIGKILL
+        // after the grace period, then waits.
+        await proc.waitForExitWithDeadline(
+            graceSeconds: shutdownGracePeriod,
+            serviceName: name,
+        )
         process = nil
         state = .stopped
     }

--- a/macos/HarborClerkServer/HarborClerkServer/Services/TikaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/TikaService.swift
@@ -60,18 +60,16 @@ final class TikaService: ManagedService {
             return
         }
         proc.terminate() // SIGTERM
-        // JVM can be slow to unwind — 10s grace, then SIGKILL
-        DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
-            guard proc.isRunning else { return }
-            Log.logger("lifecycle").warning("Tika still running after 10s, sending SIGKILL")
-            kill(proc.processIdentifier, SIGKILL)
-        }
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                c.resume()
-            }
-        }
+        // JVM can be slow to unwind — 10s grace, then SIGKILL. Uses the
+        // shared helper so the Pipe+waitUntilExit deadlock pattern
+        // (audit memo: project_menubar_process_management_audit.md)
+        // can't make this stall the rest of stopAll().
+        //
+        // NOTE: Tika's JVM can fork child JVMs for heavy extractions.
+        // SIGKILL on the tracked PID doesn't catch those grandchildren —
+        // Tier B follow-up is to use posix_spawn + setpgid so killpg can
+        // hit the whole tree.
+        await proc.waitForExitWithDeadline(graceSeconds: 10, serviceName: name)
         process = nil
         state = .stopped
     }

--- a/macos/HarborClerkServer/HarborClerkServerTests/ProcessExtensionsTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/ProcessExtensionsTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import HarborClerkServer
+
+/// Tests for the shared shutdown helpers introduced to fix the
+/// "Quit hangs after a few hours" failure mode. See
+/// `project_menubar_process_management_audit.md`.
+///
+/// Most of what we want to validate is behaviour of `Foundation.Process`
+/// under shutdown — which is genuinely hard to unit-test. We can however
+/// verify the pure helpers do what they say on the tin:
+///
+/// - `detachPipesForShutdown()` clears readabilityHandlers and replaces
+///   the Process's stdout/stderr with `/dev/null`. We exercise this with
+///   a real (short-lived) `/bin/sleep` subprocess.
+/// - `waitForExitWithDeadline()` returns even when the child blocks past
+///   the grace period, because the SIGKILL fallback escalates. Exercised
+///   with `/bin/sleep 30` and a 1-second grace.
+///
+/// These tests are intentionally end-to-end against real OS process
+/// machinery — that's where the bugs live. They should still be fast
+/// (under a few seconds each).
+final class ProcessExtensionsTests: XCTestCase {
+
+    /// Spawn `/bin/sleep N`, attach a Pipe to stdout/stderr like
+    /// `Log.createPipe` does, then verify `detachPipesForShutdown()`
+    /// nils the readabilityHandler and closes the read-end fd. We do
+    /// NOT reassign `standardOutput` — that would raise
+    /// `NSInvalidArgumentException: task already launched`, which is
+    /// exactly the bug the first iteration of this helper had.
+    func testDetachPipesClearsReadabilityHandlerAndClosesReadEnd() throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        proc.arguments = ["5"]
+
+        let pipe = Pipe()
+        pipe.fileHandleForReading.readabilityHandler = { _ in }
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+
+        try proc.run()
+        defer {
+            if proc.isRunning {
+                kill(proc.processIdentifier, SIGKILL)
+                proc.waitUntilExit()
+            }
+        }
+
+        proc.detachPipesForShutdown()
+
+        // The handler on the pipe must be nilled — that's the GCD ref the
+        // helper is breaking so waitUntilExit can complete.
+        XCTAssertNil(
+            pipe.fileHandleForReading.readabilityHandler,
+            "readabilityHandler should be nil after detach",
+        )
+
+        // standardOutput remains the Pipe — we don't reassign it. This is
+        // a regression guard against the earlier version that reassigned
+        // to FileHandle.nullDevice and crashed on launched processes with
+        // "task already launched" (`NSInvalidArgumentException`).
+        XCTAssertIdentical(
+            proc.standardOutput as AnyObject?,
+            pipe as AnyObject,
+            "standardOutput should still be the Pipe; we don't reassign on launched processes",
+        )
+    }
+
+    /// Detach is idempotent — calling it twice is safe and produces the
+    /// same end state. Important because shutdown paths can race.
+    func testDetachPipesIsIdempotent() throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        proc.arguments = ["5"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        try proc.run()
+        defer {
+            if proc.isRunning {
+                kill(proc.processIdentifier, SIGKILL)
+                proc.waitUntilExit()
+            }
+        }
+
+        proc.detachPipesForShutdown()
+        proc.detachPipesForShutdown()  // second call must not crash
+
+        XCTAssertNil(pipe.fileHandleForReading.readabilityHandler)
+    }
+
+    /// When stdout and stderr point to the same Pipe instance (the
+    /// `Log.createPipe` pattern), detach must not double-close the read
+    /// end — second close would throw. The implementation uses `!==`
+    /// identity to skip the duplicate.
+    func testDetachPipesHandlesSharedPipeForStdoutAndStderr() throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        proc.arguments = ["5"]
+        let sharedPipe = Pipe()
+        proc.standardOutput = sharedPipe
+        proc.standardError = sharedPipe
+        try proc.run()
+        defer {
+            if proc.isRunning {
+                kill(proc.processIdentifier, SIGKILL)
+                proc.waitUntilExit()
+            }
+        }
+
+        // No assertion needed — the test passes if detach doesn't throw.
+        proc.detachPipesForShutdown()
+    }
+
+    /// `waitForExitWithDeadline` must return within (grace + small slack)
+    /// even when the child is `sleep 30` — because SIGKILL escalates
+    /// after the grace period. Without the SIGKILL fallback this test
+    /// would hang for 30s and timeout the test runner.
+    func testWaitForExitWithDeadlineEscalatesToSigkill() async throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        proc.arguments = ["30"]
+        try proc.run()
+
+        // Send SIGTERM — sleep traps SIGTERM cleanly and exits, but on
+        // some systems / under load it can take a moment. The deadline
+        // is what we're really testing.
+        proc.terminate()
+
+        let start = Date()
+        await proc.waitForExitWithDeadline(graceSeconds: 1.0, serviceName: "test-sleep")
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertFalse(proc.isRunning, "Process must be dead after waitForExitWithDeadline")
+        // Allow generous slack (5s) so this test isn't flaky on a loaded CI
+        // host. The point is just that we didn't wait 30s.
+        XCTAssertLessThan(
+            elapsed,
+            5.0,
+            "Wait should have completed within grace + slack, not 30s; took \(elapsed)s",
+        )
+    }
+
+    /// When the child exits cleanly before the grace expires, no SIGKILL
+    /// fires and we return promptly. Verified by spawning `/usr/bin/true`
+    /// (which exits immediately) with a long grace.
+    func testWaitForExitWithDeadlineReturnsPromptlyOnCleanExit() async throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try proc.run()
+
+        let start = Date()
+        await proc.waitForExitWithDeadline(graceSeconds: 30.0, serviceName: "test-true")
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertFalse(proc.isRunning)
+        XCTAssertEqual(proc.terminationStatus, 0)
+        XCTAssertLessThan(
+            elapsed,
+            2.0,
+            "Should not wait for grace period when child exited immediately",
+        )
+    }
+
+    /// Calling `waitForExitWithDeadline` on a Process that's already
+    /// exited returns immediately and doesn't touch the Pipes (defensive
+    /// — used during shutdown when state can be racy).
+    func testWaitForExitWithDeadlineReturnsImmediatelyForExitedProcess() async throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try proc.run()
+        proc.waitUntilExit()  // already exited
+
+        let start = Date()
+        await proc.waitForExitWithDeadline(graceSeconds: 30.0, serviceName: "test-already-dead")
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.5)
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -3160,11 +3160,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

User reports HarborClerkServer cannot be quit cleanly via the "Quit" menu after a few hours of uptime — workers stuck on "Stopping", everything else on "Shutdown Pending", with no escape short of `kill` from a terminal. This is the **Tier A** subset of fixes from the [process-management audit](https://github.com/r0shi/harborclerk/blob/fix/menubar-shutdown-deadline/macos/HarborClerkServer/HarborClerkServer/ProcessExtensions.swift) — three root causes, addressed.

### Root causes addressed

**1. `stopAll()` and `restartForChangedSettings` worker blocks had no SIGKILL escape hatch.** Both reimplemented worker shutdown inline rather than using `WorkerService.stop()`, with sequential unbounded `waitUntilExit()` and no grace-period SIGKILL fallback. A single hung worker stalled the entire shutdown indefinitely; non-worker services stayed in `.shutdownPending` forever.

**2. Pipe + `waitUntilExit` deadlock pattern.** Apple's `waitUntilExit` waits for both process termination AND all `Pipe` references released. `Log.createPipe()` nils the readabilityHandler on EOF (the documented fix) but only when the child cleanly closes its end — a hung child never sends EOF, so the handler never runs, the pipe stays alive, and the wait blocks indefinitely.

**3. `applicationShouldTerminate` had no overall deadline.** It awaited `stopAll()` and only called `NSApp.reply` when done. If `stopAll()` hung, `NSApp.reply` never fired, macOS waited indefinitely, and the user couldn't quit without Force Quit or Terminal.

### What landed

**`ProcessExtensions.swift`** — two helpers used by every service stop path:

- `detachPipesForShutdown()` — nils the `readabilityHandler` on each attached Pipe's read end, closes the read-end FileHandle. Closing the read end causes any blocked child write to return `EPIPE`/`SIGPIPE`, unwedging children stuck in `write(2)` because the pipe buffer was full and our handler had fallen behind under GCD load. Intentionally does **not** reassign `standardOutput`/`standardError` — `Foundation.Process` raises `NSInvalidArgumentException: task already launched` if you do that on a running process. (First iteration of this helper had that bug — the unit tests caught it before the PR was opened.)
- `waitForExitWithDeadline(graceSeconds:serviceName:)` — detaches pipes, schedules a SIGKILL escalation after the grace period, then waits. The standard `PythonService.stop()` pattern, hoisted out so `stopAll()` and `restartForChangedSettings` can use it without reimplementing.

**`ServiceManager.forceKillEverything()`** — synchronously SIGKILLs every tracked child by walking three PID sources: live `service.process` refs, the `postmaster.pid` file (Postgres's actual postmaster — `pg_ctl` doesn't surface it), and `child-pids.txt` (catches anything in-memory state lost track of mid-shutdown).

**`stopAll()` worker block rewrite** — parallel SIGTERM → parallel waits in a `TaskGroup`, each task calling `waitForExitWithDeadline`. Bounded at `worker.shutdownGracePeriod` (10s) regardless of how many workers are hung. Each worker transitions to `.stopped` independently as its wait completes.

**`restartForChangedSettings` worker block rewrite** — same task-group + `waitForExitWithDeadline` pattern. This path runs every time the user changes a Preferences setting that requires a worker restart (port change, worker preset, log level) — fresh-eyes review correctly flagged it as having the same shape as the `stopAll` bug.

**`applicationShouldTerminate` 30-second hard deadline** — runs concurrently with the normal `stopAll()`. If `stopAll()` finishes first, the deadline task is cancelled and the original `.terminateLater` handshake proceeds. If `stopAll()` doesn't return in 30s, `forceKillEverything()` SIGKILLs everything we know about and `exit(0)`. Better an unclean shutdown than an unkillable menubar app.

### Out of scope (durable memo + queued for follow-up PRs)

See `project_menubar_process_management_audit.md` for the full audit. The Tier B + C items deferred from this PR:

- **Tier B — process groups via `posix_spawn`** so SIGKILL catches grandchildren (Tika's child JVMs, worker-spawned `tesseract`/`pdftoppm`, etc.). Currently `kill(pid, SIGKILL)` only hits the tracked PID.
- **Tier B — shutdown-aware HealthChecker** that cancels in-flight `attemptAutoRestart` tasks when `stopAll` begins. The current guard checks state once, then awaits — the gate can be passed before shutdown starts and the restart races the teardown.
- **Tier B — "Force Stop All" menu item** that hits `forceKillEverything()` directly, so users have an escape hatch without waiting the 30s.
- **Tier C — architectural: move Postgres + Tika to launchd-managed LaunchAgents.** They'd survive menubar crashes (we've had two — see `project_menubar_crashes_during_model_switch.md`), get correct process-group cleanup for free, and skip the Pipe/waitUntilExit dance entirely. ~2-3 day refactor, separate project.

### Test plan

- [x] Build clean (`xcodebuild ... build`)
- [x] All 63 HarborClerkServerTests pass (was 57 — 6 new in `ProcessExtensionsTests`)
- [x] New tests cover: detach happy path (handler nilled, read end closed, Pipe not reassigned), idempotency, shared-pipe case (stdout==stderr), SIGKILL escalation after grace, prompt return on clean exit, no-op for already-exited process
- [x] Fresh-eyes review caught 1 finding ≥80 confidence (`restartForChangedSettings` had the same bug as `stopAll`), addressed in [36f8d73](https://github.com/r0shi/harborclerk/commit/36f8d73)
- [x] First iteration of `detachPipesForShutdown` reassigned `standardOutput`/`standardError` — production-fatal because `Process` raises `NSInvalidArgumentException` on a launched process. Caught by `testWaitForExitWithDeadlineEscalatesToSigkill` and fixed before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
