### PR TITLE
feat(menubar): Force Stop All menu item (PR-3 of 4)

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -125,6 +125,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         stopItem.target = self
         menu.addItem(stopItem)
 
+        let forceStopItem = NSMenuItem(title: "Force Stop All", action: #selector(forceStopAllServices), keyEquivalent: "")
+        forceStopItem.target = self
+        menu.addItem(forceStopItem)
+
         menu.addItem(NSMenuItem.separator())
 
         let statusWindowItem = NSMenuItem(title: "Show Status Window...", action: #selector(showStatusWindow), keyEquivalent: "s")
@@ -213,6 +217,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func stopAllServices() {
         Task { await serviceManager.stopAll() }
+    }
+
+    /// Manual escape hatch for users who'd rather not wait the 30s deadline
+    /// in applicationShouldTerminate. SIGKILLs every tracked subprocess and
+    /// leaves the menubar open so the user can re-Start All when ready.
+    /// Destructive operation, gated by an NSAlert confirmation.
+    @objc private func forceStopAllServices() {
+        let alert = NSAlert()
+        alert.messageText = "Force Stop All Services?"
+        alert.informativeText = """
+            This will SIGKILL every Harbor Clerk subprocess.
+
+            In-flight database transactions and document processing will be lost. \
+            The menubar will stay open so you can Start All when ready.
+
+            Use Quit instead if you want a clean shutdown.
+            """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Force Stop")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        Task {
+            // forceKillEverything is synchronous (sends SIGKILL, doesn't
+            // wait for processes to die). The menubar stays open afterward,
+            // and the user's next Start All click lands on a freshly-empty
+            // state because removePidFile happens during the kill pass.
+            //
+            // NOTE for PR-4: once Postgres + Tika move to launchd agents,
+            // this handler also needs to await each agent.stop() to issue
+            // launchctl bootout — otherwise launchd's KeepAlive would
+            // resurrect the postmaster after our SIGKILL.
+            self.serviceManager.forceKillEverything()
+            self.serviceManager.notifyStateChanged()
+        }
     }
 
     @objc private func showStatusWindow() {

--- a/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
@@ -95,4 +95,26 @@ final class ServiceConfigTests: XCTestCase {
         let body = String(source[forceKillRange.upperBound..<(nextFuncRange?.lowerBound ?? source.endIndex)])
         XCTAssertTrue(body.contains("killpg("), "forceKillEverything must call killpg to reach grandchildren")
     }
+
+    /// AppDelegate.setupMenu must register a "Force Stop All" item and the
+    /// handler must call forceKillEverything(). Source-text guard —
+    /// runtime menu inspection is brittle from a non-UI XCTest. Manual
+    /// smoke testing covers the dialog itself.
+    func testAppDelegateRegistersForceStopAllMenuItem() throws {
+        let thisFile = URL(fileURLWithPath: #file)
+        let appDelegateURL = thisFile
+            .deletingLastPathComponent()  // → HarborClerkServerTests/
+            .deletingLastPathComponent()  // → HarborClerkServer/ project root
+            .appendingPathComponent("HarborClerkServer")
+            .appendingPathComponent("AppDelegate.swift")
+        let source = try String(contentsOf: appDelegateURL, encoding: .utf8)
+        XCTAssertTrue(
+            source.contains("\"Force Stop All\""),
+            "AppDelegate.swift must declare a 'Force Stop All' menu item",
+        )
+        XCTAssertTrue(
+            source.contains("forceKillEverything()"),
+            "AppDelegate.swift must call serviceManager.forceKillEverything() in the Force Stop All handler",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

PR-3 of four sub-PRs for the menubar process management Tier B+C refactor. Adds a "Force Stop All" menu item — manual escape hatch for users who don't want to wait the 30-second deadline in `applicationShouldTerminate`.

Spec: `docs/superpowers/specs/2026-05-11-menubar-process-mgmt-tier-bc-design.md`
Plan: `docs/superpowers/plans/2026-05-11-pr-3-force-stop-all-menu.md`

## What landed

Single-file UX addition reusing `forceKillEverything()` from PR #341:

- **New menu item** "Force Stop All" inserted under the existing "Stop All" entry.
- **NSAlert confirmation** gating the destructive action with explicit consequences ("This will SIGKILL every Harbor Clerk subprocess. In-flight database transactions and document processing will be lost.").
- **Menubar stays open** after Force Stop completes (differs from the 30-second deadline path which `exit(0)`s — the deadline implies "we wanted to quit and couldn't"; this implies "I want to break things and stay here to fix them").
- **Source-text guard test** in `ServiceConfigTests.swift` to catch regressions where the wiring gets accidentally removed.

## TODO for PR-4

When Postgres + Tika move to launchd agents in PR-4, this handler also needs to `await agent.stop()` for each launchd-managed service — otherwise launchd's `KeepAlive` resurrects the postmaster immediately after our SIGKILL. Comment left inline at the call site.

## Test plan

- [x] Source-text guard test: `testAppDelegateRegistersForceStopAllMenuItem`
- [x] `xcodebuild build` + `xcodebuild test` clean (72 tests pass — 71 after PR-2 + 1 new here)
- [x] Plan explicitly skips the formal fresh-eyes review for this size of change (single-file UI addition reusing already-tested helper)
- [ ] Manual smoke test (operator): build the app, click the new menu item, verify the alert appears + Cancel/Force Stop both behave correctly + services come back via Start All

## Out of scope

- **PR-4:** launchd migration for Postgres + Tika

🤖 Generated with [Claude Code](https://claude.com/claude-code)
