### PR TITLE
fix(pipeline): three background-stage bugs from PR #327 (typo, re-enqueue loop, status poison)

### DIFF
--- a/src/harbor_clerk/worker/entry.py
+++ b/src/harbor_clerk/worker/entry.py
@@ -23,7 +23,7 @@ from harbor_clerk.db_sync import _make_sync_url, get_sync_session
 from harbor_clerk.events import publish_job_event
 from harbor_clerk.models import Document, IngestionJob
 from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
-from harbor_clerk.worker.pipeline import STAGE_CONFIG
+from harbor_clerk.worker.pipeline import _BACKGROUND_STAGES, STAGE_CONFIG
 from harbor_clerk.worker.stages import STAGE_FUNCTIONS
 
 logger = logging.getLogger(__name__)
@@ -243,8 +243,16 @@ def execute_job(doc_id: uuid.UUID, stage: JobStage) -> None:
                 job.error = error_msg
                 job.finished_at = datetime.now(UTC)
 
+            # Background stages (summarize) must not touch pipeline_status —
+            # it reflects the gating-stage progression only. The doc may
+            # already be `ready` when summarize errors; flipping it to
+            # `error` would regress a successfully-ingested doc into a
+            # failed-looking state in the UI just because the optional
+            # summary couldn't be produced. enqueue_stage + mark_stage_done
+            # already enforce this for the success path; the error path
+            # missed the memo when PR #327 moved summarize to background.
             doc = session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one_or_none()
-            if doc:
+            if doc and stage not in _BACKGROUND_STAGES:
                 doc.pipeline_status = PipelineStatus.error
                 doc.error = error_msg
 

--- a/src/harbor_clerk/worker/pipeline.py
+++ b/src/harbor_clerk/worker/pipeline.py
@@ -301,13 +301,21 @@ def advance_pipeline(doc_id: uuid.UUID) -> None:
                 continue
             to_enqueue.append(stage)
 
-        # Background stages run alongside but never gate finalize. Enqueued
-        # the first time we see chunk done so they aren't repeatedly
-        # re-queued on each advance_pipeline tick.
+        # Background stages: enqueued the first time we see chunk done, then
+        # left alone. The check is "any existing job row for this stage" —
+        # not just queued/running/done — otherwise an errored summarize gets
+        # re-enqueued on every advance_pipeline tick. That has two bad
+        # effects: (1) it loops indefinitely, retrying the same broken
+        # summary, and (2) when the re-enqueue happens we'd return below
+        # before reaching the phase-3 finalize gate, so finalize would
+        # never fire for any doc whose summarize errored. Admin endpoints
+        # (/system/resummarize-all, /docs/X/resummarize) still re-enqueue
+        # explicitly via enqueue_stage(), which handles its own upsert.
+        existing_stages = {j.stage for j in all_jobs}
         background_to_enqueue: list[JobStage] = []
         if JobStage.chunk in completed:
             for stage in _BACKGROUND_STAGES:
-                if stage in completed or stage in in_flight:
+                if stage in existing_stages:
                     continue
                 background_to_enqueue.append(stage)
 

--- a/src/harbor_clerk/worker/stages/summarize.py
+++ b/src/harbor_clerk/worker/stages/summarize.py
@@ -41,7 +41,10 @@ def _user_llm_active() -> bool:
     session = get_sync_session()
     try:
         recent_chat = session.execute(
-            select(ChatMessage.id).where(ChatMessage.role == "user").where(ChatMessage.created_at > cutoff).limit(1)
+            select(ChatMessage.message_id)
+            .where(ChatMessage.role == "user")
+            .where(ChatMessage.created_at > cutoff)
+            .limit(1)
         ).first()
         if recent_chat:
             return True

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -432,3 +432,123 @@ async def test_summarize_not_in_finalize_gate(db_session):
         assert finalize_job.status == JobStatus.queued
     finally:
         sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_advance_pipeline_does_not_re_enqueue_errored_background_stage(db_session):
+    """Regression: previously advance_pipeline would re-enqueue an errored
+    summarize on every tick because the check was 'not in (done, queued,
+    running)'. Re-enqueue caused two bad effects: (1) infinite-ish retry of
+    a broken summary, and (2) returning before the phase-3 finalize gate,
+    so finalize never fired for any doc whose summarize errored. Bug
+    visible in production as 10,576 docs stuck with summarize=error,
+    finalize=missing, pipeline_status=error.
+
+    Now: an errored background stage stays errored. Admin endpoints
+    (/system/resummarize-all, /docs/X/resummarize) handle explicit retry.
+    """
+    from harbor_clerk.worker.pipeline import advance_pipeline
+
+    doc = Document(
+        title="Errored background no-retry",
+        canonical_filename="err.pdf",
+        status="active",
+        sha256=b"e" * 32,
+        pipeline_status=PipelineStatus.embedded,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+
+    sync_session = get_sync_session()
+    try:
+        for stage in (JobStage.extract, JobStage.chunk, JobStage.entities, JobStage.embed):
+            sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=stage, status=JobStatus.done))
+        # Summarize errored on its first attempt.
+        sync_session.add(
+            IngestionJob(
+                doc_id=doc.doc_id,
+                stage=JobStage.summarize,
+                status=JobStatus.error,
+                error="AttributeError: type object 'ChatMessage' has no attribute 'id'",
+            )
+        )
+        sync_session.commit()
+    finally:
+        sync_session.close()
+
+    advance_pipeline(doc.doc_id)
+
+    sync_session = get_sync_session()
+    try:
+        # Summarize stays errored — NOT auto-retried back to queued.
+        summarize_job = sync_session.execute(
+            select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.summarize)
+        ).scalar_one()
+        assert summarize_job.status == JobStatus.error
+
+        # Finalize fires — gate is {entities, embed}, both done.
+        finalize_job = sync_session.execute(
+            select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.finalize)
+        ).scalar_one()
+        assert finalize_job.status == JobStatus.queued
+    finally:
+        sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_background_stage_error_does_not_poison_pipeline_status(db_session, monkeypatch):
+    """Regression: the worker error handler in entry.py used to set
+    doc.pipeline_status = error on any stage failure, including background
+    stages. PR #327 designed background stages NOT to touch pipeline_status
+    (both enqueue_stage and mark_stage_done guard against it) but the error
+    path was missed. Effect: a doc fully ingested through finalize would
+    flip from Ready → error when its (optional) summary errored later.
+    """
+    from harbor_clerk.worker.entry import execute_job
+
+    doc = Document(
+        title="Background error no-poison",
+        canonical_filename="poison.pdf",
+        status="active",
+        sha256=b"p" * 32,
+        # Doc has already finalized — pipeline_status should stay here.
+        pipeline_status=PipelineStatus.ready,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+
+    sync_session = get_sync_session()
+    try:
+        sync_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.summarize, status=JobStatus.queued))
+        sync_session.commit()
+    finally:
+        sync_session.close()
+
+    # Make the summarize stage raise so we exercise the error branch.
+    def _boom(_doc_id):
+        raise AttributeError("type object 'ChatMessage' has no attribute 'id'")
+
+    from harbor_clerk.worker import entry as entry_mod
+
+    monkeypatch.setitem(entry_mod.STAGE_FUNCTIONS, JobStage.summarize, _boom)
+
+    execute_job(doc.doc_id, JobStage.summarize)
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc.doc_id)).scalar_one()
+        # KEY assertion: pipeline_status stays ready, NOT regressed to error.
+        assert refreshed.pipeline_status == PipelineStatus.ready
+        assert refreshed.error is None
+
+        # The job itself records the error (so the UI's summary-state chip
+        # can show "Failed") — that's separate from doc.pipeline_status.
+        job = sync_session.execute(
+            select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id, IngestionJob.stage == JobStage.summarize)
+        ).scalar_one()
+        assert job.status == JobStatus.error
+        assert "ChatMessage" in (job.error or "")
+    finally:
+        sync_session.close()

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from harbor_clerk.llm.summarize import (
     _compute_max_input_chars,
@@ -516,3 +517,24 @@ class TestClassifyDocType:
             mock_settings.return_value.llm_model_id = ""
             result = classify_doc_type(["Some text content"], mime_type="application/pdf")
             assert result == "PDF Document"
+
+
+class TestUserLLMActiveQueriesChatMessage:
+    """Regression: PR #327's _user_llm_active() used ChatMessage.id, but the
+    model defines message_id (not id). Every summarize call crashed
+    immediately with AttributeError: type object 'ChatMessage' has no
+    attribute 'id', failing the yield-to-interactive guard before the
+    stage did any work. Visible in production as 100% summarize failure
+    on a fresh corpus ingest.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_chat_messages_returns_false_without_attribute_error(self, db_session):
+        """The query must execute against the real ChatMessage model without
+        crashing. Empty table → False (no recent user activity).
+        The db_session fixture exists purely to ensure Alembic has run and
+        the chat_messages table is present before _user_llm_active opens
+        its own sync session."""
+        from harbor_clerk.worker.stages.summarize import _user_llm_active
+
+        assert _user_llm_active() is False


### PR DESCRIPTION
## Summary

PR [#327](https://github.com/r0shi/harborclerk/pull/327) ("decouple summarize from finalize gate") introduced the background-stage concept but left three rough edges that compound on a fresh corpus ingest. Symptom on the BIG test-corpora run: **all 10,576 docs ended with `summarize=error`, no `finalize` row, `pipeline_status=error`** — even though every retrieval-relevant stage (extract/ocr/chunk/entities/embed) succeeded. The queue tray UI rendered this as "OCR pending", which is what surfaced the issue.

### Bug 1 — `ChatMessage.id` typo
[summarize.py:_user_llm_active](src/harbor_clerk/worker/stages/summarize.py:42) queries `ChatMessage.id`. The model defines `message_id` (not `id`). Every summarize call crashed immediately with `AttributeError: type object 'ChatMessage' has no attribute 'id'` before doing any work. Tests didn't catch it because none exercised the yield-to-interactive guard against a real session.

### Bug 2 — Errored background stage re-enqueued, blocking finalize
[pipeline.py:advance_pipeline](src/harbor_clerk/worker/pipeline.py) checked `stage not in completed or in_flight` to decide whether to enqueue a background stage. An **errored** summarize is in neither, so it got re-enqueued on every `advance_pipeline` tick. The re-enqueue made `all_new` non-empty, returning before the phase-3 finalize gate. **Result: `finalize` never fires for any doc whose summarize errored.**

Log trace confirming for doc `b03ef192`:
```
21:21:02,131  Enqueued summarize (initial)
21:21:10,076  summarize failed: AttributeError ChatMessage.id
21:22:26,191  Enqueued summarize (re-enqueue after embed-done)
21:22:26,203  summarize failed (again)
```

**Fix:** skip background-stage enqueue if **any** existing job row exists for the stage. Background stages are enqueued exactly once by the orchestrator. Admin endpoints (`/system/resummarize-all`, `/docs/X/resummarize`) handle explicit retry via `enqueue_stage`, which has its own upsert and is unchanged.

### Bug 3 — Background-stage error poisons `doc.pipeline_status`
[entry.py error handler](src/harbor_clerk/worker/entry.py) unconditionally set `doc.pipeline_status = error` on any stage failure. PR #327 explicitly designed background stages NOT to touch `pipeline_status` (both `enqueue_stage` and `mark_stage_done` already guard this), but the error path was missed. **Effect:** a fully-finalized doc whose summary errors regresses from Ready → error in the UI even though retrieval works fine.

**Fix:** guard the assignment behind `stage not in _BACKGROUND_STAGES`. The `IngestionJob.error` still records the failure (so the doc-row summary chip shows "Failed"), but doc-level state is preserved.

## What this doesn't fix

The 10,576 stuck docs on BIG. The cleanest path is to let the test-corpora harness's `delete-all-documents` wipe them on the next phase-1 re-ingest. The new code prevents recurrence.

## Test plan

- [x] **`test_advance_pipeline_does_not_re_enqueue_errored_background_stage`** — errored summarize stays errored; finalize fires once `{entities, embed}` are done. *Fails without the pipeline.py change.*
- [x] **`test_background_stage_error_does_not_poison_pipeline_status`** — a doc at `pipeline_status=ready` whose summarize raises does NOT regress to `error`. *Fails without the entry.py change.*
- [x] **`test_no_chat_messages_returns_false_without_attribute_error`** — `_user_llm_active()` runs against the real `ChatMessage` model without raising. *Fails without the typo fix.*
- [x] 86 tests pass across `test_pipeline`, `test_summarize`, `test_chunking`, `test_watch_pipeline`. Ruff lint + format clean.
- [x] Fresh-eyes code-reviewer pass: no ≥80-confidence correctness findings on this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
