### PR TITLE
fix(research): query expansion, abandonment, missing citations (#368)

### DIFF
--- a/alembic/versions/0023_research_state_citations.py
+++ b/alembic/versions/0023_research_state_citations.py
@@ -26,7 +26,7 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "research_state",
-        sa.Column("citations", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("citations", postgresql.JSONB(), nullable=True),
     )
 
 

--- a/alembic/versions/0023_research_state_citations.py
+++ b/alembic/versions/0023_research_state_citations.py
@@ -1,0 +1,34 @@
+"""Add research_state.citations — docs that informed the research answer.
+
+The research engine does retrieval internally and never writes tool-result
+messages, so the read-time citation extraction in routes/research.py always
+produced an empty list. The engine now persists the "docs that informed the
+answer" set here instead.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-05-22
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "research_state",
+        sa.Column("citations", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("research_state", "citations")

--- a/docs/superpowers/plans/2026-05-22-research-engine-defect-fixes.md
+++ b/docs/superpowers/plans/2026-05-22-research-engine-defect-fixes.md
@@ -1,0 +1,871 @@
+# Research-engine defect fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the three research-engine defects from issue #368 — garbage corpus-seeded queries, a "no relevant findings" verdict that wrongly becomes terminal, and an always-empty `result.citations`.
+
+**Architecture:** All three fixes live in `src/harbor_clerk/llm/research.py`; Fix 3 also adds a `research_state.citations` column (Alembic migration 0023) and updates `api/routes/research.py`. Fixes are additive and independent; tested with mocked LLM calls.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0 async, Alembic, pytest + pytest-asyncio, httpx.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-research-engine-defect-fixes-design.md`
+
+---
+
+## File structure
+
+- `src/harbor_clerk/llm/research.py` — all three fixes' engine logic.
+- `src/harbor_clerk/models/research_state.py` — add `citations` column (Fix 3).
+- `alembic/versions/0023_research_state_citations.py` — new migration (Fix 3).
+- `src/harbor_clerk/api/routes/research.py` — read citations from state (Fix 3).
+- `src/harbor_clerk/api/schemas/research.py` — stale-comment fix (Fix 3).
+- `tests/test_research_engine.py` — new; unit tests for Fixes 1, 2, 3a.
+- `tests/test_api_research_citations.py` — existing; extend for Fix 3.
+
+---
+
+## Task 1: Fix 1 — drop corpus-seeded queries
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/research.py`
+- Test: `tests/test_research_engine.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_research_engine.py`:
+
+```python
+"""Unit tests for research engine internals (harbor_clerk.llm.research)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from harbor_clerk.llm.research import _plan_queries
+
+_DEPTH = {"max_queries": 15, "k_per_query": 20, "max_passages": 60, "gap_round": True, "paginate": True}
+
+
+@pytest.mark.asyncio
+async def test_plan_queries_returns_only_llm_queries_no_seeded_garbage():
+    """After dropping corpus seeding, _plan_queries returns exactly the
+    LLM-planned queries. The old code concatenated corpus entities with the
+    question into ungrammatical seeded queries ('Globex What major vendor
+    relationships'); none of those may appear."""
+    llm_response = json.dumps({"queries": ["governing law clauses", "termination notice periods"]})
+    # entity_overview is what the deleted seeding path called; patching it
+    # proves the new code never seeds even when entities are available.
+    entity_response = json.dumps({"top_entities": [{"entity_type": "ORG", "entity_text": "Globex"}]})
+    with (
+        patch("harbor_clerk.llm.research._llm_complete", new=AsyncMock(return_value=llm_response)),
+        patch("harbor_clerk.llm.research.execute_tool", new=AsyncMock(return_value=entity_response)),
+    ):
+        queries = await _plan_queries(
+            client=None,
+            url="http://llm.test",
+            user_question="What are the major vendor relationships?",
+            topic_hint=None,
+            depth_config=_DEPTH,
+            doc_list=None,
+            user_id=None,
+        )
+    assert queries == ["governing law clauses", "termination notice periods"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py::test_plan_queries_returns_only_llm_queries_no_seeded_garbage -v`
+Expected: FAIL — the result includes a seeded entry like `"Globex What major vendor relationships"`.
+
+- [ ] **Step 3: Delete the seeding code**
+
+In `src/harbor_clerk/llm/research.py`:
+1. Delete the entire `_seed_queries_from_corpus` function (currently `async def _seed_queries_from_corpus(...)` through its `return seeded`).
+2. Delete the `_SEED_QUERY_BLOCKED_ENTITY_TYPES` constant and its preceding comment block (the comment near line 59 about `CARDINAL`/`ORDINAL` polluting seeded queries).
+3. If `execute_tool` is now unused in the module, leave its import — it's used elsewhere in research.py (`_search_fan_out` etc.); only remove the import if a lint run flags it unused.
+
+- [ ] **Step 4: Update `_plan_queries`**
+
+In `_plan_queries`, change the LLM query target and remove the seeded merge.
+
+Change this line:
+```python
+    llm_target = max(5, depth_config["max_queries"] // 2)
+```
+to:
+```python
+    # The LLM is the sole query source now (corpus seeding removed); ask it
+    # for the full budget — it is a far better generator than the deleted
+    # entity-concatenation, and _is_plausible_query still filters junk.
+    llm_target = depth_config["max_queries"]
+```
+
+Replace this block:
+```python
+    # Corpus-seeded queries (model-independent)
+    seeded = await _seed_queries_from_corpus(user_question, user_id, topic_hint)
+
+    # Merge: LLM queries first (higher intent), then seeded (breadth), dedupe
+    seen_lower: set[str] = set()
+    merged: list[str] = []
+    for q in llm_queries + seeded:
+        q = q.strip()
+        if q and q.lower() not in seen_lower:
+            seen_lower.add(q.lower())
+            merged.append(q)
+
+    return merged[: depth_config["max_queries"]]
+```
+with:
+```python
+    # Dedupe (case-insensitive), preserving order.
+    seen_lower: set[str] = set()
+    merged: list[str] = []
+    for q in llm_queries:
+        q = q.strip()
+        if q and q.lower() not in seen_lower:
+            seen_lower.add(q.lower())
+            merged.append(q)
+
+    return merged[: depth_config["max_queries"]]
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run ruff and the existing research tests**
+
+Run: `uv run ruff check src/harbor_clerk/llm/research.py && DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_api_research_citations.py tests/test_llm_citations.py -q`
+Expected: ruff clean; existing tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/harbor_clerk/llm/research.py tests/test_research_engine.py
+git commit -m "fix(research): drop garbage corpus-seeded queries (#368)"
+```
+
+---
+
+## Task 2: Fix 2 — sentinel detection + forceful note-extraction prompt
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/research.py`
+- Test: `tests/test_research_engine.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_research_engine.py`:
+
+```python
+from harbor_clerk.llm.research import _is_no_findings_sentinel
+
+
+def test_is_no_findings_sentinel_matches_the_sentinel():
+    assert _is_no_findings_sentinel("No relevant findings in this passage set.")
+    # Tolerant of trailing whitespace / case / wrapping the engine may add.
+    assert _is_no_findings_sentinel("  no relevant findings in this passage set  ")
+    assert _is_no_findings_sentinel("No relevant findings in this passage set")
+
+
+def test_is_no_findings_sentinel_rejects_real_notes_and_empty_corpus_string():
+    # A real note must not be treated as the bail sentinel.
+    assert not _is_no_findings_sentinel("- Acme signed a 30-day termination clause [Doc, page 2]")
+    # _extract_notes's genuinely-empty return is a DIFFERENT string and must
+    # not match — that case is truly empty and should not trigger a retry.
+    assert not _is_no_findings_sentinel("No relevant passages were found in the corpus.")
+    assert not _is_no_findings_sentinel("")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py -k sentinel -v`
+Expected: FAIL with `ImportError: cannot import name '_is_no_findings_sentinel'`.
+
+- [ ] **Step 3: Add the sentinel helper, the forceful prompt, and the relevance floor**
+
+In `src/harbor_clerk/llm/research.py`, add the forceful note-extraction system prompt next to `_NOTE_EXTRACTION_SYSTEM`:
+
+```python
+_NOTE_EXTRACTION_SYSTEM_FORCEFUL = (
+    "You are extracting research notes from search results. These passages "
+    "are the TOP-RANKED retrieval matches for the research question and are "
+    "very likely relevant — a prior extraction attempt wrongly dismissed "
+    "them.\n\n"
+    "Rules:\n"
+    "- Cite every finding as [Document Title, page X] — exactly as shown in the passages\n"
+    "- Write one note per distinct finding\n"
+    "- Skip irrelevant or redundant passages\n"
+    "- Preserve factual details — names, numbers, dates\n"
+    "- If a passage contradicts another, note both with their citations\n"
+    "- Write in plain text with citations, not JSON\n"
+    "- Extract the relevant findings. Return `No relevant findings in this "
+    "passage set.` ONLY if the passages genuinely contain nothing on-topic "
+    "— do not use it as a shortcut. Do not invent content from titles or "
+    "general knowledge."
+)
+```
+
+Add the relevance-floor constant next to the `_DEPTH_CONFIGS` block (near line 139):
+
+```python
+# When note extraction returns the "no relevant findings" sentinel, retry it
+# forcefully only if retrieval actually found strong matches — i.e. the top
+# coverage score clears this floor. Below it, the corpus genuinely lacks the
+# information and the honest "no findings" answer is correct. Hybrid-retrieval
+# scores in observed research runs ranged ~0.5-1.7; 1.0 separates a solid
+# match from weak noise. Tunable.
+_RETRIEVAL_RELEVANCE_FLOOR = 1.0
+```
+
+Add the sentinel helper near `_extract_notes`:
+
+```python
+# The exact sentinel _NOTE_EXTRACTION_SYSTEM tells the model to return when a
+# passage set is off-topic. Distinct from _extract_notes's genuinely-empty
+# return ("No relevant passages were found in the corpus.").
+_NO_FINDINGS_SENTINEL_PREFIX = "no relevant findings in this passage set"
+
+
+def _is_no_findings_sentinel(notes_text: str) -> bool:
+    """True if note extraction bailed with the 'no relevant findings'
+    sentinel. Tolerant of case and surrounding whitespace."""
+    return notes_text.strip().lower().startswith(_NO_FINDINGS_SENTINEL_PREFIX)
+```
+
+- [ ] **Step 4: Add the `forceful` parameter to `_extract_notes`**
+
+Change the `_extract_notes` signature:
+```python
+async def _extract_notes(
+    client: httpx.AsyncClient,
+    url: str,
+    user_question: str,
+    passages_text: str,
+) -> str:
+```
+to:
+```python
+async def _extract_notes(
+    client: httpx.AsyncClient,
+    url: str,
+    user_question: str,
+    passages_text: str,
+    *,
+    forceful: bool = False,
+) -> str:
+```
+
+Inside `_extract_notes`, change the system-prompt line in the `messages` list:
+```python
+        {"role": "system", "content": _NOTE_EXTRACTION_SYSTEM},
+```
+to:
+```python
+        {"role": "system", "content": _NOTE_EXTRACTION_SYSTEM_FORCEFUL if forceful else _NOTE_EXTRACTION_SYSTEM},
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py -k sentinel -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/llm/research.py tests/test_research_engine.py
+git commit -m "fix(research): add forceful note-extraction prompt + sentinel helper (#368)"
+```
+
+---
+
+## Task 3: Fix 2 — retry-then-fallback orchestrator, wired into research_stream
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/research.py`
+- Test: `tests/test_research_engine.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_research_engine.py`:
+
+```python
+from harbor_clerk.llm.research import _extract_notes_with_retry
+
+_SENTINEL = "No relevant findings in this passage set."
+_PASSAGES = "\n---\n**[0265_quarterly_report, page 1]**\nQ1 consulting revenue up 14%.\n"
+
+
+def _coverage(top_score: float) -> dict:
+    return {"c1": {"doc_id": "d1", "doc_title": "0265_quarterly_report", "page": 1, "score": top_score}}
+
+
+@pytest.mark.asyncio
+async def test_retry_not_triggered_when_extraction_succeeds():
+    """A normal (non-sentinel) extraction result passes straight through."""
+    real_notes = "- Q1 consulting revenue up 14% [0265_quarterly_report, page 1]"
+    with patch("harbor_clerk.llm.research._extract_notes", new=AsyncMock(return_value=real_notes)) as m:
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(1.7))
+    assert out == real_notes
+    assert m.await_count == 1  # no retry
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_when_forceful_extraction_succeeds():
+    """Sentinel + high retrieval score → forceful retry; if the retry yields
+    real notes, those are used."""
+    real_notes = "- Q1 consulting revenue up 14% [0265_quarterly_report, page 1]"
+    with patch(
+        "harbor_clerk.llm.research._extract_notes",
+        new=AsyncMock(side_effect=[_SENTINEL, real_notes]),
+    ) as m:
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(1.7))
+    assert out == real_notes
+    assert m.await_count == 2
+    assert m.await_args_list[1].kwargs.get("forceful") is True
+
+
+@pytest.mark.asyncio
+async def test_retry_falls_back_to_raw_passages_when_retry_also_bails():
+    """Sentinel twice → raw passages become the notes."""
+    with patch(
+        "harbor_clerk.llm.research._extract_notes",
+        new=AsyncMock(side_effect=[_SENTINEL, _SENTINEL]),
+    ):
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(1.7))
+    assert out.startswith("## Raw passages")
+    assert "0265_quarterly_report" in out
+
+
+@pytest.mark.asyncio
+async def test_low_score_sentinel_is_trusted_no_retry():
+    """Sentinel + low retrieval score → the sentinel is kept; the corpus
+    genuinely lacks the information. No retry."""
+    with patch("harbor_clerk.llm.research._extract_notes", new=AsyncMock(return_value=_SENTINEL)) as m:
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(0.3))
+    assert _is_no_findings_sentinel(out)
+    assert m.await_count == 1  # no retry below the relevance floor
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py -k retry -v`
+Expected: FAIL with `ImportError: cannot import name '_extract_notes_with_retry'`.
+
+- [ ] **Step 3: Add the `_extract_notes_with_retry` orchestrator**
+
+In `src/harbor_clerk/llm/research.py`, add directly after `_extract_notes`:
+
+```python
+async def _extract_notes_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    user_question: str,
+    passages_text: str,
+    coverage: dict[str, dict],
+) -> str:
+    """Extract notes, but don't let a weak model's 'no relevant findings'
+    verdict be terminal when retrieval clearly succeeded.
+
+    If extraction returns the sentinel AND the top coverage score clears
+    _RETRIEVAL_RELEVANCE_FLOOR, retry once with the forceful prompt; if the
+    retry also bails, fall back to handing the raw passages to synthesis.
+    Below the floor the sentinel is trusted — the corpus genuinely lacks
+    the information.
+    """
+    notes_text = await _extract_notes(client, url, user_question, passages_text)
+    if not _is_no_findings_sentinel(notes_text):
+        return notes_text
+
+    top_score = max((c.get("score", 0) for c in coverage.values()), default=0)
+    if top_score < _RETRIEVAL_RELEVANCE_FLOOR:
+        logger.info("Note extraction returned no-findings; top score %.2f below floor — trusting it", top_score)
+        return notes_text
+
+    logger.info("Note extraction bailed despite top score %.2f — retrying forcefully", top_score)
+    notes_text = await _extract_notes(client, url, user_question, passages_text, forceful=True)
+    if not _is_no_findings_sentinel(notes_text):
+        return notes_text
+
+    logger.warning("Forceful note extraction also bailed — passing raw passages to synthesis")
+    return f"## Raw passages\n{passages_text[:_NOTE_PROMPT_CHAR_CAP]}"
+```
+
+- [ ] **Step 4: Wire it into `research_stream`**
+
+In `research_stream`, find the round-1 note-extraction block. Replace this:
+```python
+                    else:
+                        try:
+                            notes_text = await _extract_notes(client, llm_url, user_question, passages_text)
+                        except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as exc:
+                            logger.error("LLM error during note extraction: %s", exc)
+                            # Fallback: use raw passages as notes
+                            notes_text = f"## Raw passages\n{passages_text[:_NOTE_PROMPT_CHAR_CAP]}"
+```
+with:
+```python
+                    else:
+                        try:
+                            notes_text = await _extract_notes_with_retry(
+                                client, llm_url, user_question, passages_text, coverage
+                            )
+                        except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as exc:
+                            logger.error("LLM error during note extraction: %s", exc)
+                            # Fallback: use raw passages as notes
+                            notes_text = f"## Raw passages\n{passages_text[:_NOTE_PROMPT_CHAR_CAP]}"
+```
+
+Leave the gap-round note extraction (the later `_extract_notes` call) unchanged — gap rounds are supplementary.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Run ruff**
+
+Run: `uv run ruff check src/harbor_clerk/llm/research.py`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/harbor_clerk/llm/research.py tests/test_research_engine.py
+git commit -m "fix(research): retry note extraction before accepting 'no findings' (#368)"
+```
+
+---
+
+## Task 4: Fix 3a — `_read_evidence` returns the docs that informed the answer
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/research.py`
+- Test: `tests/test_research_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_research_engine.py`:
+
+```python
+from harbor_clerk.llm.research import _read_evidence
+
+
+@pytest.mark.asyncio
+async def test_read_evidence_returns_passages_and_evidence_docs():
+    """_read_evidence returns (passages_text, evidence_docs); evidence_docs
+    lists the distinct docs whose passages were read into passages_text."""
+    coverage = {
+        "c1": {"doc_id": "d1", "doc_title": "alpha", "page": 1, "score": 2.0, "snippet": "alpha text"},
+        "c2": {"doc_id": "d2", "doc_title": "beta", "page": 3, "score": 1.5, "snippet": "beta text"},
+    }
+    read_result = json.dumps(
+        {
+            "passages": [
+                {"chunk_id": "c1", "text": "alpha body", "doc_title": "alpha", "page": 1},
+                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "page": 3},
+            ]
+        }
+    )
+    with patch("harbor_clerk.llm.research.execute_tool", new=AsyncMock(return_value=read_result)):
+        passages_text, evidence_docs = await _read_evidence(
+            coverage, user_id=None, max_passages=10, context_budget_chars=100_000
+        )
+    assert "alpha body" in passages_text and "beta body" in passages_text
+    by_id = {d["doc_id"]: d for d in evidence_docs}
+    assert set(by_id) == {"d1", "d2"}
+    assert by_id["d1"]["doc_title"] == "alpha"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py::test_read_evidence_returns_passages_and_evidence_docs -v`
+Expected: FAIL — `_read_evidence` currently returns a bare string, so the tuple-unpack raises `ValueError`.
+
+- [ ] **Step 3: Make `_read_evidence` return `(passages_text, evidence_docs)`**
+
+In `_read_evidence`, change the return type annotation `-> str:` to `-> tuple[str, list[dict]]:`.
+
+Find the early-return for no selected chunks:
+```python
+    if not selected:
+        return ""
+```
+change to:
+```python
+    if not selected:
+        return "", []
+```
+
+Initialize an accumulator next to `passages_text = ""`:
+```python
+    passages_text = ""
+    total_chars = 0
+```
+change to:
+```python
+    passages_text = ""
+    total_chars = 0
+    evidence_docs: list[dict] = []
+    seen_evidence_docs: set[str] = set()
+```
+
+Inside the passage loop, immediately after the line `passages_text += entry` and `total_chars += len(entry)`, record the doc — only for passages that actually made it into `passages_text` (i.e. after the budget check that `break`s). The existing lines are:
+```python
+                if total_chars + len(entry) > context_budget_chars:
+                    break
+                passages_text += entry
+                total_chars += len(entry)
+```
+change to:
+```python
+                if total_chars + len(entry) > context_budget_chars:
+                    break
+                passages_text += entry
+                total_chars += len(entry)
+                # Record the doc behind this passage — the "informed the
+                # answer" set used to populate result.citations (Fix 3).
+                info = coverage.get(cid) if cid else None
+                if info and info.get("doc_id") and info["doc_id"] not in seen_evidence_docs:
+                    seen_evidence_docs.add(info["doc_id"])
+                    evidence_docs.append(
+                        {"doc_id": info["doc_id"], "doc_title": info.get("doc_title", ""), "page": passage.get("page")}
+                    )
+```
+
+Change the final `return passages_text` to:
+```python
+    return passages_text, evidence_docs
+```
+
+- [ ] **Step 4: Update both `_read_evidence` call sites in `research_stream`**
+
+`_read_evidence` is called twice in `research_stream` — the round-1 read and the gap-round read. Find each `... = await _read_evidence(...)` call.
+
+Round-1 call — change:
+```python
+                    passages_text = await _read_evidence(...)
+```
+to:
+```python
+                    passages_text, evidence_docs = await _read_evidence(...)
+```
+
+Gap-round call — change:
+```python
+                        gap_passages = await _read_evidence(...)
+```
+to:
+```python
+                        gap_passages, gap_evidence_docs = await _read_evidence(...)
+```
+
+(The keyword/positional args inside each call are unchanged — only the assignment target changes. `evidence_docs` / `gap_evidence_docs` are consumed in Task 6; an unused local is fine until then but Task 6 lands in the same PR.)
+
+- [ ] **Step 5: Run test + ruff**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py -v && uv run ruff check src/harbor_clerk/llm/research.py`
+Expected: all PASS; ruff clean (ruff may warn `evidence_docs`/`gap_evidence_docs` unused — acceptable, consumed in Task 6; if ruff errors on it, prefix the gap one with `_` and rename back in Task 6).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/llm/research.py tests/test_research_engine.py
+git commit -m "fix(research): _read_evidence returns the docs that informed the answer (#368)"
+```
+
+---
+
+## Task 5: Fix 3b — `research_state.citations` column + migration 0023
+
+**Files:**
+- Modify: `src/harbor_clerk/models/research_state.py`
+- Create: `alembic/versions/0023_research_state_citations.py`
+- Test: `tests/test_research_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_research_engine.py`:
+
+```python
+import uuid as _uuid
+
+
+@pytest.mark.asyncio
+async def test_research_state_citations_column_roundtrips(db_session):
+    """ResearchState persists a citations JSON list."""
+    from harbor_clerk.models import Conversation
+    from harbor_clerk.models.research_state import ResearchState
+
+    conv = Conversation(title="t")
+    db_session.add(conv)
+    await db_session.flush()
+
+    cites = [{"doc_id": str(_uuid.uuid4()), "doc_title": "alpha", "page": 1}]
+    db_session.add(
+        ResearchState(
+            conversation_id=conv.conversation_id,
+            strategy="search",
+            status="completed",
+            max_rounds=500,
+            citations=cites,
+        )
+    )
+    await db_session.commit()
+
+    row = (await db_session.execute(select(ResearchState))).scalar_one()
+    assert row.citations == cites
+```
+
+Add `from sqlalchemy import select` to the test file's imports if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py::test_research_state_citations_column_roundtrips -v`
+Expected: FAIL — `ResearchState` has no `citations` attribute / column.
+
+- [ ] **Step 3: Add the `citations` column to the model**
+
+In `src/harbor_clerk/models/research_state.py`, add after the `depth` column line:
+```python
+    citations: Mapped[Any | None] = mapped_column(JSONB, nullable=True)
+```
+(`Any`, `JSONB`, and `Mapped`/`mapped_column` are already imported in this file.)
+
+- [ ] **Step 4: Create the Alembic migration**
+
+Create `alembic/versions/0023_research_state_citations.py`:
+
+```python
+"""Add research_state.citations — docs that informed the research answer.
+
+The research engine does retrieval internally and never writes tool-result
+messages, so the read-time citation extraction in routes/research.py always
+produced an empty list. The engine now persists the "docs that informed the
+answer" set here instead.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-05-22
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "research_state",
+        sa.Column("citations", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("research_state", "citations")
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+The `db_session` fixture runs `alembic upgrade head`, which applies 0023.
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_research_engine.py::test_research_state_citations_column_roundtrips -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the migration reverts cleanly**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run alembic downgrade 0022 && DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run alembic upgrade head`
+Expected: both succeed with no error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/harbor_clerk/models/research_state.py alembic/versions/0023_research_state_citations.py tests/test_research_engine.py
+git commit -m "fix(research): add research_state.citations column + migration 0023 (#368)"
+```
+
+---
+
+## Task 6: Fix 3c — persist citations from the engine, surface them in the API
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/research.py`
+- Modify: `src/harbor_clerk/api/routes/research.py`
+- Modify: `src/harbor_clerk/api/schemas/research.py`
+- Test: `tests/test_api_research_citations.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `tests/test_api_research_citations.py` and read its existing fixtures/helpers (it already builds a research conversation + `ResearchState` and calls the research-detail endpoint). Append a test in the same style:
+
+```python
+@pytest.mark.asyncio
+async def test_research_detail_surfaces_state_citations(db_session, client, admin_user):
+    """result.citations is populated from research_state.citations."""
+    from harbor_clerk.models import Conversation
+    from harbor_clerk.models.research_state import ResearchState
+
+    conv = Conversation(title="cites")
+    db_session.add(conv)
+    await db_session.flush()
+    cites = [{"doc_id": "d-1", "doc_title": "alpha", "page": 2}]
+    db_session.add(
+        ResearchState(
+            conversation_id=conv.conversation_id,
+            strategy="search",
+            status="completed",
+            max_rounds=500,
+            citations=cites,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.get(f"/api/research/{conv.conversation_id}")
+    assert resp.status_code == 200
+    assert resp.json()["citations"] == cites
+```
+
+Match the auth/headers pattern the other tests in this file use (e.g. an `admin_user` token header) — copy it from an existing test in the file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_api_research_citations.py::test_research_detail_surfaces_state_citations -v`
+Expected: FAIL — `citations` comes back `[]` (route still derives it from tool-result messages).
+
+- [ ] **Step 3: Persist citations from `research_stream`**
+
+In `src/harbor_clerk/llm/research.py`, in `research_stream`, after the round-1 read assigns `evidence_docs` (Task 4), seed a run-level accumulator. Just before the round-1 `_read_evidence` call, add:
+```python
+                    research_citations: list[dict] = []
+```
+After the round-1 `passages_text, evidence_docs = await _read_evidence(...)` line, add:
+```python
+                    research_citations = list(evidence_docs)
+```
+After the gap-round `gap_passages, gap_evidence_docs = await _read_evidence(...)` line, add:
+```python
+                        seen_cite_ids = {c["doc_id"] for c in research_citations}
+                        research_citations.extend(
+                            d for d in gap_evidence_docs if d["doc_id"] not in seen_cite_ids
+                        )
+```
+
+In the synthesis-completion block, where `state.status = "completed"` is set (research.py ~1368), add `state.citations`:
+```python
+            state.status = "completed"
+            state.notes = notes
+            state.citations = research_citations
+            state.current_round = step_count
+            state.completed_at = datetime.now(UTC)
+            state.progress = {"step": step_count}
+            await session.commit()
+```
+
+Note: `research_citations` is initialized inside the search-strategy branch. If a code path reaches the synthesis block without entering that branch, `state.citations` must still be safe to set — initialize `research_citations: list[dict] = []` once near the top of `research_stream` (with the other run-level locals) instead of inside the branch, so it is always defined.
+
+- [ ] **Step 4: Surface citations from state in the route**
+
+In `src/harbor_clerk/api/routes/research.py`, replace this block:
+```python
+    tool_results_by_id: dict[str, tuple[str, str]] = {}
+    # Citations derived from every tool result emitted during the research
+    # turn. Computed at read-time so research detail surfaces citations
+    # without needing a new persisted column. ``dedupe_citations`` collapses
+    # the same (doc_id, chunk_id) seen across multiple searches and keeps
+    # the highest score.
+    citations_acc: list[dict] = []
+    for m in all_msgs:
+        if m.role == "tool" and m.tool_call_id and m.content:
+            tool_results_by_id[m.tool_call_id] = (_summarize_tool_result(m.content), m.content)
+            citations_acc.extend(extract_citations_from_tool_result(m.content))
+    citations = dedupe_citations(citations_acc)
+```
+with:
+```python
+    tool_results_by_id: dict[str, tuple[str, str]] = {}
+    for m in all_msgs:
+        if m.role == "tool" and m.tool_call_id and m.content:
+            tool_results_by_id[m.tool_call_id] = (_summarize_tool_result(m.content), m.content)
+    # Citations are persisted on research_state by the research engine — the
+    # docs whose passages informed the synthesized report. (The engine does
+    # retrieval internally and emits no tool-result messages, so the old
+    # read-time extraction always produced an empty list.)
+    citations = dedupe_citations(state.citations or [])
+```
+
+In the same file, the import line:
+```python
+    from harbor_clerk.llm.citations import dedupe_citations, extract_citations_from_tool_result
+```
+becomes:
+```python
+    from harbor_clerk.llm.citations import dedupe_citations
+```
+
+- [ ] **Step 5: Fix the stale schema comment**
+
+In `src/harbor_clerk/api/schemas/research.py`, update the comment above the `citations` field (currently "Deduped citation records derived from the tool-result messages of the research turn ... so historical research surfaces citations too.") to:
+```python
+    # Deduped citation records — the documents whose passages informed the
+    # synthesized report, persisted on research_state.citations by the
+    # research engine.
+    citations: list[dict] = []
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_api_research_citations.py tests/test_research_engine.py -v`
+Expected: all PASS.
+
+- [ ] **Step 7: Run ruff + the full research-adjacent suite**
+
+Run: `uv run ruff check src/harbor_clerk/llm/research.py src/harbor_clerk/api/routes/research.py src/harbor_clerk/models/research_state.py && uv run ruff format --check src/harbor_clerk/llm/research.py src/harbor_clerk/api/routes/research.py && DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest tests/test_api_research_citations.py tests/test_llm_citations.py tests/test_research_engine.py -q`
+Expected: ruff clean; all tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/harbor_clerk/llm/research.py src/harbor_clerk/api/routes/research.py src/harbor_clerk/api/schemas/research.py tests/test_api_research_citations.py
+git commit -m "fix(research): populate result.citations from research_state (#368)"
+```
+
+---
+
+## Task 7: Final verification + fresh-eyes review
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full lint, format, and test pass**
+
+Run: `uv run ruff check . && uv run ruff format --check . && DATABASE_URL='postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test' uv run pytest -q`
+Expected: all clean / PASS. Investigate and fix any failure before proceeding.
+
+- [ ] **Step 2: Fresh-eyes code review**
+
+Per the standing directive, dispatch a `feature-dev:code-reviewer` subagent against the branch tip with a minimal prompt (no focus areas, no carve-outs). Address every finding at confidence ≥ 80 before opening the PR.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin fix/research-engine-defects
+```
+Open the PR with `gh pr create`, base `main`, titled `fix(research): query expansion, premature abandonment, missing citations (#368)`, body summarizing the three fixes and linking issue #368. Mark the issue's three defects as addressed.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Fix 1 → Task 1; Fix 2 → Tasks 2-3; Fix 3 → Tasks 4 (`_read_evidence`), 5 (column + migration), 6 (persist + surface + comment). Testing section → tests in each task + Task 7. Packaging (one PR, fresh-eyes review) → Task 7.
+- **`_RETRIEVAL_RELEVANCE_FLOOR`:** provisional 1.0, justified inline from observed score ranges and flagged tunable — a deliberate value, not a placeholder.
+- **Type consistency:** `_read_evidence` returns `tuple[str, list[dict]]` (Task 4), consumed as `passages_text, evidence_docs` / `gap_passages, gap_evidence_docs` (Task 4) and accumulated into `research_citations` (Task 6). `_extract_notes` `forceful` kwarg (Task 2) is used by `_extract_notes_with_retry` (Task 3). `_is_no_findings_sentinel` (Task 2) used in Task 3. `research_state.citations` (Task 5) read in Task 6.

--- a/docs/superpowers/specs/2026-05-22-research-engine-defect-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-22-research-engine-defect-fixes-design.md
@@ -1,0 +1,152 @@
+# Research-engine defect fixes — design
+
+Tracking issue: [#368](https://github.com/r0shi/harborclerk/issues/368)
+
+## Context
+
+Analysis of the `2026-05-05-prod` test-corpora sweep surfaced three defects in
+Harbor Clerk's research engine (`src/harbor_clerk/llm/research.py`). They
+explain why local models scored far worse on research questions than on ask
+questions (research 94% fail / 0 pass vs ask 76% fail). These are product
+bugs — research is a shipping feature, so real users on local models hit the
+same behavior.
+
+This design fixes all three in one PR. Out of scope: judge-verdict
+calibration (a separate scoring concern), the DeepSeek SSE-watchdog (lives in
+the test harness, not the research engine), and selectable citation methods
+(deferred — see the `research-citations-selectable-methods` note).
+
+## Fix 1 — Drop corpus-seeded queries
+
+### Problem
+
+`_seed_queries_from_corpus` (research.py:457) builds queries by concatenating
+a corpus entity with the question's first four long words:
+`seeded.append(f"{name} {q_short}")`. The result is ungrammatical word salad —
+`"Party Identify major vendor relationships"`,
+`"0001Invoice Compare quarterly performance trends"`. `_plan_queries` merges
+~7-8 of these into every research run alongside the ~7 good LLM-planned
+queries. Confirmed systematic across all corpora and models. The area was
+already patched once (the `CARDINAL`/`ORDINAL` filtering); the
+`{entity} {verb-phrase}` strategy itself is the defect.
+
+### Change
+
+- Delete `_seed_queries_from_corpus` and the `_SEED_QUERY_BLOCKED_ENTITY_TYPES`
+  constant. The `entity_overview` tool call inside the function goes away.
+- `_plan_queries`: drop the seeded-merge. The returned query list is the
+  LLM-planned queries only — deduped, capped at `depth_config["max_queries"]`.
+- Keep the existing keyword fallback (research.py:547-553) for when the LLM
+  produces no plausible queries.
+- Raise `llm_target` from `max(5, max_queries // 2)` to the full
+  `depth_config["max_queries"]`. The LLM is now the sole query source and is a
+  far better generator than entity-concatenation; ask it for the full budget.
+  `_is_plausible_query` still filters junk.
+
+### Files
+
+`src/harbor_clerk/llm/research.py`
+
+## Fix 2 — Don't let "No relevant findings" be terminal
+
+### Problem
+
+`_extract_notes` may return the sentinel
+`No relevant findings in this passage set.` — the note-extraction prompt's
+anti-hallucination escape hatch. A weak model takes that shortcut even when
+retrieval surfaced clearly-relevant documents (observed: `synthetic-research-1`
+retrieved `0265_quarterly_report` at score 1.72 for a quarterly-performance
+question, then the model returned the sentinel). The sentinel becomes the
+notes, and synthesis answers "the corpus did not yield evidence."
+
+### Change
+
+In `research_stream`, immediately after the round-1 `_extract_notes` call
+(research.py ~1162):
+
+1. **Detect the sentinel** — match tolerantly:
+   `notes_text.strip().lower().startswith("no relevant findings")`. This is
+   distinct from `_extract_notes`'s genuinely-empty return
+   (`"No relevant passages were found in the corpus."`, research.py:818),
+   which must NOT trigger a retry.
+2. **Compute top retrieval score** — `max(c["score"] for c in coverage.values())`.
+3. **If sentinel AND top score ≥ `_RETRIEVAL_RELEVANCE_FLOOR`:** re-run
+   `_extract_notes` once with `forceful=True`.
+4. **If the retry also returns the sentinel:** raw-passage fallback —
+   `notes_text = f"## Raw passages\n{passages_text[:_NOTE_PROMPT_CHAR_CAP]}"`
+   (the existing fallback form already used for the time-budget and
+   LLM-error cases).
+5. **If top score < floor:** leave the sentinel as the notes. The corpus
+   genuinely lacks the information; the honest "no findings" answer is correct.
+
+Supporting changes:
+
+- `_extract_notes` gains a `forceful: bool = False` parameter. When true it
+  uses a new system-prompt constant `_NOTE_EXTRACTION_SYSTEM_FORCEFUL` — the
+  same extraction rules, but prefaced with: these passages are the
+  top-ranked retrieval matches for the question and are very likely relevant;
+  extract the findings; return "No relevant findings" only if the passages
+  genuinely contain nothing on-topic, not as a shortcut.
+- New module constant `_RETRIEVAL_RELEVANCE_FLOOR`. Provisional value 1.0;
+  set the final value after sanity-checking the coverage-score distributions
+  in the run data. Tunable.
+- Scope: round-1 note extraction only. Gap-round note extraction
+  (research.py ~1280) is supplementary and stays unchanged.
+
+### Files
+
+`src/harbor_clerk/llm/research.py`
+
+## Fix 3 — Populate `result.citations`
+
+### Problem
+
+A research response's `result.citations` is always `[]`. Root cause:
+`routes/research.py:147-161` computes citations at read-time via
+`extract_citations_from_tool_result` over the conversation's messages. But
+`research_stream` does retrieval internally (`_search_fan_out`,
+`_read_evidence`) and saves only one assistant message — the report. There are
+no tool-result messages, so nothing is extracted.
+
+### Change
+
+Chosen semantics: `citations` = the documents that informed the answer — the
+distinct docs whose passages `_read_evidence` selected into `passages_text`.
+
+- `_read_evidence` (research.py:714): in addition to the formatted
+  `passages_text`, return the metadata of the selected chunks' docs
+  (`doc_id`, `doc_title`, `page`). Change the return type to
+  `(passages_text, evidence_docs)`; update both call sites (round-1 read and
+  the gap-round read at research.py ~1266).
+- `research_stream`: accumulate `evidence_docs` across the round-1 read and
+  any gap-round reads; dedupe by `doc_id`.
+- When `research_stream` saves the assistant `ChatMessage` (research.py:1359),
+  set `rag_context` to `{"citations": [{doc_id, doc_title, page}, ...]}`.
+  `ChatMessage.rag_context` is an existing JSONB column — **no migration**.
+- `routes/research.py`: for the research turn, read citations from the
+  assistant message's `rag_context["citations"]` instead of
+  `extract_citations_from_tool_result`. Keep the `dedupe_citations` pass.
+- `schemas/research.py:63-67`: update the now-stale comment ("derived from the
+  tool-result messages").
+
+### Files
+
+`src/harbor_clerk/llm/research.py`, `src/harbor_clerk/api/routes/research.py`,
+`src/harbor_clerk/api/schemas/research.py` (comment only)
+
+## Testing
+
+- **Fix 1:** `_plan_queries` returns only LLM-planned queries; no seeded
+  entries; the keyword fallback still fires when the LLM yields nothing.
+- **Fix 2:** sentinel + high top-score → retry happens; sentinel returned
+  twice → notes become the raw-passage block; sentinel + low top-score →
+  sentinel kept, no retry. Mock `_extract_notes` / `_llm_complete`.
+- **Fix 3:** `_read_evidence` returns the selected-doc set; `research_stream`
+  writes it into `rag_context`; `routes/research.py` surfaces it on
+  `result.citations`.
+- The existing research test suite stays green.
+
+## Packaging
+
+One PR. A fresh-eyes `feature-dev:code-reviewer` pass on the branch tip
+before opening the PR, per the standing review directive.

--- a/docs/superpowers/specs/2026-05-22-research-engine-defect-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-22-research-engine-defect-fixes-design.md
@@ -120,18 +120,25 @@ distinct docs whose passages `_read_evidence` selected into `passages_text`.
   the gap-round read at research.py ~1266).
 - `research_stream`: accumulate `evidence_docs` across the round-1 read and
   any gap-round reads; dedupe by `doc_id`.
-- When `research_stream` saves the assistant `ChatMessage` (research.py:1359),
-  set `rag_context` to `{"citations": [{doc_id, doc_title, page}, ...]}`.
-  `ChatMessage.rag_context` is an existing JSONB column — **no migration**.
-- `routes/research.py`: for the research turn, read citations from the
-  assistant message's `rag_context["citations"]` instead of
-  `extract_citations_from_tool_result`. Keep the `dedupe_citations` pass.
+- Add a `citations` JSONB column to the `research_state` table (the
+  `ResearchState` model), nullable. New Alembic migration
+  `0023_research_state_citations.py` (`revision = "0023"`,
+  `down_revision = "0022"`).
+- `research_stream` sets `state.citations` to the deduped citation list
+  `[{doc_id, doc_title, page}, ...]` on the final commit (alongside
+  `state.status = "completed"`).
+- `routes/research.py`: for the research turn, read citations from
+  `state.citations` instead of `extract_citations_from_tool_result`. Keep the
+  `dedupe_citations` pass as a safety net.
 - `schemas/research.py:63-67`: update the now-stale comment ("derived from the
   tool-result messages").
 
 ### Files
 
-`src/harbor_clerk/llm/research.py`, `src/harbor_clerk/api/routes/research.py`,
+`src/harbor_clerk/llm/research.py`,
+`src/harbor_clerk/models/research_state.py`,
+`alembic/versions/0023_research_state_citations.py` (new),
+`src/harbor_clerk/api/routes/research.py`,
 `src/harbor_clerk/api/schemas/research.py` (comment only)
 
 ## Testing
@@ -142,8 +149,8 @@ distinct docs whose passages `_read_evidence` selected into `passages_text`.
   twice → notes become the raw-passage block; sentinel + low top-score →
   sentinel kept, no retry. Mock `_extract_notes` / `_llm_complete`.
 - **Fix 3:** `_read_evidence` returns the selected-doc set; `research_stream`
-  writes it into `rag_context`; `routes/research.py` surfaces it on
-  `result.citations`.
+  writes it to `state.citations`; `routes/research.py` surfaces it on
+  `result.citations`. Migration `0023` applies and reverts cleanly.
 - The existing research test suite stays green.
 
 ## Packaging

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -154,7 +154,9 @@ async def get_research(
     # Citations are persisted on research_state by the research engine — the
     # docs whose passages informed the synthesized report. (The engine does
     # retrieval internally and emits no tool-result messages, so the old
-    # read-time extraction always produced an empty list.)
+    # read-time extraction always produced an empty list.) Records are
+    # doc-granularity {doc_id, doc_title, page} with no chunk_id, so
+    # dedupe_citations effectively collapses duplicates by doc_id.
     citations = dedupe_citations(state.citations or [])
 
     # Build message dicts

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -144,21 +144,18 @@ async def get_research(
 
     # Build tool result lookup for enrichment
     from harbor_clerk.api.routes.chat import _enrich_tool_calls
-    from harbor_clerk.llm.citations import dedupe_citations, extract_citations_from_tool_result
+    from harbor_clerk.llm.citations import dedupe_citations
     from harbor_clerk.llm.tools import summarize_tool_result as _summarize_tool_result
 
     tool_results_by_id: dict[str, tuple[str, str]] = {}
-    # Citations derived from every tool result emitted during the research
-    # turn. Computed at read-time so research detail surfaces citations
-    # without needing a new persisted column. ``dedupe_citations`` collapses
-    # the same (doc_id, chunk_id) seen across multiple searches and keeps
-    # the highest score.
-    citations_acc: list[dict] = []
     for m in all_msgs:
         if m.role == "tool" and m.tool_call_id and m.content:
             tool_results_by_id[m.tool_call_id] = (_summarize_tool_result(m.content), m.content)
-            citations_acc.extend(extract_citations_from_tool_result(m.content))
-    citations = dedupe_citations(citations_acc)
+    # Citations are persisted on research_state by the research engine — the
+    # docs whose passages informed the synthesized report. (The engine does
+    # retrieval internally and emits no tool-result messages, so the old
+    # read-time extraction always produced an empty list.)
+    citations = dedupe_citations(state.citations or [])
 
     # Build message dicts
     messages: list[dict] = []

--- a/src/harbor_clerk/api/schemas/research.py
+++ b/src/harbor_clerk/api/schemas/research.py
@@ -60,11 +60,9 @@ class ResearchDetail(BaseModel):
     report: str | None = None
     model_id: str | None = None
     messages: list[dict]
-    # Deduped citation records derived from the tool-result messages of the
-    # research turn. Each entry has at minimum ``doc_id`` (when the underlying
-    # tool exposed it); additional fields include ``doc_title``, ``chunk_id``,
-    # ``pages``, ``score``. Computed at read-time from persisted tool messages
-    # so historical research surfaces citations too.
+    # Deduped citation records — the documents whose passages informed the
+    # synthesized report, persisted on research_state.citations by the
+    # research engine.
     citations: list[dict] = []
     # Free-text reason set when the research moved to ``interrupted`` or
     # ``failed``. Examples: ``"Synthesis failed: LLM error (502)"``,

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -683,10 +683,13 @@ async def _read_evidence(
     user_id: uuid.UUID | None,
     max_passages: int,
     context_budget_chars: int,
-) -> str:
+) -> tuple[str, list[dict]]:
     """Phase 3: Read full passages for top-scoring chunks.
 
-    Returns formatted passage text for note extraction, bounded by context budget.
+    Returns (passages_text, evidence_docs) where passages_text is the
+    formatted passage text for note extraction (bounded by context budget)
+    and evidence_docs is the list of distinct docs whose passages were
+    read into passages_text (used to populate result.citations — Fix 3).
     """
     # Sort by score descending, pick diverse docs
     sorted_chunks_all = sorted(coverage.items(), key=lambda x: x[1]["score"], reverse=True)
@@ -721,11 +724,13 @@ async def _read_evidence(
     selected = selected[:max_passages]
 
     if not selected:
-        return ""
+        return "", []
 
     # Read in batches of 20
     passages_text = ""
     total_chars = 0
+    evidence_docs: list[dict] = []
+    seen_evidence_docs: set[str] = set()
 
     for i in range(0, len(selected), 20):
         batch_ids = selected[i : i + 20]
@@ -764,6 +769,14 @@ async def _read_evidence(
                     break
                 passages_text += entry
                 total_chars += len(entry)
+                # Record the doc behind this passage — the "informed the
+                # answer" set used to populate result.citations (Fix 3).
+                info = coverage.get(cid) if cid else None
+                if info and info.get("doc_id") and info["doc_id"] not in seen_evidence_docs:
+                    seen_evidence_docs.add(info["doc_id"])
+                    evidence_docs.append(
+                        {"doc_id": info["doc_id"], "doc_title": info.get("doc_title", ""), "page": passage.get("page")}
+                    )
 
         except Exception:
             logger.exception("read_passages failed for batch starting at %d", i)
@@ -771,7 +784,7 @@ async def _read_evidence(
         if total_chars >= context_budget_chars:
             break
 
-    return passages_text
+    return passages_text, evidence_docs
 
 
 # The exact sentinel _NOTE_EXTRACTION_SYSTEM tells the model to return when a
@@ -1120,7 +1133,7 @@ async def research_stream(
                         }
                     )
 
-                    passages_text = await _read_evidence(
+                    passages_text, evidence_docs = await _read_evidence(
                         coverage,
                         user_id,
                         depth_config["max_passages"],
@@ -1283,7 +1296,7 @@ async def research_stream(
                         # doesn't re-discover the same chunks.
                         coverage.update(new_chunks)
 
-                        gap_passages = await _read_evidence(
+                        gap_passages, gap_evidence_docs = await _read_evidence(
                             new_chunks,
                             user_id,
                             20,

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -482,7 +482,6 @@ async def _plan_queries(
     topic_hint: str | None,
     depth_config: dict,
     doc_list: list[dict] | None,
-    user_id: uuid.UUID | None,
 ) -> list[str]:
     """Phase 1: LLM generates diverse search queries for the research run."""
     # LLM-planned queries
@@ -1023,7 +1022,6 @@ async def research_stream(
                             topic_hint,
                             depth_config,
                             doc_list,
-                            user_id,
                         )
                     except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as exc:
                         logger.error("LLM error during query planning: %s", exc)

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -840,6 +840,40 @@ async def _extract_notes(
     )
 
 
+async def _extract_notes_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    user_question: str,
+    passages_text: str,
+    coverage: dict[str, dict],
+) -> str:
+    """Extract notes, but don't let a weak model's 'no relevant findings'
+    verdict be terminal when retrieval clearly succeeded.
+
+    If extraction returns the sentinel AND the top coverage score clears
+    _RETRIEVAL_RELEVANCE_FLOOR, retry once with the forceful prompt; if the
+    retry also bails, fall back to handing the raw passages to synthesis.
+    Below the floor the sentinel is trusted — the corpus genuinely lacks
+    the information.
+    """
+    notes_text = await _extract_notes(client, url, user_question, passages_text)
+    if not _is_no_findings_sentinel(notes_text):
+        return notes_text
+
+    top_score = max((c.get("score", 0) for c in coverage.values()), default=0)
+    if top_score < _RETRIEVAL_RELEVANCE_FLOOR:
+        logger.info("Note extraction returned no-findings; top score %.2f below floor — trusting it", top_score)
+        return notes_text
+
+    logger.info("Note extraction bailed despite top score %.2f — retrying forcefully", top_score)
+    notes_text = await _extract_notes(client, url, user_question, passages_text, forceful=True)
+    if not _is_no_findings_sentinel(notes_text):
+        return notes_text
+
+    logger.warning("Forceful note extraction also bailed — passing raw passages to synthesis")
+    return f"## Raw passages\n{passages_text[:_NOTE_PROMPT_CHAR_CAP]}"
+
+
 async def _check_gaps(
     client: httpx.AsyncClient,
     url: str,
@@ -1143,7 +1177,9 @@ async def research_stream(
                         )
                     else:
                         try:
-                            notes_text = await _extract_notes(client, llm_url, user_question, passages_text)
+                            notes_text = await _extract_notes_with_retry(
+                                client, llm_url, user_question, passages_text, coverage
+                            )
                         except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as exc:
                             logger.error("LLM error during note extraction: %s", exc)
                             # Fallback: use raw passages as notes

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -986,6 +986,8 @@ async def research_stream(
 
         try:
             if resume_from_synthesis:
+                # Preserve citations the interrupted run already persisted.
+                research_citations = list(state.citations or [])
                 logger.info(
                     "Resuming research %s from synthesis (notes len=%d)",
                     conversation_id,

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -56,12 +56,6 @@ _MAX_TOKENS_NOTES = 8000
 _MAX_TOKENS_GAP = 5000
 _MAX_TOKENS_SYNTHESIS = 10000
 
-# spaCy entity types that are useless as search seeds. CARDINAL/ORDINAL
-# dominate the corpus's top-entity list ("one", "first", "two", "1", "2") and
-# polluted seeded queries with garbage like "1 Please compare different wine".
-# DATE/TIME/MONEY/PERCENT/QUANTITY similarly don't represent topical content.
-_SEED_QUERY_BLOCKED_ENTITY_TYPES = frozenset({"CARDINAL", "ORDINAL", "DATE", "TIME", "MONEY", "PERCENT", "QUANTITY"})
-
 # Cap the prefill-heavy note-extraction prompt. 30K chars ≈ 8.5K tokens — keeps
 # Gemma-26B-class prefill under ~45 s. Was 80K (≈22K tokens, ~110 s prefill).
 _NOTE_PROMPT_CHAR_CAP = 30_000
@@ -454,60 +448,6 @@ def _build_synthesis_messages(user_question: str, notes: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-async def _seed_queries_from_corpus(
-    user_question: str,
-    user_id: uuid.UUID | None,
-    topic_hint: str | None,
-) -> list[str]:
-    """Generate model-independent queries from corpus metadata.
-
-    Pulls top entities and topic keywords, combines them with question
-    keywords to produce queries that don't depend on LLM quality.
-    """
-    seeded: list[str] = []
-
-    # Extract a few keywords from the question for cross-referencing
-    q_words = [w for w in user_question.split() if len(w) > 3]
-    q_short = " ".join(q_words[:4]) if q_words else user_question
-
-    # Seed from entities — skip useless types (CARDINAL/ORDINAL/DATE/etc.)
-    # which dominate the top-entity list with values like "one", "first", "1"
-    # that produce nonsense queries when concatenated with the question.
-    try:
-        entity_json = await execute_tool("entity_overview", {}, user_id, mode="research")
-        entity_data = json.loads(entity_json)
-        kept = 0
-        for ent in entity_data.get("top_entities", []):
-            if kept >= 10:
-                break
-            etype = (ent.get("entity_type") or "").upper()
-            if etype in _SEED_QUERY_BLOCKED_ENTITY_TYPES:
-                continue
-            name = (ent.get("entity_text") or "").strip()
-            # Defense-in-depth: also drop pure-numeric / single-letter / very short tokens
-            if not name or len(name) < 3 or name.replace(".", "").replace(",", "").isdigit():
-                continue
-            if name.lower() in user_question.lower():
-                continue
-            seeded.append(f"{name} {q_short}")
-            kept += 1
-    except Exception:
-        logger.debug("entity_overview failed for seed queries", exc_info=True)
-
-    # Seed from topic keywords
-    if topic_hint:
-        for line in topic_hint.split("\n"):
-            # Topic lines look like "- Topic Name: keyword1, keyword2, ..."
-            if ":" in line:
-                keywords_part = line.split(":", 1)[1].strip()
-                keywords = [kw.strip() for kw in keywords_part.split(",") if kw.strip()]
-                for kw in keywords[:2]:
-                    if kw.lower() not in user_question.lower():
-                        seeded.append(f"{kw} {q_short}")
-
-    return seeded
-
-
 async def _plan_queries(
     client: httpx.AsyncClient,
     url: str,
@@ -525,7 +465,10 @@ async def _plan_queries(
     if doc_list:
         doc_text = "\n".join(f"- {d['title']}" for d in doc_list[:50])
         user_content += f"\n\nDocuments in corpus:\n{doc_text}"
-    llm_target = max(5, depth_config["max_queries"] // 2)
+    # The LLM is the sole query source now (corpus seeding removed); ask it
+    # for the full budget — it is a far better generator than the deleted
+    # entity-concatenation, and _is_plausible_query still filters junk.
+    llm_target = depth_config["max_queries"]
     user_content += f"\n\nGenerate {llm_target} search queries."
 
     messages = [
@@ -552,13 +495,10 @@ async def _plan_queries(
             llm_queries.append(" ".join(words[: len(words) // 2]))
             llm_queries.append(" ".join(words[len(words) // 2 :]))
 
-    # Corpus-seeded queries (model-independent)
-    seeded = await _seed_queries_from_corpus(user_question, user_id, topic_hint)
-
-    # Merge: LLM queries first (higher intent), then seeded (breadth), dedupe
+    # Dedupe (case-insensitive), preserving order.
     seen_lower: set[str] = set()
     merged: list[str] = []
-    for q in llm_queries + seeded:
+    for q in llm_queries:
         q = q.strip()
         if q and q.lower() not in seen_lower:
             seen_lower.add(q.lower())
@@ -992,13 +932,12 @@ async def research_stream(
                         )
                     except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as exc:
                         logger.error("LLM error during query planning: %s", exc)
-                        # Fallback: seeded queries only (no LLM)
+                        # Fallback: use question and keyword splits when the LLM is unreachable.
                         queries = [user_question]
-                        try:
-                            seeded = await _seed_queries_from_corpus(user_question, user_id, topic_hint)
-                            queries.extend(seeded)
-                        except Exception:
-                            pass
+                        words = user_question.split()
+                        if len(words) > 3:
+                            queries.append(" ".join(words[: len(words) // 2]))
+                            queries.append(" ".join(words[len(words) // 2 :]))
 
                     step_count = 1
                     state.current_round = step_count

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -119,6 +119,24 @@ _NOTE_EXTRACTION_SYSTEM = (
     "general knowledge."
 )
 
+_NOTE_EXTRACTION_SYSTEM_FORCEFUL = (
+    "You are extracting research notes from search results. These passages "
+    "are the TOP-RANKED retrieval matches for the research question and are "
+    "very likely relevant — a prior extraction attempt wrongly dismissed "
+    "them.\n\n"
+    "Rules:\n"
+    "- Cite every finding as [Document Title, page X] — exactly as shown in the passages\n"
+    "- Write one note per distinct finding\n"
+    "- Skip irrelevant or redundant passages\n"
+    "- Preserve factual details — names, numbers, dates\n"
+    "- If a passage contradicts another, note both with their citations\n"
+    "- Write in plain text with citations, not JSON\n"
+    "- Extract the relevant findings. Return `No relevant findings in this "
+    "passage set.` ONLY if the passages genuinely contain nothing on-topic "
+    "— do not use it as a shortcut. Do not invent content from titles or "
+    "general knowledge."
+)
+
 _GAP_ANALYSIS_SYSTEM = (
     "You are checking research coverage. Given the original question and notes "
     "gathered so far, identify any obvious gaps.\n\n"
@@ -136,6 +154,14 @@ _DEPTH_CONFIG = {
     "standard": {"max_queries": 15, "k_per_query": 20, "max_passages": 60, "gap_round": True, "paginate": True},
     "thorough": {"max_queries": 25, "k_per_query": 30, "max_passages": 100, "gap_round": True, "paginate": True},
 }
+
+# When note extraction returns the "no relevant findings" sentinel, retry it
+# forcefully only if retrieval actually found strong matches — i.e. the top
+# coverage score clears this floor. Below it, the corpus genuinely lacks the
+# information and the honest "no findings" answer is correct. Hybrid-retrieval
+# scores in observed research runs ranged ~0.5-1.7; 1.0 separates a solid
+# match from weak noise. Tunable.
+_RETRIEVAL_RELEVANCE_FLOOR = 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -747,11 +773,25 @@ async def _read_evidence(
     return passages_text
 
 
+# The exact sentinel _NOTE_EXTRACTION_SYSTEM tells the model to return when a
+# passage set is off-topic. Distinct from _extract_notes's genuinely-empty
+# return ("No relevant passages were found in the corpus.").
+_NO_FINDINGS_SENTINEL_PREFIX = "no relevant findings in this passage set"
+
+
+def _is_no_findings_sentinel(notes_text: str) -> bool:
+    """True if note extraction bailed with the 'no relevant findings'
+    sentinel. Tolerant of case and surrounding whitespace."""
+    return notes_text.strip().lower().startswith(_NO_FINDINGS_SENTINEL_PREFIX)
+
+
 async def _extract_notes(
     client: httpx.AsyncClient,
     url: str,
     user_question: str,
     passages_text: str,
+    *,
+    forceful: bool = False,
 ) -> str:
     """Phase 4: LLM extracts cited notes from retrieved passages."""
     if not passages_text.strip():
@@ -774,7 +814,7 @@ async def _extract_notes(
         passages_text = truncated
 
     messages = [
-        {"role": "system", "content": _NOTE_EXTRACTION_SYSTEM},
+        {"role": "system", "content": _NOTE_EXTRACTION_SYSTEM_FORCEFUL if forceful else _NOTE_EXTRACTION_SYSTEM},
         {
             "role": "user",
             "content": (

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -119,6 +119,7 @@ _NOTE_EXTRACTION_SYSTEM = (
     "general knowledge."
 )
 
+# Rules below are intentionally duplicated from _NOTE_EXTRACTION_SYSTEM — keep in sync.
 _NOTE_EXTRACTION_SYSTEM_FORCEFUL = (
     "You are extracting research notes from search results. These passages "
     "are the TOP-RANKED retrieval matches for the research question and are "
@@ -776,13 +777,17 @@ async def _read_evidence(
 # The exact sentinel _NOTE_EXTRACTION_SYSTEM tells the model to return when a
 # passage set is off-topic. Distinct from _extract_notes's genuinely-empty
 # return ("No relevant passages were found in the corpus.").
-_NO_FINDINGS_SENTINEL_PREFIX = "no relevant findings in this passage set"
+_NO_FINDINGS_SENTINEL_PREFIX = "no relevant findings"
 
 
 def _is_no_findings_sentinel(notes_text: str) -> bool:
     """True if note extraction bailed with the 'no relevant findings'
-    sentinel. Tolerant of case and surrounding whitespace."""
-    return notes_text.strip().lower().startswith(_NO_FINDINGS_SENTINEL_PREFIX)
+    sentinel. Tolerant of case, surrounding whitespace, and a leading
+    markdown bullet ('- ', '* ', '#') a weak model may prepend.
+
+    The genuinely-empty return ("No relevant passages were found in the
+    corpus.") deliberately does NOT match — 'passages' != 'findings'."""
+    return notes_text.strip().lstrip("-*•# ").lower().startswith(_NO_FINDINGS_SENTINEL_PREFIX)
 
 
 async def _extract_notes(

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -92,7 +92,7 @@ _QUERY_PLANNING_SYSTEM = (
     "Given a research question, generate diverse search queries that together "
     "cover all angles of the topic.\n\n"
     "Rules:\n"
-    "- Generate 5-15 queries depending on question complexity\n"
+    "- Generate the number of queries requested, covering the question from multiple angles\n"
     "- Vary phrasing: use synonyms, related terms, specific entities\n"
     "- Include both broad and narrow queries\n"
     "- For comparative questions, generate queries for each side\n"
@@ -457,7 +457,7 @@ async def _plan_queries(
     doc_list: list[dict] | None,
     user_id: uuid.UUID | None,
 ) -> list[str]:
-    """Phase 1: LLM generates diverse search queries, supplemented by corpus-seeded queries."""
+    """Phase 1: LLM generates diverse search queries for the research run."""
     # LLM-planned queries
     user_content = f"Research question: {user_question}"
     if topic_hint:

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -982,6 +982,7 @@ async def research_stream(
         start_time = datetime.now(UTC)
         step_count = 0
         collected_notes: list[str] = []
+        research_citations: list[dict] = []
 
         try:
             if resume_from_synthesis:
@@ -1139,6 +1140,7 @@ async def research_stream(
                         depth_config["max_passages"],
                         passage_budget_chars,
                     )
+                    research_citations = list(evidence_docs)
 
                     yield _sse(
                         {
@@ -1302,6 +1304,8 @@ async def research_stream(
                             20,
                             passage_budget_chars // 3,
                         )
+                        seen_cite_ids = {c["doc_id"] for c in research_citations}
+                        research_citations.extend(d for d in gap_evidence_docs if d["doc_id"] not in seen_cite_ids)
                         if gap_passages.strip():
                             try:
                                 gap_notes = await _extract_notes(
@@ -1400,6 +1404,7 @@ async def research_stream(
 
             state.status = "completed"
             state.notes = notes
+            state.citations = research_citations
             state.current_round = step_count
             state.completed_at = datetime.now(UTC)
             state.progress = {"step": step_count}

--- a/src/harbor_clerk/models/research_state.py
+++ b/src/harbor_clerk/models/research_state.py
@@ -28,3 +28,4 @@ class ResearchState(Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     depth: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    citations: Mapped[Any | None] = mapped_column(JSONB, nullable=True)

--- a/tests/test_api_research_citations.py
+++ b/tests/test_api_research_citations.py
@@ -1,15 +1,13 @@
 """Tests for ResearchDetail.citations on GET /api/research/{conv_id}.
 
-The research route computes citations at read-time from the persisted
-``ChatMessage(role='tool')`` rows of the turn — the same data the
-``citations_extract`` module knows how to parse. These tests verify the
-wire-up: seed a finished research with tool messages, fetch detail, expect
-deduped citations on the response.
+Citations are persisted on ``research_state.citations`` by the research engine
+and surfaced verbatim (after dedupe_citations) by the detail endpoint. These
+tests verify that wire-up: seed a ResearchState with citations, fetch detail,
+expect those citations on the response.
 """
 
 from __future__ import annotations
 
-import json
 import uuid
 
 from harbor_clerk.models import ChatMessage, Conversation
@@ -23,13 +21,12 @@ async def _seed_research(
     *,
     status: str = "completed",
     error: str | None = None,
-    tool_messages: list[tuple[str, str]] | None = None,
+    citations: list[dict] | None = None,
 ) -> uuid.UUID:
-    """Insert a conversation + research_state + (optionally) tool messages.
+    """Insert a conversation + research_state + optional persisted citations.
 
-    ``tool_messages`` is a list of (tool_call_id, raw_result_json_str). The
-    helper creates one assistant message with matching tool_calls plus one
-    tool result message per entry.
+    ``citations`` is stored directly on ``research_state.citations`` — matching
+    what the research engine writes at completion time.
     """
     conv_id = uuid.uuid4()
     conv = Conversation(
@@ -47,6 +44,7 @@ async def _seed_research(
         error=error,
         current_round=2,
         max_rounds=4,
+        citations=citations,
     )
     db_session.add(state)
 
@@ -58,17 +56,6 @@ async def _seed_research(
             content="What's in the corpus?",
         )
     )
-
-    if tool_messages:
-        for tc_id, raw in tool_messages:
-            db_session.add(
-                ChatMessage(
-                    conversation_id=conv_id,
-                    role="tool",
-                    tool_call_id=tc_id,
-                    content=raw,
-                )
-            )
 
     if status == "completed":
         db_session.add(
@@ -84,112 +71,78 @@ async def _seed_research(
     return conv_id
 
 
-async def test_research_detail_citations_empty_when_no_tools(client, admin_user, admin_token, db_session):
-    conv_id = await _seed_research(db_session, admin_user, tool_messages=None)
+async def test_research_detail_citations_empty_when_no_citations(client, admin_user, admin_token, db_session):
+    # No citations persisted on state → empty list on the wire.
+    conv_id = await _seed_research(db_session, admin_user, citations=None)
     resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
     assert resp.status_code == 200
     assert resp.json()["citations"] == []
 
 
-async def test_research_detail_citations_from_kb_search(client, admin_user, admin_token, db_session):
-    raw = json.dumps(
+async def test_research_detail_citations_multiple_docs(client, admin_user, admin_token, db_session):
+    # Multiple docs persisted by the engine are all surfaced.
+    cites = [
         {
-            "hits": [
-                {
-                    "doc_id": "11111111-1111-1111-1111-111111111111",
-                    "chunk_id": "aaa",
-                    "doc_title": "Doc A",
-                    "score": 0.9,
-                    "pages": "1-2",
-                },
-                {
-                    "doc_id": "22222222-2222-2222-2222-222222222222",
-                    "chunk_id": "bbb",
-                    "doc_title": "Doc B",
-                    "score": 0.7,
-                },
-            ]
-        }
-    )
-    conv_id = await _seed_research(db_session, admin_user, tool_messages=[("call_1", raw)])
+            "doc_id": "11111111-1111-1111-1111-111111111111",
+            "doc_title": "Doc A",
+            "page": 1,
+        },
+        {
+            "doc_id": "22222222-2222-2222-2222-222222222222",
+            "doc_title": "Doc B",
+            "page": 3,
+        },
+    ]
+    conv_id = await _seed_research(db_session, admin_user, citations=cites)
     resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
     assert resp.status_code == 200
-    cites = resp.json()["citations"]
-    assert {c["doc_id"] for c in cites} == {
+    returned = resp.json()["citations"]
+    assert {c["doc_id"] for c in returned} == {
         "11111111-1111-1111-1111-111111111111",
         "22222222-2222-2222-2222-222222222222",
     }
-    a = next(c for c in cites if c["doc_id"] == "11111111-1111-1111-1111-111111111111")
-    assert a["chunk_id"] == "aaa"
+    a = next(c for c in returned if c["doc_id"] == "11111111-1111-1111-1111-111111111111")
     assert a["doc_title"] == "Doc A"
-    assert a["score"] == 0.9
-    assert a["pages"] == "1-2"
+    assert a["page"] == 1
 
 
-async def test_research_detail_citations_deduped_across_tool_results(client, admin_user, admin_token, db_session):
-    # Same chunk surfaces in two searches → dedupe to one entry, with the
-    # higher score winning (matches the dedupe_citations contract).
-    r1 = json.dumps({"hits": [{"doc_id": "D1", "chunk_id": "C1", "score": 0.5}]})
-    r2 = json.dumps(
-        {
-            "hits": [
-                {"doc_id": "D1", "chunk_id": "C1", "score": 0.85},
-                {"doc_id": "D2", "chunk_id": "C2", "score": 0.6},
-            ]
-        }
-    )
-    conv_id = await _seed_research(
-        db_session,
-        admin_user,
-        tool_messages=[("call_1", r1), ("call_2", r2)],
-    )
+async def test_research_detail_citations_deduped_by_doc_id(client, admin_user, admin_token, db_session):
+    # dedupe_citations collapses duplicate doc_id entries (same doc, different
+    # pages) — the route passes state.citations through dedupe_citations.
+    cites = [
+        {"doc_id": "D1", "doc_title": "Doc 1", "page": 1},
+        {"doc_id": "D1", "doc_title": "Doc 1", "page": 2},
+        {"doc_id": "D2", "doc_title": "Doc 2", "page": 5},
+    ]
+    conv_id = await _seed_research(db_session, admin_user, citations=cites)
     resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
     assert resp.status_code == 200
-    cites = resp.json()["citations"]
-    assert len(cites) == 2
-    by_chunk = {c["chunk_id"]: c for c in cites}
-    assert by_chunk["C1"]["score"] == 0.85
-    assert by_chunk["C2"]["score"] == 0.6
+    returned = resp.json()["citations"]
+    # After dedupe: D1 appears once, D2 once
+    doc_ids = [c["doc_id"] for c in returned]
+    assert doc_ids.count("D1") == 1
+    assert doc_ids.count("D2") == 1
 
 
-async def test_research_detail_citations_skips_error_payloads(client, admin_user, admin_token, db_session):
-    # A failed tool call returns {"error": ...}. Those must not produce
-    # citations — the extractor is best-effort and treats errors as no-ops.
-    err = json.dumps({"error": "no such doc_id"})
-    ok = json.dumps({"hits": [{"doc_id": "D1", "chunk_id": "C1"}]})
-    conv_id = await _seed_research(
-        db_session,
-        admin_user,
-        tool_messages=[("call_err", err), ("call_ok", ok)],
-    )
+async def test_research_detail_citations_single_doc(client, admin_user, admin_token, db_session):
+    # Single citation roundtrips cleanly.
+    cites = [{"doc_id": "D1", "doc_title": "Solo Doc", "page": 7}]
+    conv_id = await _seed_research(db_session, admin_user, citations=cites)
     resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
     assert resp.status_code == 200
-    cites = resp.json()["citations"]
-    assert len(cites) == 1
-    assert cites[0]["doc_id"] == "D1"
+    returned = resp.json()["citations"]
+    assert len(returned) == 1
+    assert returned[0]["doc_id"] == "D1"
+    assert returned[0]["doc_title"] == "Solo Doc"
+    assert returned[0]["page"] == 7
 
 
-async def test_research_detail_citations_from_read_passages_keeps_chunk_only(
-    client, admin_user, admin_token, db_session
-):
-    # kb_read_passages doesn't include doc_id. Those chunk-only entries still
-    # appear in citations so the UI can show them; the test harness ignores
-    # entries without doc_id for citation_overlap.
-    raw = json.dumps(
-        {
-            "passages": [
-                {"chunk_id": "C1", "doc_title": "X", "pages": "5", "text": "..."},
-            ]
-        }
-    )
-    conv_id = await _seed_research(db_session, admin_user, tool_messages=[("call_1", raw)])
+async def test_research_detail_citations_empty_list_in_state(client, admin_user, admin_token, db_session):
+    # Explicit empty list on state → empty list on the wire (not None).
+    conv_id = await _seed_research(db_session, admin_user, citations=[])
     resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
     assert resp.status_code == 200
-    cites = resp.json()["citations"]
-    assert len(cites) == 1
-    assert "doc_id" not in cites[0]
-    assert cites[0]["chunk_id"] == "C1"
-    assert cites[0]["doc_title"] == "X"
+    assert resp.json()["citations"] == []
 
 
 # ── error field ──
@@ -227,3 +180,41 @@ async def test_research_detail_error_field_surfaces_synthesis_failure(client, ad
     resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
     assert resp.status_code == 200
     assert resp.json()["error"] == "Synthesis failed: LLM error (502)"
+
+
+async def test_research_detail_surfaces_state_citations(db_session, client, admin_user, admin_token):
+    """result.citations is populated from research_state.citations."""
+    import uuid as _uuid
+
+    conv_id = _uuid.uuid4()
+    conv = Conversation(
+        conversation_id=conv_id,
+        user_id=admin_user.user_id,
+        title="cites",
+        mode="research",
+    )
+    db_session.add(conv)
+    await db_session.flush()
+    cites = [{"doc_id": "d-1", "doc_title": "alpha", "page": 2}]
+    db_session.add(
+        ResearchState(
+            conversation_id=conv_id,
+            strategy="search",
+            status="completed",
+            max_rounds=500,
+            citations=cites,
+        )
+    )
+    # Add user message so the route can find `question`
+    db_session.add(
+        ChatMessage(
+            conversation_id=conv_id,
+            role="user",
+            content="What is in the corpus?",
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.get(f"/api/research/{conv_id}", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["citations"] == cites

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -34,3 +34,22 @@ async def test_plan_queries_returns_only_llm_queries_no_seeded_garbage():
             user_id=None,
         )
     assert queries == ["governing law clauses", "termination notice periods"]
+
+
+@pytest.mark.asyncio
+async def test_plan_queries_keyword_fallback_when_llm_yields_nothing():
+    """When the LLM returns no plausible queries, _plan_queries falls back to
+    the question itself plus two keyword-split halves."""
+    with patch("harbor_clerk.llm.research._llm_complete", new=AsyncMock(return_value='{"queries": []}')):
+        queries = await _plan_queries(
+            client=None,
+            url="http://llm.test",
+            user_question="What are the major vendor relationships over time",
+            topic_hint=None,
+            depth_config=_DEPTH,
+            doc_list=None,
+            user_id=None,
+        )
+    assert queries[0] == "What are the major vendor relationships over time"
+    assert "What are the major" in queries
+    assert "vendor relationships over time" in queries

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -33,7 +33,6 @@ async def test_plan_queries_returns_only_llm_queries_no_seeded_garbage():
             topic_hint=None,
             depth_config=_DEPTH,
             doc_list=None,
-            user_id=None,
         )
     assert queries == ["governing law clauses", "termination notice periods"]
 
@@ -50,7 +49,6 @@ async def test_plan_queries_keyword_fallback_when_llm_yields_nothing():
             topic_hint=None,
             depth_config=_DEPTH,
             doc_list=None,
-            user_id=None,
         )
     assert queries[0] == "What are the major vendor relationships over time"
     assert "What are the major" in queries

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -60,6 +60,9 @@ def test_is_no_findings_sentinel_matches_the_sentinel():
     # Tolerant of trailing whitespace / case / wrapping the engine may add.
     assert _is_no_findings_sentinel("  no relevant findings in this passage set  ")
     assert _is_no_findings_sentinel("No relevant findings in this passage set")
+    # Weak models often prepend a markdown bullet to the sentinel line.
+    assert _is_no_findings_sentinel("- No relevant findings in this passage set.")
+    assert _is_no_findings_sentinel("* no relevant findings in this passage set")
 
 
 def test_is_no_findings_sentinel_rejects_real_notes_and_empty_corpus_string():

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -1,0 +1,36 @@
+"""Unit tests for research engine internals (harbor_clerk.llm.research)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from harbor_clerk.llm.research import _plan_queries
+
+_DEPTH = {"max_queries": 15, "k_per_query": 20, "max_passages": 60, "gap_round": True, "paginate": True}
+
+
+@pytest.mark.asyncio
+async def test_plan_queries_returns_only_llm_queries_no_seeded_garbage():
+    """After dropping corpus seeding, _plan_queries returns exactly the
+    LLM-planned queries. The old code concatenated corpus entities with the
+    question into ungrammatical seeded queries ('Globex What major vendor
+    relationships'); none of those may appear."""
+    llm_response = json.dumps({"queries": ["governing law clauses", "termination notice periods"]})
+    # entity_overview is what the deleted seeding path called; patching it
+    # proves the new code never seeds even when entities are available.
+    entity_response = json.dumps({"top_entities": [{"entity_type": "ORG", "entity_text": "Globex"}]})
+    with (
+        patch("harbor_clerk.llm.research._llm_complete", new=AsyncMock(return_value=llm_response)),
+        patch("harbor_clerk.llm.research.execute_tool", new=AsyncMock(return_value=entity_response)),
+    ):
+        queries = await _plan_queries(
+            client=None,
+            url="http://llm.test",
+            user_question="What are the major vendor relationships?",
+            topic_hint=None,
+            depth_config=_DEPTH,
+            doc_list=None,
+            user_id=None,
+        )
+    assert queries == ["governing law clauses", "termination notice periods"]

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -209,5 +209,7 @@ async def test_research_state_citations_column_roundtrips(db_session, admin_user
     )
     await db_session.commit()
 
-    row = (await db_session.execute(select(ResearchState))).scalar_one()
+    row = (
+        await db_session.execute(select(ResearchState).where(ResearchState.conversation_id == conv.conversation_id))
+    ).scalar_one()
     assert row.citations == cites

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -1,9 +1,11 @@
 """Unit tests for research engine internals (harbor_clerk.llm.research)."""
 
 import json
+import uuid as _uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy import select
 
 from harbor_clerk.llm.research import _extract_notes_with_retry, _is_no_findings_sentinel, _plan_queries, _read_evidence
 
@@ -183,3 +185,29 @@ async def test_read_evidence_excludes_budget_truncated_passages_from_evidence_do
     assert big in passages_text
     assert "beta body" not in passages_text
     assert {d["doc_id"] for d in evidence_docs} == {"d1"}
+
+
+@pytest.mark.asyncio
+async def test_research_state_citations_column_roundtrips(db_session, admin_user):
+    """ResearchState persists a citations JSON list."""
+    from harbor_clerk.models import Conversation
+    from harbor_clerk.models.research_state import ResearchState
+
+    conv = Conversation(title="t", user_id=admin_user.user_id)
+    db_session.add(conv)
+    await db_session.flush()
+
+    cites = [{"doc_id": str(_uuid.uuid4()), "doc_title": "alpha", "page": 1}]
+    db_session.add(
+        ResearchState(
+            conversation_id=conv.conversation_id,
+            strategy="search",
+            status="completed",
+            max_rounds=500,
+            citations=cites,
+        )
+    )
+    await db_session.commit()
+
+    row = (await db_session.execute(select(ResearchState))).scalar_one()
+    assert row.citations == cites

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from harbor_clerk.llm.research import _is_no_findings_sentinel, _plan_queries
+from harbor_clerk.llm.research import _extract_notes_with_retry, _is_no_findings_sentinel, _plan_queries
 
 _DEPTH = {"max_queries": 15, "k_per_query": 20, "max_passages": 60, "gap_round": True, "paginate": True}
 
@@ -72,3 +72,58 @@ def test_is_no_findings_sentinel_rejects_real_notes_and_empty_corpus_string():
     # not match — that case is truly empty and should not trigger a retry.
     assert not _is_no_findings_sentinel("No relevant passages were found in the corpus.")
     assert not _is_no_findings_sentinel("")
+
+
+_SENTINEL = "No relevant findings in this passage set."
+_PASSAGES = "\n---\n**[0265_quarterly_report, page 1]**\nQ1 consulting revenue up 14%.\n"
+
+
+def _coverage(top_score: float) -> dict:
+    return {"c1": {"doc_id": "d1", "doc_title": "0265_quarterly_report", "page": 1, "score": top_score}}
+
+
+@pytest.mark.asyncio
+async def test_retry_not_triggered_when_extraction_succeeds():
+    """A normal (non-sentinel) extraction result passes straight through."""
+    real_notes = "- Q1 consulting revenue up 14% [0265_quarterly_report, page 1]"
+    with patch("harbor_clerk.llm.research._extract_notes", new=AsyncMock(return_value=real_notes)) as m:
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(1.7))
+    assert out == real_notes
+    assert m.await_count == 1  # no retry
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_when_forceful_extraction_succeeds():
+    """Sentinel + high retrieval score → forceful retry; if the retry yields
+    real notes, those are used."""
+    real_notes = "- Q1 consulting revenue up 14% [0265_quarterly_report, page 1]"
+    with patch(
+        "harbor_clerk.llm.research._extract_notes",
+        new=AsyncMock(side_effect=[_SENTINEL, real_notes]),
+    ) as m:
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(1.7))
+    assert out == real_notes
+    assert m.await_count == 2
+    assert m.await_args_list[1].kwargs.get("forceful") is True
+
+
+@pytest.mark.asyncio
+async def test_retry_falls_back_to_raw_passages_when_retry_also_bails():
+    """Sentinel twice → raw passages become the notes."""
+    with patch(
+        "harbor_clerk.llm.research._extract_notes",
+        new=AsyncMock(side_effect=[_SENTINEL, _SENTINEL]),
+    ):
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(1.7))
+    assert out.startswith("## Raw passages")
+    assert "0265_quarterly_report" in out
+
+
+@pytest.mark.asyncio
+async def test_low_score_sentinel_is_trusted_no_retry():
+    """Sentinel + low retrieval score → the sentinel is kept; the corpus
+    genuinely lacks the information. No retry."""
+    with patch("harbor_clerk.llm.research._extract_notes", new=AsyncMock(return_value=_SENTINEL)) as m:
+        out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(0.3))
+    assert _is_no_findings_sentinel(out)
+    assert m.await_count == 1  # no retry below the relevance floor

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from harbor_clerk.llm.research import _plan_queries
+from harbor_clerk.llm.research import _is_no_findings_sentinel, _plan_queries
 
 _DEPTH = {"max_queries": 15, "k_per_query": 20, "max_passages": 60, "gap_round": True, "paginate": True}
 
@@ -53,3 +53,19 @@ async def test_plan_queries_keyword_fallback_when_llm_yields_nothing():
     assert queries[0] == "What are the major vendor relationships over time"
     assert "What are the major" in queries
     assert "vendor relationships over time" in queries
+
+
+def test_is_no_findings_sentinel_matches_the_sentinel():
+    assert _is_no_findings_sentinel("No relevant findings in this passage set.")
+    # Tolerant of trailing whitespace / case / wrapping the engine may add.
+    assert _is_no_findings_sentinel("  no relevant findings in this passage set  ")
+    assert _is_no_findings_sentinel("No relevant findings in this passage set")
+
+
+def test_is_no_findings_sentinel_rejects_real_notes_and_empty_corpus_string():
+    # A real note must not be treated as the bail sentinel.
+    assert not _is_no_findings_sentinel("- Acme signed a 30-day termination clause [Doc, page 2]")
+    # _extract_notes's genuinely-empty return is a DIFFERENT string and must
+    # not match — that case is truly empty and should not trigger a retry.
+    assert not _is_no_findings_sentinel("No relevant passages were found in the corpus.")
+    assert not _is_no_findings_sentinel("")

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from harbor_clerk.llm.research import _extract_notes_with_retry, _is_no_findings_sentinel, _plan_queries
+from harbor_clerk.llm.research import _extract_notes_with_retry, _is_no_findings_sentinel, _plan_queries, _read_evidence
 
 _DEPTH = {"max_queries": 15, "k_per_query": 20, "max_passages": 60, "gap_round": True, "paginate": True}
 
@@ -127,3 +127,29 @@ async def test_low_score_sentinel_is_trusted_no_retry():
         out = await _extract_notes_with_retry(None, "http://x", "q", _PASSAGES, _coverage(0.3))
     assert _is_no_findings_sentinel(out)
     assert m.await_count == 1  # no retry below the relevance floor
+
+
+@pytest.mark.asyncio
+async def test_read_evidence_returns_passages_and_evidence_docs():
+    """_read_evidence returns (passages_text, evidence_docs); evidence_docs
+    lists the distinct docs whose passages were read into passages_text."""
+    coverage = {
+        "c1": {"doc_id": "d1", "doc_title": "alpha", "page": 1, "score": 2.0, "snippet": "alpha text"},
+        "c2": {"doc_id": "d2", "doc_title": "beta", "page": 3, "score": 1.5, "snippet": "beta text"},
+    }
+    read_result = json.dumps(
+        {
+            "passages": [
+                {"chunk_id": "c1", "text": "alpha body", "doc_title": "alpha", "page": 1},
+                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "page": 3},
+            ]
+        }
+    )
+    with patch("harbor_clerk.llm.research.execute_tool", new=AsyncMock(return_value=read_result)):
+        passages_text, evidence_docs = await _read_evidence(
+            coverage, user_id=None, max_passages=10, context_budget_chars=100_000
+        )
+    assert "alpha body" in passages_text and "beta body" in passages_text
+    by_id = {d["doc_id"]: d for d in evidence_docs}
+    assert set(by_id) == {"d1", "d2"}
+    assert by_id["d1"]["doc_title"] == "alpha"

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -153,3 +153,33 @@ async def test_read_evidence_returns_passages_and_evidence_docs():
     by_id = {d["doc_id"]: d for d in evidence_docs}
     assert set(by_id) == {"d1", "d2"}
     assert by_id["d1"]["doc_title"] == "alpha"
+    assert by_id["d1"]["page"] == 1
+    assert by_id["d2"]["page"] == 3
+
+
+@pytest.mark.asyncio
+async def test_read_evidence_excludes_budget_truncated_passages_from_evidence_docs():
+    """A passage skipped because it would exceed context_budget_chars must
+    NOT appear in evidence_docs — evidence_docs tracks only the passages
+    that actually made it into passages_text."""
+    coverage = {
+        "c1": {"doc_id": "d1", "doc_title": "alpha", "page": 1, "score": 2.0, "snippet": "a"},
+        "c2": {"doc_id": "d2", "doc_title": "beta", "page": 2, "score": 1.5, "snippet": "b"},
+    }
+    big = "x" * 400
+    read_result = json.dumps(
+        {
+            "passages": [
+                {"chunk_id": "c1", "text": big, "doc_title": "alpha", "page": 1},
+                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "page": 2},
+            ]
+        }
+    )
+    with patch("harbor_clerk.llm.research.execute_tool", new=AsyncMock(return_value=read_result)):
+        passages_text, evidence_docs = await _read_evidence(
+            coverage, user_id=None, max_passages=10, context_budget_chars=450
+        )
+    # The big first passage fits; the second is over budget and skipped.
+    assert big in passages_text
+    assert "beta body" not in passages_text
+    assert {d["doc_id"] for d in evidence_docs} == {"d1"}


### PR DESCRIPTION
## Summary

Fixes the three research-engine defects tracked in #368, surfaced by the `2026-05-05-prod` test-corpora sweep where research scored 94% fail / 0 pass vs ask's 76% fail.

- **Fix 1 — Drop corpus-seeded queries.** `_seed_queries_from_corpus` concatenated a corpus entity with the question's first long words, producing ungrammatical word-salad queries (`"Party Identify major vendor relationships"`) that polluted every research run. Deleted; the LLM is now the sole query source and is asked for the full query budget. Keyword fallback retained.
- **Fix 2 — Don't let "No relevant findings" be terminal.** Weak models took the note-extraction anti-hallucination escape hatch even when retrieval surfaced clearly-relevant docs. Round-1 note extraction now retries once with a forceful prompt when the sentinel appears alongside a high top retrieval score (`_RETRIEVAL_RELEVANCE_FLOOR`), falling back to raw passages if the retry also bails. A genuinely-empty corpus still yields the honest "no findings" answer.
- **Fix 3 — Populate `result.citations`.** Research responses always returned `citations: []` because the engine does retrieval internally and emits no tool-result messages. `_read_evidence` now returns the docs whose passages informed the answer; these are persisted to a new `research_state.citations` JSONB column (migration `0023`) and surfaced on the response.

Built via subagent-driven development against the design doc and plan committed on this branch. Each task got two-stage review (spec compliance + code quality); the branch tip got a final unconstrained `feature-dev:code-reviewer` pass.

## Test plan

- [x] `uv run ruff check .` + `ruff format --check` clean
- [x] Full pytest suite green (734 passed, 17 skipped locally)
- [x] Migration `0023` round-trip covered by `test_migrations.py`
- [x] New coverage in `tests/test_research_engine.py` (sentinel detection, query planning, evidence-doc selection) and rewritten `tests/test_api_research_citations.py`

Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
