### PR TITLE
fix(mail): activate relabel-restore path + scope ingest failures to savepoints

### DIFF
--- a/src/harbor_clerk/mail/ingest.py
+++ b/src/harbor_clerk/mail/ingest.py
@@ -276,26 +276,40 @@ async def ingest_pending_messages(
             deduped_count += 1
             continue
 
+        # Per-message savepoint so a failure inside create_attachment_documents
+        # (or anywhere else in this try) rolls back BOTH the email Document
+        # and any attachment Documents already flushed within this iteration.
+        # The previous version manually nilled msg.email_doc_id on exception,
+        # but the email Document row from the first session.flush() had
+        # already been written to the outer transaction — when the outer
+        # commit ran in mail_observer.on_tick, the row persisted as a
+        # permanent orphan that the cross-label dedup query (which filters
+        # on `email_doc_id IS NOT NULL`) skipped on retry, leaving exactly
+        # one ghost Document per failed message. The savepoint scopes
+        # rollback to this iteration only; msg.eml_sha256 (set above,
+        # outside the savepoint) survives so the next tick's retry can
+        # short-circuit on dedup if appropriate.
         try:
-            parsed = parse_eml(eml_bytes)
-            email_doc = await create_email_document(
-                session,
-                parsed=parsed,
-                eml_bytes=eml_bytes,
-                eml_sha256=real_sha,
-                label=label,
-            )
-            await session.flush()
+            async with session.begin_nested():
+                parsed = parse_eml(eml_bytes)
+                email_doc = await create_email_document(
+                    session,
+                    parsed=parsed,
+                    eml_bytes=eml_bytes,
+                    eml_sha256=real_sha,
+                    label=label,
+                )
+                await session.flush()
 
-            attachment_docs = await create_attachment_documents(
-                session,
-                parsed=parsed,
-                parent_doc=email_doc,
-                label=label,
-            )
-            await session.flush()
+                attachment_docs = await create_attachment_documents(
+                    session,
+                    parsed=parsed,
+                    parent_doc=email_doc,
+                    label=label,
+                )
+                await session.flush()
 
-            msg.email_doc_id = email_doc.doc_id
+                msg.email_doc_id = email_doc.doc_id
 
             # enqueue_stage is sync (uses psycopg2). Run in the default thread executor
             # so the event loop stays responsive — the mail observer's per-label tasks
@@ -314,11 +328,9 @@ async def ingest_pending_messages(
                 msg.imap_uid,
                 exc,
             )
-            # Roll back this savepoint so other messages in the batch still commit.
-            # Without per-message savepoints we'd need session.rollback() which
-            # would discard the eml_sha256 update too. Instead: reset email_doc_id
-            # and continue. Next tick will re-pick this message via email_doc_id IS NULL.
-            msg.email_doc_id = None
+            # The savepoint already rolled back the email_doc/attachment_doc
+            # rows + msg.email_doc_id link. Nothing further to undo. The
+            # next tick will re-pick this message via email_doc_id IS NULL.
             continue
 
     return IngestSummary(

--- a/src/harbor_clerk/mail/sync.py
+++ b/src/harbor_clerk/mail/sync.py
@@ -141,6 +141,15 @@ async def sync_label_initial(
             )
         ).scalar_one_or_none()
         if existing is not None:
+            # Relabel: user removed then re-applied the label. The row sat
+            # at status='unlabeled' (set by detect_unlabeled_messages); flip
+            # it back to 'active' so Stage 3's restore_documents_for_relabeled
+            # can revive the associated Documents. Without this flip, those
+            # Documents stay in status='deleted' forever — re-labeling never
+            # restores them.
+            if existing.status == "unlabeled":
+                existing.status = "active"
+                existing.unlabeled_at = None
             duplicate_count += 1
             continue
         # Placeholder eml_sha256 — Stage 3 fills with the actual SHA when fetching the .eml.
@@ -218,6 +227,12 @@ async def sync_label_incremental(
             )
         ).scalar_one_or_none()
         if existing is not None:
+            # Relabel: see sync_label_initial for the rationale. Flip
+            # status='unlabeled' rows back to 'active' so Stage 3's
+            # restore_documents_for_relabeled can revive their Documents.
+            if existing.status == "unlabeled":
+                existing.status = "active"
+                existing.unlabeled_at = None
             duplicate_count += 1
             continue
         placeholder_sha = hashlib.sha256(f"placeholder:{label.label_id}:{uid}".encode()).digest()

--- a/tests/mail/test_ingest.py
+++ b/tests/mail/test_ingest.py
@@ -298,6 +298,84 @@ async def test_ingest_dedupes_across_labels_via_sha(db_session, mail_account, mo
     assert msg_b.eml_sha256 == real_sha
 
 
+async def test_ingest_rolls_back_email_doc_when_attachment_creation_fails(
+    db_session, watched_label, mock_aioimap, monkeypatch
+):
+    """Regression: a mid-batch failure in create_attachment_documents must
+    NOT leave a permanent orphan email Document.
+
+    Pre-fix flow: session.flush() wrote the email Document; then
+    create_attachment_documents raised (e.g. storage failure); the except
+    set msg.email_doc_id=None but the email Document row stayed in the
+    outer transaction. mail_observer.on_tick's outer commit persisted it.
+    Subsequent ticks couldn't dedup against it (cross-label dedup filters
+    on email_doc_id IS NOT NULL), so they re-created the same Document
+    on retry, accumulating one ghost per failure.
+
+    Fix: per-message session.begin_nested() savepoint scopes rollback to
+    this iteration. When create_attachment_documents raises, both the
+    email Document and any partial attachments roll back together.
+    """
+    monkeypatch.setattr("harbor_clerk.mail.ingest.enqueue_stage", lambda *a, **kw: None)
+
+    # Patch create_attachment_documents to always raise — simulates a
+    # storage backend failure after the email .eml was successfully put.
+    async def boom(*args, **kwargs):
+        raise RuntimeError("simulated storage failure mid-batch")
+
+    monkeypatch.setattr("harbor_clerk.mail.ingest.create_attachment_documents", boom)
+
+    eml = build_email_with_attachments(
+        message_id="<rollback@example.com>",
+        subject="Rollback test",
+        body_text="Body.",
+        attachments=[("doomed.pdf", "application/pdf", b"%PDF-1.4 fake")],
+    )
+    placeholder_sha = hashlib.sha256(b"placeholder").digest()
+    msg = WatchedMessage(
+        label_id=watched_label.label_id,
+        message_id="<rollback@example.com>",
+        imap_uid=99,
+        eml_sha256=placeholder_sha,
+        status="active",
+        email_doc_id=None,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+
+    mock_aioimap.set_login_response("OK", b"OK")
+    mock_aioimap.set_uid_fetch_response(
+        "OK",
+        [
+            b"99 (UID 99 BODY[] {%d}" % len(eml),
+            eml,
+            b")",
+            b"OK FETCH completed",
+        ],
+    )
+
+    conn = IMAPConnection(host="h", port=993, username="u", password="p")
+    await conn.connect()
+    await conn.login()
+    summary = await ingest_pending_messages(db_session, conn, watched_label)
+    await conn.logout()
+    await db_session.commit()
+
+    # No Documents survived for this message.
+    assert summary.new_email_doc_count == 0
+    assert summary.new_attachment_doc_count == 0
+    docs = (await db_session.execute(select(Document))).scalars().all()
+    assert len(docs) == 0, f"orphan Document(s) survived rollback: {[d.title for d in docs]}"
+
+    # msg.email_doc_id is still None — next tick will re-pick it via the
+    # `email_doc_id IS NULL` SELECT in ingest_pending_messages.
+    await db_session.refresh(msg)
+    assert msg.email_doc_id is None
+    # msg.eml_sha256 was updated OUTSIDE the savepoint, so the real SHA
+    # persists across the failed iteration. Next tick reuses it.
+    assert msg.eml_sha256 == hashlib.sha256(eml).digest()
+
+
 async def test_ingest_enqueues_extract_for_each_new_doc(db_session, watched_label, mock_aioimap, monkeypatch):
     """ingest_pending_messages should call enqueue_stage(extract) for the
     email Document and each attachment Document."""

--- a/tests/mail/test_sync_incremental.py
+++ b/tests/mail/test_sync_incremental.py
@@ -73,6 +73,72 @@ async def test_incremental_sync_fetches_only_new_uids(db_session, watched_label,
     assert watched_label.last_uid_seen == 7
 
 
+async def test_incremental_sync_restores_unlabeled_messages_on_relabel(db_session, watched_label, mock_aioimap):
+    """Regression: when a message is removed from the label (status='unlabeled')
+    and then re-applied, the sync's dedup branch must flip it back to 'active'
+    so Stage 3's restore_documents_for_relabeled finds it.
+
+    Pre-fix: the dedup branch unconditionally `continue`'d on an existing row,
+    leaving status='unlabeled' indefinitely. restore_documents_for_relabeled
+    found 0 rows and the previously-soft-deleted Documents stayed deleted
+    forever.
+    """
+    import hashlib
+    from datetime import UTC, datetime
+
+    # Seed: one existing watched_message at status='unlabeled' (as if Stage 2's
+    # lifecycle had detected it disappeared from the label earlier).
+    watched_label.last_uid_seen = 9
+    watched_label.uidvalidity = 12345
+    await db_session.flush()
+    existing = WatchedMessage(
+        label_id=watched_label.label_id,
+        message_id="<relabel@example.com>",
+        imap_uid=10,
+        eml_sha256=hashlib.sha256(b"placeholder").digest(),
+        status="unlabeled",
+        unlabeled_at=datetime.now(UTC),
+    )
+    db_session.add(existing)
+    await db_session.flush()
+
+    mock_aioimap.set_login_response("OK", b"OK")
+    mock_aioimap.set_select_response(
+        "OK",
+        [
+            b"* 1 EXISTS",
+            b"* OK [UIDVALIDITY 12345] UIDs valid",
+            b"OK SELECT completed",
+        ],
+    )
+    # Server reports the same UID 10 (label was re-applied — UID may even
+    # differ in practice, but the message_id match is what dedup pivots on).
+    mock_aioimap.set_uid_search_response("OK", [b"10"])
+    mock_aioimap.set_uid_fetch_response(
+        "OK",
+        [
+            b"10 (UID 10 BODY[HEADER.FIELDS (MESSAGE-ID)] {44}",
+            b"Message-ID: <relabel@example.com>\r\n",
+            b")",
+            b"OK FETCH completed",
+        ],
+    )
+
+    conn = IMAPConnection(host="imap.example.com", port=993, username="x", password="y")
+    await conn.connect()
+    await conn.login()
+    summary = await sync_label_incremental(db_session, conn, watched_label)
+    await conn.logout()
+    await db_session.commit()
+
+    # Dedup branch hit (same message_id), and the row was flipped.
+    assert summary.new_count == 0
+    assert summary.duplicate_count == 1
+    await db_session.refresh(existing)
+    assert existing.status == "active"
+    assert existing.unlabeled_at is None
+
+
 async def test_incremental_sync_no_new_messages(db_session, watched_label, mock_aioimap):
     """If `UID last+1:*` returns empty, sync is a no-op."""
     watched_label.last_uid_seen = 100


### PR DESCRIPTION
## Summary

Two data-integrity bugs in the mail subsystem, both surfaced by [PR #283](https://github.com/r0shi/harborclerk/pull/283)'s code review and captured in `pr_followups.md`.

### 1. `restore_documents_for_relabeled` was dead code (score 75)

`document_lifecycle.py` exposes a function that restores soft-deleted Documents whose `WatchedMessage` returns to `status='active'`. But no Stage 2 code path actually transitioned `unlabeled → active`. `sync_label_initial` and `sync_label_incremental` treated existing rows as duplicates and `continue`'d unconditionally. Re-applying a Gmail label to a previously-unlabeled message left its Documents in `status='deleted'` permanently.

**Fix:** in both sync functions' dedup branches, if `existing.status == "unlabeled"`, flip back to `"active"` and clear `unlabeled_at`. Stage 3's `restore_documents_for_relabeled` then sees the row and revives the Documents.

### 2. Mid-batch flush race producing orphan email Documents (score 72)

`ingest_pending_messages` flushed the email Document, then called `create_attachment_documents`. If that raised (storage failure mid-batch), the misleading `# Roll back this savepoint` comment notwithstanding, **there was no savepoint** — the already-flushed email Document sat in the outer transaction and got committed by `mail_observer.on_tick`'s outer commit. The except set `msg.email_doc_id = None`, so cross-label dedup (filters on `email_doc_id IS NOT NULL`) skipped the orphan on retry, producing exactly one ghost Document per failed message.

**Fix:** wrap the per-message body in `async with session.begin_nested():`. Real savepoint scopes rollback to this iteration: email Document, attachment Documents, and `msg.email_doc_id` all unwind atomically. `msg.eml_sha256` (set above, outside the savepoint) survives, so the next tick's retry can short-circuit on dedup if appropriate.

## Out of scope

External side effects — `storage.put_object` calls inside `create_email_document` and `create_attachment_documents` — don't roll back with the SAVEPOINT. A failed iteration can leave orphan storage objects. That's a separate cleanup problem (storage-object reaper) and was already implicit in the pre-fix behavior; this PR is strictly about DB-side correctness.

## Test plan

- [x] 2 regression tests added, both pass:
  - `test_incremental_sync_restores_unlabeled_messages_on_relabel` (sync.py path)
  - `test_ingest_rolls_back_email_doc_when_attachment_creation_fails` (ingest.py path)
- [x] All 66 mail tests pass
- [x] ruff check clean
- [x] ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
