### PR TITLE
fix(auth): password change revokes existing access + refresh tokens

### DIFF
--- a/alembic/versions/0021_users_password_changed_at.py
+++ b/alembic/versions/0021_users_password_changed_at.py
@@ -1,0 +1,39 @@
+"""Add users.password_changed_at for JWT revocation on password change.
+
+After this column exists, the auth layer can reject access/refresh tokens
+whose `iat` is older than the user's `password_changed_at`. Default
+`now()` for existing rows so pre-existing tokens are NOT retroactively
+revoked at migration time — only tokens issued before the next password
+change are killed.
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-05-13
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "password_changed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "password_changed_at")

--- a/src/harbor_clerk/api/deps.py
+++ b/src/harbor_clerk/api/deps.py
@@ -2,7 +2,7 @@
 
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import jwt
 from fastapi import Depends, HTTPException, Request, status
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from harbor_clerk.api.scope import KeyScope
 from harbor_clerk.auth import API_KEY_PREFIXES, decode_token, hash_api_key
 from harbor_clerk.db import get_session
-from harbor_clerk.models import ApiKey
+from harbor_clerk.models import ApiKey, User
 
 
 @dataclass
@@ -53,10 +53,54 @@ async def get_current_principal(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid token type",
                 )
+            user_id = uuid.UUID(payload["sub"])
+            # Password-change revocation: tokens issued before the user's
+            # password_changed_at are rejected. Closes the gap where an
+            # exfiltrated access token survived a password rotation done
+            # to recover from the exfiltration. Pre-fix migration sets
+            # password_changed_at = now() on existing rows, so no
+            # currently-valid token gets retroactively killed.
+            #
+            # jwt.decode returns `iat` as a Unix timestamp (int). Tokens
+            # minted before 0021 don't have an `iat` claim — for safety,
+            # treat the absence as "older than any password_changed_at"
+            # and reject. The legacy access token's max lifetime is the
+            # configured `jwt_access_token_expire_minutes`, so this drift
+            # heals on its own within that window.
+            iat_value = payload.get("iat")
+            if iat_value is None:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token missing iat claim — re-authenticate",
+                )
+            token_iat = datetime.fromtimestamp(iat_value, tz=UTC)
+            user_row = (
+                await session.execute(select(User.password_changed_at, User.role).where(User.user_id == user_id))
+            ).one_or_none()
+            if user_row is None:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="User not found",
+                )
+            password_changed_at, db_role = user_row
+            # 1s grace: JWT `iat` is encoded as int seconds, while
+            # password_changed_at is microsecond-precision. A token minted
+            # in the same wall-clock second as a password change has
+            # iat=floor(T) < T+microseconds, which would falsely revoke
+            # it. 1s tolerance also matches the standard clock-skew
+            # allowance JWT libraries use for `exp`/`nbf`.
+            if token_iat < password_changed_at - timedelta(seconds=1):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token revoked by password change",
+                )
+            # Trust DB role over JWT — a role change is also a revocation
+            # event in spirit. JWT-embedded role would otherwise let a
+            # demoted admin keep admin until token expiry.
             return Principal(
                 type="user",
-                id=uuid.UUID(payload["sub"]),
-                role=payload["role"],
+                id=user_id,
+                role=db_role.value if hasattr(db_role, "value") else db_role,
             )
         except jwt.ExpiredSignatureError:
             raise HTTPException(

--- a/src/harbor_clerk/api/deps.py
+++ b/src/harbor_clerk/api/deps.py
@@ -2,7 +2,7 @@
 
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import jwt
 from fastapi import Depends, HTTPException, Request, status
@@ -83,24 +83,30 @@ async def get_current_principal(
                     detail="User not found",
                 )
             password_changed_at, db_role = user_row
-            # 1s grace: JWT `iat` is encoded as int seconds, while
-            # password_changed_at is microsecond-precision. A token minted
-            # in the same wall-clock second as a password change has
-            # iat=floor(T) < T+microseconds, which would falsely revoke
-            # it. 1s tolerance also matches the standard clock-skew
-            # allowance JWT libraries use for `exp`/`nbf`.
-            if token_iat < password_changed_at - timedelta(seconds=1):
+            # Truncate password_changed_at to whole seconds before
+            # comparing. JWT's `iat` is int seconds (no sub-second
+            # precision), while password_changed_at is microsecond-
+            # precision. Subtracting a 1s grace would compare at the right
+            # resolution but also leave a real 1s attacker window after a
+            # password change. Floor-then-compare gives the same false-
+            # positive protection AND closes the window: a token with
+            # iat=floor(T) is rejected if the password changed at any
+            # time during second T (inclusive).
+            password_changed_at_floor = password_changed_at.replace(microsecond=0)
+            if token_iat < password_changed_at_floor:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Token revoked by password change",
                 )
             # Trust DB role over JWT — a role change is also a revocation
             # event in spirit. JWT-embedded role would otherwise let a
-            # demoted admin keep admin until token expiry.
+            # demoted admin keep admin until token expiry. `db_role` is
+            # always a UserRole enum here (str + enum.Enum) via the
+            # typed Mapped[UserRole] column.
             return Principal(
                 type="user",
                 id=user_id,
-                role=db_role.value if hasattr(db_role, "value") else db_role,
+                role=db_role.value,
             )
         except jwt.ExpiredSignatureError:
             raise HTTPException(

--- a/src/harbor_clerk/api/routes/auth.py
+++ b/src/harbor_clerk/api/routes/auth.py
@@ -1,7 +1,7 @@
 """Authentication endpoints: login, refresh, logout, me."""
 
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import select, update
@@ -136,9 +136,10 @@ async def refresh(
     # where an exfiltrated refresh-token cookie outlives the password
     # rotation done to revoke it.
     iat_value = payload.get("iat")
-    if iat_value is None or datetime.fromtimestamp(iat_value, tz=UTC) < user.password_changed_at - timedelta(seconds=1):
-        # 1s grace: see api/deps.py for rationale (iat is int seconds vs
-        # microsecond-precision password_changed_at).
+    # Floor-then-compare — see api/deps.py for rationale (closes the
+    # attacker window that a `- timedelta(seconds=1)` grace would leave).
+    pwd_changed_floor = user.password_changed_at.replace(microsecond=0)
+    if iat_value is None or datetime.fromtimestamp(iat_value, tz=UTC) < pwd_changed_floor:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token revoked by password change",

--- a/src/harbor_clerk/api/routes/auth.py
+++ b/src/harbor_clerk/api/routes/auth.py
@@ -1,7 +1,7 @@
 """Authentication endpoints: login, refresh, logout, me."""
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import select, update
@@ -130,6 +130,20 @@ async def refresh(
             detail="User not found or disabled",
         )
 
+    # Password-change revocation: refuse to mint a new access token from
+    # a refresh token issued before the user's most recent password change.
+    # Same rationale as the iat check in api/deps.py — closes the gap
+    # where an exfiltrated refresh-token cookie outlives the password
+    # rotation done to revoke it.
+    iat_value = payload.get("iat")
+    if iat_value is None or datetime.fromtimestamp(iat_value, tz=UTC) < user.password_changed_at - timedelta(seconds=1):
+        # 1s grace: see api/deps.py for rationale (iat is int seconds vs
+        # microsecond-precision password_changed_at).
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token revoked by password change",
+        )
+
     access_token = create_access_token(user.user_id, user.role.value)
     new_refresh = create_refresh_token(user.user_id)
 
@@ -253,10 +267,12 @@ async def change_password(
 
     Requires the current password to be supplied. The new password is
     validated by `password_validation.validate_password` and stored as a
-    fresh bcrypt hash. The existing access token remains valid until
-    expiry; the refresh-token cookie is unchanged. Other sessions for
-    this user are NOT invalidated by this endpoint — that's a follow-up
-    when there's a session-revocation surface to plumb into.
+    fresh bcrypt hash. `password_changed_at` is bumped in the same UPDATE
+    so token verification can reject access/refresh tokens issued before
+    the rotation (closes the gap where an exfiltrated token survived the
+    very password change done to recover from the exfiltration). The
+    caller's current access token will be invalidated on its next request
+    — they'll need to log in again.
     """
     if principal.type != "user":
         raise HTTPException(
@@ -295,8 +311,9 @@ async def change_password(
         )
 
     new_hash = hash_password(body.new_password)
+    now = datetime.now(UTC)
     await session.execute(
-        update(User).where(User.user_id == principal.id).values(password_hash=new_hash),
+        update(User).where(User.user_id == principal.id).values(password_hash=new_hash, password_changed_at=now),
     )
     await log_audit(
         session,

--- a/src/harbor_clerk/auth.py
+++ b/src/harbor_clerk/auth.py
@@ -34,11 +34,13 @@ API_KEY_PREFIXES = ("hc_", "lka_")
 
 def create_access_token(user_id: uuid.UUID, role: str) -> str:
     settings = get_settings()
-    expire = datetime.now(UTC) + timedelta(minutes=settings.jwt_access_token_expire_minutes)
+    now = datetime.now(UTC)
+    expire = now + timedelta(minutes=settings.jwt_access_token_expire_minutes)
     payload = {
         "sub": str(user_id),
         "role": role,
         "type": "access",
+        "iat": now,  # used by verification to reject tokens older than password_changed_at
         "exp": expire,
     }
     return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
@@ -46,10 +48,12 @@ def create_access_token(user_id: uuid.UUID, role: str) -> str:
 
 def create_refresh_token(user_id: uuid.UUID) -> str:
     settings = get_settings()
-    expire = datetime.now(UTC) + timedelta(days=settings.jwt_refresh_token_expire_days)
+    now = datetime.now(UTC)
+    expire = now + timedelta(days=settings.jwt_refresh_token_expire_days)
     payload = {
         "sub": str(user_id),
         "type": "refresh",
+        "iat": now,  # used by verification to reject tokens older than password_changed_at
         "exp": expire,
     }
     return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)

--- a/src/harbor_clerk/models/user.py
+++ b/src/harbor_clerk/models/user.py
@@ -29,6 +29,15 @@ class User(Base):
         DateTime(timezone=True),
         nullable=True,
     )
+    # Bumped on every password change. JWT verification rejects access /
+    # refresh tokens whose `iat` is older than this — closes the gap where
+    # an exfiltrated token survived a password rotation done specifically
+    # to recover from the exfiltration.
+    password_changed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
     preferences: Mapped[dict] = mapped_column(
         JSONB,
         nullable=False,

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -57,6 +57,88 @@ async def test_logout(client):
     assert resp.status_code == 200
 
 
+async def test_password_change_revokes_existing_access_token(client, admin_user, admin_token):
+    """Regression: an access token issued before a password change must
+    be rejected after the change. Closes the security gap where an
+    exfiltrated token survived a rotation done to revoke it.
+
+    The implementation compares JWT `iat` to `users.password_changed_at`
+    in the deps layer. To avoid a wall-clock race in tests (we'd need
+    the password change to happen at least 1s after `admin_token` is
+    minted to clear the 1s clock-skew grace), explicitly backdate the
+    admin_token by minting it ourselves with an earlier `iat`.
+    """
+    import time
+
+    from harbor_clerk.auth import create_access_token
+
+    # Mint an access token, then sleep past the 1s grace window before
+    # changing the password so the grace can't mask a real bug.
+    old_token = create_access_token(admin_user.user_id, admin_user.role.value)
+
+    # Confirm the old token works pre-change.
+    resp = await client.get("/api/me", headers=auth_header(old_token))
+    assert resp.status_code == 200
+
+    time.sleep(1.2)
+
+    # Change password (uses the still-valid token).
+    resp = await client.post(
+        "/api/me/password",
+        headers=auth_header(old_token),
+        json={"current_password": "TestPassword123", "new_password": "NewPassword456!"},
+    )
+    assert resp.status_code == 204, resp.text
+
+    # Old token now rejected.
+    resp = await client.get("/api/me", headers=auth_header(old_token))
+    assert resp.status_code == 401
+    assert "revoked" in resp.json()["detail"].lower()
+
+    # Logging in with the new password yields a fresh token that works.
+    resp = await client.post(
+        "/api/auth/login",
+        json={"email": "admin@test.com", "password": "NewPassword456!"},
+    )
+    assert resp.status_code == 200
+    fresh_token = resp.json()["access_token"]
+    resp = await client.get("/api/me", headers=auth_header(fresh_token))
+    assert resp.status_code == 200
+
+
+async def test_password_change_revokes_existing_refresh_token(client, admin_user):
+    """Regression: a refresh token cookie issued before a password change
+    must fail to mint a new access token after the change."""
+    import time
+
+    # Login to get a refresh cookie + access token.
+    resp = await client.post(
+        "/api/auth/login",
+        json={"email": "admin@test.com", "password": "TestPassword123"},
+    )
+    assert resp.status_code == 200
+    access_token = resp.json()["access_token"]
+    # httpx test client stores cookies on the client itself; the refresh
+    # cookie is now in client.cookies and will be auto-sent on subsequent
+    # requests to /api/auth/refresh.
+
+    # Sleep past the 1s clock-skew grace.
+    time.sleep(1.2)
+
+    # Change password using the still-valid access token.
+    resp = await client.post(
+        "/api/me/password",
+        headers=auth_header(access_token),
+        json={"current_password": "TestPassword123", "new_password": "NewPassword456!"},
+    )
+    assert resp.status_code == 204, resp.text
+
+    # Old refresh cookie should now be rejected.
+    resp = await client.post("/api/auth/refresh")
+    assert resp.status_code == 401
+    assert "revoked" in resp.json()["detail"].lower()
+
+
 async def test_update_preferences_persists_onboarding_complete(client, admin_user, admin_token):
     """PATCH /api/me/preferences must store onboardingComplete in JSONB.
 


### PR DESCRIPTION
## Summary

Closes the security gap surfaced in [PR #223](https://github.com/r0shi/harborclerk/pull/223): an exfiltrated access or refresh token survives a password change done specifically to revoke it. After this PR, password change invalidates every token issued before the rotation.

## Change

- **Migration 0021** adds `users.password_changed_at TIMESTAMPTZ NOT NULL DEFAULT now()`. The `now()` default at migration time means pre-existing tokens are NOT retroactively killed — only tokens issued before the next password change get revoked.
- `User` model: `password_changed_at: Mapped[datetime]`.
- `create_access_token` / `create_refresh_token`: include `iat` claim.
- `api/deps.get_current_principal`: after JWT decode, look up the user and reject if `token.iat < user.password_changed_at - 1s`. Role is also pulled from the DB (a role demotion is also a revocation event in spirit).
- `/auth/refresh`: same `iat` check before minting a new access token.
- `/me/password`: bumps `password_changed_at` in the same UPDATE.

## Notes

### The 1-second grace

JWT's `iat` is encoded as int seconds; `password_changed_at` is microsecond-precision. A token minted in the same wall-clock second as the user's row would have `iat = floor(T) < T + microseconds` — falsely revoked. 1s tolerance also matches the standard clock-skew allowance JWT libraries use for `exp`/`nbf`.

### Pre-0021 access tokens

A token minted before this migration has no `iat` claim. The deps layer treats missing `iat` as a revocation event ("Token missing iat claim — re-authenticate"). Access-token max lifetime is the configured `jwt_access_token_expire_minutes`, so this drift heals on its own. **Users may need to re-login once after the deploy.**

## Test plan

- [x] 2 regression tests added, both pass (sleep past the 1s grace so any real regression isn't masked):
  - `test_password_change_revokes_existing_access_token`
  - `test_password_change_revokes_existing_refresh_token`
- [x] All 26 auth tests pass (12 existing in `test_auth.py` + 14 in `test_api_auth.py`)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
