### PR TITLE
fix(test-corpora): --rerun 'id=A,id=B' now actually matches all listed ids

### DIFF
--- a/scripts/test_corpora/runner/state.py
+++ b/scripts/test_corpora/runner/state.py
@@ -189,9 +189,30 @@ class StateFile:
 
     # ── selectors ──
 
+    # User-facing selector keys that don't match the Unit attribute name.
+    # ``id`` → ``question_id`` because the documented runbook (and the natural
+    # operator shorthand) is ``--rerun 'id=cuad-ask-1'``; previously this
+    # silently matched zero because ``getattr(u, "id", "")`` returned "".
+    _FIELD_ALIASES = {"id": "question_id"}
+
+    @classmethod
+    def _resolve_field(cls, name: str) -> str:
+        return cls._FIELD_ALIASES.get(name, name)
+
+    @staticmethod
+    def _normalize_selectors(selectors: dict[str, str | list[str]]) -> dict[str, list[str]]:
+        """Accept either single-value or multi-value selectors and return the
+        multi-value shape. Lets existing in-process callers keep passing
+        ``{"corpus": "cuad"}`` while the CLI passes ``{"id": ["a","b","c"]}``.
+        """
+        norm: dict[str, list[str]] = {}
+        for k, v in selectors.items():
+            norm[k] = list(v) if isinstance(v, list) else [v]
+        return norm
+
     @staticmethod
     def _selector_matches(actual: object, wanted: str) -> bool:
-        """Compare a unit field's value against a CLI selector value.
+        """Compare a unit field's value against a single CLI selector value.
 
         Handles three field shapes the CLI plumbs through:
           - ``str`` fields (``corpus``, ``model``, ``question_id``, ``depth``,
@@ -218,11 +239,29 @@ class StateFile:
             return wanted[1:] in actual_str
         return actual_str == wanted
 
-    def rerun(self, selectors: dict[str, str]) -> int:
-        """Flip units matching all selectors back to PENDING. Returns count."""
+    def _unit_matches_selectors(self, u: Unit, selectors: dict[str, list[str]]) -> bool:
+        """A unit matches if, for each selector key, ANY listed value matches
+        the unit's field (OR within key), and EVERY selector key matches
+        (AND across keys). Repeated keys in the CLI string become a single
+        list entry here — ``--rerun 'id=A,id=B'`` matches units whose
+        ``question_id`` is A or B.
+        """
+        return all(
+            any(self._selector_matches(getattr(u, self._resolve_field(k), ""), v) for v in values)
+            for k, values in selectors.items()
+        )
+
+    def rerun(self, selectors: dict[str, str | list[str]]) -> int:
+        """Flip units matching all selectors back to PENDING. Returns count.
+
+        Selector semantics: AND across keys, OR within a key. ``--rerun
+        'id=A,id=B,phase=4'`` matches units whose phase is 4 AND whose
+        question_id is A or B.
+        """
+        norm = self._normalize_selectors(selectors)
         n = 0
         for u in self._units.values():
-            if all(self._selector_matches(getattr(u, k, ""), v) for k, v in selectors.items()):
+            if self._unit_matches_selectors(u, norm):
                 u.status = Status.PENDING
                 u.heartbeat = None
                 u.started_at = None
@@ -230,10 +269,11 @@ class StateFile:
                 n += 1
         return n
 
-    def skip(self, selectors: dict[str, str]) -> int:
+    def skip(self, selectors: dict[str, str | list[str]]) -> int:
+        norm = self._normalize_selectors(selectors)
         n = 0
         for u in self._units.values():
-            if all(self._selector_matches(getattr(u, k, ""), v) for k, v in selectors.items()):
+            if self._unit_matches_selectors(u, norm):
                 u.status = Status.SKIPPED
                 n += 1
         return n

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -333,10 +333,25 @@ def make_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _parse_selectors(s: str) -> dict[str, str]:
+def _parse_selectors(s: str) -> dict[str, list[str]]:
+    """Parse the CLI selector string into a multimap.
+
+    ``id=A,id=B,phase=4`` → ``{"id": ["A", "B"], "phase": ["4"]}``.
+
+    Repeated keys accumulate into a list (OR within key). Different keys are
+    AND'd downstream in ``StateFile.rerun`` / ``skip``. The previous
+    ``dict(...)`` implementation silently collapsed repeated keys to the last
+    value, so ``--rerun 'id=A,id=B,id=C'`` matched only ``C``.
+    """
     if not s:
         return {}
-    return dict(part.split("=", 1) for part in s.split(",") if "=" in part)
+    result: dict[str, list[str]] = {}
+    for part in s.split(","):
+        if "=" not in part:
+            continue
+        k, v = part.split("=", 1)
+        result.setdefault(k, []).append(v)
+    return result
 
 
 def _phase_range(s: str) -> set[int]:

--- a/scripts/test_corpora/tests/test_parse_selectors.py
+++ b/scripts/test_corpora/tests/test_parse_selectors.py
@@ -1,0 +1,47 @@
+"""Tests for the CLI selector parser in sweep.py.
+
+The previous implementation called ``dict(...)`` over the comma-split parts,
+silently collapsing repeated keys to the last value. The runbook's documented
+multi-id syntax (``--rerun 'id=A,id=B,id=C'``) silently matched zero units
+as a result.
+"""
+
+from __future__ import annotations
+
+from scripts.test_corpora.runner.sweep import _parse_selectors
+
+
+def test_empty_string_returns_empty_dict():
+    assert _parse_selectors("") == {}
+
+
+def test_single_key_value_pair():
+    assert _parse_selectors("phase=4") == {"phase": ["4"]}
+
+
+def test_distinct_keys_each_become_a_list():
+    assert _parse_selectors("phase=4,corpus=cuad") == {"phase": ["4"], "corpus": ["cuad"]}
+
+
+def test_repeated_keys_accumulate_into_a_list_in_order():
+    """Regression: ``dict(...)`` collapsed repeated keys to the last value, so
+    the documented runbook syntax was silently broken."""
+    assert _parse_selectors("id=A,id=B,id=C") == {"id": ["A", "B", "C"]}
+
+
+def test_mixed_repeated_and_distinct_keys():
+    result = _parse_selectors("id=cuad-ask-1,id=cuad-ask-2,id=enron-research-1,phase=4")
+    assert result == {
+        "id": ["cuad-ask-1", "cuad-ask-2", "enron-research-1"],
+        "phase": ["4"],
+    }
+
+
+def test_values_containing_equals_signs_survive_intact():
+    """``error=~no=match found`` should parse with ``~no=match found`` as the
+    value (split only on the first ``=``)."""
+    assert _parse_selectors("error=~no=match found") == {"error": ["~no=match found"]}
+
+
+def test_garbage_parts_without_equals_are_dropped():
+    assert _parse_selectors("phase=4,garbage,corpus=cuad") == {"phase": ["4"], "corpus": ["cuad"]}

--- a/scripts/test_corpora/tests/test_state.py
+++ b/scripts/test_corpora/tests/test_state.py
@@ -259,6 +259,73 @@ def test_rerun_substring_selector_handles_none_error(tmp_path: Path):
     assert n == 0
 
 
+def test_rerun_multi_value_id_selector_matches_any_listed_id(tmp_path: Path):
+    """Regression: the CLI string ``id=A,id=B,id=C`` used to collapse into a
+    single dict entry (``{"id": "C"}``) and silently match zero units,
+    because (a) the parser called ``dict(...)`` over repeated keys and
+    (b) Unit has no ``id`` attribute. The runbook's documented
+    cuad-ask-1/2/3 + cuad-research-1 + enron-research-1 regen recipe never
+    actually worked. After the fix, all five listed ids flip to PENDING.
+    """
+    sf = StateFile(tmp_path / "state.json")
+    qids = ["cuad-ask-1", "cuad-ask-2", "cuad-ask-3", "cuad-research-1", "cuad-ask-10"]
+    sf.register([Unit(phase=1, corpus="cuad", model="claude-baseline", question_id=q, depth="standard") for q in qids])
+    for q in qids:
+        sf.set_status(1, "cuad", "claude-baseline", q, "standard", Status.DONE)
+
+    n = sf.rerun({"id": ["cuad-ask-1", "cuad-ask-2", "cuad-ask-3", "cuad-research-1"]})
+    assert n == 4
+
+    statuses = {u.question_id: u.status for u in sf.units()}
+    assert statuses["cuad-ask-1"] == Status.PENDING
+    assert statuses["cuad-ask-2"] == Status.PENDING
+    assert statuses["cuad-ask-3"] == Status.PENDING
+    assert statuses["cuad-research-1"] == Status.PENDING
+    # cuad-ask-10 was not in the selector list — must stay DONE despite the
+    # "cuad-ask-1" substring overlap (proves we're doing exact equality, not
+    # accidental substring matching).
+    assert statuses["cuad-ask-10"] == Status.DONE
+
+
+def test_rerun_id_alias_maps_to_question_id(tmp_path: Path):
+    """``id`` is the runbook-documented shorthand for ``question_id``.
+    Without an alias, ``getattr(u, "id", "")`` returns "" and matches
+    nothing — which is exactly the bug that made the documented regen
+    recipe silently no-op."""
+    sf = StateFile(tmp_path / "state.json")
+    sf.register([Unit(phase=1, corpus="cuad", model="claude-baseline", question_id="cuad-ask-1", depth="standard")])
+    sf.set_status(1, "cuad", "claude-baseline", "cuad-ask-1", "standard", Status.DONE)
+
+    n = sf.rerun({"id": "cuad-ask-1"})
+    assert n == 1
+    u = sf.get(1, "cuad", "claude-baseline", "cuad-ask-1", "standard")
+    assert u is not None and u.status == Status.PENDING
+
+
+def test_rerun_combines_multi_id_and_phase_selectors(tmp_path: Path):
+    """AND across keys, OR within a key: ``--rerun 'id=A,id=B,phase=4'``
+    should match units whose phase==4 AND (question_id==A OR ==B)."""
+    sf = StateFile(tmp_path / "state.json")
+    sf.register(
+        [
+            Unit(phase=1, corpus="cuad", model="claude-baseline", question_id="A", depth="standard"),
+            Unit(phase=4, corpus="cuad", model="qwen3-8b", question_id="A", depth="standard"),
+            Unit(phase=4, corpus="cuad", model="qwen3-8b", question_id="B", depth="standard"),
+            Unit(phase=4, corpus="cuad", model="qwen3-8b", question_id="C", depth="standard"),
+        ]
+    )
+    for u in sf.units():
+        sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.DONE)
+
+    n = sf.rerun({"id": ["A", "B"], "phase": "4"})
+    assert n == 2  # phase-4 A + phase-4 B; phase-1 A excluded, phase-4 C excluded
+
+    assert sf.get(1, "cuad", "claude-baseline", "A", "standard").status == Status.DONE
+    assert sf.get(4, "cuad", "qwen3-8b", "A", "standard").status == Status.PENDING
+    assert sf.get(4, "cuad", "qwen3-8b", "B", "standard").status == Status.PENDING
+    assert sf.get(4, "cuad", "qwen3-8b", "C", "standard").status == Status.DONE
+
+
 def test_skip_status_selector_matches_enum_value(tmp_path: Path):
     """Same selector fix applies to --skip; verify it works end-to-end."""
     sf = StateFile(tmp_path / "state.json")


### PR DESCRIPTION
## Summary

Two harness bugs were silently making the documented regen-corrupt-baselines recipe in [RUNBOOK.md L258](../blob/main/scripts/test_corpora/RUNBOOK.md) a no-op. Operators on MINI (and just now on BIG) were seeing `flipped 0 units to PENDING via --rerun` followed by `sweep complete after 0.0s` and reasonably concluding the harness was broken.

Two compounding bugs:

1. **`_parse_selectors` collapsed repeated keys.** `dict(...)` over comma-split `(key, value)` pairs keeps only the last value, so `--rerun 'id=A,id=B,id=C'` evaluated to `{"id": "C"}`.
2. **`Unit` has no `id` attribute.** Its field is `question_id`. So `getattr(u, "id", "")` returned `""` and matched zero units anyway.

Either bug alone would have made the documented syntax fail silently; together they were silently-silent.

## Fix

- `_parse_selectors` now returns `dict[str, list[str]]` — repeated keys accumulate, OR-matched within a key, AND-matched across keys. Operator can also still pass one selector per key (single-value).
- `StateFile._FIELD_ALIASES` maps `id` → `question_id` so the runbook documented shorthand works without forcing operators to know the attribute name.
- `rerun` / `skip` normalize at the boundary so all existing in-process callers (and 7 existing tests) keep working unchanged.

## Verified against real state.json

Run against the user's `2026-05-05-prod/state.json`:

| invocation | before | after |
| --- | --- | --- |
| phase 1, 5 ids | 0 flipped | **5 flipped** |
| phase 4, 5 ids | 0 flipped | **30 flipped** (5 ids × 6 models) |
| phase 4, `corpus=synthetic` | 108 flipped | 108 flipped (regression-checked, unchanged) |

## Test plan

- [x] 10 new unit tests: 3 in `test_state.py` (multi-value id, id-alias, mixed AND/OR), 7 in `test_parse_selectors.py` (parser surface incl. repeated keys, distinct keys, garbage parts, `=` inside values).
- [x] 27 of 27 selector / state tests pass.
- [x] Ruff lint + format clean on changed files.
- [x] Full test_corpora suite: 203 passed (1 pre-existing failure, missing `en_core_web_sm` spaCy model — unrelated, env-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
