### PR TITLE
fix(queue-tray): summarize events polluted Active list with stale/garbage stage state

### DIFF
--- a/frontend/src/hooks/useQueueTray.ts
+++ b/frontend/src/hooks/useQueueTray.ts
@@ -201,6 +201,17 @@ export function useQueueTray() {
         return
       }
 
+      // Summarize is a background stage (PR #327 decoupled it from
+      // finalize) and renders exclusively in the Summarizing section,
+      // fed by the snapshot poll's `summarizing` array. Ignoring its
+      // queued/running events here keeps them out of activeItems —
+      // otherwise summarize-only docs land in Active with garbage
+      // stage state, because PIPELINE_STAGES doesn't include
+      // 'summarize', so the pre-fill loop is a no-op and
+      // computeCurrentStage falls through to 'extract'. Errors still
+      // surface — the status === 'error' branch above ran first.
+      if (stage === 'summarize') return
+
       // If this doc is in the completed list, remove it (re-queued)
       setCompleted((prev) => {
         if (!prev.some((c) => c.doc_id === did)) return prev
@@ -220,7 +231,8 @@ export function useQueueTray() {
         const filename = event.filename || existing?.filename || did
 
         // If this is a new item and the event is for a stage beyond extract,
-        // pre-fill earlier stages as done (e.g. resummarize only re-runs summarize)
+        // pre-fill earlier stages as done (e.g. backfill returns embed-running
+        // for a doc whose extract/ocr/chunk events fired before the page loaded).
         if (!existing && stage !== 'extract') {
           const stageIdx = PIPELINE_STAGES.indexOf(stage)
           for (let i = 0; i < stageIdx; i++) {
@@ -303,8 +315,12 @@ export function useQueueTray() {
 
         // Ghost-removal: anything in activeItems that's not in the
         // backfill response has finished (or errored) and we missed the
-        // notification. Drop it silently.
-        const liveVids = new Set(events.map((e) => e.doc_id))
+        // notification. Drop it silently. Summarize events are excluded
+        // from `liveVids` because they belong in the Summarizing section
+        // (see the summarize guard in onEvent above) — including them
+        // would keep summarize-only docs alive in Active with stale
+        // pre-summarize stage state from before fan-out.
+        const liveVids = new Set(events.filter((e) => e.stage !== 'summarize').map((e) => e.doc_id))
         setActiveItems((prev) => {
           let changed = false
           const next = new Map(prev)


### PR DESCRIPTION
## Summary
- The Processing drawer's **Active** tab disagreed with the **Pipeline** tab: with ~880 docs queued at `summarize`, Pipeline correctly showed `Sum=880` + all other queues idle, but Active showed 874–880 docs with bogus stage labels ("Extracting · Step 1/6", "Chunking · Step 3/6", "Queued" with all-empty bars).
- Root cause: `/api/jobs/active` returns every queued/running ingestion_job — including `summarize` — but the frontend's `PIPELINE_STAGES` excludes summarize (background stage since [#327], rendered in the Summarizing section since [#328]). Summarize events were leaking into `activeItems` and rendering with garbage stage state because the pre-fill / `computeCurrentStage` paths can't reconcile a stage they don't know about.
- Two-line filter on `stage === 'summarize'` in `useQueueTray.ts` keeps summarize events out of `activeItems` while still letting summarize errors surface (the `status === 'error'` branch runs first).

## Why the Active list went wrong
- **Screenshot 3 manifestation** (876 docs, all "Queued", empty bars): for docs the frontend never saw prior stages of, the stages map ended up as just `{summarize: queued}`. `PIPELINE_STAGES.indexOf('summarize')` is `-1`, the pre-fill loop is a no-op, `computeCurrentStage` falls through to `'extract'`, and `computeItemStatus` sees no running stage in PIPELINE_STAGES → renders as "Queued · 0% · Step 0/6".
- **Screenshot 1 manifestation** ("Chunking · Step 3/6", "Embedding · 72 pages · Step 5/6"): for docs with prior SSE history, stale `chunk: running` / `embed: running` stayed in the stages map. `/api/jobs/active` only returns *currently* queued/running jobs, so the missed `done` events for those earlier stages never get reconciled — adding `{summarize: queued}` on top of the staleness doesn't advance anything.
- The 15s `resync()` ghost-removal couldn't repair this on its own because the summarize backfill events put these docs into `liveVids`, keeping them alive in Active.

## What changed
`frontend/src/hooks/useQueueTray.ts` — two places, both filtering on `stage === 'summarize'`:

1. **`onEvent`**: early-return for `stage === 'summarize'` after the finalize-done and error branches. Summarize errors still flow to the Errors section because the `status === 'error'` branch above already ran. SSE + backfill summarize events both go through `onEvent`, so this catches both paths.
2. **`resync()` ghost-removal**: build `liveVids` from non-summarize events only. This purges any previously-leaked summarize-only docs on the next 15s tick and ensures fresh-page docs whose only in-flight job is summarize never get re-added.

Also updated the stale comment on the pre-fill block — the old `(e.g. resummarize only re-runs summarize)` example was actively misleading after this change.

## Reviewer notes
- The fix is minimal and targeted; no architecture changes. The QueuePill's existing `summarizingOnly` rest state (`activeCount === 0 && summarizingCount > 0`, [QueuePill.tsx:28](https://github.com/r0shi/harborclerk/blob/main/frontend/src/components/queue-tray/QueuePill.tsx#L28)) becomes reachable as originally designed.
- **Fan-out edge case**: when a doc is mid-fan-out and `entities` / `embed` are queued alongside `summarize`, only the summarize event is dropped — `entities` and `embed` events flow into Active normally, so the doc continues to show real pre-summarize progress.
- **Backfill efficiency**: the backend still returns summarize rows in `/api/jobs/active`. They're now discarded client-side. Filtering server-side would save bandwidth on large summarize backlogs but is a separate change — `/api/jobs/active`'s job-event contract is shared with the SSE shape used elsewhere, so I left it alone.

## Test plan
- [ ] With many docs queued at `summarize` (e.g. mid-backlog), open the Processing drawer
  - [ ] Active tab count matches the actual pre-summarize work (should be 0 if everything else is done)
  - [ ] Summarizing section shows the summarize backlog count
  - [ ] QueuePill (drawer closed) shows the purple "Summarizing N" rest state, not the amber "N processing"
- [ ] Trigger `/system/resummarize-all` (or per-doc resummarize) — affected docs appear only in Summarizing, never in Active with bogus extract/chunk state
- [ ] Force a summarize error (or simulate one) — doc still surfaces in the Errors section
- [ ] In-flight fan-out doc (entities/embed running alongside summarize queued) still renders in Active with `Entities`/`Embedding` progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
