### PR TITLE
fix(documents): surface "No LLM active" call-to-action for admins

### DIFF
--- a/frontend/src/components/SummaryChip.tsx
+++ b/frontend/src/components/SummaryChip.tsx
@@ -14,6 +14,12 @@ const LABELS: Record<Exclude<SummaryState, 'none'>, string> = {
   failed: 'Summary Failed',
 }
 
+const TOOLTIPS: Partial<Record<Exclude<SummaryState, 'none'>, string>> = {
+  extractive:
+    'No language model was active when this summary was generated, so the system fell back to an extractive heuristic. Configure an LLM in System Settings → Models for higher-quality summaries on future documents.',
+  failed: 'The summarize stage errored. The document is otherwise fully ingested and searchable.',
+}
+
 const STYLES: Record<Exclude<SummaryState, 'none'>, { bg: string; fg: string }> = {
   generating: { bg: 'rgba(186,140,255,0.16)', fg: '#c4a4ff' },
   pending: { bg: 'rgba(255,214,10,0.12)', fg: '#ffd60a' },
@@ -33,11 +39,13 @@ export default function SummaryChip({ state }: SummaryChipProps) {
   if (state === 'none') return null
   const { bg, fg } = STYLES[state]
   const label = LABELS[state]
+  const tooltip = TOOLTIPS[state]
   const pulseDot = state === 'generating'
   return (
     <span
       className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium whitespace-nowrap"
       style={{ background: bg, color: fg }}
+      title={tooltip}
     >
       <span
         className={`h-1.5 w-1.5 rounded-full ${pulseDot ? 'animate-pulse' : ''}`}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -3,8 +3,8 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents } from '../hooks/useJobEvents'
-import { useLLMStatus } from '../hooks/useLLMStatus'
 import { useSystemConfig } from '../hooks/useSystemConfig'
+import { useLLMStatusContext } from '../components/LLMStatusBanner'
 import { PageHeader } from '../components/PageHeader'
 import { StatusPill, type PillState } from '../components/StatusPill'
 import { IconTile } from '../components/IconTile'
@@ -151,7 +151,11 @@ function Pagination({
 export default function DocumentsPage() {
   const { user, isAdmin, updatePreferences } = useAuth()
   const sysConfig = useSystemConfig()
-  const { status: llmStatus } = useLLMStatus()
+  // Use the shared context (provided by Layout via LLMStatusProvider)
+  // rather than calling useLLMStatus() directly — that would spawn a
+  // second independent polling loop alongside the one LLMStatusBanner
+  // already drives.
+  const { status: llmStatus } = useLLMStatusContext()
   // Mirror DocumentDetailPage's SourceFileSection: only show download UI when
   // the deployment has enabled `allow_source_download`. Default off everywhere
   // (the API returns 403); on macOS the user-facing escape hatch is Reveal in

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents } from '../hooks/useJobEvents'
+import { useLLMStatus } from '../hooks/useLLMStatus'
 import { useSystemConfig } from '../hooks/useSystemConfig'
 import { PageHeader } from '../components/PageHeader'
 import { StatusPill, type PillState } from '../components/StatusPill'
@@ -150,6 +151,7 @@ function Pagination({
 export default function DocumentsPage() {
   const { user, isAdmin, updatePreferences } = useAuth()
   const sysConfig = useSystemConfig()
+  const { status: llmStatus } = useLLMStatus()
   // Mirror DocumentDetailPage's SourceFileSection: only show download UI when
   // the deployment has enabled `allow_source_download`. Default off everywhere
   // (the API returns 403); on macOS the user-facing escape hatch is Reveal in
@@ -622,6 +624,25 @@ export default function DocumentsPage() {
           </>
         }
       />
+      {/* "No LLM model" banner — surfaces the actionable fix for users who'd
+          otherwise just see "Extractive Only" pills without knowing what to
+          do about them. Only shown to admins (only they can change the
+          model). `unknown` is the pre-first-tick state — don't flash the
+          banner during it. */}
+      {isAdmin && llmStatus.state === 'deactivated' && (
+        <div className="mb-3 flex items-center justify-between rounded-md border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-sm">
+          <span className="text-amber-900 dark:text-amber-200">
+            No language model is active. Document summaries fall back to an extractive heuristic — for higher-quality
+            summaries, activate a model.
+          </span>
+          <Link
+            to="/admin/models"
+            className="ml-3 shrink-0 rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700"
+          >
+            System Settings → Models
+          </Link>
+        </div>
+      )}
       {/* Filter bar */}
       {(filterOptions.mime_types.length > 0 ||
         filterOptions.doc_types.length > 0 ||


### PR DESCRIPTION
## Summary

[PR #328](https://github.com/r0shi/harborclerk/pull/328)'s deferred follow-up: "Summary blocked: no LLM model configured" surfacing.

### Scope correction from the original follow-up note

The follow-up note in `pr_followups.md` claimed summarize jobs sit `queued` indefinitely when no LLM is configured, with the chip showing "Summary Pending" forever. **That's not actually what happens** — `generate_summary` always falls through to Apple Intelligence (macOS) or extractive heuristic, so the job completes and the chip renders "Extractive Only". The actual UX gap is different: a non-technical user sees "Extractive Only" pills without knowing what they mean or how to upgrade quality. This PR addresses that.

## Change

1. **Admin-only banner on /docs** when `useLLMStatus().status.state === 'deactivated'`. Amber card with a direct link to System Settings → Models. Suppressed during the `unknown` pre-first-tick state so it doesn't flash on page load. Non-admins don't see it (they can't fix it).
2. **Tooltip on SummaryChip** ("Extractive Only" and "Summary Failed" states) explaining the state in plain English via `title=` attribute.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean (one pre-existing fast-refresh warning unrelated to this PR)
- [ ] Manual: with `llm_model_id` set, banner does not appear; clear it, banner appears with link to /admin/models
- [ ] Manual: hover over an "Extractive Only" pill on a doc row → tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
