### PR TITLE
fix(system-status): refresh mail accounts when page Refresh is clicked

### DIFF
--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -82,9 +82,12 @@ export default function SystemStatusPage() {
     run()
   }, [])
 
+  const [refreshKey, setRefreshKey] = useState(0)
+
   function handleRefresh() {
     loadHealth()
     loadStats()
+    setRefreshKey((k) => k + 1)
   }
 
   if (loading) return <div className="text-gray-500 dark:text-gray-400">Loading...</div>
@@ -136,7 +139,7 @@ export default function SystemStatusPage() {
         </div>
       )}
 
-      <MailAccountsStatus />
+      <MailAccountsStatus refreshKey={refreshKey} />
     </div>
   )
 }
@@ -187,7 +190,7 @@ function statusBadgeClass(status: MailAccountResponse['status']): string {
   }
 }
 
-function MailAccountsStatus() {
+function MailAccountsStatus({ refreshKey }: { refreshKey: number }) {
   const [accounts, setAccounts] = useState<MailAccountResponse[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -207,7 +210,7 @@ function MailAccountsStatus() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [refreshKey])
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary

`MailAccountsStatus` (introduced in [#287](https://github.com/r0shi/harborclerk/pull/287)) does its own `useEffect`-on-mount fetch with no external trigger. After fixing an `auth_error` on a mail account, clicking the page-level "Refresh" button left the stale error visible — admin had to reload the whole page.

This was the [only ≥80 finding](https://github.com/r0shi/harborclerk/pull/287) (score 85) from the formal PR #287 review.

## Change

- `SystemStatusPage` maintains a `refreshKey` counter
- `handleRefresh` bumps the counter alongside `loadHealth()` / `loadStats()`
- `MailAccountsStatus` accepts `refreshKey: number` and lists it as a `useEffect` dependency

## Test plan

- [x] `tsc --noEmit` clean
- [x] eslint clean
- [ ] Manual: induce auth_error → fix it → click page Refresh → stale error clears without full reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
