### PR TITLE
feat(menubar): launchd migration for Postgres + Tika (PR-4 of 4)

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
+++ b/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		A100000060 /* ProcessExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000060; };
 		A100000061 /* LaunchctlClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000061; };
 		A100000062 /* LaunchdPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000062; };
+		A100000063 /* LaunchdAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000063; };
 		AT10000001 /* WorkerCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000001; };
 		AT10000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000002; };
 		AT10000003 /* OverallStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000003; };
@@ -39,6 +40,7 @@
 		AT10000011 /* ProcessExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000011; };
 		AT10000012 /* LaunchctlClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000012; };
 		AT10000013 /* LaunchdPlistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000013; };
+		AT10000014 /* LaunchdAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000014; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +77,7 @@
 		B100000060 /* ProcessExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensions.swift; sourceTree = "<group>"; };
 		B100000061 /* LaunchctlClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClient.swift; sourceTree = "<group>"; };
 		B100000062 /* LaunchdPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlist.swift; sourceTree = "<group>"; };
+		B100000063 /* LaunchdAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdAgent.swift; sourceTree = "<group>"; };
 		D100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D100000002 /* HarborClerkServer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HarborClerkServer.entitlements; sourceTree = "<group>"; };
 		CT10000001 /* HarborClerkServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HarborClerkServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +91,7 @@
 		BT10000011 /* ProcessExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensionsTests.swift; sourceTree = "<group>"; };
 		BT10000012 /* LaunchctlClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClientTests.swift; sourceTree = "<group>"; };
 		BT10000013 /* LaunchdPlistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlistTests.swift; sourceTree = "<group>"; };
+		BT10000014 /* LaunchdAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdAgentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +138,7 @@
 				B100000060 /* ProcessExtensions.swift */,
 				B100000061 /* LaunchctlClient.swift */,
 				B100000062 /* LaunchdPlist.swift */,
+				B100000063 /* LaunchdAgent.swift */,
 				B100000016 /* Assets.xcassets */,
 				D100000001 /* Info.plist */,
 				D100000002 /* HarborClerkServer.entitlements */,
@@ -178,6 +183,7 @@
 				BT10000011 /* ProcessExtensionsTests.swift */,
 				BT10000012 /* LaunchctlClientTests.swift */,
 				BT10000013 /* LaunchdPlistTests.swift */,
+				BT10000014 /* LaunchdAgentTests.swift */,
 			);
 			path = HarborClerkServerTests;
 			sourceTree = "<group>";
@@ -315,6 +321,7 @@
 				A100000060 /* ProcessExtensions.swift in Sources */,
 				A100000061 /* LaunchctlClient.swift in Sources */,
 				A100000062 /* LaunchdPlist.swift in Sources */,
+				A100000063 /* LaunchdAgent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -332,6 +339,7 @@
 				AT10000011 /* ProcessExtensionsTests.swift in Sources */,
 				AT10000012 /* LaunchctlClientTests.swift in Sources */,
 				AT10000013 /* LaunchdPlistTests.swift in Sources */,
+				AT10000014 /* LaunchdAgentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
+++ b/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A100000050 /* MasterKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000050; };
 		A100000060 /* ProcessExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000060; };
 		A100000061 /* LaunchctlClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000061; };
+		A100000062 /* LaunchdPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000062; };
 		AT10000001 /* WorkerCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000001; };
 		AT10000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000002; };
 		AT10000003 /* OverallStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000003; };
@@ -37,6 +38,7 @@
 		AT10000010 /* MasterKeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000010; };
 		AT10000011 /* ProcessExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000011; };
 		AT10000012 /* LaunchctlClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000012; };
+		AT10000013 /* LaunchdPlistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000013; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +74,7 @@
 		B100000050 /* MasterKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyManager.swift; sourceTree = "<group>"; };
 		B100000060 /* ProcessExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensions.swift; sourceTree = "<group>"; };
 		B100000061 /* LaunchctlClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClient.swift; sourceTree = "<group>"; };
+		B100000062 /* LaunchdPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlist.swift; sourceTree = "<group>"; };
 		D100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D100000002 /* HarborClerkServer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HarborClerkServer.entitlements; sourceTree = "<group>"; };
 		CT10000001 /* HarborClerkServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HarborClerkServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -84,6 +87,7 @@
 		BT10000010 /* MasterKeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyManagerTests.swift; sourceTree = "<group>"; };
 		BT10000011 /* ProcessExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensionsTests.swift; sourceTree = "<group>"; };
 		BT10000012 /* LaunchctlClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClientTests.swift; sourceTree = "<group>"; };
+		BT10000013 /* LaunchdPlistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlistTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +133,7 @@
 				B100000050 /* MasterKeyManager.swift */,
 				B100000060 /* ProcessExtensions.swift */,
 				B100000061 /* LaunchctlClient.swift */,
+				B100000062 /* LaunchdPlist.swift */,
 				B100000016 /* Assets.xcassets */,
 				D100000001 /* Info.plist */,
 				D100000002 /* HarborClerkServer.entitlements */,
@@ -172,6 +177,7 @@
 				BT10000010 /* MasterKeyManagerTests.swift */,
 				BT10000011 /* ProcessExtensionsTests.swift */,
 				BT10000012 /* LaunchctlClientTests.swift */,
+				BT10000013 /* LaunchdPlistTests.swift */,
 			);
 			path = HarborClerkServerTests;
 			sourceTree = "<group>";
@@ -308,6 +314,7 @@
 				A100000050 /* MasterKeyManager.swift in Sources */,
 				A100000060 /* ProcessExtensions.swift in Sources */,
 				A100000061 /* LaunchctlClient.swift in Sources */,
+				A100000062 /* LaunchdPlist.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,6 +331,7 @@
 				AT10000010 /* MasterKeyManagerTests.swift in Sources */,
 				AT10000011 /* ProcessExtensionsTests.swift in Sources */,
 				AT10000012 /* LaunchctlClientTests.swift in Sources */,
+				AT10000013 /* LaunchdPlistTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
+++ b/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		A100000061 /* LaunchctlClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000061; };
 		A100000062 /* LaunchdPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000062; };
 		A100000063 /* LaunchdAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000063; };
+		A100000064 /* ProcessAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000064; };
 		AT10000001 /* WorkerCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000001; };
 		AT10000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000002; };
 		AT10000003 /* OverallStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000003; };
@@ -78,6 +79,7 @@
 		B100000061 /* LaunchctlClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClient.swift; sourceTree = "<group>"; };
 		B100000062 /* LaunchdPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlist.swift; sourceTree = "<group>"; };
 		B100000063 /* LaunchdAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdAgent.swift; sourceTree = "<group>"; };
+		B100000064 /* ProcessAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessAsync.swift; sourceTree = "<group>"; };
 		D100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D100000002 /* HarborClerkServer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HarborClerkServer.entitlements; sourceTree = "<group>"; };
 		CT10000001 /* HarborClerkServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HarborClerkServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +141,7 @@
 				B100000061 /* LaunchctlClient.swift */,
 				B100000062 /* LaunchdPlist.swift */,
 				B100000063 /* LaunchdAgent.swift */,
+				B100000064 /* ProcessAsync.swift */,
 				B100000016 /* Assets.xcassets */,
 				D100000001 /* Info.plist */,
 				D100000002 /* HarborClerkServer.entitlements */,
@@ -322,6 +325,7 @@
 				A100000061 /* LaunchctlClient.swift in Sources */,
 				A100000062 /* LaunchdPlist.swift in Sources */,
 				A100000063 /* LaunchdAgent.swift in Sources */,
+				A100000064 /* ProcessAsync.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
+++ b/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		A100000028 /* WatcherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000028; };
 		A100000050 /* MasterKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000050; };
 		A100000060 /* ProcessExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000060; };
+		A100000061 /* LaunchctlClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000061; };
 		AT10000001 /* WorkerCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000001; };
 		AT10000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000002; };
 		AT10000003 /* OverallStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000003; };
@@ -35,6 +36,7 @@
 		AT10000007 /* BundleResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000007; };
 		AT10000010 /* MasterKeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000010; };
 		AT10000011 /* ProcessExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000011; };
+		AT10000012 /* LaunchctlClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000012; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +71,7 @@
 		B100000028 /* WatcherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatcherService.swift; sourceTree = "<group>"; };
 		B100000050 /* MasterKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyManager.swift; sourceTree = "<group>"; };
 		B100000060 /* ProcessExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensions.swift; sourceTree = "<group>"; };
+		B100000061 /* LaunchctlClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClient.swift; sourceTree = "<group>"; };
 		D100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D100000002 /* HarborClerkServer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HarborClerkServer.entitlements; sourceTree = "<group>"; };
 		CT10000001 /* HarborClerkServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HarborClerkServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -80,6 +83,7 @@
 		BT10000007 /* BundleResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleResourceTests.swift; sourceTree = "<group>"; };
 		BT10000010 /* MasterKeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyManagerTests.swift; sourceTree = "<group>"; };
 		BT10000011 /* ProcessExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessExtensionsTests.swift; sourceTree = "<group>"; };
+		BT10000012 /* LaunchctlClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchctlClientTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +128,7 @@
 				B100000015 /* PreferencesWindow.swift */,
 				B100000050 /* MasterKeyManager.swift */,
 				B100000060 /* ProcessExtensions.swift */,
+				B100000061 /* LaunchctlClient.swift */,
 				B100000016 /* Assets.xcassets */,
 				D100000001 /* Info.plist */,
 				D100000002 /* HarborClerkServer.entitlements */,
@@ -166,6 +171,7 @@
 				BT10000007 /* BundleResourceTests.swift */,
 				BT10000010 /* MasterKeyManagerTests.swift */,
 				BT10000011 /* ProcessExtensionsTests.swift */,
+				BT10000012 /* LaunchctlClientTests.swift */,
 			);
 			path = HarborClerkServerTests;
 			sourceTree = "<group>";
@@ -301,6 +307,7 @@
 				A100000028 /* WatcherService.swift in Sources */,
 				A100000050 /* MasterKeyManager.swift in Sources */,
 				A100000060 /* ProcessExtensions.swift in Sources */,
+				A100000061 /* LaunchctlClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -316,6 +323,7 @@
 				AT10000007 /* BundleResourceTests.swift in Sources */,
 				AT10000010 /* MasterKeyManagerTests.swift in Sources */,
 				AT10000011 /* ProcessExtensionsTests.swift in Sources */,
+				AT10000012 /* LaunchctlClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -243,7 +243,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
-        Task {
+        Task { @MainActor in
+            // Prevent auto-restart of menubar-spawned children — without
+            // this, the SIGKILLs below trigger each PythonService's
+            // terminationHandler restart loop, plus the
+            // onUnexpectedExit -> attemptAutoRestart path on max-restart
+            // exhaustion. Smoke testing PR-4 step 7 showed Embedder,
+            // LLM, API, and Watcher coming back to Running after Force
+            // Stop because of this.
+            //
+            // Two-pronged: (1) set state=.stopping on every service
+            // *before* SIGKILL — PythonService/LlamaService
+            // terminationHandlers guard on `state == .running` and
+            // become no-ops; (2) flip isShuttingDown so any leak-through
+            // auto-restart Task early-returns in attemptAutoRestart.
+            // Same approach as stopAll() but without the orderly
+            // shutdown sequence.
+            self.serviceManager.isShuttingDown = true
+            await self.healthChecker.cancelInFlightRestarts()
+            for service in self.serviceManager.services where service.state != .stopped {
+                service.state = .stopping
+            }
+            self.serviceManager.notifyStateChanged()
+
             // forceKillEverything sends SIGKILL to every tracked subprocess.
             // After PR-4 it's async because Tika's PID is queried via
             // `launchctl print`. The menubar stays open afterward, and the
@@ -259,6 +281,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await self.serviceManager.postgresService.stop()
             await self.serviceManager.tikaService.stop()
 
+            // Mark every service as stopped — the UI was in an
+            // intermediate .stopping state, and the SIGKILL'd processes
+            // can't transition themselves. Workers, embedder, llm, api,
+            // watcher all get nilled here so a subsequent Start All
+            // lands cleanly. (forceKillEverything itself doesn't touch
+            // .state — keeping it that way means it's safe to call
+            // from anywhere, e.g. the 30s deadline path.)
+            for service in self.serviceManager.services {
+                service.state = .stopped
+                if let pySvc = service as? PythonService { pySvc.process = nil }
+            }
+            self.serviceManager.isShuttingDown = false
             self.serviceManager.notifyStateChanged()
         }
     }

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -290,7 +290,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // from anywhere, e.g. the 30s deadline path.)
             for service in self.serviceManager.services {
                 service.state = .stopped
+                // Clear stale Process refs so processIdentifier doesn't
+                // surface a dead PID before Foundation's kqueue catches
+                // up. Both python services and the llama server hold a
+                // Process — handle both. Postgres/Tika are launchd-managed
+                // and don't have a menubar-side Process to clear.
                 if let pySvc = service as? PythonService { pySvc.process = nil }
+                if let llama = service as? LlamaService { llama.process = nil }
             }
             self.serviceManager.isShuttingDown = false
             self.serviceManager.notifyStateChanged()

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -240,16 +240,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
         Task {
-            // forceKillEverything is synchronous (sends SIGKILL, doesn't
-            // wait for processes to die). The menubar stays open afterward,
-            // and the user's next Start All click lands on a freshly-empty
-            // state because removePidFile happens during the kill pass.
+            // forceKillEverything sends SIGKILL to every tracked subprocess.
+            // After PR-4 it's async because Tika's PID is queried via
+            // `launchctl print`. The menubar stays open afterward, and the
+            // user's next Start All click lands on a freshly-empty state
+            // because removePidFile happens during the kill pass.
             //
-            // NOTE for PR-4: once Postgres + Tika move to launchd agents,
-            // this handler also needs to await each agent.stop() to issue
-            // launchctl bootout — otherwise launchd's KeepAlive would
-            // resurrect the postmaster after our SIGKILL.
-            self.serviceManager.forceKillEverything()
+            // Task 7 (PR-4) adds explicit `agent.stop()` for postgres + tika
+            // here so launchd's KeepAlive doesn't resurrect them after our
+            // SIGKILL.
+            await self.serviceManager.forceKillEverything()
             self.serviceManager.notifyStateChanged()
         }
     }

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -73,6 +73,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 "Shutdown exceeded \(deadlineSeconds, privacy: .public)s deadline — force-killing tracked children and exiting"
             )
             await self.serviceManager.forceKillEverything()
+            // launchd-managed agents — bootout so KeepAlive doesn't
+            // resurrect the postmaster / Tika JVM after our SIGKILL.
+            await self.serviceManager.postgresService.stop()
+            await self.serviceManager.tikaService.stop()
             // exit(0) bypasses any further AppKit teardown. We've signalled
             // every child we know about; the kernel will reparent any
             // survivors to launchd. Reaching this line means stopAll() was
@@ -245,11 +249,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // `launchctl print`. The menubar stays open afterward, and the
             // user's next Start All click lands on a freshly-empty state
             // because removePidFile happens during the kill pass.
-            //
-            // Task 7 (PR-4) adds explicit `agent.stop()` for postgres + tika
-            // here so launchd's KeepAlive doesn't resurrect them after our
-            // SIGKILL.
             await self.serviceManager.forceKillEverything()
+
+            // launchd-managed agents — let launchctl bootout do the right
+            // thing for them rather than relying on just the SIGKILL above.
+            // Without bootout, launchd's KeepAlive would observe the
+            // unexpected exit and auto-restart the postmaster / Tika JVM,
+            // defeating the user's "stop everything" intent.
+            await self.serviceManager.postgresService.stop()
+            await self.serviceManager.tikaService.stop()
+
             self.serviceManager.notifyStateChanged()
         }
     }

--- a/macos/HarborClerkServer/HarborClerkServer/HealthChecker.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/HealthChecker.swift
@@ -97,6 +97,13 @@ final class HealthChecker {
                     changed = true
                     Log.logger("health").error(
                         "[\(service.name, privacy: .public)] \(self.consecutiveFailuresBeforeError, privacy: .public) consecutive failures — marked errored")
+
+                    // Skip auto-restart for launchd-managed services —
+                    // launchd's KeepAlive handles their crash recovery and
+                    // we'd double-restart otherwise. The menubar's role for
+                    // these is just status display.
+                    guard !service.isLaunchdManaged else { continue }
+
                     // Dispatch the auto-restart as a tracked Task instead
                     // of awaiting inline. See `taskHandles` doc for the
                     // race this closes. `defer` can't directly mutate

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
@@ -72,9 +72,29 @@ final class RealLaunchctlClient: LaunchctlClient {
 
         return await withCheckedContinuation { c in
             DispatchQueue.global().async {
+                // Drain pipes on background queues so the child can keep
+                // writing without blocking on pipe-buffer-full. Without
+                // this, `launchctl print` output > ~64 KB deadlocks because
+                // waitUntilExit waits for the child but the child is
+                // stuck in write(2). Same pattern PR-1 applied to Python
+                // service pipes.
+                let outQueue = DispatchQueue(label: "launchctl-stdout-drain")
+                let errQueue = DispatchQueue(label: "launchctl-stderr-drain")
+                var outData = Data()
+                var errData = Data()
+                let group = DispatchGroup()
+                group.enter()
+                outQueue.async {
+                    outData = stdout.fileHandleForReading.readDataToEndOfFile()
+                    group.leave()
+                }
+                group.enter()
+                errQueue.async {
+                    errData = stderr.fileHandleForReading.readDataToEndOfFile()
+                    group.leave()
+                }
                 proc.waitUntilExit()
-                let outData = stdout.fileHandleForReading.readDataToEndOfFile()
-                let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+                group.wait()
                 c.resume(returning: LaunchctlResult(
                     exitCode: proc.terminationStatus,
                     stdout: String(data: outData, encoding: .utf8) ?? "",

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
@@ -137,6 +137,12 @@ final class RealLaunchctlClient: LaunchctlClient {
 /// writers leave the group before the consumer thread enters `group.wait()`
 /// and reads `.value`. Swift's Sendable checker can't prove this so we
 /// assert it ourselves.
+///
+/// IMPORTANT: never read `.value` before the gating `group.wait()` returns.
+/// The DispatchGroup is what synchronizes the writes, not the class itself.
+/// A future maintainer adding a read on the producer side (before the
+/// consumer's group.wait) would silently introduce a data race that the
+/// @unchecked annotation suppresses.
 private final class MutableBox<T>: @unchecked Sendable {
     var value: T
     init(_ initial: T) { self.value = initial }

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
@@ -60,49 +60,86 @@ final class RealLaunchctlClient: LaunchctlClient {
         proc.standardOutput = stdout
         proc.standardError = stderr
 
-        do {
-            try proc.run()
-        } catch {
-            return LaunchctlResult(
-                exitCode: -1,
-                stdout: "",
-                stderr: "failed to launch launchctl: \(error)",
-            )
-        }
-
         return await withCheckedContinuation { c in
+            // Three things must complete before we resume:
+            //   1. child exits (terminationHandler fires)
+            //   2. stdout drain hits EOF
+            //   3. stderr drain hits EOF
+            // A DispatchGroup gates the resume on all three.
+            let group = DispatchGroup()
+            let outBox = MutableBox<Data>(.init())
+            let errBox = MutableBox<Data>(.init())
+
+            // Drain stdout/stderr on background queues. Without concurrent
+            // drains, `launchctl print` output > ~64 KB would block in the
+            // child's write(2) (kernel pipe buffer fills).
+            group.enter()
             DispatchQueue.global().async {
-                // Drain pipes on background queues so the child can keep
-                // writing without blocking on pipe-buffer-full. Without
-                // this, `launchctl print` output > ~64 KB deadlocks because
-                // waitUntilExit waits for the child but the child is
-                // stuck in write(2). Same pattern PR-1 applied to Python
-                // service pipes.
-                let outQueue = DispatchQueue(label: "launchctl-stdout-drain")
-                let errQueue = DispatchQueue(label: "launchctl-stderr-drain")
-                var outData = Data()
-                var errData = Data()
-                let group = DispatchGroup()
-                group.enter()
-                outQueue.async {
-                    outData = stdout.fileHandleForReading.readDataToEndOfFile()
-                    group.leave()
-                }
-                group.enter()
-                errQueue.async {
-                    errData = stderr.fileHandleForReading.readDataToEndOfFile()
-                    group.leave()
-                }
-                proc.waitUntilExit()
+                outBox.value = stdout.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+            group.enter()
+            DispatchQueue.global().async {
+                errBox.value = stderr.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+
+            // terminationHandler fires from Foundation's internal queue
+            // when the child exits, regardless of which thread launched
+            // the Process. Replaces `proc.waitUntilExit()` — empirically
+            // unreliable when `proc.run()` is called from one thread
+            // (MainActor here) and the wait is called from another
+            // (DispatchQueue.global()). Witnessed in the wild on first
+            // launch: `sample` of the hung menubar showed a worker thread
+            // spinning `mach_msg2_trap` inside `waitUntilExit` with no
+            // live child process and both pipe drains already finished.
+            // The termination signal reached Foundation but the dispatch
+            // queue's runloop never woke up.
+            group.enter()
+            proc.terminationHandler = { _ in group.leave() }
+
+            do {
+                try proc.run()
+            } catch {
+                // terminationHandler will NOT fire if run() threw —
+                // balance the third group.enter() manually, and close
+                // the read ends so the drains don't block forever.
+                try? stdout.fileHandleForReading.close()
+                try? stderr.fileHandleForReading.close()
+                group.leave()
+                c.resume(returning: LaunchctlResult(
+                    exitCode: -1,
+                    stdout: "",
+                    stderr: "failed to launch launchctl: \(error)",
+                ))
+                return
+            }
+
+            // Wait for all three (term + 2 drains) on a background queue
+            // so we don't block the calling actor.
+            DispatchQueue.global().async {
                 group.wait()
                 c.resume(returning: LaunchctlResult(
                     exitCode: proc.terminationStatus,
-                    stdout: String(data: outData, encoding: .utf8) ?? "",
-                    stderr: String(data: errData, encoding: .utf8) ?? "",
+                    stdout: String(data: outBox.value, encoding: .utf8) ?? "",
+                    stderr: String(data: errBox.value, encoding: .utf8) ?? "",
                 ))
             }
         }
     }
+}
+
+/// Reference wrapper so `let` closures can mutate captured state without
+/// `inout` gymnastics. Used by `RealLaunchctlClient.run` to assemble
+/// stdout/stderr Data across three concurrent dispatch blocks.
+///
+/// `@unchecked Sendable` because access is serialized by a DispatchGroup —
+/// writers leave the group before the consumer thread enters `group.wait()`
+/// and reads `.value`. Swift's Sendable checker can't prove this so we
+/// assert it ourselves.
+private final class MutableBox<T>: @unchecked Sendable {
+    var value: T
+    init(_ initial: T) { self.value = initial }
 }
 
 /// Test implementation that records every invocation and returns

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchctlClient.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Result of a `launchctl` invocation.
+struct LaunchctlResult: Equatable {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+
+    var success: Bool { exitCode == 0 }
+}
+
+/// Abstraction over `/bin/launchctl` invocations so the LaunchdAgent
+/// lifecycle logic is unit-testable. Production uses `RealLaunchctlClient`
+/// which shells out via `Process`; tests use `FakeLaunchctlClient` which
+/// records invocations and returns scripted results.
+protocol LaunchctlClient: AnyObject {
+    /// `launchctl bootstrap <domain-target> <plist-path>`
+    func bootstrap(domain: String, plistPath: URL) async -> LaunchctlResult
+
+    /// `launchctl bootout <service-target>` where service-target is
+    /// `<domain>/<label>` (or pass the plist path — both work; the
+    /// service-target form is preferred).
+    func bootout(serviceTarget: String) async -> LaunchctlResult
+
+    /// `launchctl kickstart -k <service-target>` — start the service, or
+    /// restart if already running (-k for "kill and restart").
+    func kickstart(serviceTarget: String) async -> LaunchctlResult
+
+    /// `launchctl print <service-target>` — returns the parsed PID + state.
+    /// Result.stdout is the raw output; the caller (LaunchdAgent) parses.
+    func print_(serviceTarget: String) async -> LaunchctlResult
+}
+
+/// Production implementation that shells out via `Process`.
+final class RealLaunchctlClient: LaunchctlClient {
+    private static let launchctlPath = "/bin/launchctl"
+
+    func bootstrap(domain: String, plistPath: URL) async -> LaunchctlResult {
+        await run(["bootstrap", domain, plistPath.path])
+    }
+
+    func bootout(serviceTarget: String) async -> LaunchctlResult {
+        await run(["bootout", serviceTarget])
+    }
+
+    func kickstart(serviceTarget: String) async -> LaunchctlResult {
+        await run(["kickstart", "-k", serviceTarget])
+    }
+
+    func print_(serviceTarget: String) async -> LaunchctlResult {
+        await run(["print", serviceTarget])
+    }
+
+    private func run(_ args: [String]) async -> LaunchctlResult {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: Self.launchctlPath)
+        proc.arguments = args
+        let stdout = Pipe()
+        let stderr = Pipe()
+        proc.standardOutput = stdout
+        proc.standardError = stderr
+
+        do {
+            try proc.run()
+        } catch {
+            return LaunchctlResult(
+                exitCode: -1,
+                stdout: "",
+                stderr: "failed to launch launchctl: \(error)",
+            )
+        }
+
+        return await withCheckedContinuation { c in
+            DispatchQueue.global().async {
+                proc.waitUntilExit()
+                let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+                c.resume(returning: LaunchctlResult(
+                    exitCode: proc.terminationStatus,
+                    stdout: String(data: outData, encoding: .utf8) ?? "",
+                    stderr: String(data: errData, encoding: .utf8) ?? "",
+                ))
+            }
+        }
+    }
+}
+
+/// Test implementation that records every invocation and returns
+/// caller-scripted results. Default behaviour: every call returns
+/// success with empty output.
+final class FakeLaunchctlClient: LaunchctlClient {
+    /// Recorded invocations, in call order. Format: "verb arg1 arg2 ..."
+    /// e.g. "bootstrap gui/501 /Users/alex/Library/LaunchAgents/com.example.plist"
+    private(set) var invocations: [String] = []
+
+    /// Override the result for the next matching invocation. Set on a
+    /// per-verb basis. If not set, defaults to a success result.
+    var nextBootstrapResult: LaunchctlResult?
+    var nextBootoutResult: LaunchctlResult?
+    var nextKickstartResult: LaunchctlResult?
+    var nextPrintResult: LaunchctlResult?
+
+    func bootstrap(domain: String, plistPath: URL) async -> LaunchctlResult {
+        invocations.append("bootstrap \(domain) \(plistPath.path)")
+        let r = nextBootstrapResult ?? .ok
+        nextBootstrapResult = nil
+        return r
+    }
+    func bootout(serviceTarget: String) async -> LaunchctlResult {
+        invocations.append("bootout \(serviceTarget)")
+        let r = nextBootoutResult ?? .ok
+        nextBootoutResult = nil
+        return r
+    }
+    func kickstart(serviceTarget: String) async -> LaunchctlResult {
+        invocations.append("kickstart \(serviceTarget)")
+        let r = nextKickstartResult ?? .ok
+        nextKickstartResult = nil
+        return r
+    }
+    func print_(serviceTarget: String) async -> LaunchctlResult {
+        invocations.append("print \(serviceTarget)")
+        let r = nextPrintResult ?? .ok
+        nextPrintResult = nil
+        return r
+    }
+}
+
+extension LaunchctlResult {
+    static let ok = LaunchctlResult(exitCode: 0, stdout: "", stderr: "")
+}

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
@@ -41,41 +41,66 @@ final class LaunchdAgent {
         self.log = Log.logger("launchd-\(label.replacingOccurrences(of: ".", with: "-"))")
     }
 
-    /// Write the plist to disk if its contents differ from the new
-    /// `content`. If the plist had to be rewritten (or wasn't on disk),
-    /// bootout the existing service (idempotent — bootout of a not-
-    /// loaded service is allowed) and bootstrap the new one.
+    /// Make the plist match `plistContent` on disk AND ensure the service
+    /// is loaded in launchd. Two independent goals because they're tracked
+    /// in two different places:
+    ///   - plist file on disk (under ~/Library/LaunchAgents/)
+    ///   - service-target loaded in the user's gui/<uid> domain
+    ///
+    /// `stop()` calls `bootout`, which unloads the service from the domain
+    /// but leaves the plist file alone. So a subsequent launch can see a
+    /// matching plist with no loaded service — we must still bootstrap, or
+    /// the next `kickstart` will fail with "Could not find service".
     ///
     /// Called by services during their start() — every menubar launch
     /// runs this, so plist drift across upgrades / bundle moves is
-    /// self-healing.
+    /// self-healing, AND the loaded-state is self-healing across the
+    /// stop→start cycle that happens every menubar quit/relaunch.
     func ensureInstalled(plistContent: String) async throws {
         let onDisk = try? String(contentsOf: plistURL, encoding: .utf8)
-        if onDisk == plistContent {
-            log.debug("plist on disk matches; no rewrite needed")
+        let plistMatches = (onDisk == plistContent)
+
+        if !plistMatches {
+            log.info("plist content drift — bootout, rewrite, bootstrap")
+
+            // Bootout if currently loaded. Don't error if it wasn't loaded;
+            // we just want a known-clean state before the rewrite + bootstrap.
+            _ = await launchctl.bootout(serviceTarget: serviceTarget)
+
+            // Make sure the parent directory exists.
+            try FileManager.default.createDirectory(
+                at: plistURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+            )
+
+            do {
+                try plistContent.write(to: plistURL, atomically: true, encoding: .utf8)
+            } catch {
+                throw LaunchdAgentError.plistWriteFailed(plistURL, error)
+            }
+
+            // We just bootout'd; the service is guaranteed not loaded.
+            // Bootstrap unconditionally.
+            let bootstrap = await launchctl.bootstrap(domain: domainTarget, plistPath: plistURL)
+            guard bootstrap.success else { throw LaunchdAgentError.bootstrapFailed(bootstrap) }
             return
         }
 
-        log.info("plist content drift — bootout, rewrite, bootstrap")
-
-        // Bootout if currently loaded. Don't error if it wasn't loaded;
-        // we just want a known-clean state before bootstrap.
-        _ = await launchctl.bootout(serviceTarget: serviceTarget)
-
-        // Make sure the parent directory exists.
-        try FileManager.default.createDirectory(
-            at: plistURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true,
-        )
-
-        do {
-            try plistContent.write(to: plistURL, atomically: true, encoding: .utf8)
-        } catch {
-            throw LaunchdAgentError.plistWriteFailed(plistURL, error)
+        // Plist matches on disk, but plist-on-disk and service-loaded are
+        // independent: `stop()` calls bootout, which unloads the service
+        // from the domain but leaves the plist file in place. So the
+        // matching-plist path doesn't guarantee a loaded service. Verify
+        // and re-bootstrap if needed — otherwise the next kickstart fails
+        // with "Could not find service", and the menubar reports the
+        // service as errored on every launch after a clean quit.
+        let currentState = await status()
+        if currentState == .notLoaded {
+            log.info("plist matches but service not loaded — bootstrap")
+            let bootstrap = await launchctl.bootstrap(domain: domainTarget, plistPath: plistURL)
+            guard bootstrap.success else { throw LaunchdAgentError.bootstrapFailed(bootstrap) }
+        } else {
+            log.debug("plist matches and service is loaded — no action needed")
         }
-
-        let bootstrap = await launchctl.bootstrap(domain: domainTarget, plistPath: plistURL)
-        guard bootstrap.success else { throw LaunchdAgentError.bootstrapFailed(bootstrap) }
     }
 
     /// `launchctl kickstart -k` — starts the service, or restarts it

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
@@ -1,0 +1,125 @@
+import Foundation
+import os
+
+enum LaunchdAgentError: LocalizedError {
+    case plistWriteFailed(URL, Error)
+    case bootstrapFailed(LaunchctlResult)
+    case bootoutFailed(LaunchctlResult)
+    case kickstartFailed(LaunchctlResult)
+
+    var errorDescription: String? {
+        switch self {
+        case .plistWriteFailed(let url, let err): return "failed to write plist at \(url.path): \(err)"
+        case .bootstrapFailed(let r):              return "launchctl bootstrap failed (exit \(r.exitCode)): \(r.stderr)"
+        case .bootoutFailed(let r):                return "launchctl bootout failed (exit \(r.exitCode)): \(r.stderr)"
+        case .kickstartFailed(let r):              return "launchctl kickstart failed (exit \(r.exitCode)): \(r.stderr)"
+        }
+    }
+}
+
+enum LaunchdServiceState: Equatable {
+    case loaded(pid: Int32?)   // pid nil if loaded-but-not-running
+    case notLoaded
+}
+
+/// Wraps the lifecycle of one LaunchAgent: idempotent plist install,
+/// start (kickstart), stop (bootout), status (print + parse), uninstall
+/// (bootout + delete plist).
+final class LaunchdAgent {
+    let label: String
+    let plistURL: URL
+    private let launchctl: LaunchctlClient
+    private let log: Logger
+
+    var domainTarget: String { "gui/\(getuid())" }
+    var serviceTarget: String { "\(domainTarget)/\(label)" }
+
+    init(label: String, plistURL: URL, launchctl: LaunchctlClient = RealLaunchctlClient()) {
+        self.label = label
+        self.plistURL = plistURL
+        self.launchctl = launchctl
+        self.log = Log.logger("launchd-\(label.replacingOccurrences(of: ".", with: "-"))")
+    }
+
+    /// Write the plist to disk if its contents differ from the new
+    /// `content`. If the plist had to be rewritten (or wasn't on disk),
+    /// bootout the existing service (idempotent — bootout of a not-
+    /// loaded service is allowed) and bootstrap the new one.
+    ///
+    /// Called by services during their start() — every menubar launch
+    /// runs this, so plist drift across upgrades / bundle moves is
+    /// self-healing.
+    func ensureInstalled(plistContent: String) async throws {
+        let onDisk = try? String(contentsOf: plistURL, encoding: .utf8)
+        if onDisk == plistContent {
+            log.debug("plist on disk matches; no rewrite needed")
+            return
+        }
+
+        log.info("plist content drift — bootout, rewrite, bootstrap")
+
+        // Bootout if currently loaded. Don't error if it wasn't loaded;
+        // we just want a known-clean state before bootstrap.
+        _ = await launchctl.bootout(serviceTarget: serviceTarget)
+
+        // Make sure the parent directory exists.
+        try FileManager.default.createDirectory(
+            at: plistURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+        )
+
+        do {
+            try plistContent.write(to: plistURL, atomically: true, encoding: .utf8)
+        } catch {
+            throw LaunchdAgentError.plistWriteFailed(plistURL, error)
+        }
+
+        let bootstrap = await launchctl.bootstrap(domain: domainTarget, plistPath: plistURL)
+        guard bootstrap.success else { throw LaunchdAgentError.bootstrapFailed(bootstrap) }
+    }
+
+    /// `launchctl kickstart -k` — starts the service, or restarts it
+    /// if already running. After ensureInstalled, this is the verb to
+    /// actually launch the process.
+    func start() async throws {
+        let r = await launchctl.kickstart(serviceTarget: serviceTarget)
+        guard r.success else { throw LaunchdAgentError.kickstartFailed(r) }
+    }
+
+    /// `launchctl bootout` — stops the service. Does NOT uninstall the
+    /// plist or unregister from launchd; that's `uninstall()`.
+    func stop() async throws {
+        let r = await launchctl.bootout(serviceTarget: serviceTarget)
+        // bootout of a not-loaded service may exit non-zero. We treat
+        // any "service not found" outcome as success — the goal is
+        // "service is not running" and that goal is met.
+        if !r.success && !r.stderr.lowercased().contains("could not find service") {
+            throw LaunchdAgentError.bootoutFailed(r)
+        }
+    }
+
+    /// Parse `launchctl print <service-target>` for PID + load state.
+    /// Returns .notLoaded if launchctl reports no such service.
+    func status() async -> LaunchdServiceState {
+        let r = await launchctl.print_(serviceTarget: serviceTarget)
+        if !r.success {
+            // Common failure: "Could not find service ... in domain ..."
+            return .notLoaded
+        }
+        // launchctl print output is human-readable; we look for the
+        // "pid = N" line. Absent → loaded but not running. Present → loaded
+        // and running.
+        if let pidLine = r.stdout.split(separator: "\n").first(where: { $0.contains("pid =") }) {
+            let pidStr = pidLine.split(separator: "=").last?.trimmingCharacters(in: .whitespaces) ?? ""
+            return .loaded(pid: Int32(pidStr))
+        }
+        return .loaded(pid: nil)
+    }
+
+    /// Stop + delete plist + remove launchd registration. Used by
+    /// "Uninstall Services" (future) and at-uninstall scripts.
+    func uninstall() async {
+        try? await stop()
+        try? FileManager.default.removeItem(at: plistURL)
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
@@ -106,7 +106,25 @@ final class LaunchdAgent {
     /// `launchctl kickstart -k` — starts the service, or restarts it
     /// if already running. After ensureInstalled, this is the verb to
     /// actually launch the process.
+    ///
+    /// Skip-when-already-running: kickstart's `-k` flag means "Kill the
+    /// service instance if it is currently running, then start it again"
+    /// — which would defeat the whole crash-survival selling point of
+    /// PR-4 (postgres+tika kept alive across a menubar crash via
+    /// launchd's KeepAlive should NOT be SIGTERMed by the next menubar
+    /// launch). Check status first: if a live PID is already attached
+    /// to this service-target, leave it alone.
     func start() async throws {
+        if case .loaded(let maybePid) = await status(),
+           let pid = maybePid, pid > 0,
+           kill(pid, 0) == 0 {
+            // Already running with a live PID — skip kickstart. The
+            // existing process continues serving (the whole point of the
+            // crash-survival path). The caller's subsequent health check
+            // will verify the running process is responsive.
+            log.info("service already running (pid \(pid, privacy: .public)) — skip kickstart")
+            return
+        }
         let r = await launchctl.kickstart(serviceTarget: serviceTarget)
         guard r.success else { throw LaunchdAgentError.kickstartFailed(r) }
     }

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchdAgent.swift
@@ -93,9 +93,23 @@ final class LaunchdAgent {
         // bootout of a not-loaded service may exit non-zero. We treat
         // any "service not found" outcome as success — the goal is
         // "service is not running" and that goal is met.
-        if !r.success && !r.stderr.lowercased().contains("could not find service") {
+        if !r.success && !Self.isNotLoadedError(r.stderr) {
             throw LaunchdAgentError.bootoutFailed(r)
         }
+    }
+
+    /// True when the stderr indicates the service was already not loaded.
+    /// Three forms observed across macOS versions:
+    ///   "Could not find service ..." (older / common)
+    ///   "Boot-out failed: 36: Operation now in progress" (EBUSY, recent macOS)
+    ///   "Boot-out failed: 3: No such process" (ESRCH)
+    /// Plus a generic "no such process" fallback.
+    private static func isNotLoadedError(_ stderr: String) -> Bool {
+        let s = stderr.lowercased()
+        return s.contains("could not find service")
+            || s.contains("boot-out failed: 36")
+            || s.contains("boot-out failed: 3")
+            || s.contains("no such process")
     }
 
     /// Parse `launchctl print <service-target>` for PID + load state.
@@ -108,8 +122,12 @@ final class LaunchdAgent {
         }
         // launchctl print output is human-readable; we look for the
         // "pid = N" line. Absent → loaded but not running. Present → loaded
-        // and running.
-        if let pidLine = r.stdout.split(separator: "\n").first(where: { $0.contains("pid =") }) {
+        // and running. Trim leading whitespace/tabs first so we match
+        // "pid =" but NOT "original pid =" (a stopped-but-loaded marker
+        // whose stale value could be SIGKILLed against a recycled PID).
+        if let pidLine = r.stdout.split(separator: "\n").first(where: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("pid =")
+        }) {
             let pidStr = pidLine.split(separator: "=").last?.trimmingCharacters(in: .whitespaces) ?? ""
             return .loaded(pid: Int32(pidStr))
         }

--- a/macos/HarborClerkServer/HarborClerkServer/LaunchdPlist.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LaunchdPlist.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Generates LaunchAgent plist XML for our two launchd-managed services.
+///
+/// The plists hold absolute paths to the bundled binaries plus the user's
+/// data + logs directories. Because the bundle can live in any location
+/// (the user might keep it in /Applications, ~/Applications, or run it
+/// from a build directory), plist contents are regenerated on every
+/// menubar startup from the current `Bundle.main.resourceURL` and
+/// `AppSettings`. LaunchdAgent.ensureInstalled compares the generated
+/// content to what's on disk and only bootout-rewrite-bootstraps when
+/// something changed.
+enum LaunchdPlist {
+
+    /// Postgres LaunchAgent plist contents. The `Program` is `postgres`
+    /// directly (NOT `pg_ctl`) so launchd tracks the postmaster's PID.
+    /// pg_ctl is a wrapper that starts postgres and exits; if launchd
+    /// tracked pg_ctl it would either restart-loop it or consider the
+    /// service gone.
+    static func postgres(bundle: URL, dataDir: URL, logsDir: URL, port: Int) -> String {
+        let postgresBin = bundle.appendingPathComponent("postgres/bin/postgres").path
+        let pgBinDir = bundle.appendingPathComponent("postgres/bin").path
+        let pgLibDir = bundle.appendingPathComponent("postgres/lib").path
+        let pgShareDir = bundle.appendingPathComponent("postgres/share").path
+        let logFile = logsDir.appendingPathComponent("postgres-launchd.log").path
+
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>com.harborclerk.postgres</string>
+            <key>Program</key>
+            <string>\(postgresBin)</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>\(postgresBin)</string>
+                <string>-D</string>
+                <string>\(dataDir.path)</string>
+                <string>-p</string>
+                <string>\(port)</string>
+                <string>-k</string>
+                <string>/tmp</string>
+            </array>
+            <key>EnvironmentVariables</key>
+            <dict>
+                <key>PGDATA</key>
+                <string>\(dataDir.path)</string>
+                <key>PATH</key>
+                <string>\(pgBinDir):/usr/bin:/bin</string>
+                <key>LD_LIBRARY_PATH</key>
+                <string>\(pgLibDir)</string>
+                <key>DYLD_LIBRARY_PATH</key>
+                <string>\(pgLibDir)</string>
+                <key>PGSHARE</key>
+                <string>\(pgShareDir)</string>
+            </dict>
+            <key>RunAtLoad</key>
+            <false/>
+            <key>KeepAlive</key>
+            <dict>
+                <key>SuccessfulExit</key>
+                <false/>
+            </dict>
+            <key>StandardOutPath</key>
+            <string>\(logFile)</string>
+            <key>StandardErrorPath</key>
+            <string>\(logFile)</string>
+        </dict>
+        </plist>
+        """
+    }
+
+    /// Tika LaunchAgent plist contents. Same shape as postgres.
+    static func tika(bundle: URL, logsDir: URL, port: Int) -> String {
+        let javaBin = bundle.appendingPathComponent("java/Contents/Home/bin/java").path
+        let javaHome = bundle.appendingPathComponent("java/Contents/Home").path
+        let tikaJar = bundle.appendingPathComponent("tika/tika-server.jar").path
+        let logFile = logsDir.appendingPathComponent("tika-launchd.log").path
+
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>com.harborclerk.tika</string>
+            <key>Program</key>
+            <string>\(javaBin)</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>\(javaBin)</string>
+                <string>-jar</string>
+                <string>\(tikaJar)</string>
+                <string>--host</string>
+                <string>127.0.0.1</string>
+                <string>--port</string>
+                <string>\(port)</string>
+            </array>
+            <key>EnvironmentVariables</key>
+            <dict>
+                <key>JAVA_HOME</key>
+                <string>\(javaHome)</string>
+                <key>PATH</key>
+                <string>\(javaHome)/bin:/usr/bin:/bin</string>
+            </dict>
+            <key>RunAtLoad</key>
+            <false/>
+            <key>KeepAlive</key>
+            <dict>
+                <key>SuccessfulExit</key>
+                <false/>
+            </dict>
+            <key>StandardOutPath</key>
+            <string>\(logFile)</string>
+            <key>StandardErrorPath</key>
+            <string>\(logFile)</string>
+        </dict>
+        </plist>
+        """
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServer/MigrationRunner.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/MigrationRunner.swift
@@ -50,13 +50,12 @@ struct MigrationRunner {
         proc.standardOutput = pipe
         proc.standardError = pipe
 
-        try proc.run()
-        let exitCode: Int32 = await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                c.resume(returning: proc.terminationStatus)
-            }
-        }
+        // `Process.runAndAwait` uses terminationHandler — safer than
+        // `waitUntilExit` (see ProcessAsync.swift). Alembic typically
+        // runs for seconds, so the short-lived-child race that hung
+        // launchctl in the wild doesn't apply here, but use the same
+        // helper everywhere so we have one wait pattern to reason about.
+        let exitCode = try await proc.runAndAwait()
 
         if exitCode != 0 {
             throw ServiceError.startFailed("Alembic", "exit code \(exitCode)")

--- a/macos/HarborClerkServer/HarborClerkServer/ProcessAsync.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ProcessAsync.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension Process {
+    /// Async-await replacement for `try run()` followed by `waitUntilExit()`.
+    /// Safe to call from any actor / dispatch queue.
+    ///
+    /// Uses `terminationHandler`, which Foundation fires from its internal
+    /// queue when the child exits. Replaces `waitUntilExit()` because that
+    /// method spins a CFRunLoop on the *calling* thread, and the
+    /// termination notification doesn't reliably wake up a dispatch-queue
+    /// runloop when `run()` and `waitUntilExit()` happen on different
+    /// threads. Witnessed in the wild during PR-4 smoke testing:
+    /// `launchctl bootout` (a ~7ms child) hung the menubar forever on
+    /// first launch — `sample` showed a worker thread spinning
+    /// `mach_msg2_trap` inside `waitUntilExit` with no live child and
+    /// pipe drains already finished.
+    ///
+    /// The hypothesis is a race with very-short-lived children: the
+    /// termination notification arrives before the wait thread's runloop
+    /// has fully attached as a listener. The `terminationHandler` path
+    /// has no such race because the handler is installed *before* `run()`
+    /// — Foundation guarantees the closure runs when the child exits
+    /// regardless of timing or thread.
+    ///
+    /// `MigrationRunner.runAlembic`, `PostgresService.healthCheck`,
+    /// `bundledPgMajorVersion`, `initializeDatabase`, and
+    /// `createDatabaseAndExtensions` all previously used the unsafe
+    /// pattern; this helper exists so they migrate to one shared
+    /// implementation.
+    ///
+    /// Returns `terminationStatus` on clean exit. Throws if `run()` throws
+    /// (e.g. executable not found). The caller still owns stdout/stderr
+    /// pipe setup; this helper only manages the lifecycle.
+    func runAndAwait() async throws -> Int32 {
+        // Edge case: an earlier termination handler could still be set
+        // (callers shouldn't rely on this, but be defensive). Replace it
+        // — we own the lifecycle for this call.
+        try await withCheckedThrowingContinuation { (c: CheckedContinuation<Int32, Error>) in
+            terminationHandler = { proc in
+                c.resume(returning: proc.terminationStatus)
+            }
+            do {
+                try run()
+            } catch {
+                // run() failed — terminationHandler will never fire.
+                // Clear it (release the captured continuation) and throw.
+                terminationHandler = nil
+                c.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -187,10 +187,15 @@ class ServiceManager: ObservableObject {
     private func savePidFile() {
         var pids: [String] = []
         for service in services {
+            // Skip launchd-managed services — launchd tracks their PIDs
+            // and they're not orphans-from-our-perspective (a menubar
+            // crash leaves them running, and the next launch will
+            // re-attach via launchctl).
+            if let lm = service as? PostgresService, lm.isLaunchdManaged { continue }
+            if let lm = service as? TikaService, lm.isLaunchdManaged { continue }
+
             if let pySvc = service as? PythonService, let proc = pySvc.process, proc.isRunning {
                 pids.append(String(proc.processIdentifier))
-            } else if let tika = service as? TikaService, let pid = tika.processIdentifier {
-                pids.append(String(pid))
             } else if let llama = service as? LlamaService, let pid = llama.processIdentifier {
                 pids.append(String(pid))
             }
@@ -453,12 +458,41 @@ class ServiceManager: ObservableObject {
     /// this only catches the tracked PIDs, not their descendants. Tika's
     /// child JVMs and worker-spawned utilities can survive. Adding
     /// `posix_spawn` + `setpgid` + `killpg` is the durable fix.
-    func forceKillEverything() {
+    ///
+    /// Now `async` because launchd-managed services expose their PID via
+    /// `launchctl print` (queried inside `TikaService.processIdentifier`).
+    /// Postgres still uses postmaster.pid (same as the pre-launchd path —
+    /// the file is on-disk regardless of who's managing the postmaster).
+    func forceKillEverything() async {
         let logger = Log.logger("lifecycle")
         var killed: Set<Int32> = []
 
-        // 1) Every Process we currently hold.
         for service in services {
+            // launchd-managed services: query launchctl for pid, then SIGKILL.
+            // Tika's pid comes from `launchctl print`; Postgres uses postmaster.pid
+            // below (no async needed there).
+            if let tika = service as? TikaService, tika.isLaunchdManaged {
+                if let pid = await tika.processIdentifier, pid > 0 {
+                    // killpg reaches grandchildren when the tracked PID is a pgid leader.
+                    // launchd runs each agent in its own process group, so this catches
+                    // Tika's child JVMs.
+                    if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
+                    killed.insert(pid)
+                }
+                continue
+            }
+            if let postgres = service as? PostgresService, postgres.isLaunchdManaged {
+                // Use postmaster.pid (same as pre-launchd path).
+                let pgPidFile = AppSettings.shared.postgresDataDir.appendingPathComponent("postmaster.pid")
+                if let contents = try? String(contentsOf: pgPidFile, encoding: .utf8),
+                   let pidLine = contents.components(separatedBy: "\n").first,
+                   let pid = Int32(pidLine), pid > 0 {
+                    if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
+                    killed.insert(pid)
+                }
+                continue
+            }
+            // Non-launchd menubar children — same as before (post-PR-2).
             if let pySvc = service as? PythonService, let proc = pySvc.process {
                 let pid = proc.processIdentifier
                 if pid > 0 {
@@ -468,12 +502,6 @@ class ServiceManager: ObservableObject {
                     if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
                     killed.insert(pid)
                 }
-            } else if let tika = service as? TikaService, let pid = tika.processIdentifier {
-                // killpg reaches grandchildren when the tracked PID is a pgid leader
-                // (which it is, post-PR-2). Fall back to plain kill() for belt-and-
-                // suspenders.
-                if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
-                killed.insert(pid)
             } else if let llama = service as? LlamaService, let pid = llama.processIdentifier {
                 // killpg reaches grandchildren when the tracked PID is a pgid leader
                 // (which it is, post-PR-2). Fall back to plain kill() for belt-and-
@@ -483,24 +511,9 @@ class ServiceManager: ObservableObject {
             }
         }
 
-        // 2) Postgres — pg_ctl forks a postmaster we don't directly hold;
-        //    read its PID from the data dir so it doesn't survive as an
-        //    orphan still holding port 5433.
-        let pgPidFile = AppSettings.shared.postgresDataDir.appendingPathComponent("postmaster.pid")
-        if let contents = try? String(contentsOf: pgPidFile, encoding: .utf8),
-           let pidLine = contents.components(separatedBy: "\n").first,
-           let pid = Int32(pidLine), pid > 0, !killed.contains(pid)
-        {
-            // killpg reaches grandchildren when the tracked PID is a pgid leader
-            // (which it is, post-PR-2). Fall back to plain kill() for belt-and-
-            // suspenders.
-            if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
-            killed.insert(pid)
-        }
-
-        // 3) child-pids.txt — anything our in-memory state lost track of
-        //    (e.g. an auto-restart that swapped the Process ref after the
-        //    last savePidFile call).
+        // child-pids.txt — anything our in-memory state lost track of
+        // (e.g. an auto-restart that swapped the Process ref after the
+        // last savePidFile call).
         if let contents = try? String(contentsOf: Self.pidFileURL, encoding: .utf8) {
             for line in contents.components(separatedBy: "\n") {
                 let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -614,13 +627,10 @@ class ServiceManager: ObservableObject {
         service.state = .starting
         notifyStateChanged()
 
-        // Wire up auto-restart callback for crash recovery
-        if let tika = service as? TikaService {
-            tika.onUnexpectedExit = { [weak self, weak tika] in
-                guard let self, let svc = tika else { return }
-                Task { @MainActor in await self.attemptAutoRestart(svc) }
-            }
-        } else if let llama = service as? LlamaService {
+        // Wire up auto-restart callback for crash recovery.
+        // Tika is launchd-managed (PR-4) — KeepAlive handles its crash
+        // recovery, no `onUnexpectedExit` to wire up here.
+        if let llama = service as? LlamaService {
             llama.onUnexpectedExit = { [weak self, weak llama] in
                 guard let self, let svc = llama else { return }
                 Task { @MainActor in await self.attemptAutoRestart(svc) }

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -14,9 +14,20 @@ extension Notification.Name {
 protocol ManagedService: AnyObject {
     var name: String { get }
     var state: ServiceState { get set }
+    /// True for services whose lifecycle runs under launchd (PostgresService,
+    /// TikaService). HealthChecker uses this to skip its own auto-restart
+    /// path — launchd's KeepAlive already handles crash recovery, and
+    /// double-restarting via both layers would be a foot-gun.
+    var isLaunchdManaged: Bool { get }
     func start() async throws
     func stop() async
     func healthCheck() async -> Bool
+}
+
+/// Default-false `isLaunchdManaged` for services that aren't launchd-managed.
+/// PostgresService and TikaService override with `let isLaunchdManaged = true`.
+extension ManagedService {
+    var isLaunchdManaged: Bool { false }
 }
 
 // MARK: - Health-probe helper

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -272,6 +272,12 @@ class ServiceManager: ObservableObject {
         // ProcessAsync.swift). On error we still try to read the pipe;
         // it'll be empty and we fall through to the no-output guard.
         _ = try? await proc.runAndAwait()
+        // Explicitly close the parent's write-end copy before the read.
+        // Foundation usually closes it on its own when the child exits,
+        // but that's undocumented — without our own close, an unlucky
+        // future regression would leave readDataToEndOfFile blocked on
+        // MainActor.
+        try? pipe.fileHandleForWriting.close()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
 
         guard let output = String(data: data, encoding: .utf8)?

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -267,14 +267,12 @@ class ServiceManager: ObservableObject {
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
-        try? proc.run()
-        let data: Data = await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                let d = pipe.fileHandleForReading.readDataToEndOfFile()
-                c.resume(returning: d)
-            }
-        }
+        // `Process.runAndAwait` uses terminationHandler — safer than
+        // `waitUntilExit` for short-lived children like lsof (see
+        // ProcessAsync.swift). On error we still try to read the pipe;
+        // it'll be empty and we fall through to the no-output guard.
+        _ = try? await proc.runAndAwait()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
 
         guard let output = String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines),

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -4,7 +4,11 @@ import os
 final class LlamaService: ManagedService {
     let name = "LLM"
     var state: ServiceState = .stopped
-    private var process: Process?
+    /// Internal so `AppDelegate.forceStopAllServices` can nil this after a
+    /// SIGKILL pass — matches the access level of `PythonService.process`.
+    /// Without the nil, `processIdentifier` could surface a stale dead-PID
+    /// until Foundation's kqueue catches up.
+    var process: Process?
     /// Called after process exits unexpectedly and state is set to .errored.
     var onUnexpectedExit: (@MainActor () -> Void)?
 

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -316,6 +316,14 @@ final class PostgresService: ManagedService {
         // `postgres --version` output is ~27 bytes — well under the
         // 64KB pipe buffer, so reading after exit is safe (no need
         // for concurrent drain).
+        //
+        // Explicitly close the parent's copy of the write end before
+        // reading. The child's copy is already closed (process exited),
+        // and Foundation usually closes the parent's copy too — but
+        // that's undocumented. Without our own close, an unlucky
+        // Foundation regression would leave `readDataToEndOfFile`
+        // waiting for EOF forever, on MainActor.
+        try? pipe.fileHandleForWriting.close()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         // Output: "postgres (PostgreSQL) 18.3\n"
         guard let output = String(data: data, encoding: .utf8),

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -4,7 +4,23 @@ import os
 final class PostgresService: ManagedService {
     let name = "PostgreSQL"
     var state: ServiceState = .stopped
-    private var process: Process?
+    /// True for the launchd-managed services. The HealthChecker uses
+    /// this to skip its own auto-restart path — launchd's KeepAlive
+    /// already handles crash recovery, and double-restarting would be
+    /// a foot-gun.
+    let isLaunchdManaged = true
+
+    private let agent: LaunchdAgent
+
+    init(launchctl: LaunchctlClient = RealLaunchctlClient()) {
+        let plistURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/com.harborclerk.postgres.plist")
+        self.agent = LaunchdAgent(
+            label: "com.harborclerk.postgres",
+            plistURL: plistURL,
+            launchctl: launchctl,
+        )
+    }
 
     private var pgBinDir: URL {
         Bundle.main.resourceURL!.appendingPathComponent("postgres/bin")
@@ -74,7 +90,9 @@ final class PostgresService: ManagedService {
         // Ensure logging_collector config exists (upgrade from pre-0.4.1)
         try ensureLoggingConfig()
 
-        // Remove stale PID file if no process is actually running
+        // Stale postmaster.pid removal: same logic as before, but now we
+        // don't manually invoke pg_ctl stop — launchctl bootout (inside
+        // agent.ensureInstalled) handles the lingering instance.
         let pidFile = dataDir.appendingPathComponent("postmaster.pid")
         if fm.fileExists(atPath: pidFile.path) {
             let action = Self.stalePidAction(pidFileContents: try? String(contentsOf: pidFile))
@@ -85,92 +103,34 @@ final class PostgresService: ManagedService {
             case .removeUnparseable:
                 try? fm.removeItem(at: pidFile)
             case .keep:
-                // PostgreSQL is still running (possibly shutting down) — stop it first
-                Log.logger("postgresql").warning("Existing PostgreSQL process found, stopping it before start")
-                let stopProc = Process()
-                stopProc.executableURL = pgBinDir.appendingPathComponent("pg_ctl")
-                stopProc.arguments = ["-D", dataDir.path, "stop", "-m", "immediate"]
-                stopProc.environment = pgEnvironment()
-                stopProc.standardOutput = FileHandle.nullDevice
-                stopProc.standardError = FileHandle.nullDevice
-                try? stopProc.run()
-                await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                    DispatchQueue.global().async {
-                        stopProc.waitUntilExit()
-                        c.resume()
-                    }
-                }
+                Log.logger("postgresql").warning("Existing PostgreSQL process found; bootout will handle it")
+                // Don't kill manually — let agent.ensureInstalled's bootout
+                // do it cleanly via launchctl.
             }
         }
 
-        // Start PostgreSQL via pg_ctl
-        // Logs are handled by logging_collector (configured in conf.d/harbor_clerk.conf)
-        // Do NOT use Log.createPipe() — pg_ctl can fill the pipe buffer and deadlock
-        // with waitUntilExit() if the readability handler stalls.
-        let pgCtl = pgBinDir.appendingPathComponent("pg_ctl")
-        let proc = Process()
-        proc.executableURL = pgCtl
-        proc.arguments = [
-            "-D", dataDir.path,
-            "-o", "-p \(port) -k /tmp",
-            "start",
-        ]
-        proc.environment = pgEnvironment()
-        proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
+        // Install/refresh the plist with current bundle paths.
+        let plist = LaunchdPlist.postgres(
+            bundle: Bundle.main.resourceURL!,
+            dataDir: dataDir,
+            logsDir: AppSettings.shared.logsDir,
+            port: port,
+        )
+        try await agent.ensureInstalled(plistContent: plist)
 
-        try proc.run()
-        let exitCode: Int32 = await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                c.resume(returning: proc.terminationStatus)
-            }
-        }
-
-        if exitCode != 0 {
-            throw ServiceError.startFailed(name, "pg_ctl start exited with \(exitCode)")
-        }
+        // launchctl kickstart -k starts (or restarts) the service.
+        try await agent.start()
     }
 
     func stop() async {
         state = .stopping
-
-        // Phase 1: pg_ctl stop -m fast (SIGINT — orderly shutdown)
-        let pgCtl = pgBinDir.appendingPathComponent("pg_ctl")
-        let fastProc = Process()
-        fastProc.executableURL = pgCtl
-        fastProc.arguments = ["-D", dataDir.path, "stop", "-m", "fast", "-t", "15"]
-        fastProc.environment = pgEnvironment()
-        fastProc.standardOutput = FileHandle.nullDevice
-        fastProc.standardError = FileHandle.nullDevice
-        try? fastProc.run()
-        let fastExited = await Self.awaitExitedCleanly(fastProc)
-
-        if !fastExited {
-            // Phase 2: pg_ctl stop -m immediate (SIGQUIT — skip recovery)
-            Log.logger("lifecycle").warning("PostgreSQL fast shutdown failed, trying immediate mode")
-            let immProc = Process()
-            immProc.executableURL = pgCtl
-            immProc.arguments = ["-D", dataDir.path, "stop", "-m", "immediate"]
-            immProc.environment = pgEnvironment()
-            immProc.standardOutput = FileHandle.nullDevice
-            immProc.standardError = FileHandle.nullDevice
-            try? immProc.run()
-            let immExited = await Self.awaitExitedCleanly(immProc)
-
-            if !immExited {
-                // Phase 3: read postmaster.pid and SIGKILL
-                Log.logger("lifecycle").warning("PostgreSQL immediate shutdown failed, sending SIGKILL")
-                let pidFile = dataDir.appendingPathComponent("postmaster.pid")
-                if let contents = try? String(contentsOf: pidFile),
-                   let pidLine = contents.components(separatedBy: "\n").first,
-                   let pid = Int32(pidLine) {
-                    kill(pid, SIGKILL)
-                    usleep(1_000_000) // 1s for process to die
-                }
-            }
+        do {
+            try await agent.stop()
+        } catch {
+            Log.logger("postgresql").error(
+                "launchctl bootout failed: \(error.localizedDescription, privacy: .public)"
+            )
         }
-
         state = .stopped
     }
 
@@ -316,7 +276,7 @@ final class PostgresService: ManagedService {
             }
         }
 
-        // Stop — will be started properly by ServiceManager
+        // Stop — will be started properly by ServiceManager (via launchd)
         let stopProc = Process()
         stopProc.executableURL = pgCtl
         stopProc.arguments = ["-D", dataDir.path, "stop", "-m", "fast"]

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -64,7 +64,7 @@ final class PostgresService: ManagedService {
         let pgVersionFile = dataDir.appendingPathComponent("PG_VERSION")
 
         // Determine bundled PG major version (e.g. "18" from "postgres (PostgreSQL) 18.3")
-        let expectedMajor = bundledPgMajorVersion()
+        let expectedMajor = await bundledPgMajorVersion()
 
         // Check if data directory needs (re-)initialization
         var needsInit = false
@@ -323,25 +323,39 @@ final class PostgresService: ManagedService {
     }
 
     /// Extract the major version from the bundled postgres binary (e.g. "18").
-    private func bundledPgMajorVersion() -> String {
-        let proc = Process()
-        proc.executableURL = pgBinDir.appendingPathComponent("postgres")
-        proc.arguments = ["--version"]
-        proc.environment = pgEnvironment()
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = FileHandle.nullDevice
-        do {
-            try proc.run()
-            proc.waitUntilExit()
-        } catch {
-            return ""
+    ///
+    /// Async because `start()` runs on the MainActor — calling
+    /// `proc.waitUntilExit()` synchronously there blocks the actor and
+    /// stalls every other `@MainActor` task (CLAUDE.md gotcha:
+    /// "never call proc.waitUntilExit() on MainActor — always use the
+    /// async continuation pattern").
+    private func bundledPgMajorVersion() async -> String {
+        await withCheckedContinuation { c in
+            DispatchQueue.global().async {
+                let proc = Process()
+                proc.executableURL = self.pgBinDir.appendingPathComponent("postgres")
+                proc.arguments = ["--version"]
+                proc.environment = self.pgEnvironment()
+                let pipe = Pipe()
+                proc.standardOutput = pipe
+                proc.standardError = FileHandle.nullDevice
+                do {
+                    try proc.run()
+                    proc.waitUntilExit()
+                } catch {
+                    c.resume(returning: "")
+                    return
+                }
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                // Output: "postgres (PostgreSQL) 18.3\n"
+                guard let output = String(data: data, encoding: .utf8),
+                      let versionStr = output.split(separator: " ").last else {
+                    c.resume(returning: "")
+                    return
+                }
+                c.resume(returning: String(versionStr.split(separator: ".").first ?? ""))
+            }
         }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        // Output: "postgres (PostgreSQL) 18.3\n"
-        guard let output = String(data: data, encoding: .utf8) else { return "" }
-        guard let versionStr = output.split(separator: " ").last else { return "" }
-        return String(versionStr.split(separator: ".").first ?? "")
     }
 }
 

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -34,31 +34,6 @@ final class PostgresService: ManagedService {
     private var dataDir: URL { AppSettings.shared.postgresDataDir }
     private var port: Int { AppSettings.shared.postgresPort }
 
-    /// Wait for `proc` to exit, returning whether it terminated cleanly
-    /// (status == 0). Returns `false` (rather than raising) if the
-    /// process was never launched.
-    ///
-    /// Apple's documented behaviour for `terminationStatus` on a
-    /// Process that hasn't run is to raise `NSInvalidArgumentException`.
-    /// Swift can't catch that — it propagates as an unhandled
-    /// exception and aborts the entire app, taking every spawned
-    /// subprocess (including PostgreSQL mid-query) down with it.
-    /// We've actually seen this in the wild during model-switch
-    /// teardown when `try? proc.run()` swallowed a launch failure
-    /// upstream. See `project_menubar_crashes_during_model_switch.md`.
-    ///
-    /// `processIdentifier` is 0 for a never-launched Process, so
-    /// gating on `> 0` skips the throwing read.
-    private static func awaitExitedCleanly(_ proc: Process) async -> Bool {
-        await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                let exited = proc.processIdentifier != 0 && proc.terminationStatus == 0
-                c.resume(returning: exited)
-            }
-        }
-    }
-
     func start() async throws {
         let fm = FileManager.default
         let pgVersionFile = dataDir.appendingPathComponent("PG_VERSION")
@@ -142,8 +117,14 @@ final class PostgresService: ManagedService {
         proc.environment = pgEnvironment()
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
-        try? proc.run()
-        return await Self.awaitExitedCleanly(proc)
+        // `Process.runAndAwait` uses terminationHandler under the hood —
+        // safer than waitUntilExit for very short-lived children like
+        // pg_isready (~10ms). See `ProcessAsync.swift`.
+        do {
+            return try await proc.runAndAwait() == 0
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Logging Config
@@ -194,13 +175,7 @@ final class PostgresService: ManagedService {
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
 
-        try proc.run()
-        let exitCode: Int32 = await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                proc.waitUntilExit()
-                c.resume(returning: proc.terminationStatus)
-            }
-        }
+        let exitCode = try await proc.runAndAwait()
 
         if exitCode != 0 {
             throw ServiceError.startFailed(name, "initdb failed with \(exitCode)")
@@ -228,13 +203,10 @@ final class PostgresService: ManagedService {
         startProc.environment = pgEnvironment()
         startProc.standardOutput = FileHandle.nullDevice
         startProc.standardError = FileHandle.nullDevice
-        try startProc.run()
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async { startProc.waitUntilExit(); c.resume() }
-        }
+        let startExitCode = try await startProc.runAndAwait()
 
-        guard startProc.terminationStatus == 0 else {
-            throw ServiceError.startFailed(name, "pg_ctl start (setup) exited with \(startProc.terminationStatus)")
+        guard startExitCode == 0 else {
+            throw ServiceError.startFailed(name, "pg_ctl start (setup) exited with \(startExitCode)")
         }
 
         // Wait for ready (pg_ctl -w already waits, but belt-and-suspenders)
@@ -251,10 +223,8 @@ final class PostgresService: ManagedService {
         createProc.environment = pgEnvironment()
         createProc.standardOutput = FileHandle.nullDevice
         createProc.standardError = FileHandle.nullDevice
-        try? createProc.run()
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async { createProc.waitUntilExit(); c.resume() }
-        }
+        // Best-effort — db may already exist (idempotent on re-init).
+        _ = try? await createProc.runAndAwait()
 
         // Create extensions
         let psql = pgBinDir.appendingPathComponent("psql")
@@ -270,10 +240,10 @@ final class PostgresService: ManagedService {
             extProc.environment = pgEnvironment()
             extProc.standardOutput = FileHandle.nullDevice
             extProc.standardError = FileHandle.nullDevice
-            try? extProc.run()
-            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                DispatchQueue.global().async { extProc.waitUntilExit(); c.resume() }
-            }
+            // Best-effort — extension may already exist (CREATE EXTENSION
+            // IF NOT EXISTS is idempotent, but psql connect failures
+            // shouldn't block setup).
+            _ = try? await extProc.runAndAwait()
         }
 
         // Stop — will be started properly by ServiceManager (via launchd)
@@ -283,10 +253,9 @@ final class PostgresService: ManagedService {
         stopProc.environment = pgEnvironment()
         stopProc.standardOutput = FileHandle.nullDevice
         stopProc.standardError = FileHandle.nullDevice
-        try? stopProc.run()
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global().async { stopProc.waitUntilExit(); c.resume() }
-        }
+        // Best-effort — if pg_ctl stop fails, the followup launchd
+        // bootstrap will handle the still-running postmaster.
+        _ = try? await stopProc.runAndAwait()
     }
 
     // MARK: - Stale PID Detection
@@ -324,38 +293,36 @@ final class PostgresService: ManagedService {
 
     /// Extract the major version from the bundled postgres binary (e.g. "18").
     ///
-    /// Async because `start()` runs on the MainActor — calling
-    /// `proc.waitUntilExit()` synchronously there blocks the actor and
-    /// stalls every other `@MainActor` task (CLAUDE.md gotcha:
-    /// "never call proc.waitUntilExit() on MainActor — always use the
-    /// async continuation pattern").
+    /// Async because `start()` runs on the MainActor — using
+    /// `Process.runAndAwait` (which uses terminationHandler under the
+    /// hood) keeps the wait off-MainActor and dodges the
+    /// `waitUntilExit`/short-lived-child race that hangs other call
+    /// sites (CLAUDE.md gotcha: "never call proc.waitUntilExit() on
+    /// MainActor — always use the async continuation pattern"; the
+    /// helper is the async continuation pattern).
     private func bundledPgMajorVersion() async -> String {
-        await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                let proc = Process()
-                proc.executableURL = self.pgBinDir.appendingPathComponent("postgres")
-                proc.arguments = ["--version"]
-                proc.environment = self.pgEnvironment()
-                let pipe = Pipe()
-                proc.standardOutput = pipe
-                proc.standardError = FileHandle.nullDevice
-                do {
-                    try proc.run()
-                    proc.waitUntilExit()
-                } catch {
-                    c.resume(returning: "")
-                    return
-                }
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                // Output: "postgres (PostgreSQL) 18.3\n"
-                guard let output = String(data: data, encoding: .utf8),
-                      let versionStr = output.split(separator: " ").last else {
-                    c.resume(returning: "")
-                    return
-                }
-                c.resume(returning: String(versionStr.split(separator: ".").first ?? ""))
-            }
+        let proc = Process()
+        proc.executableURL = pgBinDir.appendingPathComponent("postgres")
+        proc.arguments = ["--version"]
+        proc.environment = pgEnvironment()
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            _ = try await proc.runAndAwait()
+        } catch {
+            return ""
         }
+        // `postgres --version` output is ~27 bytes — well under the
+        // 64KB pipe buffer, so reading after exit is safe (no need
+        // for concurrent drain).
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        // Output: "postgres (PostgreSQL) 18.3\n"
+        guard let output = String(data: data, encoding: .utf8),
+              let versionStr = output.split(separator: " ").last else {
+            return ""
+        }
+        return String(versionStr.split(separator: ".").first ?? "")
     }
 }
 

--- a/macos/HarborClerkServer/HarborClerkServer/Services/TikaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/TikaService.swift
@@ -4,79 +4,52 @@ import os
 final class TikaService: ManagedService {
     let name = "Tika"
     var state: ServiceState = .stopped
-    private var process: Process?
-    /// Called after process exits unexpectedly and state is set to .errored.
-    var onUnexpectedExit: (@MainActor () -> Void)?
+    let isLaunchdManaged = true
 
-    /// Expose the child PID for orphan tracking.
-    var processIdentifier: Int32? { process?.isRunning == true ? process?.processIdentifier : nil }
+    /// Kept for forceKillEverything compatibility — when the launchd
+    /// agent is loaded, returns the launchd-tracked pid via
+    /// `agent.status()`. The expensive (async) path is fine because
+    /// forceKillEverything is only called during emergency shutdown.
+    var processIdentifier: Int32? {
+        get async {
+            if case .loaded(let pid) = await agent.status() { return pid }
+            return nil
+        }
+    }
 
-    private var javaBin: URL {
-        Bundle.main.resourceURL!.appendingPathComponent("java/Contents/Home/bin/java")
+    private let agent: LaunchdAgent
+
+    init(launchctl: LaunchctlClient = RealLaunchctlClient()) {
+        let plistURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/com.harborclerk.tika.plist")
+        self.agent = LaunchdAgent(label: "com.harborclerk.tika", plistURL: plistURL, launchctl: launchctl)
     }
-    private var tikaJar: URL {
-        Bundle.main.resourceURL!.appendingPathComponent("tika/tika-server.jar")
-    }
-    private var port: Int { AppSettings.shared.tikaPort }
 
     func start() async throws {
-        let proc = Process()
-        proc.executableURL = javaBin
-        proc.arguments = [
-            "-jar", tikaJar.path,
-            "--host", "127.0.0.1",
-            "--port", String(port),
-        ]
-
-        // Tika 3.x forks a child JVM that resolves `java` from PATH; point it at the bundled JRE.
-        let javaHome = Bundle.main.resourceURL!.appendingPathComponent("java/Contents/Home").path
-        proc.environment = [
-            "JAVA_HOME": javaHome,
-            "PATH": "\(javaHome)/bin:/usr/bin:/bin",
-        ]
-
-        let pipe = Log.createPipe(category: "tika")
-        proc.standardOutput = pipe
-        proc.standardError = pipe
-
-        let tikaLogger = Log.logger("tika")
-        proc.terminationHandler = { [weak self] p in
-            Task { @MainActor in
-                guard let self, self.state == .running else { return }
-                self.state = .errored
-                tikaLogger.error("Process exited unexpectedly (\(p.terminationStatus, privacy: .public))")
-                self.onUnexpectedExit?()
-            }
-        }
-
-        try proc.runAsProcessGroupLeader()
-        process = proc
+        let plist = LaunchdPlist.tika(
+            bundle: Bundle.main.resourceURL!,
+            logsDir: AppSettings.shared.logsDir,
+            port: AppSettings.shared.tikaPort,
+        )
+        try await agent.ensureInstalled(plistContent: plist)
+        try await agent.start()
     }
 
     func stop() async {
         state = .stopping
-        guard let proc = process, proc.isRunning else {
-            state = .stopped
-            return
+        do {
+            try await agent.stop()
+        } catch {
+            Log.logger("tika").error(
+                "launchctl bootout failed: \(error.localizedDescription, privacy: .public)"
+            )
         }
-        proc.terminate() // SIGTERM
-        // JVM can be slow to unwind — 10s grace, then SIGKILL. Uses the
-        // shared helper so the Pipe+waitUntilExit deadlock pattern
-        // (audit memo: project_menubar_process_management_audit.md)
-        // can't make this stall the rest of stopAll().
-        //
-        // Tika's JVM forks child JVMs for heavy extractions. As of PR-2,
-        // TikaService.start() launches the JVM as a process-group leader
-        // and waitForExitWithDeadline's SIGKILL escalation uses killpg —
-        // child JVMs die with the leader on force-kill.
-        await proc.waitForExitWithDeadline(graceSeconds: 10, serviceName: name)
-        process = nil
         state = .stopped
     }
 
     func healthCheck() async -> Bool {
         // Tika returns 200 on GET /tika when ready
-        guard let url = URL(string: "http://127.0.0.1:\(port)/tika") else { return false }
+        guard let url = URL(string: "http://127.0.0.1:\(AppSettings.shared.tikaPort)/tika") else { return false }
         return await httpProbeOK(url)
     }
 }

--- a/macos/HarborClerkServer/HarborClerkServerTests/HealthCheckerTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/HealthCheckerTests.swift
@@ -6,6 +6,7 @@ final class MockService: ManagedService {
     var name: String
     var state: ServiceState
     var healthCheckResult: Bool
+    var isLaunchdManaged: Bool = false
 
     init(name: String, state: ServiceState, healthCheckResult: Bool = true) {
         self.name = name
@@ -27,6 +28,7 @@ final class MockService: ManagedService {
 final class MockServiceWithFailingHealth: ManagedService {
     var name: String
     var state: ServiceState = .stopped
+    var isLaunchdManaged: Bool = false
 
     init(name: String) {
         self.name = name
@@ -211,5 +213,27 @@ final class HealthCheckerTests: XCTestCase {
 
         XCTAssertEqual(mockServices.attemptAutoRestartCalled.count, 0,
             "attemptAutoRestart must early-return when isShuttingDown == true")
+    }
+
+    /// PR-4: a launchd-managed service whose health check fails should still
+    /// transition to .errored after consecutive failures, but HealthChecker
+    /// must NOT dispatch its own auto-restart Task. launchd's KeepAlive
+    /// handles crash recovery for these services; double-restarting via both
+    /// layers would be a foot-gun.
+    @MainActor
+    func testCheckAllSkipsAutoRestartForLaunchdManagedService() async throws {
+        let mockServices = MockServiceManager()
+        let svc = MockServiceWithFailingHealth(name: "test-launchd-svc")
+        svc.isLaunchdManaged = true
+        mockServices.services = [svc]
+        let hc = HealthChecker(serviceManager: mockServices)
+
+        svc.state = .running
+        for _ in 0..<6 { await hc.tickForTesting() }
+
+        XCTAssertEqual(hc.inFlightTaskCount, 0, "must not dispatch auto-restart Task for launchd-managed service")
+        XCTAssertTrue(mockServices.attemptAutoRestartCalled.isEmpty, "must not call attemptAutoRestart")
+        // Service still moves to .errored — only the restart path is skipped.
+        XCTAssertEqual(svc.state, .errored)
     }
 }

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchctlClientTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchctlClientTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import HarborClerkServer
+
+final class LaunchctlClientTests: XCTestCase {
+    func testFakeRecordsInvocations() async throws {
+        let fake = FakeLaunchctlClient()
+        _ = await fake.bootstrap(domain: "gui/501", plistPath: URL(fileURLWithPath: "/tmp/test.plist"))
+        _ = await fake.bootout(serviceTarget: "gui/501/com.example")
+        _ = await fake.kickstart(serviceTarget: "gui/501/com.example")
+        _ = await fake.print_(serviceTarget: "gui/501/com.example")
+
+        XCTAssertEqual(fake.invocations, [
+            "bootstrap gui/501 /tmp/test.plist",
+            "bootout gui/501/com.example",
+            "kickstart gui/501/com.example",
+            "print gui/501/com.example",
+        ])
+    }
+
+    func testFakeReturnsScriptedResult() async throws {
+        let fake = FakeLaunchctlClient()
+        fake.nextBootstrapResult = LaunchctlResult(exitCode: 5, stdout: "", stderr: "bootstrap failed: domain not loaded")
+        let r = await fake.bootstrap(domain: "gui/501", plistPath: URL(fileURLWithPath: "/x"))
+        XCTAssertEqual(r.exitCode, 5)
+        XCTAssertFalse(r.success)
+        XCTAssertEqual(r.stderr, "bootstrap failed: domain not loaded")
+    }
+
+    func testFakeDefaultsToSuccess() async throws {
+        let fake = FakeLaunchctlClient()
+        let r = await fake.bootout(serviceTarget: "anything")
+        XCTAssertTrue(r.success)
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
@@ -121,9 +121,57 @@ final class LaunchdAgentTests: XCTestCase {
 
     func testStartCallsKickstart() async throws {
         let fake = FakeLaunchctlClient()
+        // Default print result (success, empty stdout) → status() reports
+        // `.loaded(pid: nil)` → not running → kickstart should fire.
         let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
         try await agent.start()
-        XCTAssertEqual(fake.invocations, ["kickstart gui/\(getuid())/com.test.a"])
+        // status() call happens first (skip-when-running check), then kickstart.
+        XCTAssertEqual(fake.invocations, [
+            "print gui/\(getuid())/com.test.a",
+            "kickstart gui/\(getuid())/com.test.a",
+        ])
+    }
+
+    /// Regression test for smoke-test step 4: crash-survival path. When
+    /// the service is already running under launchd's KeepAlive (e.g.
+    /// after a menubar crash), the next menubar launch's start() must
+    /// NOT kickstart-and-restart the running process. `kickstart -k`
+    /// sends SIGTERM to the running instance first; for postgres, that's
+    /// a forced smart-shutdown of every in-flight query.
+    func testStartSkipsKickstartWhenServiceIsAlreadyRunning() async throws {
+        // Use the test runner's own PID — guaranteed alive, so the
+        // `kill(pid, 0) == 0` defensive check inside start() passes.
+        let alivePid = ProcessInfo.processInfo.processIdentifier
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 0,
+            stdout: "com.test.a = {\n\tpid = \(alivePid)\n\tstate = running\n}\n",
+            stderr: "",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.start()
+        // status() got called, but kickstart did NOT — service was already running.
+        XCTAssertEqual(fake.invocations, ["print gui/\(getuid())/com.test.a"])
+    }
+
+    /// Defensive companion: if status() reports a PID but `kill(pid, 0)`
+    /// says it's dead (launchctl's view lags exit by a tick),
+    /// kickstart should fire — don't trust the stale PID.
+    func testStartKickstartsWhenStatusPidIsStale() async throws {
+        // PID 99999999 is almost certainly not running on macOS.
+        let deadPid: Int32 = 99999999
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 0,
+            stdout: "com.test.a = {\n\tpid = \(deadPid)\n\tstate = running\n}\n",
+            stderr: "",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.start()
+        XCTAssertEqual(fake.invocations, [
+            "print gui/\(getuid())/com.test.a",
+            "kickstart gui/\(getuid())/com.test.a",
+        ])
     }
 
     func testStopCallsBootout() async throws {

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
@@ -96,6 +96,29 @@ final class LaunchdAgentTests: XCTestCase {
         }
     }
 
+    /// Companion to the regression test above — exercises bootstrap-failure
+    /// in the NEW "plist matches but service not loaded" branch (separate
+    /// code path from the drift case covered by
+    /// `testEnsureInstalledThrowsOnBootstrapFailure`).
+    func testEnsureInstalledThrowsWhenPlistMatchesNotLoadedAndBootstrapFails() async throws {
+        let plistURL = tempDir.appendingPathComponent("a.plist")
+        try "<plist>match</plist>".write(to: plistURL, atomically: true, encoding: .utf8)
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 113, stdout: "", stderr: "Could not find service")
+        fake.nextBootstrapResult = LaunchctlResult(
+            exitCode: 5, stdout: "", stderr: "bootstrap failed")
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+        do {
+            try await agent.ensureInstalled(plistContent: "<plist>match</plist>")
+            XCTFail("expected bootstrapFailed")
+        } catch let LaunchdAgentError.bootstrapFailed(r) {
+            XCTAssertEqual(r.exitCode, 5)
+        }
+        // Plist must be untouched — no rewrite in this branch.
+        XCTAssertEqual(try String(contentsOf: plistURL, encoding: .utf8), "<plist>match</plist>")
+    }
+
     func testStartCallsKickstart() async throws {
         let fake = FakeLaunchctlClient()
         let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
@@ -85,6 +85,42 @@ final class LaunchdAgentTests: XCTestCase {
         try await agent.stop()
     }
 
+    func testStopTreatsBootOutFailed36AsSuccess() async throws {
+        // Recent macOS phrasing: EBUSY when the service isn't loaded.
+        let fake = FakeLaunchctlClient()
+        fake.nextBootoutResult = LaunchctlResult(
+            exitCode: 36,
+            stdout: "",
+            stderr: "Boot-out failed: 36: Operation now in progress",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.stop()
+    }
+
+    func testStopTreatsBootOutFailed3AsSuccess() async throws {
+        // ESRCH phrasing.
+        let fake = FakeLaunchctlClient()
+        fake.nextBootoutResult = LaunchctlResult(
+            exitCode: 3,
+            stdout: "",
+            stderr: "Boot-out failed: 3: No such process",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.stop()
+    }
+
+    func testStopTreatsGenericNoSuchProcessAsSuccess() async throws {
+        // Fallback phrasing — bare "no such process".
+        let fake = FakeLaunchctlClient()
+        fake.nextBootoutResult = LaunchctlResult(
+            exitCode: 3,
+            stdout: "",
+            stderr: "no such process",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.stop()
+    }
+
     func testStopThrowsOnOtherBootoutErrors() async throws {
         let fake = FakeLaunchctlClient()
         fake.nextBootoutResult = LaunchctlResult(exitCode: 22, stdout: "", stderr: "EINVAL")
@@ -119,6 +155,22 @@ final class LaunchdAgentTests: XCTestCase {
         let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
         let state = await agent.status()
         XCTAssertEqual(state, .loaded(pid: nil))
+    }
+
+    func testStatusIgnoresOriginalPidLine() async throws {
+        // "original pid = N" appears for stopped-but-loaded services and
+        // refers to a no-longer-running PID. Returning it as the live pid
+        // could surface a stale (possibly recycled!) PID to
+        // forceKillEverything. Must be parsed as .loaded(pid: nil).
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 0,
+            stdout: "com.test.a = {\n\toriginal pid = 99999\n\tstate = waiting\n}\n",
+            stderr: "",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        let state = await agent.status()
+        XCTAssertEqual(state, .loaded(pid: nil), "original pid line must not be parsed as current pid")
     }
 
     func testStatusReturnsNotLoadedOnPrintFailure() async throws {

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
@@ -11,16 +11,49 @@ final class LaunchdAgentTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
-    func testEnsureInstalledNoOpsWhenPlistMatches() async throws {
+    func testEnsureInstalledSkipsBootstrapWhenPlistMatchesAndServiceLoaded() async throws {
         let plistURL = tempDir.appendingPathComponent("a.plist")
         try "<plist>match</plist>".write(to: plistURL, atomically: true, encoding: .utf8)
         let fake = FakeLaunchctlClient()
+        // FakeLaunchctlClient's default print result is success with empty
+        // stdout, which LaunchdAgent.status() reads as `.loaded(pid: nil)`.
+        // ensureInstalled should call print() to verify, then skip bootstrap.
         let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
 
         try await agent.ensureInstalled(plistContent: "<plist>match</plist>")
 
-        // No launchctl invocations because content matched.
-        XCTAssertEqual(fake.invocations, [])
+        // Plist matched + service loaded: one print() invocation, no rewrite, no bootstrap.
+        XCTAssertEqual(fake.invocations, ["print gui/\(getuid())/com.test.a"])
+    }
+
+    /// Regression test for the smoke-test bug: after `stop()` (bootout), the
+    /// plist remains on disk but the service is unloaded. The next launch
+    /// previously returned early because the plist matched — but then
+    /// `kickstart` failed with "Could not find service" and the menubar
+    /// reported postgres/tika as errored on every launch after the first.
+    /// ensureInstalled must check status and re-bootstrap when not loaded.
+    func testEnsureInstalledBootstrapsWhenPlistMatchesButServiceNotLoaded() async throws {
+        let plistURL = tempDir.appendingPathComponent("a.plist")
+        try "<plist>match</plist>".write(to: plistURL, atomically: true, encoding: .utf8)
+        let fake = FakeLaunchctlClient()
+        // Simulate a bootout'd-but-plist-on-disk state — `launchctl print`
+        // returns 113 "Could not find service ...", which status() maps
+        // to `.notLoaded`.
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 113,
+            stdout: "",
+            stderr: "Could not find service \"com.test.a\" in domain",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+
+        try await agent.ensureInstalled(plistContent: "<plist>match</plist>")
+
+        // Should have checked status, then bootstrapped.
+        XCTAssertEqual(fake.invocations.count, 2)
+        XCTAssertTrue(fake.invocations[0].hasPrefix("print "))
+        XCTAssertTrue(fake.invocations[1].hasPrefix("bootstrap "))
+        // Plist content unchanged on disk (no rewrite needed).
+        XCTAssertEqual(try String(contentsOf: plistURL, encoding: .utf8), "<plist>match</plist>")
     }
 
     func testEnsureInstalledBootoutRewritesBootstrapWhenDrifted() async throws {

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchdAgentTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import HarborClerkServer
+
+final class LaunchdAgentTests: XCTestCase {
+    private var tempDir: URL!
+    override func setUp() async throws {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("launchd-agent-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func testEnsureInstalledNoOpsWhenPlistMatches() async throws {
+        let plistURL = tempDir.appendingPathComponent("a.plist")
+        try "<plist>match</plist>".write(to: plistURL, atomically: true, encoding: .utf8)
+        let fake = FakeLaunchctlClient()
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+
+        try await agent.ensureInstalled(plistContent: "<plist>match</plist>")
+
+        // No launchctl invocations because content matched.
+        XCTAssertEqual(fake.invocations, [])
+    }
+
+    func testEnsureInstalledBootoutRewritesBootstrapWhenDrifted() async throws {
+        let plistURL = tempDir.appendingPathComponent("a.plist")
+        try "<plist>old</plist>".write(to: plistURL, atomically: true, encoding: .utf8)
+        let fake = FakeLaunchctlClient()
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+
+        try await agent.ensureInstalled(plistContent: "<plist>new</plist>")
+
+        XCTAssertEqual(fake.invocations.count, 2)
+        XCTAssertTrue(fake.invocations[0].hasPrefix("bootout "))
+        XCTAssertTrue(fake.invocations[1].hasPrefix("bootstrap "))
+        // Verify the plist on disk got rewritten:
+        XCTAssertEqual(try String(contentsOf: plistURL, encoding: .utf8), "<plist>new</plist>")
+    }
+
+    func testEnsureInstalledHandlesMissingPlistFile() async throws {
+        let plistURL = tempDir.appendingPathComponent("never-existed.plist")
+        let fake = FakeLaunchctlClient()
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+
+        try await agent.ensureInstalled(plistContent: "<plist>first</plist>")
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: plistURL.path))
+        XCTAssertEqual(fake.invocations.count, 2)
+    }
+
+    func testEnsureInstalledThrowsOnBootstrapFailure() async throws {
+        let plistURL = tempDir.appendingPathComponent("a.plist")
+        let fake = FakeLaunchctlClient()
+        fake.nextBootstrapResult = LaunchctlResult(exitCode: 5, stdout: "", stderr: "bootstrap failed")
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+
+        do {
+            try await agent.ensureInstalled(plistContent: "<plist>first</plist>")
+            XCTFail("expected bootstrap failure")
+        } catch let LaunchdAgentError.bootstrapFailed(r) {
+            XCTAssertEqual(r.exitCode, 5)
+        }
+    }
+
+    func testStartCallsKickstart() async throws {
+        let fake = FakeLaunchctlClient()
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.start()
+        XCTAssertEqual(fake.invocations, ["kickstart gui/\(getuid())/com.test.a"])
+    }
+
+    func testStopCallsBootout() async throws {
+        let fake = FakeLaunchctlClient()
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        try await agent.stop()
+        XCTAssertEqual(fake.invocations, ["bootout gui/\(getuid())/com.test.a"])
+    }
+
+    func testStopTreatsNotFoundAsSuccess() async throws {
+        let fake = FakeLaunchctlClient()
+        fake.nextBootoutResult = LaunchctlResult(exitCode: 113, stdout: "", stderr: "Could not find service \"com.test.a\" in domain")
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        // Should NOT throw — the goal "service is not running" is met.
+        try await agent.stop()
+    }
+
+    func testStopThrowsOnOtherBootoutErrors() async throws {
+        let fake = FakeLaunchctlClient()
+        fake.nextBootoutResult = LaunchctlResult(exitCode: 22, stdout: "", stderr: "EINVAL")
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        do {
+            try await agent.stop()
+            XCTFail("expected throw")
+        } catch is LaunchdAgentError {
+            // ok
+        }
+    }
+
+    func testStatusReturnsLoadedWithPidWhenPrintShowsPid() async throws {
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 0,
+            stdout: "com.test.a = {\n\tpid = 12345\n\tstate = running\n}\n",
+            stderr: "",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        let state = await agent.status()
+        XCTAssertEqual(state, .loaded(pid: 12345))
+    }
+
+    func testStatusReturnsLoadedNilWhenPrintShowsNoPid() async throws {
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(
+            exitCode: 0,
+            stdout: "com.test.a = {\n\tstate = waiting\n}\n",
+            stderr: "",
+        )
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        let state = await agent.status()
+        XCTAssertEqual(state, .loaded(pid: nil))
+    }
+
+    func testStatusReturnsNotLoadedOnPrintFailure() async throws {
+        let fake = FakeLaunchctlClient()
+        fake.nextPrintResult = LaunchctlResult(exitCode: 113, stdout: "", stderr: "Could not find service")
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: tempDir.appendingPathComponent("a.plist"), launchctl: fake)
+        let state = await agent.status()
+        XCTAssertEqual(state, .notLoaded)
+    }
+
+    func testUninstallStopsAndDeletesPlist() async throws {
+        let plistURL = tempDir.appendingPathComponent("a.plist")
+        try "<plist>x</plist>".write(to: plistURL, atomically: true, encoding: .utf8)
+        let fake = FakeLaunchctlClient()
+        let agent = LaunchdAgent(label: "com.test.a", plistURL: plistURL, launchctl: fake)
+        await agent.uninstall()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: plistURL.path))
+        XCTAssertTrue(fake.invocations.contains(where: { $0.hasPrefix("bootout ") }))
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServerTests/LaunchdPlistTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/LaunchdPlistTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import HarborClerkServer
+
+final class LaunchdPlistTests: XCTestCase {
+    private let testBundle = URL(fileURLWithPath: "/Applications/HarborClerkServer.app/Contents/Resources")
+    private let testDataDir = URL(fileURLWithPath: "/Users/test/Library/Application Support/Harbor Clerk/postgres-data")
+    private let testLogsDir = URL(fileURLWithPath: "/Users/test/Library/Application Support/Harbor Clerk/logs")
+
+    func testPostgresPlistIsValidXMLPropertyList() throws {
+        let xml = LaunchdPlist.postgres(bundle: testBundle, dataDir: testDataDir, logsDir: testLogsDir, port: 5433)
+        let data = xml.data(using: .utf8)!
+        // PropertyListSerialization will throw if the XML doesn't parse
+        // as a property list. That's our basic correctness check.
+        let parsed = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any]
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed?["Label"] as? String, "com.harborclerk.postgres")
+    }
+
+    func testPostgresPlistHasCorrectKeys() throws {
+        let xml = LaunchdPlist.postgres(bundle: testBundle, dataDir: testDataDir, logsDir: testLogsDir, port: 5433)
+        let parsed = try PropertyListSerialization.propertyList(from: xml.data(using: .utf8)!, options: [], format: nil) as! [String: Any]
+
+        XCTAssertEqual(parsed["Label"] as? String, "com.harborclerk.postgres")
+        XCTAssertEqual(parsed["Program"] as? String, testBundle.appendingPathComponent("postgres/bin/postgres").path)
+        XCTAssertEqual(parsed["RunAtLoad"] as? Bool, false)
+        let keepAlive = parsed["KeepAlive"] as? [String: Any]
+        XCTAssertEqual(keepAlive?["SuccessfulExit"] as? Bool, false)
+        let env = parsed["EnvironmentVariables"] as? [String: String]
+        XCTAssertEqual(env?["PGDATA"], testDataDir.path)
+    }
+
+    func testPostgresPlistArgsIncludePortAndDataDir() throws {
+        let xml = LaunchdPlist.postgres(bundle: testBundle, dataDir: testDataDir, logsDir: testLogsDir, port: 5433)
+        let parsed = try PropertyListSerialization.propertyList(from: xml.data(using: .utf8)!, options: [], format: nil) as! [String: Any]
+        let args = parsed["ProgramArguments"] as! [String]
+        XCTAssertTrue(args.contains("5433"))
+        XCTAssertTrue(args.contains(testDataDir.path))
+        XCTAssertTrue(args.contains("-D"))
+        XCTAssertTrue(args.contains("-p"))
+    }
+
+    func testTikaPlistIsValidPropertyList() throws {
+        let xml = LaunchdPlist.tika(bundle: testBundle, logsDir: testLogsDir, port: 9998)
+        let parsed = try PropertyListSerialization.propertyList(from: xml.data(using: .utf8)!, options: [], format: nil) as! [String: Any]
+        XCTAssertEqual(parsed["Label"] as? String, "com.harborclerk.tika")
+        let env = parsed["EnvironmentVariables"] as? [String: String]
+        XCTAssertEqual(env?["JAVA_HOME"], testBundle.appendingPathComponent("java/Contents/Home").path)
+    }
+
+    func testTikaPlistArgsIncludePort() throws {
+        let xml = LaunchdPlist.tika(bundle: testBundle, logsDir: testLogsDir, port: 9998)
+        let parsed = try PropertyListSerialization.propertyList(from: xml.data(using: .utf8)!, options: [], format: nil) as! [String: Any]
+        let args = parsed["ProgramArguments"] as! [String]
+        XCTAssertTrue(args.contains("9998"))
+        XCTAssertTrue(args.contains("--host"))
+        XCTAssertTrue(args.contains("127.0.0.1"))
+    }
+}


### PR DESCRIPTION
## Summary

PR-4 (the last and largest) of the four-PR menubar process management Tier B+C refactor. Moves Postgres and Tika out of the menubar's direct subprocess management into `launchd`-managed `LaunchAgent`s under `gui/$UID`. Postgres now survives menubar crashes (closes the mid-query data-loss exposure from `project_menubar_crashes_during_model_switch.md`); Tika sheds its child-JVM leak risk by inheriting `launchd`'s correct process-group cleanup; both services skip the `Pipe`+`waitUntilExit` dance entirely because `launchd` routes stdio to files.

Spec: `docs/superpowers/specs/2026-05-11-menubar-process-mgmt-tier-bc-design.md`
Plan: `docs/superpowers/plans/2026-05-11-pr-4-launchd-postgres-tika.md`
Audit: `~/.claude/projects/.../memory/project_menubar_process_management_audit.md`

## What landed

**Three new modules** (~380 lines total, fully tested against a `FakeLaunchctlClient`):

- **`LaunchctlClient`** — protocol over `/bin/launchctl` invocations with `RealLaunchctlClient` (shells via `Process` with **concurrent pipe drain** to avoid the 64KB-buffer deadlock that fresh-eyes review caught — finding 85) and `FakeLaunchctlClient` (records invocations, scriptable per-verb results).
- **`LaunchdPlist`** — `postgres()` and `tika()` static generators. `Program` is `postgres` directly (not `pg_ctl`) so `launchd` tracks the postmaster PID. `RunAtLoad=false` + `KeepAlive={SuccessfulExit:false}` per the spec's control model Y.
- **`LaunchdAgent`** — `ensureInstalled` / `start` / `stop` / `status` / `uninstall`. Idempotent: only `bootout`-rewrite-`bootstrap` when the on-disk plist content differs (handles bundle moves and version upgrades cleanly). `stop()` treats *three* not-loaded error phrasings as success (`could not find service`, `Boot-out failed: 36`, `Boot-out failed: 3` — fresh-eyes review finding 82).

**Service refactor:**

- `PostgresService` keeps the `ManagedService` surface; `start()` retains `initdb`/`createDatabaseAndExtensions`/`ensureLoggingConfig` for first-run setup, then delegates to `LaunchdAgent`. `stop()` is a single `agent.stop()` call. `bundledPgMajorVersion()` is now `async` (fresh-eyes review finding 80 — was synchronously blocking the MainActor, explicit CLAUDE.md violation).
- `TikaService` delegates fully. `processIdentifier` is now `async` (queries `launchctl print`), parser tightened to ignore `original pid = N` lines so stale PIDs don't surface to `forceKillEverything` (fresh-eyes review finding 70).
- `ServiceManager.forceKillEverything()` is now `async` (cascades from the `TikaService` change). `savePidFile()` skips launchd-managed services. Tika's `onUnexpectedExit` wiring removed — `launchd`'s `KeepAlive` handles crash recovery for these now.
- `HealthChecker.checkAll()` skips dispatching auto-restart Tasks for `isLaunchdManaged` services — `launchd`'s `KeepAlive` already does it.
- `AppDelegate`'s **Force Stop All** and **30-second deadline** paths both `await` `forceKillEverything()` plus `postgresService.stop()` + `tikaService.stop()` so launchd's `KeepAlive` doesn't immediately resurrect the postmaster after our `SIGKILL`.

## Test plan

- [x] 24 new tests across `LaunchctlClientTests` (3), `LaunchdPlistTests` (5), `LaunchdAgentTests` (12 — 11 from the implementer + 4 added by the fixup), and `HealthCheckerTests` (1 new for `isLaunchdManaged` skip)
- [x] **97 total tests pass** locally (was 72 post-PR-3)
- [x] `xcodebuild build` clean
- [x] Spec-compliance review ✓ — all 7 tasks PASS
- [x] Code-quality review ✓ — only sub-80 findings
- [x] Minimal-prompt fresh-eyes review per the standing directive ✓ — found 3 findings ≥80 + 1 worth-fixing (pipe deadlock, narrow bootout match, MainActor stall, original-pid parser), all addressed in [8e1972b](https://github.com/r0shi/harborclerk/commit/8e1972b)

## Manual smoke testing (REQUIRED before/after merge)

Unit tests cover the protocol-level lifecycle logic against `FakeLaunchctlClient`, but cannot validate that `/bin/launchctl` actually does what we expect. The plan's Task 8 lists the smoke matrix; minimum the reviewer should verify:

1. First-run with no `~/Library/LaunchAgents/com.harborclerk.*.plist`: plists get written, bootstrap+kickstart, postgres + tika come up.
2. Second launch (plist matches): kickstart-only, no bootout-rewrite cycle.
3. Bundle moved between launches: bootout-rewrite-bootstrap fires.
4. **The crash-survival win:** `kill -9 <menubar-pid>` while postgres+tika running → both keep running. Relaunch menubar → services already up via `agent.status()`.
5. Postgres crash (`kill -9 $(cat postmaster.pid)`): launchd's `KeepAlive` restarts within ~1s; `HealthChecker` does NOT also restart (the `isLaunchdManaged` skip).
6. Quit menu: `stopAll` runs, postgres+tika `bootout`, app quits within 30s.
7. Force Stop All: confirmation dialog; on confirm, menubar children SIGKILLed AND launchd agents `bootout`. Menubar stays open.

## Out of scope (captured in `pr_followups.md`)

- `uninstall.sh` / "Uninstall Services" menu item — plists in `~/Library/LaunchAgents/` survive app deletion. Harmless cruft; documented for follow-up.
- `SMAppService.agent` migration — Apple's blessed framework path; not needed because we're not sandboxed and bundle paths vary.
- Embedder / llama-server / API / workers to launchd — too much reconfig friction for too little survival benefit.

## The four-PR arc

| PR | Status | Scope |
|---|---|---|
| #343 | ✅ merged | shutdown-aware HealthChecker |
| #344 | ✅ merged | process groups via setpgid |
| #345 | ✅ merged | Force Stop All menu |
| **#TBD** | **this** | launchd migration for Postgres + Tika |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
