### PR TITLE
ci(security): fail pip-audit only on advisories with a fix available

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,10 +19,26 @@ jobs:
       - name: Upgrade pip in venv (CVE-2026-3219 fix in 26.1)
         run: .venv/bin/python -m pip install --upgrade 'pip>=26.1'
 
-      - uses: pypa/gh-action-pip-audit@v1.1.0
-        with:
-          virtual-environment: .venv
-          severity: HIGH
+      - name: pip-audit (fail only on advisories with a fix available)
+        run: |
+          # pip-audit has no severity or ignore-unfixed filter, and the
+          # pypa/gh-action-pip-audit action has no "only fixable" mode, so we
+          # run pip-audit directly and gate on whether a fix exists. This is
+          # the same --ignore-unfixed policy the Trivy scans below already
+          # apply: advisories with no upstream fix (e.g. the torch/transformers
+          # malicious-checkpoint RCEs) are reported but do not fail the build;
+          # an advisory that has a fix available does fail it.
+          .venv/bin/python -m pip freeze --exclude-editable > /tmp/frozen.txt
+          uvx pip-audit -r /tmp/frozen.txt --no-deps --format json --progress-spinner off --output /tmp/pip-audit.json || true
+          if [ ! -s /tmp/pip-audit.json ]; then echo "::error::pip-audit produced no report"; exit 1; fi
+          jq -r '.dependencies[] as $d | $d.vulns[] | "  [\(if (.fix_versions|length>0) then "FIX AVAILABLE" else "no fix" end)] \($d.name) \($d.version) \(.id)"' /tmp/pip-audit.json
+          total=$(jq '[.dependencies[].vulns[]] | length' /tmp/pip-audit.json)
+          fixable=$(jq '[.dependencies[].vulns[] | select(.fix_versions|length>0)] | length' /tmp/pip-audit.json)
+          echo "pip-audit: $total advisory(ies) total, $fixable with a fix available"
+          if [ "$fixable" -ne 0 ]; then
+            echo "::error::pip-audit found $fixable advisory(ies) with a fix available; upgrade the affected package(s)"
+            exit 1
+          fi
 
       - name: npm audit (high/critical)
         run: cd frontend && npm ci && npm audit --audit-level=high


### PR DESCRIPTION
## Summary

`dependency-audit` is failing on every open PR (#369 and the whole Dependabot queue) and would fail on any new PR to `main`. The cause is repo-wide, not PR-specific:

- `pypa/gh-action-pip-audit@v1.1.0` has **no `severity` input** — the workflow's `severity: HIGH` was silently ignored (CI even emits an `Unexpected input(s) 'severity'` warning). The check has always failed on *any* advisory, not just HIGH.
- A batch of **21 advisories in `torch` 2.10.0, `transformers` 5.3.0, `joblib` 1.5.3, `pyjwt` 2.12.1** landed in the PyPI advisory DB this week. **None have a fix version** — torch/transformers are at current releases, the joblib/pyjwt ones are disputed by their suppliers. They reach the audited root venv transitively via `sentence-transformers`.

## Change

Replace the action step with a direct `pip-audit` run that gates on whether a fix exists — the same `--ignore-unfixed` policy the Trivy container scans in this same workflow already apply:

- Advisory with **no upstream fix** → reported in the log, does **not** fail the build.
- Advisory **with a fix available** → still fails the build (e.g. the `idna` 3.11 → 3.15 case would still be caught).

Verified locally against the `uv sync --extra test` environment: 21 advisories, 0 with a fix → step exits 0.

## Test plan

- [ ] `dependency-audit` passes on this PR (proves the new logic green-lights the 21 unfixable advisories)
- [ ] CI log lists each advisory tagged `[no fix]` / `[FIX AVAILABLE]`

Once merged, #369 and the Dependabot PRs rebase and clear the same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
