### PR TITLE
fix(menubar): probe + claim llama port on every LlamaService.start()

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -260,7 +260,14 @@ class ServiceManager: ObservableObject {
 
     /// Kill any process listening on the given port (leftover from a prior run).
     /// PostgreSQL handles stale PIDs via pg_ctl / postmaster.pid, so skip it.
-    private func killStaleProcess(onPort port: Int) async {
+    ///
+    /// `static nonisolated` so services (e.g. `LlamaService.start()`) can
+    /// call it directly at the top of their own start path, without
+    /// depending on `ServiceManager.startAll()` having claimed the port
+    /// first. This closes the auto-restart / model-switch / manual-restart
+    /// gap where a prior llama-server outlived the menubar and held the
+    /// port through the next start attempt.
+    static func killStaleProcess(onPort port: Int) async {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         proc.arguments = ["-ti", "tcp:\(port)"]
@@ -331,19 +338,19 @@ class ServiceManager: ObservableObject {
         guard await runMigrations() else { return }
 
         // 3. Tika (JVM startup can take ~30-60s)
-        await killStaleProcess(onPort: settings.tikaPort)
+        await Self.killStaleProcess(onPort: settings.tikaPort)
         await startService(tikaService)
 
         // 4. Embedder (can take a while for model load)
-        await killStaleProcess(onPort: settings.embedderPort)
+        await Self.killStaleProcess(onPort: settings.embedderPort)
         await startService(embedderService)
 
         // 5. LLM server (skip silently if no model selected)
-        await killStaleProcess(onPort: settings.llamaPort)
+        await Self.killStaleProcess(onPort: settings.llamaPort)
         await startService(llamaService)
 
         // 6. API server
-        await killStaleProcess(onPort: settings.apiPort)
+        await Self.killStaleProcess(onPort: settings.apiPort)
         await startService(apiService)
 
         // 7. Workers

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -35,6 +35,16 @@ final class LlamaService: ManagedService {
             return
         }
 
+        // Defensive port probe. `ServiceManager.startAll()` already calls
+        // this for the llama port, but `start()` is also invoked from
+        // auto-restart, model switch, and manual-restart paths that
+        // bypass startAll. If the previous llama-server (or anything
+        // else) is still holding port 8102, the new process exits
+        // immediately with "couldn't bind HTTP server socket" and the
+        // service goes to errored — fixable only by manual intervention
+        // until now.
+        await ServiceManager.killStaleProcess(onPort: settings.llamaPort)
+
         let yarnEnabled = settings.llmYarnEnabled
         let yarnConfig = settings.activeModelYarn
         let useYarn = yarnEnabled && yarnConfig != nil


### PR DESCRIPTION
## Summary

`ServiceManager.startAll()` already calls `killStaleProcess(onPort: settings.llamaPort)` so the **cold-launch** path was safe. But `LlamaService.start()` is also invoked from three paths that bypass `startAll()`:

- **Auto-restart** (`attemptAutoRestart` → `restartService`)
- **Model switch** (`handleConfigChange`)
- **Manual Restart-LLM** click

In any of these, if a prior `llama-server` outlived the menubar (process-group leak, OOM, mid-shutdown SIGSEGV) and still holds port 8102, the new process exits immediately with `couldn't bind HTTP server socket` and the service stays errored until manual intervention.

Captured in `pr_followups.md` as a deferred item from PR #226.

## Change

- Promote `ServiceManager.killStaleProcess` from `private` instance method to `static` so any service can call it without holding a `ServiceManager` ref.
- Invoke `await ServiceManager.killStaleProcess(onPort: settings.llamaPort)` at the top of `LlamaService.start()`, after the model-path checks but before the `Process` is spawned.
- Existing call sites in `startAll()` updated to `Self.killStaleProcess`.

## Test plan

- [x] `xcodebuild build` clean
- [ ] Manual smoke: with llama-server running, force-kill the menubar via Force Stop All, confirm the llama-server child gets killed too (PR-3's `killpg` path); relaunch and confirm LLM starts. Should still work — this PR only adds a defensive probe that no-ops when the port is free.
- [ ] Manual smoke: manufacture a stuck llama-server (e.g. `llama-server` binary launched outside the menubar holding port 8102), then click Start LLM in the menubar. Should kill the stale process and start cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
