### PR TITLE
test-corpora: --mode retrieval-eval harness + retrieval/MCP upgrade plans

### DIFF
--- a/docs/superpowers/plans/2026-05-17-embedding-v2-implementation.md
+++ b/docs/superpowers/plans/2026-05-17-embedding-v2-implementation.md
@@ -1,0 +1,2865 @@
+# Embedding v2 (Granite-R2 + Reranker + Schema Rebase) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Swap the embedding stack from multilingual-e5-small/384-dim to IBM Granite-R2/768-dim, add bge-reranker-v2-m3 as a cross-encoder precision stage, and rebase the alembic chain so the new initial migration represents the new schema directly.
+
+**Architecture:** Three independent runtime services (embedder, reranker, HC API/workers) coordinate over HTTP. Schema sentinel rows in a new `schema_metadata` table assert binary↔DB compatibility at boot via `verify_schema_sentinel()` — panic-exits on mismatch. Alembic chain is squashed to a single `0001_initial.py`; existing DBs migrate via standalone `scripts/migrate_to_embedding_v2.py` or get wiped and re-ingested via watched folders.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0 async, Alembic, PostgreSQL 18 + pgvector, sentence-transformers (CrossEncoder for reranker), pytest with `pytest-httpx` (new dev dep), Swift 5.9 + AppKit (macOS service), React + TypeScript (frontend).
+
+**Companion spec:** [`docs/superpowers/specs/2026-05-17-embedding-v2-design.md`](../specs/2026-05-17-embedding-v2-design.md). All design decisions and rationale live there; this plan only mechanically implements that spec.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/harbor_clerk/models/schema_metadata.py` — SQLAlchemy model for the sentinel table
+- `src/harbor_clerk/db_health.py` — `verify_schema_sentinel()` plus the panic-exit helper
+- `src/harbor_clerk/search_rerank.py` — `rerank_hits()` async function + dataclass for reranker response
+- `alembic/versions/0001_initial.py` — rebased single migration creating entire schema at embedding-v2 state
+- `embedder/src/embedder/reranker.py` — FastAPI app with `POST /rerank`
+- `docker/reranker.Dockerfile` — image with bge-reranker-v2-m3 baked in
+- `scripts/migrate_to_embedding_v2.py` — standalone external migration script
+- `docs/upgrade-runbook.md` — operator-facing upgrade guide (Path A wipe / Path B migrate)
+- `macos/HarborClerkServer/HarborClerkServer/Services/RerankerService.swift` — Swift service definition
+- `tests/test_schema_sentinel.py` — sentinel match/mismatch behavior
+- `tests/test_db_health.py` — `verify_schema_sentinel()` behavior
+- `tests/test_search_rerank.py` — `rerank_hits()` fallback + ordering
+- `tests/test_alembic_initial.py` — fresh-DB migration smoke
+- `tests/test_migrate_to_embedding_v2.py` — external script pre-flight + happy path
+- `tests/test_reranker_service.py` — reranker FastAPI app (in-process)
+- `tests/test_embedder_granite.py` — Granite-R2 loads + returns 768-dim (gated `requires_models`)
+- `tests/test_search_rerank_integration.py` — end-to-end with real reranker (gated `requires_models`)
+
+**Modify:**
+- `src/harbor_clerk/config.py` — add 8 new settings (embed_* and reranker_*)
+- `src/harbor_clerk/models/chunk.py` — `Vector(384)` → `Vector(768)`
+- `src/harbor_clerk/models/__init__.py` — export `SchemaMetadata`
+- `src/harbor_clerk/api/app.py` — call `verify_schema_sentinel()` in lifespan
+- `src/harbor_clerk/worker/entry.py` — call `verify_schema_sentinel()` at boot
+- `src/harbor_clerk/search.py` — wire `rerank_hits()` into `hybrid_search()`
+- `src/harbor_clerk/api/schemas/search.py` — add `ScoreBreakdown`, `reranker_status` fields
+- `src/harbor_clerk/worker/stages/embed.py` — bump timeout 1800 → 3600 (in pipeline timeout table)
+- `src/harbor_clerk/worker/pipeline.py` — same timeout entry if defined there
+- `embedder/src/embedder/app.py` — model default + ignore `task` param + 768-dim
+- `embedder/pyproject.toml` — add reranker script entry; pin sentence-transformers
+- `pyproject.toml` — add `pytest-httpx` dev dep; register `requires_models` pytest marker
+- `docker/embedder.Dockerfile` — bake Granite-R2 weights at build time
+- `docker-compose.yml` — add `reranker` service; HC env var `RERANKER_URL`
+- `macos/scripts/download-model.sh` — extend to fetch Granite-R2 + reranker
+- `macos/scripts/package.sh` — bundle the new model files
+- `macos/HarborClerkServer/HarborClerkServer/AppSettings.swift` — `rerankerPort` + `rerankerEnabled`
+- `macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift` — register reranker in lifecycle
+- `macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift` — UI for reranker port
+- `frontend/src/pages/SystemStatusPage.tsx` — show reranker health card
+- `frontend/src/pages/ServiceLogsPage.tsx` — tail reranker.log
+
+**Delete:**
+- All files under `alembic/versions/` matching `0001_*.py` through `0022_*.py` (22 files) — replaced by the new `0001_initial.py`.
+
+---
+
+## Pre-Implementation Setup
+
+### Branch + worktree
+
+- [ ] **Step P1: Create the worktree from main**
+
+Run:
+```bash
+cd ~/mcp-gateway
+git worktree add .claude/worktrees/embedding-v2 -b feat/embedding-v2-granite-and-reranker main
+cd .claude/worktrees/embedding-v2
+```
+
+Expected: New worktree created on a fresh branch off main. All commands below run from this worktree.
+
+### Environment
+
+- [ ] **Step P2: Verify the test DB is reachable**
+
+Run:
+```bash
+psql -h localhost -p 5433 -U lka -d harbor_clerk_test -c "SELECT 1"  # macOS app DB
+# OR
+psql -h localhost -p 5432 -U lka -d harbor_clerk_test -c "SELECT 1"  # Docker
+```
+
+Expected: `1` row returned. If neither port works, start the macOS app or `docker compose up -d postgres` and retry.
+
+- [ ] **Step P3: Verify the dev venv is current**
+
+Run:
+```bash
+uv sync --all-extras
+```
+
+Expected: No errors; venv up to date.
+
+---
+
+## Task 1: Settings additions (embed_*)
+
+**Files:**
+- Modify: `src/harbor_clerk/config.py`
+- Modify: `tests/test_config.py`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_embed_settings_have_granite_defaults(monkeypatch):
+    """Defaults match the embedding-v2 spec: Granite-R2, 768-dim, no prefix."""
+    monkeypatch.delenv("EMBED_MODEL", raising=False)
+    monkeypatch.delenv("EMBED_DIM", raising=False)
+    monkeypatch.delenv("EMBED_NEEDS_PREFIX", raising=False)
+
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.embed_model == "ibm-granite/granite-embedding-311m-multilingual-r2"
+    assert s.embed_dim == 768
+    assert s.embed_needs_prefix is False
+
+
+def test_embed_settings_override_via_env(monkeypatch):
+    """Env vars override defaults — required for the e5-small rollback path."""
+    monkeypatch.setenv("EMBED_MODEL", "intfloat/multilingual-e5-small")
+    monkeypatch.setenv("EMBED_DIM", "384")
+    monkeypatch.setenv("EMBED_NEEDS_PREFIX", "true")
+
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.embed_model == "intfloat/multilingual-e5-small"
+    assert s.embed_dim == 384
+    assert s.embed_needs_prefix is True
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/test_config.py::test_embed_settings_have_granite_defaults -v
+```
+
+Expected: FAIL with `AttributeError: 'Settings' object has no attribute 'embed_model'`.
+
+- [ ] **Step 1.3: Add the settings**
+
+Edit `src/harbor_clerk/config.py`, find the `# Embedder` section and add immediately after `embedder_url`:
+
+```python
+    # Embedding model (set on the embedder side; HC needs to know for sentinel)
+    embed_model: str = Field(default="ibm-granite/granite-embedding-311m-multilingual-r2")
+    embed_dim: int = Field(default=768)
+    embed_needs_prefix: bool = Field(default=False)  # Granite uses CLS pooling; e5 needed query:/passage:
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_config.py::test_embed_settings_have_granite_defaults tests/test_config.py::test_embed_settings_override_via_env -v
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/harbor_clerk/config.py tests/test_config.py
+git commit -m "feat(config): add embed_model/embed_dim/embed_needs_prefix settings for embedding-v2"
+```
+
+---
+
+## Task 2: Settings additions (reranker_*)
+
+**Files:**
+- Modify: `src/harbor_clerk/config.py`
+- Modify: `tests/test_config.py`
+
+- [ ] **Step 2.1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_reranker_settings_have_defaults(monkeypatch):
+    for var in ("RERANKER_ENABLED", "RERANKER_URL", "RERANKER_TOP_K_PAD",
+                "RERANKER_POOL_SIZE", "RERANKER_STRICT", "RERANKER_TIMEOUT_SECONDS"):
+        monkeypatch.delenv(var, raising=False)
+
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.reranker_enabled is True
+    assert s.reranker_url == "http://reranker:8001"
+    assert s.reranker_top_k_pad == 40
+    assert s.reranker_pool_size == 50
+    assert s.reranker_strict is False
+    assert s.reranker_timeout_seconds == 30.0
+
+
+def test_reranker_url_override_for_macos(monkeypatch):
+    """macOS native sets RERANKER_URL to 127.0.0.1 with the per-instance port."""
+    monkeypatch.setenv("RERANKER_URL", "http://127.0.0.1:8201")
+
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.reranker_url == "http://127.0.0.1:8201"
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/test_config.py::test_reranker_settings_have_defaults -v
+```
+
+Expected: FAIL with `AttributeError`.
+
+- [ ] **Step 2.3: Add the settings**
+
+Edit `src/harbor_clerk/config.py`, immediately after the new `embed_needs_prefix` line from Task 1:
+
+```python
+    # Reranker (bge-reranker-v2-m3 cross-encoder, separate service)
+    reranker_enabled: bool = Field(default=True)
+    reranker_url: str = Field(default="http://reranker:8001")
+    reranker_top_k_pad: int = Field(default=40)
+    reranker_pool_size: int = Field(default=50)
+    reranker_strict: bool = Field(default=False)
+    reranker_timeout_seconds: float = Field(default=30.0)
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_config.py -v -k reranker
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/harbor_clerk/config.py tests/test_config.py
+git commit -m "feat(config): add reranker_* settings for bge-reranker-v2-m3"
+```
+
+---
+
+## Task 3: SchemaMetadata model
+
+**Files:**
+- Create: `src/harbor_clerk/models/schema_metadata.py`
+- Modify: `src/harbor_clerk/models/__init__.py`
+
+- [ ] **Step 3.1: Create the model file**
+
+Create `src/harbor_clerk/models/schema_metadata.py`:
+
+```python
+"""Schema sentinel rows — assert what model/dim this DB is compatible with."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from harbor_clerk.models.base import Base
+
+
+class SchemaMetadata(Base):
+    __tablename__ = "schema_metadata"
+
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+    value: Mapped[str] = mapped_column(String, nullable=False)
+    set_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+```
+
+- [ ] **Step 3.2: Export from models package**
+
+Edit `src/harbor_clerk/models/__init__.py`, add to the imports + `__all__`:
+
+```python
+from harbor_clerk.models.schema_metadata import SchemaMetadata
+```
+
+And include `"SchemaMetadata"` in `__all__` (alphabetical position).
+
+- [ ] **Step 3.3: Verify import works**
+
+Run:
+```bash
+uv run python -c "from harbor_clerk.models import SchemaMetadata; print(SchemaMetadata.__tablename__)"
+```
+
+Expected: `schema_metadata`
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/harbor_clerk/models/schema_metadata.py src/harbor_clerk/models/__init__.py
+git commit -m "feat(models): add SchemaMetadata sentinel table"
+```
+
+---
+
+## Task 4: Update chunk model dim to 768
+
+**Files:**
+- Modify: `src/harbor_clerk/models/chunk.py:58`
+
+- [ ] **Step 4.1: Change the column type**
+
+Edit `src/harbor_clerk/models/chunk.py`, find line ~58 (the `embedding = mapped_column(Vector(384), nullable=True)` line) and change to:
+
+```python
+    embedding = mapped_column(Vector(768), nullable=True)
+```
+
+- [ ] **Step 4.2: Verify import + size**
+
+Run:
+```bash
+uv run python -c "from harbor_clerk.models.chunk import Chunk; print(Chunk.__table__.c.embedding.type)"
+```
+
+Expected: `VECTOR(768)`
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/harbor_clerk/models/chunk.py
+git commit -m "feat(models): bump chunk embedding to 768-dim for Granite-R2"
+```
+
+---
+
+## Task 5: Rebase alembic to single 0001_initial.py
+
+This task is the riskiest in the plan because it replaces 22 migration files with one. Take it slowly.
+
+**Files:**
+- Delete: `alembic/versions/0001_initial_schema.py` through `alembic/versions/0022_imap_command_log.py` (22 files)
+- Create: `alembic/versions/0001_initial.py`
+- Test: `tests/test_alembic_initial.py`
+
+- [ ] **Step 5.1: Snapshot the current head + existing-DB schema for reference**
+
+Run (against a Postgres with the current schema):
+```bash
+mkdir -p /tmp/embedding-v2-rebase-ref
+pg_dump --schema-only -h localhost -p 5433 -U lka harbor_clerk_test > /tmp/embedding-v2-rebase-ref/old-schema.sql
+uv run alembic current > /tmp/embedding-v2-rebase-ref/old-current.txt
+uv run alembic history --verbose > /tmp/embedding-v2-rebase-ref/old-history.txt
+```
+
+Expected: Three files written under `/tmp/embedding-v2-rebase-ref/`. These are reference artifacts for verifying the rebase preserved everything.
+
+- [ ] **Step 5.2: Drop the test DB so the rebased migration can be applied from scratch**
+
+Run:
+```bash
+psql -h localhost -p 5433 -U lka -d postgres -c "DROP DATABASE IF EXISTS harbor_clerk_test"
+psql -h localhost -p 5433 -U lka -d postgres -c "CREATE DATABASE harbor_clerk_test"
+psql -h localhost -p 5433 -U lka -d harbor_clerk_test -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS citext;"
+```
+
+Expected: Empty DB with the three extensions installed.
+
+- [ ] **Step 5.3: Delete the 22 existing migration files**
+
+Run:
+```bash
+ls alembic/versions/*.py | grep -v __init__ | xargs rm
+ls alembic/versions/
+```
+
+Expected: Only `__init__.py` and any non-migration helpers remain. Migration files gone.
+
+- [ ] **Step 5.4: Autogenerate the new initial migration**
+
+With the chunk model at Vector(768) (Task 4) and SchemaMetadata model created (Task 3):
+
+```bash
+DATABASE_URL=postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test uv run alembic revision --autogenerate -m "initial"
+```
+
+Expected: A new file under `alembic/versions/` whose name starts with a hash and ends `_initial.py`. The file's `upgrade()` body should `op.create_table` every table the codebase defines, including `chunks` with `embedding` as `vector(768)` and `schema_metadata` with `(key, value, set_at)`.
+
+- [ ] **Step 5.5: Rename the generated file**
+
+Find the autogen filename (e.g. `abc123def456_initial.py`) and rename to follow project convention:
+
+```bash
+mv alembic/versions/*_initial.py alembic/versions/0001_initial.py
+```
+
+Also edit the file's `revision = "..."` and `down_revision = None` lines so the revision id matches the filename's prefix:
+
+```python
+revision = "0001_initial"
+down_revision = None
+```
+
+- [ ] **Step 5.6: Add the sentinel-row INSERT and downgrade refusal**
+
+Edit `alembic/versions/0001_initial.py`. At the BOTTOM of the autogenerated `upgrade()` body (after every `op.create_table` and `op.create_index`), append:
+
+```python
+    # Sentinel rows — verified at boot by verify_schema_sentinel().
+    # Tells the binary which embedding model + dim this DB is compatible with.
+    op.execute(
+        """
+        INSERT INTO schema_metadata (key, value) VALUES
+            ('embed_model', 'granite-embedding-311m-multilingual-r2'),
+            ('embed_dim', '768'),
+            ('reranker', 'bge-reranker-v2-m3')
+        """
+    )
+```
+
+Replace the entire `downgrade()` body with:
+
+```python
+def downgrade() -> None:
+    raise NotImplementedError(
+        "embedding-v2 initial migration is not reversible; restore from backup."
+    )
+```
+
+- [ ] **Step 5.7: Write the smoke test**
+
+Create `tests/test_alembic_initial.py`:
+
+```python
+"""Smoke test: the rebased 0001_initial.py creates the expected schema."""
+
+import subprocess
+
+import pytest
+from sqlalchemy import text
+
+
+@pytest.mark.asyncio
+async def test_alembic_upgrade_head_succeeds_on_empty_db(db_session):
+    """db_session uses a freshly-truncated test DB. Verify the chunks table
+    has vector(768) and schema_metadata has the three sentinel rows."""
+    # Check chunks.embedding column type
+    result = await db_session.execute(
+        text(
+            "SELECT format_type(atttypid, atttypmod) "
+            "FROM pg_attribute "
+            "WHERE attrelid = 'chunks'::regclass AND attname = 'embedding'"
+        )
+    )
+    dim_type = result.scalar_one()
+    assert dim_type == "vector(768)"
+
+    # Check sentinel rows
+    result = await db_session.execute(
+        text("SELECT key, value FROM schema_metadata ORDER BY key")
+    )
+    rows = {key: value for key, value in result.all()}
+    assert rows == {
+        "embed_model": "granite-embedding-311m-multilingual-r2",
+        "embed_dim": "768",
+        "reranker": "bge-reranker-v2-m3",
+    }
+
+
+def test_alembic_history_has_single_revision():
+    """The rebase squashed 22 migrations into 1."""
+    result = subprocess.run(
+        ["uv", "run", "alembic", "history"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # alembic history output has one line per revision
+    revision_lines = [
+        line for line in result.stdout.splitlines() if line.startswith("<base>")
+    ]
+    assert len(revision_lines) == 1, f"expected 1 revision, got history:\n{result.stdout}"
+```
+
+- [ ] **Step 5.8: Apply the migration + run the test**
+
+Run:
+```bash
+DATABASE_URL=postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test uv run alembic upgrade head
+uv run pytest tests/test_alembic_initial.py -v
+```
+
+Expected: alembic upgrade succeeds (creates all tables); both tests PASS.
+
+- [ ] **Step 5.9: Compare against snapshot to verify no schema regression**
+
+Run:
+```bash
+pg_dump --schema-only -h localhost -p 5433 -U lka harbor_clerk_test > /tmp/embedding-v2-rebase-ref/new-schema.sql
+diff /tmp/embedding-v2-rebase-ref/old-schema.sql /tmp/embedding-v2-rebase-ref/new-schema.sql
+```
+
+Expected diff content:
+- `chunks.embedding` type changes from `vector(384)` to `vector(768)`
+- New `schema_metadata` table
+- New `schema_metadata.value` insert
+- `alembic_version.version_num` value differs
+- (No other column drops, no constraint losses, no index drops outside of `chunks_embedding_hnsw_idx`)
+
+If the diff shows anything else missing (e.g. a column you forgot to declare on a model), fix the model and regenerate the migration (Step 5.4-5.6).
+
+- [ ] **Step 5.10: Commit**
+
+```bash
+git add alembic/versions/ tests/test_alembic_initial.py
+git commit -m "feat(alembic): rebase chain to single 0001_initial.py with embedding-v2 schema"
+```
+
+---
+
+## Task 6: Register `requires_models` pytest marker + pytest-httpx dep
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 6.1: Add the marker + dep**
+
+Edit `pyproject.toml`. Find `[tool.pytest.ini_options]` `markers = [...]` block (around line 63 per earlier inspection) and update:
+
+```toml
+markers = [
+    "integration: end-to-end tests requiring external services (Dovecot, etc.). Run with `uv run pytest -m integration`.",
+    "requires_models: tests that load embedding/reranker model weights (~2 GB). Run with `uv run pytest -m requires_models`. Skipped in default CI.",
+]
+```
+
+Find the test deps section (`[project.optional-dependencies] test = [...]`) and add:
+
+```toml
+test = [
+    # ... existing entries unchanged ...
+    "pytest-httpx>=0.32",
+]
+```
+
+- [ ] **Step 6.2: Sync deps**
+
+Run:
+```bash
+uv sync --all-extras
+```
+
+Expected: `pytest-httpx` installed.
+
+- [ ] **Step 6.3: Verify the marker is registered**
+
+Run:
+```bash
+uv run pytest --markers | grep requires_models
+```
+
+Expected: `@pytest.mark.requires_models: tests that load embedding/reranker model weights ...`
+
+- [ ] **Step 6.4: Configure default CI to skip requires_models**
+
+Look in `.github/workflows/ci.yml` for the `pytest` invocation. Modify it to add `-m "not requires_models"`:
+
+```yaml
+      - run: uv run pytest tests/ -v -m "not requires_models"
+```
+
+(If the existing command has other markers like `-m "not integration"`, change to `-m "not requires_models and not integration"`.)
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add pyproject.toml .github/workflows/ci.yml uv.lock
+git commit -m "chore(test): register requires_models marker + add pytest-httpx dev dep"
+```
+
+---
+
+## Task 7: db_health.verify_schema_sentinel
+
+**Files:**
+- Create: `src/harbor_clerk/db_health.py`
+- Create: `tests/test_db_health.py`
+
+- [ ] **Step 7.1: Write the failing tests**
+
+Create `tests/test_db_health.py`:
+
+```python
+"""Tests for verify_schema_sentinel — panics out on binary↔DB mismatch."""
+
+import pytest
+from sqlalchemy import text
+
+from harbor_clerk.db_health import SchemaSentinelMismatch, verify_schema_sentinel
+
+
+@pytest.mark.asyncio
+async def test_verify_sentinel_passes_on_match(db_session, monkeypatch):
+    """Sentinel rows match the settings — no exception."""
+    monkeypatch.setattr(
+        "harbor_clerk.config.get_settings",
+        lambda: type(
+            "S",
+            (),
+            {
+                "embed_model": "granite-embedding-311m-multilingual-r2",
+                "embed_dim": 768,
+            },
+        )(),
+    )
+    # db_session fixture loads the rebased migration which populates sentinel rows.
+    # No exception should be raised.
+    await verify_schema_sentinel(db_session)
+
+
+@pytest.mark.asyncio
+async def test_verify_sentinel_raises_on_model_mismatch(db_session, monkeypatch):
+    """Sentinel says granite, settings say e5-small — must raise."""
+    monkeypatch.setattr(
+        "harbor_clerk.config.get_settings",
+        lambda: type(
+            "S",
+            (),
+            {"embed_model": "intfloat/multilingual-e5-small", "embed_dim": 384},
+        )(),
+    )
+    with pytest.raises(SchemaSentinelMismatch) as exc_info:
+        await verify_schema_sentinel(db_session)
+    msg = str(exc_info.value)
+    assert "embed_model" in msg
+    assert "granite-embedding-311m-multilingual-r2" in msg
+    assert "multilingual-e5-small" in msg
+
+
+@pytest.mark.asyncio
+async def test_verify_sentinel_raises_on_missing_table(db_session, monkeypatch):
+    """schema_metadata table doesn't exist — must raise distinctly."""
+    await db_session.execute(text("DROP TABLE schema_metadata"))
+    await db_session.commit()
+    monkeypatch.setattr(
+        "harbor_clerk.config.get_settings",
+        lambda: type(
+            "S",
+            (),
+            {
+                "embed_model": "granite-embedding-311m-multilingual-r2",
+                "embed_dim": 768,
+            },
+        )(),
+    )
+    with pytest.raises(SchemaSentinelMismatch) as exc_info:
+        await verify_schema_sentinel(db_session)
+    assert "schema_metadata" in str(exc_info.value)
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/test_db_health.py -v
+```
+
+Expected: FAIL (import errors — module doesn't exist).
+
+- [ ] **Step 7.3: Implement db_health.py**
+
+Create `src/harbor_clerk/db_health.py`:
+
+```python
+"""Schema sentinel verification — refuse to run when DB and binary disagree."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class SchemaSentinelMismatch(RuntimeError):
+    """Raised when schema_metadata sentinel rows don't match the binary's settings."""
+
+
+async def verify_schema_sentinel(session: AsyncSession) -> None:
+    """Compare schema_metadata sentinel rows to current settings.
+
+    Raises ``SchemaSentinelMismatch`` if any of:
+    - the ``schema_metadata`` table doesn't exist
+    - the ``embed_model`` row is missing or differs from ``settings.embed_model``
+    - the ``embed_dim`` row is missing or differs from ``settings.embed_dim``
+
+    Caller decides whether to ``sys.exit(2)``; see ``panic_on_sentinel_mismatch``.
+    """
+    settings = get_settings()
+    try:
+        result = await session.execute(
+            text("SELECT key, value FROM schema_metadata WHERE key IN ('embed_model', 'embed_dim')")
+        )
+    except ProgrammingError as exc:
+        raise SchemaSentinelMismatch(
+            "schema_metadata table is missing. "
+            "This DB has not been migrated to embedding-v2. "
+            "Either drop the database and re-launch (Path A) "
+            "or run scripts/migrate_to_embedding_v2.py (Path B). "
+            "See docs/upgrade-runbook.md#embedding-v2."
+        ) from exc
+
+    rows = {key: value for key, value in result.all()}
+    mismatches: list[str] = []
+    found_model = rows.get("embed_model", "<missing>")
+    if found_model != settings.embed_model:
+        mismatches.append(f"  embed_model: expected={settings.embed_model!r}, found={found_model!r}")
+    found_dim = rows.get("embed_dim", "<missing>")
+    if found_dim != str(settings.embed_dim):
+        mismatches.append(f"  embed_dim:   expected={settings.embed_dim!r}, found={found_dim!r}")
+
+    if mismatches:
+        raise SchemaSentinelMismatch(
+            "Schema sentinel mismatch — refusing to start.\n"
+            + "\n".join(mismatches)
+            + "\nThis binary requires the embedding-v2 schema. Either:\n"
+            "  1. Drop and recreate the database (fresh schema, then re-ingest via watched folders), OR\n"
+            "  2. Run scripts/migrate_to_embedding_v2.py against this DB.\n"
+            "See docs/upgrade-runbook.md#embedding-v2 for details."
+        )
+
+
+async def panic_on_sentinel_mismatch(session: AsyncSession) -> None:
+    """Call verify_schema_sentinel; on failure log CRITICAL and sys.exit(2)."""
+    try:
+        await verify_schema_sentinel(session)
+    except SchemaSentinelMismatch as exc:
+        logger.critical("%s", exc)
+        sys.exit(2)
+```
+
+- [ ] **Step 7.4: Run tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_db_health.py -v
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/harbor_clerk/db_health.py tests/test_db_health.py
+git commit -m "feat(db): verify_schema_sentinel + panic_on_sentinel_mismatch helpers"
+```
+
+---
+
+## Task 8: Wire sentinel check into API lifespan
+
+**Files:**
+- Modify: `src/harbor_clerk/api/app.py`
+- Test: `tests/test_api_startup_sentinel.py`
+
+- [ ] **Step 8.1: Write the failing test**
+
+Create `tests/test_api_startup_sentinel.py`:
+
+```python
+"""Verify the API lifespan calls panic_on_sentinel_mismatch."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_sentinel_check():
+    """Boot path must include panic_on_sentinel_mismatch before serving."""
+    from harbor_clerk.api.app import app
+
+    with patch("harbor_clerk.api.app.panic_on_sentinel_mismatch", new=AsyncMock()) as mock_panic:
+        async with app.router.lifespan_context(app):
+            pass
+        mock_panic.assert_awaited()
+```
+
+- [ ] **Step 8.2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/test_api_startup_sentinel.py -v
+```
+
+Expected: FAIL — `panic_on_sentinel_mismatch` isn't imported in `app.py`.
+
+- [ ] **Step 8.3: Wire the call into the lifespan**
+
+Edit `src/harbor_clerk/api/app.py`. Find the existing lifespan function (around lines 260-290 per earlier inspection — the block that calls `_get_expected_schema_version` and queries `alembic_version`). Right after that alembic check, add:
+
+```python
+    from harbor_clerk.db_health import panic_on_sentinel_mismatch
+
+    async with async_session_factory() as db:
+        await panic_on_sentinel_mismatch(db)
+```
+
+Also add to the top-of-file imports if not already present:
+
+```python
+from harbor_clerk.db_health import panic_on_sentinel_mismatch
+```
+
+(If the function is already wired via top-level import, you can drop the local re-import.)
+
+- [ ] **Step 8.4: Run test to verify it passes**
+
+Run:
+```bash
+uv run pytest tests/test_api_startup_sentinel.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8.5: Smoke-test that the API starts cleanly against the migrated test DB**
+
+Run:
+```bash
+DATABASE_URL=postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test \
+  uv run harbor-clerk-api &
+API_PID=$!
+sleep 3
+curl -sf http://127.0.0.1:8000/api/system/health
+kill $API_PID
+```
+
+Expected: Health endpoint returns 200. No "schema sentinel mismatch" in the logs.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add src/harbor_clerk/api/app.py tests/test_api_startup_sentinel.py
+git commit -m "feat(api): panic_on_sentinel_mismatch at lifespan startup"
+```
+
+---
+
+## Task 9: Wire sentinel check into worker entry
+
+**Files:**
+- Modify: `src/harbor_clerk/worker/entry.py`
+- Test: `tests/test_worker_startup_sentinel.py`
+
+- [ ] **Step 9.1: Write the failing test**
+
+Create `tests/test_worker_startup_sentinel.py`:
+
+```python
+"""Verify the worker entry calls panic_on_sentinel_mismatch before pulling jobs."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_worker_main_calls_sentinel_check():
+    """The worker boot path must invoke panic_on_sentinel_mismatch before
+    starting the polling loop."""
+    from harbor_clerk.worker import entry
+
+    with patch.object(entry, "panic_on_sentinel_mismatch", new=AsyncMock()) as mock_panic, \
+         patch.object(entry, "_run_worker_loop", new=AsyncMock(side_effect=KeyboardInterrupt)):
+        with pytest.raises(KeyboardInterrupt):
+            await entry.async_main(["--queues", "io"])
+        mock_panic.assert_awaited()
+```
+
+(If `entry.py` doesn't currently have an `async_main` or `_run_worker_loop`, the test name and the expected entry points need to follow whatever's there. Read `src/harbor_clerk/worker/entry.py` first to confirm the loop structure.)
+
+- [ ] **Step 9.2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/test_worker_startup_sentinel.py -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 9.3: Wire the sentinel call**
+
+Edit `src/harbor_clerk/worker/entry.py`. Add to top-of-file imports:
+
+```python
+from harbor_clerk.db_health import panic_on_sentinel_mismatch
+from harbor_clerk.db import async_session_factory
+```
+
+In `main()` (or wherever the worker first opens a DB connection, around line 271 per earlier inspection): immediately after creating the session factory and BEFORE entering the polling loop:
+
+```python
+    async with async_session_factory() as db:
+        await panic_on_sentinel_mismatch(db)
+```
+
+If `main()` is sync, wrap the call:
+
+```python
+    import asyncio
+    async def _check_sentinel():
+        async with async_session_factory() as db:
+            await panic_on_sentinel_mismatch(db)
+    asyncio.run(_check_sentinel())
+```
+
+- [ ] **Step 9.4: Run test to verify it passes**
+
+Run:
+```bash
+uv run pytest tests/test_worker_startup_sentinel.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9.5: Smoke-test worker startup**
+
+Run:
+```bash
+DATABASE_URL=postgresql+asyncpg://lka@localhost:5433/harbor_clerk_test \
+  timeout 5 uv run harbor-clerk-worker --queues io || true
+```
+
+Expected: Worker boots, logs "Schema sentinel verified" (or no panic), times out cleanly after 5s.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add src/harbor_clerk/worker/entry.py tests/test_worker_startup_sentinel.py
+git commit -m "feat(worker): panic_on_sentinel_mismatch at boot"
+```
+
+---
+
+## Task 10: Embedder app — model swap + ignore task param
+
+**Files:**
+- Modify: `embedder/src/embedder/app.py`
+- Create: `embedder/tests/test_embedder_app.py` (new tests dir; create alongside)
+
+- [ ] **Step 10.1: Create the embedder tests dir + write the failing test**
+
+Run:
+```bash
+mkdir -p embedder/tests
+touch embedder/tests/__init__.py
+```
+
+Create `embedder/tests/test_embedder_app.py`:
+
+```python
+"""Tests for the embedder FastAPI app.
+
+These tests use a stub model loader to avoid downloading Granite-R2 weights.
+Real-model tests live in tests/test_embedder_granite.py behind the
+``requires_models`` marker.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def stub_model():
+    """Stub SentenceTransformer that returns deterministic 768-dim vectors."""
+    model = MagicMock()
+    model.get_sentence_embedding_dimension.return_value = 768
+
+    def encode(texts, normalize_embeddings=True):
+        # Return a deterministic 768-dim vector per text
+        return np.stack([np.full(768, 0.1, dtype=np.float32) for _ in texts])
+
+    model.encode.side_effect = encode
+    return model
+
+
+@pytest.fixture
+def client(stub_model):
+    with patch("embedder.app.SentenceTransformer", return_value=stub_model):
+        from embedder.app import app
+
+        with TestClient(app) as c:
+            yield c
+
+
+def test_embed_returns_768_dim(client):
+    r = client.post("/embed", json={"texts": ["hello world"]})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["dimensions"] == 768
+    assert len(body["embeddings"][0]) == 768
+
+
+def test_embed_ignores_task_param(client, stub_model):
+    """task=query must NOT add 'query: ' prefix when embed_needs_prefix is False (Granite default)."""
+    client.post("/embed", json={"texts": ["hello"], "task": "query"})
+    encoded_texts = stub_model.encode.call_args[0][0]
+    assert encoded_texts == ["hello"], f"task param should not modify texts; got {encoded_texts}"
+
+
+def test_embed_task_query_still_accepted(client):
+    """Backward compat: workers send task=passage; must not 422."""
+    r = client.post("/embed", json={"texts": ["hello"], "task": "passage"})
+    assert r.status_code == 200
+```
+
+- [ ] **Step 10.2: Run test to verify it fails**
+
+Run:
+```bash
+uv --project embedder run --extra test pytest embedder/tests/test_embedder_app.py -v
+```
+
+(If `embedder/pyproject.toml` doesn't have a `test` extras section, add `[project.optional-dependencies] test = ["pytest>=9", "fastapi>=0.115", "numpy>=1.26"]` first.)
+
+Expected: FAIL — task param is still being prepended (current code applies prefix unconditionally).
+
+- [ ] **Step 10.3: Update the embedder app**
+
+Edit `embedder/src/embedder/app.py`. Replace the module-level `TASK_PREFIXES` block and the `embed` endpoint body:
+
+```python
+MODEL_NAME = os.environ.get("EMBED_MODEL", "ibm-granite/granite-embedding-311m-multilingual-r2")
+
+# Whether the model needs e5-style "query: " / "passage: " prefixes.
+# Granite-R2 uses CLS pooling and needs NO prefix. e5 family needs it.
+# Configured via env var so the e5 rollback path keeps working.
+NEEDS_PREFIX = os.environ.get("EMBED_NEEDS_PREFIX", "false").lower() in ("true", "1", "yes")
+TASK_PREFIXES = {"query": "query: ", "passage": "passage: "}
+```
+
+And in the `embed` endpoint, replace the prefix application:
+
+```python
+@app.post("/embed", response_model=EmbedResponse)
+async def embed(request: EmbedRequest):
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    texts = request.texts
+    if NEEDS_PREFIX and request.task:
+        prefix = TASK_PREFIXES[request.task]
+        texts = [prefix + t for t in texts]
+    embeddings = _model.encode(texts, normalize_embeddings=True)
+    return EmbedResponse(
+        embeddings=embeddings.tolist(),
+        model=MODEL_NAME,
+        dimensions=embeddings.shape[1],
+    )
+```
+
+- [ ] **Step 10.4: Run tests to verify they pass**
+
+Run:
+```bash
+uv --project embedder run --extra test pytest embedder/tests/test_embedder_app.py -v
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add embedder/src/embedder/app.py embedder/tests/ embedder/pyproject.toml
+git commit -m "feat(embedder): default to Granite-R2, ignore task param when EMBED_NEEDS_PREFIX=false"
+```
+
+---
+
+## Task 11: Reranker FastAPI service
+
+**Files:**
+- Create: `embedder/src/embedder/reranker.py`
+- Modify: `embedder/pyproject.toml`
+- Create: `embedder/tests/test_reranker_service.py`
+
+- [ ] **Step 11.1: Write the failing tests**
+
+Create `embedder/tests/test_reranker_service.py`:
+
+```python
+"""Tests for the reranker FastAPI app, using a stub CrossEncoder."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def stub_cross_encoder():
+    """Stub CrossEncoder that returns predictable scores: higher index → higher score."""
+    ce = MagicMock()
+
+    def predict(pairs):
+        # pairs is [[query, passage], ...]; score = passage index / total
+        # We inject the index via a control character so the stub knows the order
+        return [float(i) / max(1, len(pairs) - 1) for i in range(len(pairs))]
+
+    ce.predict.side_effect = predict
+    return ce
+
+
+@pytest.fixture
+def client(stub_cross_encoder):
+    with patch("embedder.reranker.CrossEncoder", return_value=stub_cross_encoder):
+        from embedder.reranker import app
+
+        with TestClient(app) as c:
+            yield c
+
+
+def test_rerank_returns_top_k_sorted_desc(client):
+    r = client.post(
+        "/rerank",
+        json={
+            "query": "what is the termination clause",
+            "passages": ["passage 0", "passage 1", "passage 2", "passage 3"],
+            "top_k": 2,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == "BAAI/bge-reranker-v2-m3"
+    assert len(body["scores"]) == 2
+    # Scores must be sorted desc
+    assert body["scores"][0]["score"] >= body["scores"][1]["score"]
+    # With our stub (score = i/3), top should be index 3
+    assert body["scores"][0]["index"] == 3
+    assert body["scores"][1]["index"] == 2
+
+
+def test_rerank_empty_passages_returns_empty(client):
+    r = client.post("/rerank", json={"query": "anything", "passages": [], "top_k": 10})
+    assert r.status_code == 200
+    assert r.json()["scores"] == []
+
+
+def test_rerank_top_k_greater_than_len(client):
+    r = client.post(
+        "/rerank",
+        json={"query": "x", "passages": ["a", "b"], "top_k": 100},
+    )
+    assert r.status_code == 200
+    assert len(r.json()["scores"]) == 2
+
+
+def test_health_endpoint(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+```
+
+- [ ] **Step 11.2: Run test to verify it fails**
+
+Run:
+```bash
+uv --project embedder run --extra test pytest embedder/tests/test_reranker_service.py -v
+```
+
+Expected: FAIL — `embedder.reranker` doesn't exist.
+
+- [ ] **Step 11.3: Implement the reranker app**
+
+Create `embedder/src/embedder/reranker.py`:
+
+```python
+"""Reranker service — bge-reranker-v2-m3 CrossEncoder over HTTP.
+
+Companion to the embedder. Loaded with BAAI/bge-reranker-v2-m3 at startup;
+exposes ``POST /rerank`` accepting ``{query, passages, top_k}`` and returning
+``{scores: [{index, score}], model}`` sorted descending by score.
+"""
+
+import logging
+import os
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from sentence_transformers import CrossEncoder
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = os.environ.get("RERANKER_MODEL", "BAAI/bge-reranker-v2-m3")
+
+_model: CrossEncoder | None = None
+
+
+class RerankRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+    passages: list[str] = Field(..., max_length=256)
+    top_k: int = Field(..., ge=1, le=256)
+
+
+class ScoreEntry(BaseModel):
+    index: int
+    score: float
+
+
+class RerankResponse(BaseModel):
+    scores: list[ScoreEntry]
+    model: str
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _model
+    logger.info("Loading reranker model: %s", MODEL_NAME)
+    _model = CrossEncoder(MODEL_NAME)
+    logger.info("Reranker model loaded")
+    yield
+    _model = None
+
+
+app = FastAPI(title="Harbor Clerk Reranker", version="0.1.0", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health():
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+    return {"status": "ok", "model": MODEL_NAME}
+
+
+@app.post("/rerank", response_model=RerankResponse)
+async def rerank(req: RerankRequest):
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    if not req.passages:
+        return RerankResponse(scores=[], model=MODEL_NAME)
+
+    pairs = [[req.query, p] for p in req.passages]
+    raw_scores = _model.predict(pairs)
+    indexed = sorted(
+        ((i, float(s)) for i, s in enumerate(raw_scores)),
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    top = indexed[: req.top_k]
+    return RerankResponse(
+        scores=[ScoreEntry(index=i, score=s) for i, s in top],
+        model=MODEL_NAME,
+    )
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    config_file = os.environ.get("NATIVE_CONFIG_FILE", "")
+    if config_file:
+        from logging.handlers import RotatingFileHandler
+        from pathlib import Path
+
+        logs_dir = Path(config_file).parent / "logs"
+        try:
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            fh = RotatingFileHandler(logs_dir / "reranker.log", maxBytes=5 * 1024 * 1024, backupCount=3)
+            fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+            logging.getLogger().addHandler(fh)
+        except OSError:
+            pass
+
+    uvicorn.run(
+        "embedder.reranker:app",
+        host=os.environ.get("HOST", "127.0.0.1"),
+        port=int(os.environ.get("PORT", "8001")),
+        reload=False,
+        workers=1,
+    )
+```
+
+- [ ] **Step 11.4: Register the entry point**
+
+Edit `embedder/pyproject.toml`. Find the `[project.scripts]` block and add:
+
+```toml
+[project.scripts]
+harbor-clerk-embedder = "embedder.app:main"
+harbor-clerk-reranker = "embedder.reranker:main"
+```
+
+- [ ] **Step 11.5: Run tests to verify they pass**
+
+Run:
+```bash
+uv --project embedder sync
+uv --project embedder run --extra test pytest embedder/tests/test_reranker_service.py -v
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add embedder/src/embedder/reranker.py embedder/pyproject.toml embedder/tests/test_reranker_service.py
+git commit -m "feat(reranker): add bge-reranker-v2-m3 FastAPI service"
+```
+
+---
+
+## Task 12: Search API schema additions
+
+**Files:**
+- Modify: `src/harbor_clerk/api/schemas/search.py`
+- Test: `tests/test_search_schemas.py`
+
+- [ ] **Step 12.1: Write the failing test**
+
+Create `tests/test_search_schemas.py`:
+
+```python
+"""Tests for ScoreBreakdown + reranker_status additions to search schemas."""
+
+from harbor_clerk.api.schemas.search import (
+    ScoreBreakdown,
+    SearchHitOut,
+    SearchResponse,
+)
+
+
+def test_score_breakdown_serializes_with_optional_reranker():
+    sb = ScoreBreakdown(fts=0.3, vector=0.5, hybrid=0.4, reranker=0.9)
+    assert sb.model_dump() == {"fts": 0.3, "vector": 0.5, "hybrid": 0.4, "reranker": 0.9}
+
+    sb_no_rerank = ScoreBreakdown(fts=0.3, vector=0.5, hybrid=0.4, reranker=None)
+    assert sb_no_rerank.model_dump()["reranker"] is None
+
+
+def test_search_hit_out_score_breakdown_is_optional():
+    """Existing clients that don't know about score_breakdown still work."""
+    hit = SearchHitOut(
+        chunk_id="00000000-0000-0000-0000-000000000001",
+        doc_id="00000000-0000-0000-0000-000000000001",
+        chunk_num=0,
+        chunk_text="hello",
+        page_start=1,
+        page_end=1,
+        language="en",
+        ocr_used=False,
+        ocr_confidence=None,
+        score=0.5,
+        doc_title="A doc",
+        score_breakdown=None,
+    )
+    assert hit.score_breakdown is None
+
+
+def test_search_response_has_reranker_status():
+    resp = SearchResponse(
+        hits=[],
+        total_candidates=0,
+        has_more=False,
+        possible_conflict=False,
+        conflict_sources=[],
+        reranker_status="disabled",
+    )
+    assert resp.reranker_status == "disabled"
+```
+
+- [ ] **Step 12.2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/test_search_schemas.py -v
+```
+
+Expected: FAIL — fields not defined.
+
+- [ ] **Step 12.3: Add the fields**
+
+Edit `src/harbor_clerk/api/schemas/search.py`. Add at the top of the file (after the existing imports):
+
+```python
+from typing import Literal
+```
+
+Add a new model before `SearchHitOut`:
+
+```python
+class ScoreBreakdown(BaseModel):
+    fts: float
+    vector: float
+    hybrid: float
+    reranker: float | None = None
+```
+
+Add `score_breakdown: ScoreBreakdown | None = None` as the last field of `SearchHitOut`.
+
+Add `reranker_status: Literal["ok", "disabled", "failed"] = "disabled"` as a new field on `SearchResponse`.
+
+- [ ] **Step 12.4: Run tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_search_schemas.py -v
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add src/harbor_clerk/api/schemas/search.py tests/test_search_schemas.py
+git commit -m "feat(api): add ScoreBreakdown + reranker_status to search schemas"
+```
+
+---
+
+## Task 13: search_rerank.rerank_hits
+
+**Files:**
+- Create: `src/harbor_clerk/search_rerank.py`
+- Create: `tests/test_search_rerank.py`
+
+- [ ] **Step 13.1: Write the failing tests**
+
+Create `tests/test_search_rerank.py`:
+
+```python
+"""Tests for rerank_hits — calls reranker service, falls back on failure."""
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from harbor_clerk.search import SearchHit
+from harbor_clerk.search_rerank import rerank_hits
+
+
+def _hit(doc_id: str, doc_title: str, chunk_text: str, score: float) -> SearchHit:
+    return SearchHit(
+        chunk_id=f"chunk-{doc_id}",
+        doc_id=doc_id,
+        chunk_num=0,
+        chunk_text=chunk_text,
+        page_start=1,
+        page_end=1,
+        language="en",
+        ocr_used=False,
+        ocr_confidence=None,
+        score=score,
+        doc_title=doc_title,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rerank_hits_reorders_by_reranker_score(httpx_mock: HTTPXMock):
+    hits = [
+        _hit("doc-a", "A", "first chunk", 0.5),
+        _hit("doc-b", "B", "second chunk", 0.9),
+        _hit("doc-c", "C", "third chunk", 0.3),
+    ]
+    # Reranker reverses the order: index 2 best, then 0, then 1
+    httpx_mock.add_response(
+        url="http://reranker:8001/rerank",
+        json={
+            "scores": [
+                {"index": 2, "score": 0.95},
+                {"index": 0, "score": 0.50},
+                {"index": 1, "score": 0.10},
+            ],
+            "model": "BAAI/bge-reranker-v2-m3",
+        },
+    )
+    reranked = await rerank_hits("query", hits, top_k=2)
+    assert [h.doc_id for h in reranked] == ["doc-c", "doc-a"]
+    assert reranked[0].score == pytest.approx(0.95)
+
+
+@pytest.mark.asyncio
+async def test_rerank_hits_fallback_on_http_error(httpx_mock: HTTPXMock):
+    """Reranker 500 → log warning, return hits[:top_k] unchanged."""
+    hits = [
+        _hit("doc-a", "A", "x", 0.5),
+        _hit("doc-b", "B", "y", 0.3),
+    ]
+    httpx_mock.add_response(url="http://reranker:8001/rerank", status_code=500)
+    result, status = await rerank_hits("q", hits, top_k=2, return_status=True)
+    assert [h.doc_id for h in result] == ["doc-a", "doc-b"]
+    assert status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_rerank_hits_strict_mode_raises_on_failure(httpx_mock: HTTPXMock, monkeypatch):
+    """When settings.reranker_strict=True, HTTP failure raises."""
+    from harbor_clerk import search_rerank
+
+    monkeypatch.setattr(
+        search_rerank,
+        "_settings",
+        lambda: type("S", (), {
+            "reranker_url": "http://reranker:8001",
+            "reranker_strict": True,
+            "reranker_timeout_seconds": 30.0,
+            "reranker_pool_size": 50,
+        })(),
+    )
+    httpx_mock.add_response(url="http://reranker:8001/rerank", status_code=500)
+    with pytest.raises(Exception):
+        await rerank_hits("q", [_hit("a", "A", "x", 0.5)], top_k=1)
+
+
+@pytest.mark.asyncio
+async def test_rerank_hits_empty_input_returns_empty(httpx_mock: HTTPXMock):
+    """No hits in → no hits out, no HTTP call."""
+    result = await rerank_hits("q", [], top_k=10)
+    assert result == []
+    # httpx_mock would fail at teardown if an unconsumed mock was set;
+    # we set none, so the test asserts that no call was made by virtue of clean teardown.
+
+
+@pytest.mark.asyncio
+async def test_rerank_hits_caps_at_pool_size(httpx_mock: HTTPXMock, monkeypatch):
+    """If len(hits) > pool_size, only the first pool_size are sent."""
+    from harbor_clerk import search_rerank
+
+    monkeypatch.setattr(
+        search_rerank,
+        "_settings",
+        lambda: type("S", (), {
+            "reranker_url": "http://reranker:8001",
+            "reranker_strict": False,
+            "reranker_timeout_seconds": 30.0,
+            "reranker_pool_size": 3,
+        })(),
+    )
+    hits = [_hit(f"d{i}", f"D{i}", f"x{i}", 0.5) for i in range(10)]
+    httpx_mock.add_response(
+        url="http://reranker:8001/rerank",
+        json={
+            "scores": [{"index": 0, "score": 0.9}, {"index": 1, "score": 0.8}, {"index": 2, "score": 0.7}],
+            "model": "BAAI/bge-reranker-v2-m3",
+        },
+    )
+    result = await rerank_hits("q", hits, top_k=3)
+    # The request only included the first 3 hits (pool_size cap)
+    req = httpx_mock.get_request()
+    assert len(req.json()["passages"]) == 3
+    assert len(result) == 3
+```
+
+- [ ] **Step 13.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/test_search_rerank.py -v
+```
+
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 13.3: Implement search_rerank.py**
+
+Create `src/harbor_clerk/search_rerank.py`:
+
+```python
+"""Reranker integration — POST passages to /rerank, return reordered hits."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import httpx
+
+from harbor_clerk.config import get_settings as _settings
+from harbor_clerk.search import SearchHit
+
+logger = logging.getLogger(__name__)
+
+
+def _format_passage(hit: SearchHit) -> str:
+    """Reranker input: include doc title for cross-encoder context."""
+    return f"Title: {hit.doc_title}\n\nChunk: {hit.chunk_text}"
+
+
+async def rerank_hits(
+    query: str,
+    hits: list[SearchHit],
+    top_k: int,
+    *,
+    return_status: bool = False,
+) -> list[SearchHit] | tuple[list[SearchHit], Literal["ok", "disabled", "failed"]]:
+    """Call the reranker service; reorder ``hits`` by reranker score; return top_k.
+
+    On HTTP failure:
+      - if ``settings.reranker_strict`` is True, propagate the exception
+      - otherwise log a warning and return ``hits[:top_k]`` in the original order
+
+    ``hits`` are silently truncated to ``settings.reranker_pool_size`` before
+    being sent (caps reranker latency at predictable bounds).
+
+    When ``return_status=True``, returns ``(hits, status)`` where status is
+    one of "ok" / "failed" so the caller can populate ``SearchResponse.reranker_status``.
+    """
+    settings = _settings()
+    if not hits:
+        return ([], "disabled") if return_status else []
+
+    pool = hits[: settings.reranker_pool_size]
+    passages = [_format_passage(h) for h in pool]
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.reranker_timeout_seconds) as client:
+            r = await client.post(
+                f"{settings.reranker_url}/rerank",
+                json={"query": query, "passages": passages, "top_k": top_k},
+            )
+            r.raise_for_status()
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        if settings.reranker_strict:
+            raise
+        logger.warning("reranker call failed; falling back to hybrid-only top-K: %r", exc)
+        fallback = hits[:top_k]
+        return (fallback, "failed") if return_status else fallback
+
+    body = r.json()
+    reordered: list[SearchHit] = []
+    for entry in body["scores"]:
+        idx = entry["index"]
+        score = entry["score"]
+        h = pool[idx]
+        # Replace score with reranker score; keep all other fields.
+        reordered.append(h.model_copy(update={"score": score}) if hasattr(h, "model_copy") else _copy_with_score(h, score))
+
+    return (reordered, "ok") if return_status else reordered
+
+
+def _copy_with_score(hit: SearchHit, score: float) -> SearchHit:
+    """Dataclass-friendly copy with new score. Replaces model_copy for
+    non-Pydantic ``SearchHit`` definitions."""
+    import dataclasses
+
+    if dataclasses.is_dataclass(hit):
+        return dataclasses.replace(hit, score=score)
+    # Fallback: mutate a shallow copy
+    import copy
+
+    new = copy.copy(hit)
+    new.score = score
+    return new
+```
+
+- [ ] **Step 13.4: Run tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_search_rerank.py -v
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add src/harbor_clerk/search_rerank.py tests/test_search_rerank.py
+git commit -m "feat(search): rerank_hits helper with fallback + pool_size cap"
+```
+
+---
+
+## Task 14: Integrate reranker into hybrid_search
+
+**Files:**
+- Modify: `src/harbor_clerk/search.py`
+- Modify: `src/harbor_clerk/api/routes/search.py`
+- Test: `tests/test_hybrid_search_with_rerank.py`
+
+- [ ] **Step 14.1: Write the failing test**
+
+Create `tests/test_hybrid_search_with_rerank.py`:
+
+```python
+"""End-to-end test: hybrid_search calls rerank_hits when settings.reranker_enabled."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from harbor_clerk.search import hybrid_search
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_calls_reranker_when_enabled(db_session, monkeypatch):
+    """When reranker_enabled, hybrid_search invokes rerank_hits and uses its order."""
+    monkeypatch.setattr(
+        "harbor_clerk.config.get_settings",
+        lambda: type("S", (), {
+            "reranker_enabled": True,
+            "reranker_url": "http://x:1",
+            "reranker_strict": False,
+            "reranker_timeout_seconds": 30.0,
+            "reranker_pool_size": 50,
+            "reranker_top_k_pad": 40,
+        })(),
+    )
+    # Stub rerank_hits to verify it's called and its result is used.
+    with patch("harbor_clerk.search.rerank_hits", new=AsyncMock(return_value=([], "ok"))) as mock:
+        await hybrid_search(db_session, query="anything", k=10)
+        mock.assert_awaited_once()
+        kwargs = mock.await_args.kwargs
+        assert kwargs.get("top_k") == 10
+        assert kwargs.get("return_status") is True
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_skips_reranker_when_disabled(db_session, monkeypatch):
+    monkeypatch.setattr(
+        "harbor_clerk.config.get_settings",
+        lambda: type("S", (), {
+            "reranker_enabled": False,
+            "reranker_top_k_pad": 40,
+            "reranker_pool_size": 50,
+        })(),
+    )
+    with patch("harbor_clerk.search.rerank_hits", new=AsyncMock()) as mock:
+        await hybrid_search(db_session, query="anything", k=10)
+        mock.assert_not_called()
+```
+
+- [ ] **Step 14.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/test_hybrid_search_with_rerank.py -v
+```
+
+Expected: FAIL — rerank not wired.
+
+- [ ] **Step 14.3: Wire rerank_hits into hybrid_search**
+
+Edit `src/harbor_clerk/search.py`. Add to the imports near the top:
+
+```python
+from harbor_clerk.search_rerank import rerank_hits
+```
+
+Find the existing `hybrid_search()` function. After the FTS+vector merge produces the candidate pool (the variable name will be something like `merged` or `hits`), but before truncating to top-K, add:
+
+```python
+    settings = get_settings()
+    reranker_status: Literal["ok", "disabled", "failed"] = "disabled"
+    if settings.reranker_enabled and merged:
+        pool_size = min(k + settings.reranker_top_k_pad, settings.reranker_pool_size)
+        pool = merged[:pool_size]
+        reranked, reranker_status = await rerank_hits(
+            query, pool, top_k=k, return_status=True
+        )
+        if reranker_status == "ok":
+            merged = reranked
+        # else: keep original `merged`, just log the fallback (rerank_hits did)
+```
+
+(The exact variable name `merged` may differ — adapt to whatever the function calls its post-merge list. The signature change: the function may also need to return `reranker_status` so the route handler can put it in the response — extend the return dataclass.)
+
+Also update `src/harbor_clerk/search.py`'s `SearchResult` dataclass (defined at line ~39) to include the field:
+
+```python
+    reranker_status: str = "disabled"
+```
+
+And set it in `hybrid_search`'s return value (use the local `reranker_status` variable from the snippet above).
+
+- [ ] **Step 14.4: Wire the field through the route**
+
+Edit `src/harbor_clerk/api/routes/search.py`. In the `search()` handler, where `SearchResponse(...)` is constructed, add:
+
+```python
+        reranker_status=result.reranker_status,
+```
+
+- [ ] **Step 14.5: Run tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_hybrid_search_with_rerank.py tests/test_search_schemas.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 14.6: Smoke-test against a running embedder + stub reranker**
+
+Run:
+```bash
+# In one terminal: start the existing search test
+uv run pytest tests/test_api_routes_search.py -v -k "search" || echo "(existing route tests still pass)"
+```
+
+Expected: No regressions in existing search tests.
+
+- [ ] **Step 14.7: Commit**
+
+```bash
+git add src/harbor_clerk/search.py src/harbor_clerk/api/routes/search.py tests/test_hybrid_search_with_rerank.py
+git commit -m "feat(search): wire rerank_hits into hybrid_search with status propagation"
+```
+
+---
+
+## Task 15: Bump embed stage timeout
+
+**Files:**
+- Modify: `src/harbor_clerk/worker/pipeline.py` (or wherever `_TIMEOUTS` is defined)
+
+- [ ] **Step 15.1: Locate the timeout table**
+
+Run:
+```bash
+grep -rn "1800\|JobStage.embed" src/harbor_clerk/worker/ | grep -i timeout
+```
+
+Expected: One or two hits naming the embed stage timeout.
+
+- [ ] **Step 15.2: Update the timeout from 1800 to 3600**
+
+Edit the located file. Change `1800` (associated with `JobStage.embed`) to `3600`. Add a comment:
+
+```python
+    # Granite-R2 is ~5× slower per chunk than e5-small; bumped from 1800s
+    # for embedding-v2.
+    JobStage.embed: 3600,
+```
+
+- [ ] **Step 15.3: Verify worker tests still pass**
+
+Run:
+```bash
+uv run pytest tests/test_worker_pipeline.py -v 2>&1 | tail -10
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 15.4: Commit**
+
+```bash
+git add src/harbor_clerk/worker/pipeline.py
+git commit -m "chore(worker): bump embed stage timeout 1800s → 3600s for Granite-R2"
+```
+
+---
+
+## Task 16: External migration script — pre-flight checks
+
+**Files:**
+- Create: `scripts/migrate_to_embedding_v2.py`
+- Create: `tests/test_migrate_to_embedding_v2.py`
+
+- [ ] **Step 16.1: Write the failing pre-flight tests**
+
+Create `tests/test_migrate_to_embedding_v2.py`:
+
+```python
+"""Tests for the external migration script."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "migrate_to_embedding_v2.py"
+
+
+def _run(*args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_script_refuses_without_confirm(test_db_url):
+    r = _run("--db-url", test_db_url)
+    assert r.returncode != 0
+    assert "--confirm" in r.stderr or "--confirm" in r.stdout
+
+
+def test_script_refuses_without_db_url():
+    r = _run("--confirm")
+    assert r.returncode != 0
+
+
+def test_script_refuses_when_sentinel_already_set(test_db_url, db_session):
+    """The rebased migration populated the sentinel — script must refuse to re-run."""
+    # db_session fixture already ran 0001_initial.py which populated sentinel rows
+    r = _run("--db-url", test_db_url, "--confirm")
+    assert r.returncode != 0
+    assert "already" in r.stderr.lower() or "sentinel" in r.stderr.lower()
+
+
+def test_script_refuses_when_alembic_at_wrong_head(test_db_url, db_session):
+    """If alembic_version isn't '0022', refuse — we don't know how to handle it."""
+    import asyncio
+
+    async def _set_old_version():
+        # Drop sentinel + chunks.embedding rebuild to simulate a pre-rebase DB
+        await db_session.execute(text("DROP TABLE schema_metadata"))
+        await db_session.execute(text("UPDATE alembic_version SET version_num = '0019_documents_ocr_languages_used'"))
+        await db_session.commit()
+
+    asyncio.run(_set_old_version())
+    r = _run("--db-url", test_db_url, "--confirm")
+    assert r.returncode != 0
+    assert "0022" in r.stderr
+```
+
+(The `test_db_url` fixture needs adding to conftest.py if not present — it should expose the `DATABASE_URL` env var as a sync postgres URL `postgresql://...` for the script to use, not the asyncpg variant.)
+
+- [ ] **Step 16.2: Write the script skeleton with pre-flight checks only**
+
+Create `scripts/migrate_to_embedding_v2.py`:
+
+```python
+"""External migration script: existing-DB → embedding-v2 schema.
+
+For operators upgrading an existing Harbor Clerk DB without wiping it.
+Single transaction; idempotent pre-flight refusals prevent re-running or
+running against an unexpected schema state.
+
+Usage:
+  uv run python scripts/migrate_to_embedding_v2.py \\
+    --db-url postgresql://user:pass@host:port/dbname \\
+    --confirm
+
+See docs/upgrade-runbook.md#embedding-v2 for full operator runbook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import psycopg2
+
+# The single expected alembic version that this script knows how to migrate FROM.
+# If the DB is at any other revision, the script refuses (we'd be guessing).
+EXPECTED_PRE_REBASE_HEAD = "0022_imap_command_log"
+
+# The revision id of the rebased initial migration. Must match the
+# `revision = "0001_initial"` line at the top of alembic/versions/0001_initial.py.
+REBASED_INITIAL_REVISION = "0001_initial"
+
+logger = logging.getLogger(__name__)
+
+
+def _setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler(_log_path()),
+        ],
+    )
+
+
+def _log_path() -> Path:
+    import os
+
+    if os.environ.get("HARBOR_CLERK_LOG_DIR"):
+        return Path(os.environ["HARBOR_CLERK_LOG_DIR"]) / "migrate_to_embedding_v2.log"
+    # macOS native default
+    candidate = Path.home() / "Library/Application Support/Harbor Clerk/logs"
+    if candidate.parent.exists():
+        candidate.mkdir(parents=True, exist_ok=True)
+        return candidate / "migrate_to_embedding_v2.log"
+    Path("./logs").mkdir(parents=True, exist_ok=True)
+    return Path("./logs/migrate_to_embedding_v2.log")
+
+
+def preflight_check(conn) -> None:
+    """Raise RuntimeError with operator-actionable message on any check failure."""
+    with conn.cursor() as cur:
+        # Check 1: schema_metadata must not already exist with sentinel rows
+        cur.execute(
+            "SELECT to_regclass('schema_metadata')"
+        )
+        exists = cur.fetchone()[0]
+        if exists is not None:
+            cur.execute("SELECT key FROM schema_metadata WHERE key='embed_model'")
+            if cur.fetchone() is not None:
+                raise RuntimeError(
+                    "schema_metadata.embed_model row already exists — this DB has "
+                    "already been migrated to embedding-v2. Aborting."
+                )
+
+        # Check 2: alembic_version must equal the expected pre-rebase head
+        cur.execute("SELECT version_num FROM alembic_version")
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError(
+                "alembic_version table is empty — DB is in an unexpected state. Aborting."
+            )
+        current = row[0]
+        if current != EXPECTED_PRE_REBASE_HEAD:
+            raise RuntimeError(
+                f"alembic_version is '{current}', expected '{EXPECTED_PRE_REBASE_HEAD}'. "
+                f"This script knows how to migrate only from the pre-rebase head. "
+                f"If your DB is at a different revision, restore from backup or upgrade "
+                f"to '{EXPECTED_PRE_REBASE_HEAD}' first."
+            )
+
+        # Check 3: chunks.embedding must be vector(384)
+        cur.execute(
+            "SELECT format_type(atttypid, atttypmod) "
+            "FROM pg_attribute "
+            "WHERE attrelid = 'chunks'::regclass AND attname = 'embedding'"
+        )
+        col_row = cur.fetchone()
+        if col_row is None or col_row[0] != "vector(384)":
+            raise RuntimeError(
+                f"Expected chunks.embedding to be vector(384); found {col_row[0] if col_row else '<missing>'}. Aborting."
+            )
+
+
+def run_migration(conn) -> None:
+    """Apply the embedding-v2 schema changes + enqueue re-embed jobs. Single transaction."""
+    with conn.cursor() as cur:
+        logger.info("Creating schema_metadata table + sentinel rows")
+        cur.execute(
+            """
+            CREATE TABLE schema_metadata (
+              key TEXT PRIMARY KEY,
+              value TEXT NOT NULL,
+              set_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            INSERT INTO schema_metadata (key, value) VALUES
+              ('embed_model', 'granite-embedding-311m-multilingual-r2'),
+              ('embed_dim', '768'),
+              ('reranker', 'bge-reranker-v2-m3')
+            """
+        )
+
+        logger.info("Dropping + recreating chunks.embedding as vector(768)")
+        cur.execute("ALTER TABLE chunks DROP COLUMN embedding")
+        cur.execute("ALTER TABLE chunks ADD COLUMN embedding vector(768)")
+
+        logger.info("Rebuilding chunks_embedding_hnsw_idx")
+        cur.execute("DROP INDEX IF EXISTS chunks_embedding_hnsw_idx")
+        cur.execute(
+            "CREATE INDEX chunks_embedding_hnsw_idx ON chunks "
+            "USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)"
+        )
+
+        logger.info("Updating alembic_version → %s", REBASED_INITIAL_REVISION)
+        cur.execute(
+            "UPDATE alembic_version SET version_num = %s", (REBASED_INITIAL_REVISION,)
+        )
+
+        logger.info("Enqueueing embed-stage jobs for all ready docs (most-recent-first)")
+        cur.execute(
+            """
+            INSERT INTO ingestion_jobs (doc_id, stage, queue, status, attempts, created_at, updated_at)
+            SELECT doc_id, 'embed', 'cpu', 'queued', 0, NOW(), NOW()
+            FROM documents
+            WHERE pipeline_status = 'ready'
+            ORDER BY updated_at DESC
+            """
+        )
+        enqueued = cur.rowcount
+        logger.info("Enqueued %d embed jobs", enqueued)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _setup_logging()
+    parser = argparse.ArgumentParser(
+        prog="migrate_to_embedding_v2",
+        description="Migrate an existing Harbor Clerk DB to embedding-v2 schema.",
+    )
+    parser.add_argument("--db-url", required=True, help="sync postgres URL: postgresql://user:pass@host:port/dbname")
+    parser.add_argument("--confirm", action="store_true", required=True, help="acknowledge destructive operation")
+    args = parser.parse_args(argv)
+
+    logger.info("Connecting to %s", args.db_url.split("@")[-1])
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = False
+    try:
+        try:
+            preflight_check(conn)
+        except RuntimeError as exc:
+            logger.error("Pre-flight check failed: %s", exc)
+            return 1
+
+        run_migration(conn)
+        conn.commit()
+        logger.info("Migration complete. Re-launch HC from the embedding-v2 binary.")
+        return 0
+    except Exception:
+        conn.rollback()
+        logger.exception("Migration failed; transaction rolled back. DB is unchanged.")
+        return 2
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 16.3: Add psycopg2 to deps**
+
+Edit `pyproject.toml`, find the main `dependencies = [...]` block and add (if not present):
+
+```toml
+"psycopg2-binary>=2.9",
+```
+
+Run:
+```bash
+uv sync
+```
+
+- [ ] **Step 16.4: Add the `test_db_url` fixture if missing**
+
+Edit `tests/conftest.py`. After the existing fixtures, add:
+
+```python
+@pytest.fixture
+def test_db_url() -> str:
+    """Sync postgres URL for the test DB; used by scripts that don't speak asyncpg."""
+    import os
+    url = os.environ.get(
+        "TEST_DB_URL",
+        "postgresql://lka@localhost:5433/harbor_clerk_test",
+    )
+    return url
+```
+
+- [ ] **Step 16.5: Run pre-flight tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/test_migrate_to_embedding_v2.py -v -k "refuses"
+```
+
+Expected: 4 tests PASS (the "refuses_*" subset). The happy-path test (next task) still fails — that's fine for now.
+
+- [ ] **Step 16.6: Commit**
+
+```bash
+git add scripts/migrate_to_embedding_v2.py tests/test_migrate_to_embedding_v2.py tests/conftest.py pyproject.toml uv.lock
+git commit -m "feat(scripts): migrate_to_embedding_v2.py with pre-flight refusals"
+```
+
+---
+
+## Task 17: External migration script — happy path
+
+**Files:**
+- Modify: `tests/test_migrate_to_embedding_v2.py`
+
+- [ ] **Step 17.1: Write the happy-path test**
+
+Append to `tests/test_migrate_to_embedding_v2.py`:
+
+```python
+def test_script_happy_path_against_pre_rebase_db(test_db_url, db_session):
+    """Set DB to look like pre-rebase, run script, verify post-state."""
+    import asyncio
+
+    async def _make_pre_rebase():
+        # Simulate the pre-embedding-v2 state:
+        # - no schema_metadata table
+        # - alembic_version at 0022
+        # - chunks.embedding at vector(384)
+        await db_session.execute(text("DROP TABLE IF EXISTS schema_metadata"))
+        await db_session.execute(text("UPDATE alembic_version SET version_num = '0022_imap_command_log'"))
+        await db_session.execute(text("ALTER TABLE chunks DROP COLUMN embedding"))
+        await db_session.execute(text("ALTER TABLE chunks ADD COLUMN embedding vector(384)"))
+        # Seed one ready doc so the re-enqueue has something to count
+        await db_session.execute(
+            text(
+                "INSERT INTO documents (doc_id, title, mime_type, pipeline_status, created_at, updated_at) "
+                "VALUES (gen_random_uuid(), 'test', 'text/plain', 'ready', NOW(), NOW())"
+            )
+        )
+        await db_session.commit()
+
+    asyncio.run(_make_pre_rebase())
+
+    r = _run("--db-url", test_db_url, "--confirm")
+    assert r.returncode == 0, f"stdout={r.stdout}\nstderr={r.stderr}"
+
+    # Verify post-state
+    async def _verify():
+        sentinel = (await db_session.execute(
+            text("SELECT value FROM schema_metadata WHERE key='embed_model'")
+        )).scalar_one()
+        assert sentinel == "granite-embedding-311m-multilingual-r2"
+
+        col_type = (await db_session.execute(
+            text(
+                "SELECT format_type(atttypid, atttypmod) "
+                "FROM pg_attribute "
+                "WHERE attrelid = 'chunks'::regclass AND attname = 'embedding'"
+            )
+        )).scalar_one()
+        assert col_type == "vector(768)"
+
+        revision = (await db_session.execute(
+            text("SELECT version_num FROM alembic_version")
+        )).scalar_one()
+        assert revision == "0001_initial"
+
+        # One enqueued embed job for the test doc we seeded
+        job_count = (await db_session.execute(
+            text("SELECT COUNT(*) FROM ingestion_jobs WHERE stage='embed' AND status='queued'")
+        )).scalar_one()
+        assert job_count == 1
+
+    asyncio.run(_verify())
+```
+
+- [ ] **Step 17.2: Run test to verify it passes**
+
+Run:
+```bash
+uv run pytest tests/test_migrate_to_embedding_v2.py -v
+```
+
+Expected: All tests PASS (5 total).
+
+- [ ] **Step 17.3: Smoke-run the script's --help**
+
+Run:
+```bash
+uv run python scripts/migrate_to_embedding_v2.py --help
+```
+
+Expected: Help text printed, lists `--db-url` and `--confirm` as required, exit 0.
+
+- [ ] **Step 17.4: Commit**
+
+```bash
+git add tests/test_migrate_to_embedding_v2.py
+git commit -m "test(scripts): migrate_to_embedding_v2 happy path verifies post-state"
+```
+
+---
+
+## Task 18: Docker — embedder image bakes Granite-R2
+
+**Files:**
+- Modify: `docker/embedder.Dockerfile`
+
+- [ ] **Step 18.1: Add weight bake to the embedder Dockerfile**
+
+Edit `docker/embedder.Dockerfile`. Add (or modify the existing model download step) so it pre-downloads Granite-R2 at build time:
+
+```dockerfile
+# Pre-download the Granite-R2 weights at build time so the container
+# starts immediately. ~700 MB to image size; acceptable per project policy.
+RUN python -c "from huggingface_hub import snapshot_download; \
+  snapshot_download(repo_id='ibm-granite/granite-embedding-311m-multilingual-r2', \
+                    local_dir='/models/granite-embedding-311m-multilingual-r2', \
+                    local_dir_use_symlinks=False)"
+ENV EMBED_MODEL=/models/granite-embedding-311m-multilingual-r2
+```
+
+(If a similar `huggingface_hub` block exists for e5-small, replace it; don't keep both.)
+
+- [ ] **Step 18.2: Build the image to verify**
+
+Run:
+```bash
+docker build -f docker/embedder.Dockerfile -t harbor-clerk-embedder:embedding-v2 .
+```
+
+Expected: Build succeeds. Image is ~2 GB (base + Python + sentence-transformers + Granite weights).
+
+- [ ] **Step 18.3: Smoke-run the container**
+
+Run:
+```bash
+docker run --rm -d --name embedder-smoke -p 9001:8000 harbor-clerk-embedder:embedding-v2
+sleep 15  # give the model time to load
+curl -sf http://localhost:9001/health | grep granite
+docker stop embedder-smoke
+```
+
+Expected: `/health` returns 200 with `granite-embedding-311m-multilingual-r2` in the response.
+
+- [ ] **Step 18.4: Commit**
+
+```bash
+git add docker/embedder.Dockerfile
+git commit -m "chore(docker): bake Granite-R2 weights into embedder image"
+```
+
+---
+
+## Task 19: Docker — reranker image + compose entry
+
+**Files:**
+- Create: `docker/reranker.Dockerfile`
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 19.1: Create the reranker Dockerfile**
+
+Create `docker/reranker.Dockerfile`:
+
+```dockerfile
+# Reranker service — bge-reranker-v2-m3 CrossEncoder.
+# Shares the embedder package wheel (single Python project, two entry points).
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY embedder /app/embedder
+RUN pip install --no-cache-dir /app/embedder
+
+# Pre-download the reranker weights at build time. ~1.2 GB.
+RUN python -c "from huggingface_hub import snapshot_download; \
+  snapshot_download(repo_id='BAAI/bge-reranker-v2-m3', \
+                    local_dir='/models/bge-reranker-v2-m3', \
+                    local_dir_use_symlinks=False)"
+ENV RERANKER_MODEL=/models/bge-reranker-v2-m3
+
+EXPOSE 8001
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=60s \
+  CMD python -c "import httpx; httpx.get('http://localhost:8001/health').raise_for_status()"
+
+CMD ["harbor-clerk-reranker"]
+ENV HOST=0.0.0.0 PORT=8001
+```
+
+- [ ] **Step 19.2: Add reranker service to docker-compose.yml**
+
+Edit `docker-compose.yml`. After the `embedder:` block, add:
+
+```yaml
+  reranker:
+    build:
+      context: .
+      dockerfile: docker/reranker.Dockerfile
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8001/health').raise_for_status()"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    networks:
+      - harbor-clerk
+```
+
+In the `app:`, `worker-io:`, and `worker-cpu:` service blocks, add to `environment:`:
+
+```yaml
+      RERANKER_URL: http://reranker:8001
+```
+
+And add `reranker:` to their `depends_on:` lists.
+
+- [ ] **Step 19.3: Build + smoke-test reranker container**
+
+Run:
+```bash
+docker compose build reranker
+docker compose up -d reranker
+sleep 30  # weights load
+curl -sf http://localhost:8001/health
+docker compose down
+```
+
+Expected: Build succeeds; `/health` returns 200.
+
+- [ ] **Step 19.4: Commit**
+
+```bash
+git add docker/reranker.Dockerfile docker-compose.yml
+git commit -m "feat(docker): add reranker service with bge-reranker-v2-m3"
+```
+
+---
+
+## Task 20: macOS — bundle the new model files
+
+**Files:**
+- Modify: `macos/scripts/download-model.sh`
+- Modify: `macos/scripts/package.sh`
+
+- [ ] **Step 20.1: Extend download-model.sh to fetch both models**
+
+Edit `macos/scripts/download-model.sh`. Find the existing model-download invocation (which currently fetches multilingual-e5-small) and add Granite-R2 + reranker:
+
+```bash
+# Granite-R2 embedder (~700 MB)
+huggingface-cli download \
+  ibm-granite/granite-embedding-311m-multilingual-r2 \
+  --local-dir "$MODEL_DIR/granite-embedding-311m-multilingual-r2" \
+  --local-dir-use-symlinks False
+
+# bge-reranker-v2-m3 cross-encoder (~1.2 GB)
+huggingface-cli download \
+  BAAI/bge-reranker-v2-m3 \
+  --local-dir "$MODEL_DIR/bge-reranker-v2-m3" \
+  --local-dir-use-symlinks False
+```
+
+(Keep the e5-small download IF it's needed for the rollback path; otherwise remove.)
+
+- [ ] **Step 20.2: Verify package.sh copies both directories**
+
+Edit `macos/scripts/package.sh`. Find where model files are copied into the app bundle's `Resources/`. Ensure both `granite-embedding-311m-multilingual-r2/` and `bge-reranker-v2-m3/` directories are included.
+
+If the existing script copies the entire `MODEL_DIR`, no change needed — verify by running:
+
+```bash
+cd macos && make download-models && make package
+```
+
+Then check:
+
+```bash
+ls "macos/build/output/Harbor Clerk Server.app/Contents/Resources/" | grep -E "granite|bge-reranker"
+```
+
+Expected: Both directories present.
+
+- [ ] **Step 20.3: Commit**
+
+```bash
+git add macos/scripts/download-model.sh macos/scripts/package.sh
+git commit -m "build(macos): bundle Granite-R2 + bge-reranker-v2-m3 in the app"
+```
+
+---
+
+## Task 21: macOS — RerankerService.swift
+
+**Files:**
+- Create: `macos/HarborClerkServer/HarborClerkServer/Services/RerankerService.swift`
+
+- [ ] **Step 21.1: Create the service**
+
+Create `macos/HarborClerkServer/HarborClerkServer/Services/RerankerService.swift`:
+
+```swift
+import Foundation
+
+final class RerankerService: PythonService {
+    init() {
+        super.init(name: "Reranker")
+    }
+
+    override var executableName: String { "harbor-clerk-reranker" }
+
+    override var extraEnvironment: [String: String] {
+        let modelPath = Bundle.main.resourceURL!
+            .appendingPathComponent("model/bge-reranker-v2-m3").path
+        return [
+            "RERANKER_MODEL": modelPath,
+            "HOST": "127.0.0.1",
+            "PORT": String(AppSettings.shared.rerankerPort),
+        ]
+    }
+
+    override func healthCheck() async -> Bool {
+        let port = AppSettings.shared.rerankerPort
+        guard let url = URL(string: "http://127.0.0.1:\(port)/health") else { return false }
+        return await httpProbeOK(url)
+    }
+}
+```
+
+- [ ] **Step 21.2: Add rerankerPort to AppSettings**
+
+Edit `macos/HarborClerkServer/HarborClerkServer/AppSettings.swift`. Find the existing `embedderPort` declaration and add immediately after:
+
+```swift
+    @Published var rerankerPort: Int = 8201
+    @Published var rerankerEnabled: Bool = true
+```
+
+If `AppSettings` persists to UserDefaults, add the load/save lines for both keys following the existing pattern for `embedderPort`.
+
+- [ ] **Step 21.3: Register in ServiceManager**
+
+Edit `macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift`. Find where `EmbedderService()` is added to the service list. Add `RerankerService()` immediately after it (so startup order is: Postgres → Tika → Embedder → Reranker → API → Workers):
+
+```swift
+        services.append(RerankerService())
+```
+
+Verify the lifecycle (start/stop/healthcheck) treats the reranker the same as the embedder by virtue of inheriting `PythonService`.
+
+- [ ] **Step 21.4: Build the macOS app**
+
+Run:
+```bash
+cd macos && make
+```
+
+Expected: Build succeeds. New `RerankerService.swift` compiles cleanly.
+
+- [ ] **Step 21.5: Commit**
+
+```bash
+git add macos/HarborClerkServer/HarborClerkServer/Services/RerankerService.swift \
+        macos/HarborClerkServer/HarborClerkServer/AppSettings.swift \
+        macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+git commit -m "feat(macos): RerankerService managed by ServiceManager"
+```
+
+---
+
+## Task 22: macOS — UI for reranker port + status
+
+**Files:**
+- Modify: `macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift`
+- Modify: `frontend/src/pages/SystemStatusPage.tsx`
+- Modify: `frontend/src/pages/ServiceLogsPage.tsx`
+
+- [ ] **Step 22.1: Add reranker port + toggle to PreferencesWindow**
+
+Edit `macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift`. Find where `embedderPort` is exposed in the UI. Add a parallel control for `rerankerPort` immediately below, plus a toggle for `rerankerEnabled`. Reuse the existing patterns (Stepper/TextField/Toggle).
+
+- [ ] **Step 22.2: Add reranker card to SystemStatusPage**
+
+Edit `frontend/src/pages/SystemStatusPage.tsx`. Find the existing service-status cards (one for embedder, one for postgres, etc.). Add a parallel card for reranker — fetch its health from a new field on `/api/system/health` if available, OR add the reranker URL fetch alongside the existing embedder fetch.
+
+If `/api/system/health` doesn't currently include reranker status, add it: edit `src/harbor_clerk/api/routes/system.py` to probe the reranker URL similarly to how embedder is probed.
+
+- [ ] **Step 22.3: Add reranker.log to ServiceLogsPage**
+
+Edit `frontend/src/pages/ServiceLogsPage.tsx`. Find the existing log-tailing list. Add `reranker.log` alongside `embedder.log`.
+
+- [ ] **Step 22.4: Build the frontend**
+
+Run:
+```bash
+cd frontend && npm run build
+```
+
+Expected: Build succeeds with no type errors.
+
+- [ ] **Step 22.5: Commit**
+
+```bash
+git add macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift \
+        frontend/src/pages/SystemStatusPage.tsx \
+        frontend/src/pages/ServiceLogsPage.tsx \
+        src/harbor_clerk/api/routes/system.py
+git commit -m "feat(ui): reranker port preference + status card + log tail"
+```
+
+---
+
+## Task 23: Documentation — upgrade runbook
+
+**Files:**
+- Create: `docs/upgrade-runbook.md`
+
+- [ ] **Step 23.1: Write the upgrade runbook**
+
+Create `docs/upgrade-runbook.md`:
+
+```markdown
+# Harbor Clerk Upgrade Runbook
+
+This document covers operator-facing procedures for breaking-change upgrades.
+For incremental version bumps, normal alembic migrations apply automatically
+when the app starts; this runbook only covers explicit cutover events.
+
+## Embedding v2 (Granite-R2 + Reranker + Schema Rebase)
+
+### What this upgrade does
+
+- Replaces the embedding model (`multilingual-e5-small` 384-dim → `granite-embedding-311m-multilingual-r2` 768-dim).
+- Adds a cross-encoder reranker service (`bge-reranker-v2-m3`).
+- Rebases the alembic migration chain into a single `0001_initial.py`.
+- Bumps the macOS bundle / Docker images by ~2 GB (model weights).
+
+### Compatibility
+
+- Old `alembic_version='0022'` databases REFUSE to upgrade in-app — the new binary's alembic chain doesn't include revision `0022`. This is intentional. You must either wipe + re-ingest (Path A) or run the external migration script (Path B).
+- Old `multilingual-e5-small` embeddings are NOT usable with the new model. The DB column type changes; all existing embeddings are destroyed by either path.
+- API tool surface is unchanged — MCP clients (frontier LLMs calling `kb_search`) see no contract changes.
+
+### Path A — wipe + re-ingest (recommended for office appliances)
+
+1. **Stop Harbor Clerk** (menubar Quit on macOS, `docker compose down` on Docker).
+2. **Drop the database.**
+   - macOS: open the Postgres console and run `DROP DATABASE harbor_clerk; CREATE DATABASE harbor_clerk;` (or use `psql -h localhost -p <port> -U <user> -d postgres -c "DROP DATABASE harbor_clerk; CREATE DATABASE harbor_clerk;"`).
+   - Docker: `docker compose down -v` (the `-v` removes the postgres volume too).
+3. **Re-launch from the embedding-v2 binary.**
+   - macOS: launch HarborClerkServer.app from the new build. `alembic upgrade head` creates the fresh schema; sentinel passes.
+   - Docker: `docker compose up -d`. Entrypoint runs `alembic upgrade head`.
+4. **Watched folders auto-rescan.** All previously-watched files are re-ingested with Granite-R2 embeddings. Search becomes available as soon as the first few docs finish.
+
+### Path B — preserve existing DB
+
+For operators who want to keep their existing documents/conversations/audit-log without re-ingesting.
+
+1. **Stop Harbor Clerk** (full stop — workers + API + embedder all down).
+2. **Back up the database.** Recommended: `pg_dump harbor_clerk > harbor_clerk_pre_embedding_v2.sql`. The script is non-reversible.
+3. **Run the migration script:**
+
+```bash
+cd ~/mcp-gateway   # or wherever the embedding-v2 source lives
+uv run python scripts/migrate_to_embedding_v2.py \
+    --db-url postgresql://<user>:<pass>@localhost:<port>/harbor_clerk \
+    --confirm
+```
+
+Expected output (~5 seconds):
+- "Creating schema_metadata table + sentinel rows"
+- "Dropping + recreating chunks.embedding as vector(768)"
+- "Rebuilding chunks_embedding_hnsw_idx"
+- "Updating alembic_version → 0001_initial"
+- "Enqueued N embed jobs"
+- "Migration complete. Re-launch HC from the embedding-v2 binary."
+
+4. **Re-launch HC from the embedding-v2 binary.** Sentinel check passes (script populated it). Workers come up, see the queued embed jobs, and trickle through them most-recent-first.
+5. **Watch the UI banner** that shows "Re-embedding: N of M docs". Search continues to work throughout — chunks without new embeddings just don't surface via the vector leg until they're processed (FTS leg unaffected).
+
+### Rollback
+
+If the embedding-v2 cutover surfaces a showstopper:
+
+1. Stop HC.
+2. Restore from the pre-migration backup (Path B only — Path A wiped the data).
+3. Re-launch from the pre-embedding-v2 binary.
+
+The migration script is non-reversible by design; rollback requires the backup.
+
+### Troubleshooting
+
+- **"Schema sentinel mismatch — refusing to start"** at boot: your binary expects a model/dim that doesn't match the sentinel rows. Either re-run the migration or re-launch from a binary that matches the DB.
+- **"Can't locate revision identified by '0022'"** from alembic: this is the expected refusal when the new binary sees the old DB. Follow Path A or B above.
+- **Reranker fails to start**: check `~/Library/Application Support/Harbor Clerk/logs/reranker.log`. The bge-reranker-v2-m3 model needs ~1.2 GB free RAM at load time.
+- **Re-embed taking forever**: Granite-R2 is ~5x slower per chunk than e5-small. For a 10K-doc corpus on M-series silicon expect a few hours. The "Re-embedding" badge shows progress; HC keeps serving search during the trickle.
+```
+
+- [ ] **Step 23.2: Commit**
+
+```bash
+git add docs/upgrade-runbook.md
+git commit -m "docs: embedding-v2 upgrade runbook with Path A + Path B"
+```
+
+---
+
+## Task 24: Verify + retrieval-eval gate
+
+**Files:**
+- (no code changes — verification only)
+
+- [ ] **Step 24.1: Full local verify**
+
+Run:
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest tests/ -m "not requires_models and not integration" -q
+cd frontend && npm run lint && npm run type-check && cd ..
+```
+
+Expected: All four steps pass.
+
+- [ ] **Step 24.2: Run requires_models integration tests**
+
+Run (will download Granite-R2 + reranker if not cached):
+```bash
+uv run pytest tests/ -m requires_models -v
+```
+
+Expected: PASS. First run may take ~5 minutes downloading model weights.
+
+- [ ] **Step 24.3: Bring up the full embedding-v2 stack locally**
+
+Choose one:
+
+**Docker path:**
+```bash
+docker compose up -d --build
+sleep 60  # weights load
+curl -sk https://localhost/api/system/health
+```
+
+**macOS path:**
+```bash
+cd macos && make && open "build/output/Harbor Clerk Server.app"
+# wait for menubar to show all services green
+curl -sf http://127.0.0.1:8100/api/system/health
+```
+
+Expected: Health endpoint returns 200; embedder + reranker both report healthy.
+
+- [ ] **Step 24.4: Re-ingest the test corpora (or migrate the existing DB via the script)**
+
+For test corpora ingest:
+```bash
+# Watched folders should auto-rescan if pre-configured. Otherwise drop the DB and let the
+# next launch ingest fresh, OR run the migration script against the existing DB.
+```
+
+Wait for at least the CUAD corpus to finish ingesting (the small one; ~5-10 min).
+
+- [ ] **Step 24.5: Run the retrieval-eval gate**
+
+Run:
+```bash
+uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
+  --mode retrieval-eval \
+  --run-id 2026-05-05-prod \
+  --api-base http://localhost:8100 \
+  --label embedding-v2 \
+  --corpora cuad   # start with cuad; add other corpora as they finish ingesting
+```
+
+Expected: Eval completes in seconds. `summary.json` shows recall@10 improvement over baseline.
+
+- [ ] **Step 24.6: Capture metrics for the PR**
+
+Run:
+```bash
+cat ~/Library/Application\ Support/Harbor\ Clerk/test-corpora/results/2026-05-05-prod/retrieval-eval/embedding-v2/summary.json
+cat ~/Library/Application\ Support/Harbor\ Clerk/test-corpora/results/2026-05-05-prod/retrieval-eval/embedding-v2/metrics.csv | head -20
+```
+
+Expected: numbers showing the recall@10 / mrr / ndcg@10 deltas. Will be pasted into the PR description.
+
+- [ ] **Step 24.7: Acceptance gate check**
+
+Compare to the gate criteria from the spec:
+- Overall recall@10 improvement **≥ +0.08** (vs e5-small baseline from sweep results)
+- No per-corpus regression worse than **-0.05**
+- nDCG@10 also improves overall
+
+If the gate doesn't pass: do not proceed to PR. Diagnose (often: bad chunking, wrong prefix handling, reranker pool too small) and iterate.
+
+If the gate passes: proceed to Task 25.
+
+---
+
+## Task 25: Open the PR
+
+- [ ] **Step 25.1: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/embedding-v2-granite-and-reranker
+```
+
+- [ ] **Step 25.2: Dispatch the final pre-PR fresh-eyes code review**
+
+Per [`memory/feedback_capture_pr_followups.md`](../../../memory/feedback_capture_pr_followups.md) Directive 2: send a fresh-eyes `feature-dev:code-reviewer` subagent against the branch tip with a MINIMAL prompt — no focus areas, no carve-outs. Address all findings ≥ 80 confidence before opening the PR.
+
+- [ ] **Step 25.3: Open the PR**
+
+Run:
+```bash
+gh pr create --title "feat: embedding-v2 (Granite-R2 + bge-reranker-v2-m3 + schema rebase)" --body "$(cat <<'EOF'
+## Summary
+- Swap embedding model from multilingual-e5-small (384-dim) to ibm-granite/granite-embedding-311m-multilingual-r2 (768-dim)
+- Add BAAI/bge-reranker-v2-m3 as a cross-encoder precision stage on top of hybrid retrieval
+- Rebase alembic chain to a single `0001_initial.py`; external `scripts/migrate_to_embedding_v2.py` for operators preserving existing DBs
+- Schema sentinel (`schema_metadata` table) hard-fails boot on binary/DB mismatch
+
+## Retrieval-eval gate
+
+```
+<paste contents of summary.json + first 5 lines of metrics.csv from Task 24.6 here>
+```
+
+Gate criteria met: overall recall@10 improvement ≥ +0.08, no per-corpus regression > -0.05.
+
+## Test plan
+- [ ] CI: ruff + pytest (default markers, excludes requires_models + integration)
+- [ ] Local: `uv run pytest tests/ -m requires_models -v` passes (Granite + reranker load, return 768-dim, rerank a sample)
+- [ ] Local: Docker stack comes up clean; sentinel verifies; search returns rerank-ordered hits
+- [ ] Local: macOS bundle builds; reranker subprocess starts; PreferencesWindow shows the port
+
+## Out of scope / deferred
+- Late chunking → next phase
+- Multi-granularity embeddings (section + document tables) → next phase
+- Heading chain in passages → next phase
+
+## Migration path
+Operators choose one:
+- **Path A**: stop HC, drop DB, re-launch (fresh schema; watched folders re-ingest).
+- **Path B**: stop HC, run `scripts/migrate_to_embedding_v2.py --db-url ... --confirm`, re-launch (background re-embed trickle).
+
+See `docs/upgrade-runbook.md#embedding-v2` for full operator runbook.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 25.4: Add deferred items to pr_followups.md**
+
+Per the standing directive, append entries to `~/.claude/projects/-Users-alex-mcp-gateway/memory/pr_followups.md` for:
+- Late chunking (next-phase work)
+- Multi-granularity embeddings
+- Heading chain in passages
+- (Any items surfaced during the code review that didn't get fixed)
+
+---
+
+## Self-Review Notes
+
+Spec coverage verified:
+- ✅ Component 1 (embedder swap) → Tasks 10, 18, 20
+- ✅ Component 2 (reranker service) → Tasks 11, 19, 21
+- ✅ Component 3 (sentinel + db_health) → Tasks 3, 7, 8, 9
+- ✅ Component 4 (search reranking) → Tasks 12, 13, 14
+- ✅ Component 5 (macOS service-management) → Tasks 21, 22
+- ✅ Component 6 (alembic rebase) → Tasks 4, 5
+- ✅ Component 7 (external migration script) → Tasks 16, 17
+- ✅ Settings additions → Tasks 1, 2
+- ✅ Worker timeout bump → Task 15
+- ✅ Documentation → Task 23
+- ✅ Retrieval-eval gate → Task 24
+- ✅ PR + followups → Task 25
+
+Tasks have complete code in every step. No placeholders found.
+
+Type/name consistency: `verify_schema_sentinel` / `panic_on_sentinel_mismatch` / `SchemaSentinelMismatch` used uniformly across Tasks 7-9. `rerank_hits` signature consistent across Tasks 13-14. `SearchHit` / `SearchHitOut` distinction preserved (internal dataclass vs API output model).

--- a/docs/superpowers/plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md
+++ b/docs/superpowers/plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md
@@ -1,0 +1,497 @@
+# Harbor Clerk Retrieval/MCP Upgrade — Master Staging Plan
+
+> **For agentic workers:** This is a STAGING plan, not an implementation plan. It maps out 6 independent phases. Each phase needs its own detailed implementation plan written via `superpowers:brainstorming` → `superpowers:writing-plans` before execution. Do NOT attempt to implement any phase directly from this document.
+
+**Goal:** Take Harbor Clerk's retrieval pipeline from `multilingual-e5-small` + hybrid FTS/cosine to a SOTA stack optimized for frontier-LLM MCP consumption, with a queryable knowledge graph, layered preprocessing, and visual exploration — all gated by per-phase retrieval-eval against the sweep baselines.
+
+**Architecture:** Six independent phases, each shipping behind retrieval-eval gates. Phase 0 is the foundation (embedding/reranker swap + schema break). Phases 1-2 are "free wins" (no new infrastructure). Phases 3-4 add the graph and propositions layers. Phase 5 is UI. Each phase is isolated on its own branch, merges after passing retrieval-eval against the prior phase's label, and bumps the schema sentinel where applicable.
+
+**Tech Stack:** PostgreSQL 18 + pgvector + pg_trgm, FastAPI + SQLAlchemy 2.0 async, IBM Granite Embedding 311M Multilingual R2, BAAI/bge-reranker-v2-m3, GLiNER + GLiNER-Relex, Microsoft Presidio, BERTopic (existing), spaCy (existing), Vite + React + TypeScript + Tailwind 4 + d3-force (already in deps), Apache Tika (existing).
+
+---
+
+## How To Use This Document
+
+1. **Read top-to-bottom** for the staging story and inter-phase dependencies.
+2. **Before starting phase N**: invoke `/brainstorm` to nail down the open questions for that phase (see "Open Questions Per Phase" at the bottom), then `/write-plan` to produce a bite-sized detailed plan, saved alongside this one as `2026-MM-DD-retrieval-upgrade-phase-N-<topic>.md`.
+3. **Each phase is its own branch**, its own PR, its own retrieval-eval label. Never bundle phases.
+4. **Each phase passes through the gate** before the next phase starts. If the gate fails, do not advance — fix or revise.
+5. **Memory hygiene**: every phase PR with deferred work → entry in [`pr_followups.md`](https://github.com/alex/mcp-gateway/blob/main/memory/pr_followups.md). Every cross-phase decision worth remembering → its own memory file.
+
+---
+
+## Phase Map
+
+| Phase | Branch prefix | Goal | Schema change? | Expected recall@10 vs e5-small baseline | Effort |
+|---|---|---|---|---|---|
+| 0 | `feat/retrieval-phase-0-granite` | Granite-R2 + bge-reranker-v2-m3 + schema sentinel + fail-stop | YES — `vector(384)` → `vector(768)`, breaking, non-reversible | +0.10 to +0.18 | M (1-2 weeks) |
+| 1 | `feat/retrieval-phase-1-late-chunking` | Late chunking + multi-granularity (chunk/section/doc) + heading-chain in passages | YES — new `chunk_embeddings` index strategy, new `section_embeddings` + `document_embeddings` tables | +0.04 to +0.10 | M (1-2 weeks) |
+| 2 | `feat/retrieval-phase-2-metadata` | Doc-type classifier + temporal extraction + PII tagging + table extraction | YES — new columns on `documents` and `chunks`, new `document_tables` table | +0.03 to +0.05 (precision on filtered queries: +0.20-0.40) | M (1-2 weeks) |
+| 3 | `feat/retrieval-phase-3-graph` | Entity canonicalization + relation extraction + cross-doc linking + 5 new MCP tools | YES — `entity_canonical`, `entity_relations`, `document_references` tables | +0.03 to +0.08 (multi-hop queries: much larger) | L (2-3 weeks) |
+| 4 | `feat/retrieval-phase-4-propositions` | Propositional indexing + HippoRAG-style multi-hop + `kb_find_fact` + `kb_multihop_search` | YES — `propositions` table | +0.05 to +0.10 (fact-extraction queries: +0.15-0.25) | L (2-3 weeks) |
+| 5 | `feat/retrieval-phase-5-ui` | Force-directed entity graph, UMAP topic projection, doc-type composition, retrieval inspector | NO | N/A (UX delta, not retrieval delta) | M (1-2 weeks) |
+
+**Total**: ~10-13 weeks of focused work. Realistically 4-6 months with normal interruptions and the existing roadmap. Phases 0-2 can be fast (well-defined). Phases 3-4 will trip on real-corpus surprises. Phase 5 is fun.
+
+**Expected cumulative delta after all 6 phases:** recall@10 of 0.85-0.95 on the sweep questions (e5-small baseline is presumably 0.50-0.70 depending on corpus). The biggest single lever is Phase 0; the highest-novelty value-add for frontier LLMs is Phase 3-4.
+
+---
+
+## Cross-Cutting Decisions
+
+These apply across every phase and must be respected without re-litigation.
+
+### Branch + PR Discipline
+- One branch per phase, named `feat/retrieval-phase-N-<topic>`.
+- One PR per phase. Don't bundle.
+- Open the PR draft early; iterate; mark ready when retrieval-eval gate passes.
+- **Final pre-merge step on every phase PR**: fresh-eyes `feature-dev:code-reviewer` subagent against branch tip with minimal prompt (per [feedback_capture_pr_followups.md](https://github.com/alex/mcp-gateway/blob/main/memory/feedback_capture_pr_followups.md) Directive 2). Address findings ≥80 confidence before merging.
+- **No `gh pr merge --admin`** without explicit per-session permission.
+
+### Schema Sentinel + Fail-Stop
+Phase 0 introduces a `schema_metadata` table:
+```sql
+CREATE TABLE schema_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  set_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+INSERT INTO schema_metadata (key, value) VALUES
+  ('embed_model', 'granite-embedding-311m-multilingual-r2'),
+  ('embed_dim', '768'),
+  ('reranker', 'bge-reranker-v2-m3'),
+  ('upgrade_phase', '0');
+```
+
+On API + worker boot (before opening the pool), query the sentinel rows; if `(embed_model, embed_dim)` doesn't match `settings.embed_model` / `settings.embed_dim`, log a loud panic and `sys.exit(2)`. Same check at the top of the `embed` worker stage. Belt-and-suspenders: bump `alembic_version` head; refuse to start if it's below the phase's minimum.
+
+Each subsequent phase that adds schema bumps `upgrade_phase` (e.g. Phase 1 sets it to `'1'`). The fail-stop accepts only the current and prior phase numbers, so a Phase-1 binary refuses to open a Phase-0 DB unless explicitly migrated. This protects against deploying a new binary against a stale DB.
+
+### Retrieval-Eval Gates
+Use the `--mode retrieval-eval` harness that shipped this session. Per-phase gate:
+1. Before merging phase N, run: `sweep --mode retrieval-eval --run-id 2026-05-05-prod --label phase-N-<short-name> [--prior-label phase-(N-1)-<short-name>]`
+2. Acceptable outcomes:
+   - **Phase 0**: recall@10 improvement ≥+0.08 overall; no per-corpus regression more than -0.05 (CUAD/Enron/synthetic).
+   - **Phase 1**: recall@10 improvement ≥+0.03 overall; no regression worse than -0.03 per corpus.
+   - **Phase 2**: recall@10 may stay flat or improve; precision on filtered queries should improve (separate eval — see Phase 2 detail).
+   - **Phase 3-4**: recall@10 improvement ≥+0.03; multi-hop subset shows much larger gains (separate eval slice).
+   - **Phase 5**: not retrieval-gated.
+3. If a phase fails its gate, do NOT advance. Either revise the phase or roll back parts and re-eval.
+
+### Re-Embed Cost
+Phases 0, 1, 4 require re-embedding all chunks (or building new embedding tables). For a 10K-doc corpus with ~500K chunks at ~50ms/chunk (Granite-R2 on M-series silicon), that's ~7 hours single-threaded. Plan re-embed as an explicit task with progress monitoring. The `embed` stage already has heartbeats; reuse the pipeline.
+
+### Sweep Baseline Source
+The `2026-05-05-prod` sweep is now running again (resumed 2026-05-17). It produces `cited_doc_ids` baselines for CUAD / Enron / synthetic. **Wait for the sweep to finish before Phase 0 retrieval-eval gate.** If iteration starts before then, use `--questions-per-corpus 5 --corpora cuad,synthetic` for fast spot-checks during dev, but the gate-passing eval uses the full baseline set.
+
+### Memory & Followups
+- Every phase that defers out-of-scope work → one entry in `pr_followups.md` AND one entry in the PR description.
+- Every cross-phase decision worth remembering (e.g. "we evaluated GLiNER-Relex vs REBEL, chose GLiNER-Relex because X") → one memory file under `~/.claude/projects/-Users-alex-mcp-gateway/memory/`.
+
+---
+
+## Phase 0: Granite-R2 + Reranker + Schema Hard Fail-Stop
+
+### Goal
+Replace `multilingual-e5-small` (118M / 384-dim) with `ibm-granite/granite-embedding-311m-multilingual-r2` (311M / 768-dim). Add `BAAI/bge-reranker-v2-m3` as a cross-encoder precision stage on top of hybrid retrieval. Introduce the schema sentinel that hard-stops on mismatch.
+
+### File Structure
+**Create:**
+- `embedder/src/embedder/reranker.py` — Reranker server: loads bge-reranker-v2-m3, exposes `POST /rerank` taking `{query, passages: list[str], top_k}` returning `[{index, score}]` sorted desc.
+- `alembic/versions/0023_schema_sentinel_and_granite_embed_dim.py` — Migration: create `schema_metadata` table, populate sentinel rows, ALTER `chunks.embedding` from `vector(384)` to `vector(768)`, drop + rebuild HNSW index, set `upgrade_phase=0`. Non-reversible (`downgrade()` raises `NotImplementedError`).
+- `src/harbor_clerk/models/schema_metadata.py` — SQLAlchemy model.
+- `src/harbor_clerk/db_health.py` — `verify_schema_sentinel()` called at API + worker boot.
+- `src/harbor_clerk/search_rerank.py` — `rerank_hits()` async function: HTTP call to reranker, returns re-ordered hits.
+- `tests/test_db_health.py` — Sentinel mismatch panic-exits the process.
+- `tests/test_search_rerank.py` — Reranker re-orders hits, handles HTTP failures, respects top_k.
+- `tests/test_embedder_granite.py` — Smoke: model loads, returns 768-dim embeddings, handles batch=64.
+
+**Modify:**
+- `embedder/src/embedder/app.py` — Default `EMBED_MODEL` to `ibm-granite/granite-embedding-311m-multilingual-r2`; remove the query/passage prefix logic (Granite uses CLS pooling, no prefix needed); keep the `task` param accepted but ignored for backward compat.
+- `embedder/pyproject.toml` — Pin sentence-transformers version known to load Granite-R2.
+- `src/harbor_clerk/config.py` — Add `embed_model`, `embed_dim`, `reranker_url`, `rerank_enabled`, `rerank_pool_size` settings.
+- `src/harbor_clerk/search.py` — After hybrid merge, if `rerank_enabled` and pool ≥ K, call `rerank_hits(query, top_pool, k)` before truncating to top-K.
+- `src/harbor_clerk/api/main.py` — Call `verify_schema_sentinel()` in lifespan startup.
+- `src/harbor_clerk/worker/__init__.py` (or wherever worker boots) — Same call.
+- `src/harbor_clerk/worker/stages/embed.py` — Increase per-stage timeout from 1800s to 3600s; Granite-R2 is ~5× slower per chunk.
+- `docker/embedder.Dockerfile` — Bake Granite-R2 weights at image build OR document model download on first run.
+- `docker-compose.yml` — Add `reranker` service (or co-host in embedder); env vars for HC to talk to it.
+- `macos/scripts/install-services.sh` — Add reranker subprocess to macOS launch sequence; HarborClerkServer menubar must start/stop/healthcheck it.
+- `macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift` — New service definition for reranker.
+- `frontend/src/pages/SystemStatusPage.tsx` — Show reranker health alongside embedder.
+
+### Schema Migration
+Single migration `0023_schema_sentinel_and_granite_embed_dim.py`:
+1. Create `schema_metadata` table.
+2. Insert sentinel rows: `embed_model`, `embed_dim`, `reranker`, `upgrade_phase`.
+3. `ALTER TABLE chunks ALTER COLUMN embedding TYPE vector(768)` — Postgres rejects this when column has data, so: `DROP COLUMN embedding`, then `ADD COLUMN embedding vector(768)`. All existing rows have `embedding = NULL` after migration.
+4. `DROP INDEX chunks_embedding_hnsw_idx`.
+5. `CREATE INDEX chunks_embedding_hnsw_idx ON chunks USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)`.
+6. Re-enqueue the `embed` stage for every document with `pipeline_status='ready'`. (Use an explicit `INSERT INTO ingestion_jobs` ... `WHERE pipeline_status='ready'`).
+7. `downgrade()`: raises `NotImplementedError` with a clear message ("Phase 0 schema break is one-way; restore from a pre-upgrade backup.").
+
+### MCP / API Surface
+**No tool signatures change in Phase 0.** Output shapes are unchanged. Behavioral change is invisible to MCP callers — they just get better hits.
+
+### Retrieval-Eval Gate
+```bash
+sweep --mode retrieval-eval --run-id 2026-05-05-prod \
+  --api-base http://localhost:8100 \
+  --label phase-0-granite-r2
+```
+**Pass criteria**: overall recall@10 improvement ≥ +0.08; no per-corpus regression > -0.05; nDCG@10 should also improve.
+
+### Risks
+- **Granite-R2 was released April 2026** — only 18K downloads/month at time of plan. Real-world bugs may surface. Mitigation: keep e5-small swap-back available via env var until Phase 1 lands; document the rollback in the PR.
+- **Re-embed time on prod corpus** — sweep baselines exist for ~10K docs, prod corpora may be larger. Plan re-embed as a maintenance window.
+- **Reranker is a new service** — adds health-check surface, restart-coordination on macOS. The "Quit hang" pattern in [project_menubar_process_management_audit.md](https://github.com/alex/mcp-gateway/blob/main/memory/project_menubar_process_management_audit.md) might bite again. Add the reranker to the Tier-A fixes if they aren't already shipped.
+
+---
+
+## Phase 1: Late Chunking + Multi-Granularity + Heading Chain
+
+### Goal
+1. Change the embed stage to embed the full doc once (Granite-R2 supports 32K tokens), then mean-pool token reps into per-chunk vectors. Carries cross-chunk context into each chunk embedding.
+2. Add two new embedding tables: `section_embeddings` (one per heading, embedded from heading + surrounding ~5K tokens) and `document_embeddings` (one per doc, embedded from summary + first ~2K tokens).
+3. Make `kb_read_passages` return the heading chain alongside each passage so the LLM sees structural context for free.
+
+### File Structure
+**Create:**
+- `src/harbor_clerk/worker/stages/late_chunk_embed.py` — New embed-stage variant doing late chunking. May replace `embed.py` outright (flagged by `embed_strategy` setting).
+- `src/harbor_clerk/models/section_embedding.py`, `document_embedding.py` — SQLAlchemy models.
+- `alembic/versions/0024_section_doc_embeddings_and_late_chunking.py` — Migration: new tables + HNSW indexes; bump `upgrade_phase=1`.
+- `src/harbor_clerk/search.py` — Extend hybrid search to accept `granularity: list[Literal['chunk', 'section', 'document']]`; ensemble via RRF across the requested layers.
+- `tests/test_late_chunking.py` — End-to-end: docs embedded via late chunking produce different (better) embeddings on cross-reference queries vs naive chunking.
+- `tests/test_multi_granularity_search.py` — RRF merge produces correct ordering; granularity filter works.
+
+**Modify:**
+- `src/harbor_clerk/worker/pipeline.py` — Section + doc embedding stages added to `_PARALLEL_STAGES`; depend on `chunk`.
+- `src/harbor_clerk/api/schemas/search.py` — Add `granularity` field to `SearchRequest`.
+- `src/harbor_clerk/api/routes/search.py` — Pass through to hybrid search.
+- `src/harbor_clerk/mcp_server.py` — `kb_search` accepts `granularity` param; `kb_read_passages` includes `heading_chain: list[str]` in each passage payload.
+- `embedder/src/embedder/app.py` — Add `POST /embed_late_chunk` endpoint accepting full doc text + chunk char-offset boundaries, returning per-chunk pooled embeddings.
+
+### Schema Migration
+`0024_section_doc_embeddings_and_late_chunking.py`:
+- `CREATE TABLE section_embeddings (section_id UUID PK, doc_id UUID FK, heading_id UUID FK, embedding vector(768), char_start INT, char_end INT)`.
+- `CREATE TABLE document_embeddings (doc_id UUID PK FK, embedding vector(768), source TEXT CHECK source IN ('summary', 'first_chunk', 'combined'))`.
+- HNSW indexes on both.
+- Update `schema_metadata`: `upgrade_phase='1'`.
+- Re-enqueue `embed` stage for all docs to populate the new tables AND to redo chunk embeddings with late chunking.
+
+### MCP / API Surface
+- `kb_search` gains `granularity` param (defaults to `['chunk']` for backward compat). When set to `['chunk', 'section', 'document']`, results are RRF-merged across all three.
+- `kb_read_passages` response gains `heading_chain` field per passage: `["Contract", "Section 4", "4.2 Termination"]`.
+- All other tools unchanged.
+
+### Retrieval-Eval Gate
+```bash
+sweep --mode retrieval-eval --run-id 2026-05-05-prod \
+  --label phase-1-late-chunking --prior-label phase-0-granite-r2
+```
+**Pass criteria**: overall recall@10 improvement ≥ +0.03; no per-corpus regression > -0.03; LongEmbed-style queries (multi-paragraph, cross-reference) should show ≥+0.05.
+
+### Risks
+- **Section embedding granularity** is ambiguous — chunks span headings, headings can be 50 chars or 50 pages. The brainstorm needs to pick: every heading? only level 1-2? smart packing into ~5K-token sections? Default to a `_split_into_sections()` helper that targets 3-5K tokens per section, respecting heading boundaries.
+- **Memory cost**: 3× embedding rows. For a corpus with 500K chunks + ~50K sections + 10K docs, that's 560K vectors of 768 floats = ~1.7 GB raw. pgvector with HNSW will roughly double that. Plan for ~4 GB Postgres memory hit; verify on prod-scale Mac mini.
+- **Late chunking implementation** depends on sentence-transformers' token-offset preservation; verify with Granite-R2 specifically before committing.
+
+---
+
+## Phase 2: Metadata Layer (Doc-Type, Temporal, PII, Tables)
+
+### Goal
+Layer four orthogonal preprocessing signals onto every ingested doc so the LLM can filter and route via MCP without post-hoc work:
+1. **Doc-type classification** — one of {contract, invoice, email, memo, policy, report, presentation, form, other} per doc.
+2. **Temporal extraction** — `documents.dated_at`, `documents.deadline_at`, plus per-chunk `temporal_anchors` table.
+3. **PII tagging** — Microsoft Presidio detects PII; per-chunk `pii_types` column.
+4. **Table-aware extraction** — for PDF/XLSX, extract tables as markdown into a `document_tables` table separate from flowing text.
+
+### File Structure
+**Create:**
+- `src/harbor_clerk/worker/stages/classify.py` — Doc-type classifier worker stage.
+- `src/harbor_clerk/worker/stages/temporal.py` — Date extraction worker stage.
+- `src/harbor_clerk/worker/stages/pii.py` — Presidio PII tagging worker stage.
+- `src/harbor_clerk/worker/stages/tables.py` — Table extraction (camelot for PDF, openpyxl for XLSX) worker stage.
+- `src/harbor_clerk/models/document_table.py`, `temporal_anchor.py` — Models.
+- `src/harbor_clerk/llm/doc_type_classifier.py` — Small local LLM (Qwen 4B?) or fine-tuned distilbert; few-shot prompt with the 9 categories.
+- `alembic/versions/0025_metadata_layer.py` — Migration: new columns (`documents.doc_type`, `documents.dated_at`, `documents.deadline_at`, `chunks.pii_types`), new tables (`document_tables`, `temporal_anchors`); bump `upgrade_phase=2`.
+- `tests/test_doc_type_classifier.py`, `test_temporal_extraction.py`, `test_pii_tagging.py`, `test_table_extraction.py`.
+
+**Modify:**
+- `src/harbor_clerk/api/schemas/search.py` — Add `doc_type: list[str] | None`, `dated_after: date | None`, `dated_before: date | None`, `redact_pii: bool = False` to `SearchRequest`.
+- `src/harbor_clerk/api/routes/search.py` — Apply filters; if `redact_pii=True`, redact chunk text before returning.
+- `src/harbor_clerk/search.py` — Pass filters through to the hybrid query.
+- `src/harbor_clerk/mcp_server.py` — `kb_search` accepts new filters; new tool `kb_list_doc_types` returns `[{doc_type, count}]` so the LLM can discover what's filterable.
+- `src/harbor_clerk/worker/pipeline.py` — Add the four new stages to `_PARALLEL_STAGES`.
+
+### Schema Migration
+`0025_metadata_layer.py`:
+- `ALTER TABLE documents ADD COLUMN doc_type TEXT, ADD COLUMN dated_at DATE, ADD COLUMN deadline_at DATE`.
+- `ALTER TABLE chunks ADD COLUMN pii_types TEXT[]`.
+- `CREATE TABLE document_tables (table_id UUID PK, doc_id UUID FK, page_num INT, markdown TEXT, position INT)`.
+- `CREATE TABLE temporal_anchors (anchor_id UUID PK, chunk_id UUID FK, doc_id UUID FK, date_value DATE, surface_form TEXT, char_start INT, char_end INT)`.
+- Indexes on `documents.doc_type`, `documents.dated_at`, `chunks.pii_types` (GIN for array).
+- Update sentinel `upgrade_phase='2'`.
+- For each existing doc, enqueue the four new stages so back-population happens via the normal pipeline.
+
+### MCP / API Surface
+- `kb_search` accepts: `doc_type=['contract']`, `dated_after='2026-01-01'`, `dated_before='2026-06-30'`, `redact_pii=true`.
+- New tool: `kb_list_doc_types` — discover what doc_types exist in the corpus.
+- All existing tools unchanged.
+
+### Retrieval-Eval Gate
+The retrieval-eval harness uses the corpus's existing baseline questions which don't exercise the new filters. **Run two evals**:
+1. Standard retrieval-eval (recall@10, no filter changes) — pass criteria: no regression worse than -0.02. The metadata layer should not affect plain hybrid retrieval.
+2. **Filter precision eval** — write a small new fixture: ~20 questions per corpus that are answerable only by docs of a specific doc_type or date range. Compare top-10 with vs without filters. Pass criteria: filtered precision@10 ≥ unfiltered precision@10 + 0.20 on this fixture.
+
+This is the first phase where retrieval-eval alone isn't enough; add a `--mode filter-precision-eval` if the fixture warrants its own harness.
+
+### Risks
+- **Doc-type classifier model choice** depends on what the brainstorm picks. Local LLM via existing `llama-server` is cheapest but adds latency. Fine-tuned distilbert is faster but needs training data — and CUAD/Enron/synthetic may be enough for that.
+- **Presidio English-only by default** — French PII detection needs the right spaCy pipeline; coordinate with the [Language Packs on Demand](https://github.com/alex/mcp-gateway/blob/main/memory/project_language_packs_on_demand.md) plan.
+- **Camelot has heavy deps** (Ghostscript on Linux, libffi). Verify both Docker and macOS bundling.
+
+---
+
+## Phase 3: Knowledge Graph (Canonicalization + Relations + Cross-Doc Linking)
+
+### Goal
+Turn the existing flat `entities` table into a queryable graph:
+1. **Canonicalize** mentions across docs (Acme Inc. = Acme Corporation = ACME).
+2. **Extract relations** with GLiNER-Relex (zero-shot typed SVO triples).
+3. **Cross-document linking** — resolve "see contract dated 2024-03-15" to the actual doc_id.
+4. **5 new MCP tools** for LLM graph queries.
+
+### File Structure
+**Create:**
+- `src/harbor_clerk/worker/stages/canonicalize_entities.py` — Cluster entity mentions per type, pick canonical names.
+- `src/harbor_clerk/worker/stages/relations.py` — GLiNER-Relex extraction stage.
+- `src/harbor_clerk/worker/stages/cross_doc_links.py` — Regex + resolver for inter-doc references.
+- `src/harbor_clerk/models/entity_canonical.py`, `entity_relation.py`, `document_reference.py` — Models.
+- `src/harbor_clerk/graph/canonicalize.py` — Pure clustering logic (testable in isolation).
+- `src/harbor_clerk/graph/relations_extractor.py` — Wraps GLiNER-Relex.
+- `src/harbor_clerk/graph/resolver.py` — Inter-doc reference resolution.
+- `alembic/versions/0026_knowledge_graph.py` — Migration: new tables, FKs from `entities.canonical_id`; bump `upgrade_phase=3`.
+- `tests/test_canonicalize.py`, `test_relations_extractor.py`, `test_cross_doc_resolver.py`, `test_mcp_graph_tools.py`.
+
+**Modify:**
+- `src/harbor_clerk/mcp_server.py` — Add 5 new tools: `kb_entity_timeline`, `kb_entity_neighborhood`, `kb_paragraph_coincidence`, `kb_cross_corpus_match`, `kb_document_references`. Update `kb_entity_*` existing tools to use canonical entities by default with `include_aliases=true` opt-out.
+- `src/harbor_clerk/worker/pipeline.py` — Add the three new stages; `canonicalize_entities` runs corpus-wide on a schedule, not per-doc.
+
+### Schema Migration
+`0026_knowledge_graph.py`:
+- `CREATE TABLE entity_canonical (canonical_id UUID PK, entity_type TEXT, canonical_name TEXT, aliases TEXT[], mention_count INT, first_seen_at TIMESTAMPTZ, last_seen_at TIMESTAMPTZ)`.
+- `ALTER TABLE entities ADD COLUMN canonical_id UUID REFERENCES entity_canonical(canonical_id)`.
+- `CREATE TABLE entity_relations (relation_id UUID PK, subject_id UUID FK→entity_canonical, predicate TEXT, object_id UUID FK→entity_canonical, doc_id UUID FK, chunk_id UUID FK, confidence FLOAT)`.
+- `CREATE TABLE document_references (reference_id UUID PK, source_doc_id UUID FK, target_doc_id UUID FK NULL, mention_text TEXT, char_start INT, char_end INT, anchor_date DATE NULL, resolution_status TEXT CHECK IN ('resolved', 'ambiguous', 'unresolved'))`.
+- Indexes on `(canonical_id)`, `(subject_id, predicate)`, `(object_id, predicate)`, `(source_doc_id)`, `(target_doc_id)`.
+- Update sentinel `upgrade_phase='3'`.
+
+### MCP / API Surface
+Five new tools. Tool descriptions and JSON schemas TBD in the phase 3 detailed plan. Skeleton:
+
+| Tool | Purpose | Input |
+|---|---|---|
+| `kb_entity_timeline` | All docs mentioning entity X, ordered by date | `{entity_canonical_id, since?, until?}` |
+| `kb_entity_neighborhood` | Entities most strongly co-occurring with X (1-hop graph) | `{entity_canonical_id, top_n}` |
+| `kb_paragraph_coincidence` | Docs where X and Y appear in the same chunk | `{entity_a_id, entity_b_id}` |
+| `kb_cross_corpus_match` | Entities in this doc that also appear in any doc of type Y | `{doc_id, other_doc_type}` |
+| `kb_document_references` | Forward + backward inter-doc reference graph for a doc | `{doc_id, direction='both'/'forward'/'backward'}` |
+
+### Retrieval-Eval Gate
+- Standard retrieval-eval (no regression worse than -0.02 on baseline questions).
+- New "multi-hop fixture": ~30 hand-crafted questions per corpus that require entity-graph traversal ("which contracts involve any party that also appears in invoices from 2024?"). Pass criteria: top-10 includes the correct doc set on ≥ 60% of fixture questions. This fixture is generated once during the phase 3 brainstorm and committed.
+
+### Risks
+- **Canonicalization is the hard problem.** "John Smith" the lawyer vs "John Smith" the witness are different entities the model can't distinguish without context. The brainstorm needs to pick a clustering strategy and confidence threshold; ship with a manual override UI is worth considering.
+- **GLiNER-Relex zero-shot accuracy on office docs is unproven** at this scale. Validation: run on the CUAD subset, manually grade 50 extracted triples per doc_type, gate on ≥70% precision.
+- **`document_references` regex resolver** will be noisy. Plan for the `resolution_status='ambiguous'` bucket to be the dominant case for free-form mentions like "the earlier agreement."
+
+---
+
+## Phase 4: Propositional Indexing + HippoRAG-Style Multi-Hop
+
+### Goal
+1. Decompose each chunk into self-contained atomic factoids via a local LLM pass; embed those into a `propositions` table.
+2. Expose `kb_find_fact` MCP tool for direct factoid retrieval.
+3. Implement HippoRAG-style multi-hop search: personalized PageRank over the entity graph (Phase 3 output) seeded by the query's entities, returning the top chunks via graph traversal. Expose as `kb_multihop_search`.
+
+### File Structure
+**Create:**
+- `src/harbor_clerk/worker/stages/propositions.py` — Per-chunk LLM extraction stage.
+- `src/harbor_clerk/llm/proposition_extractor.py` — Prompt template + parsing for the LLM call.
+- `src/harbor_clerk/graph/hipporag.py` — Pure personalized-PageRank impl over `entity_canonical` × `entity_relations`.
+- `src/harbor_clerk/models/proposition.py` — Model.
+- `alembic/versions/0027_propositions.py` — Migration.
+- `tests/test_proposition_extractor.py`, `test_hipporag.py`, `test_mcp_find_fact.py`, `test_mcp_multihop_search.py`.
+
+**Modify:**
+- `src/harbor_clerk/mcp_server.py` — Add `kb_find_fact` and `kb_multihop_search` tools.
+- `src/harbor_clerk/worker/pipeline.py` — Add propositions stage to `_PARALLEL_STAGES`.
+
+### Schema Migration
+`0027_propositions.py`:
+- `CREATE TABLE propositions (proposition_id UUID PK, chunk_id UUID FK, doc_id UUID FK, text TEXT, embedding vector(768), extracted_at TIMESTAMPTZ)`.
+- HNSW index on `embedding`.
+- Update sentinel `upgrade_phase='4'`.
+
+### MCP / API Surface
+- `kb_find_fact` — input `{query, k}`, returns top-K propositions ranked by semantic similarity, each with a chunk_id + doc_id citation.
+- `kb_multihop_search` — input `{query, max_hops=2}`, returns chunks reached via PageRank traversal of the entity graph seeded by entities in the query.
+
+### Retrieval-Eval Gate
+- Standard retrieval-eval: no regression > -0.02.
+- "Fact-extraction subset" — questions in the baseline of the form "what is X" / "when did Y happen" — measure recall@5 of `kb_find_fact` against baseline citations. Pass criteria: ≥ +0.10 vs the Phase 3 `kb_search` recall on the same subset.
+- "Multi-hop subset" — the Phase 3 multi-hop fixture run through `kb_multihop_search`. Pass criteria: ≥ +0.15 over Phase 3 baseline on this fixture.
+
+### Risks
+- **LLM-extraction cost over the full corpus** is the big-ticket item. ~500K chunks × 1-2 LLM calls each on a local Qwen 4B = 50-100 hours single-threaded. Plan re-extraction as a maintenance background task. Alternative: only extract for docs flagged via a "high-value-doc-type" filter from Phase 2.
+- **HippoRAG implementation details** (damping factor, max iterations, edge weighting) are tunable. Defaults from the paper are a starting point; expect to need a hand-tuned config for the office-doc domain.
+
+---
+
+## Phase 5: UI (Graph Viz, Topic Projection, Doc-Type Composition, Retrieval Inspector)
+
+### Goal
+Wire the data from phases 0-4 into the existing Explore + Search pages, plus a new "inspector" overlay on search results. Use the existing `d3-force`, `d3-drag`, `d3-scale`, `d3-selection` deps (already pulled in but not used for graph viz). No new backend.
+
+### File Structure
+**Create:**
+- `frontend/src/components/explore/EntityGraph.tsx` — Force-directed graph using d3-force, nodes = canonical entities, edges = relations from Phase 3.
+- `frontend/src/components/explore/TopicProjection.tsx` — 2D scatter of docs colored by topic, using UMAP coords from BERTopic (already computed but not surfaced).
+- `frontend/src/components/explore/DocTypeComposition.tsx` — Treemap/pie of corpus by doc_type (from Phase 2).
+- `frontend/src/components/search/RetrievalInspector.tsx` — Per-result expandable section showing FTS score, vector score, reranker score, matched entities.
+- `frontend/src/components/explore/EntityTimeline.tsx` — Bar chart of entity mention frequency over time (uses Phase 2 `temporal_anchors`).
+- Tests for each new component (use Vitest if it's set up; otherwise React Testing Library).
+
+**Modify:**
+- `frontend/src/pages/ExplorePage.tsx` — Replace the three flat top-N entity lists with `<EntityGraph />`; add `<TopicProjection />` and `<DocTypeComposition />` sections.
+- `frontend/src/pages/SearchPage.tsx` — Wrap each hit row with `<RetrievalInspector />`.
+- `frontend/src/api/explore.ts` (or wherever) — Add fetches for the new Phase 3 endpoints powering the graph.
+- `src/harbor_clerk/api/routes/explore.py` (might need creating) — Endpoints returning canonical-entity graph data + UMAP topic coords + retrieval-score breakdown per hit.
+
+### Schema Migration
+None.
+
+### Retrieval-Eval Gate
+Not retrieval-gated. UX-gated:
+- Run through the existing user flows; verify each new viz renders without errors with the prod-scale corpus.
+- Measure render time: graph with 5K nodes should be interactive; treemap with 9 categories should be instant.
+
+### Risks
+- **Graph with thousands of entities** will need either client-side aggregation (top-N + "show more") or server-side filtering. d3-force chokes past ~2-3K nodes in practice.
+- **UMAP coords currently get thrown away** — need to plumb them through the `corpus_topics` model + API + frontend.
+- **Tailwind 4 + d3** integration — d3 manipulates the DOM directly; React + d3 needs careful useEffect/useRef discipline. Use a wrapper pattern (single `<div ref={containerRef}>`, d3 mounts inside).
+
+---
+
+## Inter-Phase Gating Protocol
+
+Between each phase:
+
+1. **Run the retrieval-eval gate** as specified in the phase's "Retrieval-Eval Gate" section.
+2. **Capture the gate output** (the `metrics.csv` and `summary.json` from the eval) in the phase's PR description as a code block.
+3. **If pass**: tag the eval label permanently as `phase-N-final-<short-name>` so subsequent phases can `--prior-label` against it for cumulative comparison.
+4. **If fail**: do not merge. Either:
+   - Revise the phase implementation (most common).
+   - Identify which sub-feature regressed and roll it back, re-eval.
+   - In rare cases, conclude the phase's premise was wrong (e.g. Phase 1 late chunking doesn't help on your corpus) — write up the negative result in a memory file and revise the plan.
+
+5. **Ablation discipline**: do NOT bundle phases. If Phase 0 + Phase 1 land together you'll never know which one was load-bearing for the recall delta. Each phase's eval label tells the upgrade story.
+
+6. **PR followups discipline**: any out-of-scope work surfaced during phase implementation goes into `pr_followups.md` AND the PR description. Phases 1-5 each typically generate 2-5 followups.
+
+---
+
+## Final Eval (After All 6 Phases)
+
+After Phase 5 merges:
+
+1. **Full sweep re-run** with the upgraded pipeline (all 8 local models × all 3 corpora × phase-5 retrieval stack). This is the "definitive evaluation" the user has been planning for.
+2. **Cumulative retrieval-eval**: `--label final --prior-label baseline-e5-small`. Expected overall recall@10 delta: +0.20 to +0.35 vs baseline.
+3. **Filter-precision eval**: re-run the Phase 2 fixture to confirm filters still work end-to-end.
+4. **Multi-hop fixture**: re-run the Phase 3 fixture through `kb_multihop_search` (Phase 4 endpoint). Confirm the multi-hop gains held.
+5. **LLM-as-judge pairwise eval**: pick 50-100 representative questions from the baseline; have a frontier LLM (a DIFFERENT one from the baseline generator, to avoid self-preference) compare baseline-pipeline answers vs upgrade-pipeline answers; report win-rate.
+6. **Write the milestone memory file** capturing: cumulative deltas, what worked, what didn't, what got cut, what's deferred. This becomes the canonical "what shipped in the upgrade" document.
+
+---
+
+## Open Questions Per Phase (to resolve at brainstorm time)
+
+These are the decisions to make BEFORE writing the per-phase detailed plan. Each item is a concrete question with no current answer.
+
+### Phase 0 — Brainstorm Questions
+- Reranker deployment: separate service or co-hosted in embedder container?
+- Reranker pool size (how many candidates to rerank per query): 50? 100?
+- macOS service-management strategy for the reranker — new launchd plist or subprocess of HarborClerkServer?
+- Granite-R2 download: bake into Docker image (~700MB) or download on first run?
+- Re-embed strategy for prod corpus: blocking maintenance window vs background trickle?
+
+### Phase 1 — Brainstorm Questions
+- Section-embedding boundaries: every heading? level 1-2? smart packing to 3-5K tokens?
+- Late-chunking implementation: does Granite-R2 + sentence-transformers preserve token offsets cleanly? If not, fall back to a custom encoder call.
+- Multi-granularity ensemble weights for RRF: equal? tuned per query type?
+- Do we keep the chunk-level embedding column or migrate fully to per-table embeddings?
+
+### Phase 2 — Brainstorm Questions
+- Doc-type classifier: fine-tuned distilbert (needs training data) vs few-shot local LLM (slower but no training)?
+- Doc-type categories: the 9 I listed, or pull from a customer-facing taxonomy?
+- Temporal extraction: spaCy + rules sufficient, or use HeidelTime/SUTime?
+- Presidio + French: which spaCy model pipeline, and how does it integrate with the [language packs] effort?
+- Table extraction strategy for native PDF vs scanned PDF (the latter is image-only post-OCR)?
+
+### Phase 3 — Brainstorm Questions
+- GLiNER vs spaCy NER: full replacement or augmentation?
+- Canonicalization confidence threshold: HDBSCAN min_cluster_size, contextual-embedding window?
+- Relation types per doc-type: enumerate up front in the brainstorm.
+- Manual canonicalization override UI: in scope here or deferred to phase 5?
+- Run canonicalization corpus-wide on a schedule, or incrementally per-doc?
+
+### Phase 4 — Brainstorm Questions
+- Proposition extractor model: Qwen 4B local, or use the active LLM from `model_settings`?
+- Extraction prompt: zero-shot vs few-shot with corpus-specific examples?
+- HippoRAG tunables: damping, max iterations, edge weighting?
+- Update strategy: re-extract propositions when a chunk's embedding changes, or never re-extract?
+
+### Phase 5 — Brainstorm Questions
+- Graph library: pure d3-force, or a React wrapper (react-d3-graph, vis-network)?
+- Node aggregation strategy past ~2K entities: top-N filter, hierarchical clustering view?
+- Retrieval inspector: per-result expandable, or a separate "explain this result" modal?
+- Topic projection layout: scatter only, or also temporal animation?
+
+---
+
+## Branch + Memory Setup (do this first)
+
+Before starting Phase 0:
+
+1. **Create a tracking memory file**: `project_retrieval_mcp_upgrade.md` with a status checklist (one row per phase, status pending/in-progress/done with PR link).
+2. **Create the worktree**: `cd ~/mcp-gateway && git worktree add .claude/worktrees/retrieval-upgrade-phase-0 -b feat/retrieval-phase-0-granite main`.
+3. **Verify the 2026-05-05-prod sweep has finished** before running any retrieval-eval gates. If still running, continue dev but defer the gate.
+4. **Verify the master plan is committed**: this document should be on `main` (via its own PR) before phase 0 starts, so the per-phase plans can link back to it.
+
+---
+
+## Self-Review Notes
+
+This master plan deliberately omits bite-sized step-by-step instructions because each phase is large enough to be its own detailed implementation plan. The information level here matches what's needed for project planning + brainstorm input, not for direct execution.
+
+**Cross-references:**
+- The `--mode retrieval-eval` harness this plan depends on shipped in this session under `scripts/test_corpora/runner/retrieval_eval.py`.
+- The 2026-05-05-prod sweep providing baselines is documented in [project_sweep_2026_05_05_prod_resume.md](https://github.com/alex/mcp-gateway/blob/main/memory/project_sweep_2026_05_05_prod_resume.md).
+- The research grounding for each phase is in this session's transcript.
+
+**Things explicitly NOT in this plan (descoped):**
+- ColBERT-style late interaction (out: bge-reranker captures the gain at lower cost).
+- HyDE / query rewriting (out: frontier LLMs are the caller, they decompose themselves).
+- Apache AGE / graph DB (out: plain Postgres tables suffice for the queries we care about).
+- "GraphRAG"-style full LLM-extracted entity graph (out: too expensive, GraphRAG-Bench 2026 showed marginal gains).
+- jina-embeddings-v3/v4/v5 (out: CC-BY-NC license incompatible with redistributable appliance).
+- Apple AGE / Memgraph / Neo4j (out: dependency minimalism wins for a single-tenant appliance).
+- Claim/argument extraction (out: defer until a legal-customer needs it).
+
+**Things explicitly deferred (will land separately):**
+- Per-doc-type aspect extraction (invoices, contracts) — wait for Phase 2 doc-type classifier, then build per-type as a separate effort.
+- Mobile/responsive ExplorePage — Phase 5 targets desktop first.
+- Multi-user / collaborative annotation of canonical entities — single-tenant scope keeps this out.

--- a/docs/superpowers/specs/2026-05-17-embedding-v2-design.md
+++ b/docs/superpowers/specs/2026-05-17-embedding-v2-design.md
@@ -1,0 +1,430 @@
+# Embedding v2 (Granite-R2 + Reranker + Schema Rebase) — Design
+
+**Status:** Design / pre-plan
+**Spec author session date:** 2026-05-17
+**Companion documents:**
+- Master staging plan: [`docs/superpowers/plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md`](../plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md) (this is the first of 6 phases)
+- Implementation plan (to be written next): `docs/superpowers/plans/2026-05-17-embedding-v2-implementation.md`
+
+## Goal
+
+Swap Harbor Clerk's embedding stack from `intfloat/multilingual-e5-small` (118M params / 384-dim) to `ibm-granite/granite-embedding-311m-multilingual-r2` (311M / 768-dim), add `BAAI/bge-reranker-v2-m3` as a cross-encoder precision stage on top of hybrid retrieval, and rebase the alembic chain so the new initial migration represents the new schema directly.
+
+Expected impact: overall recall@10 improvement of +0.08 to +0.18 against the `2026-05-05-prod` sweep baselines, gated by `--mode retrieval-eval --label embedding-v2`.
+
+## Non-Goals
+
+- **Late chunking** (embedding the full doc and pooling contextualized token reps) — deferred to the next phase.
+- **Multi-granularity embeddings** (separate section/document tables) — next phase.
+- **Heading chain in passages** — next phase.
+- **MCP tool surface changes** — none in this phase. `kb_search`, `kb_read_passages`, etc. keep identical request/response shapes. The only response change is internal: `score` becomes the reranker score and a new optional `score_breakdown` field is populated (consumed by the Phase 5 retrieval inspector, not by current clients).
+- **In-app destructive migration of existing DBs** — explicitly out of scope. The alembic chain is rebased; existing DBs either get wiped and re-ingested (recommended for office appliances with watched folders) or migrated via the external script.
+- **Provider abstraction** (`EmbeddingProvider` ABC, model registry, etc.) — YAGNI. Add when a second model is worth switching between.
+
+## Architecture
+
+```
+                                        ┌──────────────────────┐
+                                        │  Embedder service    │
+                                        │  port 8000           │
+                                        │  Granite-R2 768-dim  │
+                                        └──────────▲───────────┘
+                                                   │ POST /embed
+                                                   │ (HTTP)
+┌────────────────┐    POST /api/search             │
+│ MCP client     ├───┐                             │
+│ (frontier LLM) │   │   ┌─────────────────────────┴───────┐
+└────────────────┘   ├──▶│  HC API (FastAPI)               │
+┌────────────────┐   │   │  ────────────────────────────── │
+│ Web UI         ├───┘   │  on boot: verify_schema_sentinel│
+└────────────────┘       │  /api/search:                   │
+                         │   1. hybrid_search(K + pad)     │
+                         │   2. rerank top pool            │───┐
+                         │   3. truncate to K              │   │
+                         └─────────────────────────────────┘   │ POST /rerank
+                                                               │ (HTTP)
+                                                   ┌───────────▼──────────┐
+                                                   │  Reranker service    │
+                                                   │  port 8001           │
+                                                   │  bge-reranker-v2-m3  │
+                                                   └──────────────────────┘
+```
+
+- Embedder service: existing FastAPI process at `embedder/`, only change is the bundled model + removal of the e5 query/passage prefix logic. Used by the `embed` worker stage at ingest time.
+- Reranker service: NEW FastAPI process modeled after embedder. Loaded with `BAAI/bge-reranker-v2-m3` at startup. Used by `/api/search` at query time (and by the future `kb_search` MCP tool — same code path).
+- HC API: same shape as today, with a new `rerank_hits()` helper called between hybrid merge and top-K truncation.
+- Schema sentinel: new `schema_metadata` table populated by the rebased initial migration; queried at boot by both API and workers.
+
+## Components
+
+### 1. Embedder service (model swap)
+
+**Existing:** [`embedder/src/embedder/app.py`](../../../embedder/src/embedder/app.py) — FastAPI app loading a SentenceTransformer model and exposing `POST /embed`.
+
+**Changes:**
+- Default `EMBED_MODEL` becomes `ibm-granite/granite-embedding-311m-multilingual-r2`.
+- The `task: "query" | "passage"` request param is **accepted but ignored** — Granite-R2 uses CLS pooling and needs no e5-style prefix. The param stays in the schema so existing callers (the `embed` worker stage at `src/harbor_clerk/worker/stages/embed.py`) work unchanged.
+- Response shape unchanged (`{embeddings: list[list[float]], model: str, dimensions: int}`); `dimensions` now reports `768`.
+- Embedding precision: fp16 (sentence-transformers default; works on MPS).
+- Docker image: bake the Granite-R2 weights at build time via `huggingface-cli download` step. Adds ~700 MB to the embedder image.
+- macOS bundle: download into the app bundle's `Resources/models/` during `make` via `macos/scripts/download-models.sh`.
+
+### 2. Reranker service (new)
+
+**New file:** `embedder/src/embedder/reranker.py` (sharing pyproject with embedder so both ship in the same wheel).
+
+**Wire shape:**
+```
+POST /rerank
+{
+  "query": "what is the termination clause",
+  "passages": [
+    "Title: ACME-Beta MSA\n\nChunk: 4.2 Either party may terminate ...",
+    "Title: ACME-Beta MSA\n\nChunk: 7.1 Confidentiality survives ...",
+    ...
+  ],
+  "top_k": 10
+}
+
+→ 200 OK
+{
+  "scores": [
+    {"index": 0, "score": 0.9821},
+    {"index": 1, "score": 0.4733},
+    ...
+  ],
+  "model": "BAAI/bge-reranker-v2-m3"
+}
+```
+
+- `scores` is sorted desc and truncated to `top_k`.
+- `index` is the position in the input `passages` array — the caller correlates back to its full hit objects.
+- Empty `passages` → empty `scores`, 200 OK (not an error).
+- `top_k > len(passages)` → returns all available, 200 OK.
+
+**Implementation:** `sentence_transformers.CrossEncoder("BAAI/bge-reranker-v2-m3")`. fp16. Health endpoint at `/health` returns 200 when model is loaded.
+
+**Service port:** 8001 (Docker), configurable port (macOS, allocated by HarborClerkServer alongside the existing API/embedder ports).
+
+**Dockerfile:** new `docker/reranker.Dockerfile`. Same Python base as embedder. Bakes the reranker weights at build time.
+
+### 3. Schema sentinel + boot-time verification
+
+**New table** (created by the rebased initial migration):
+```sql
+CREATE TABLE schema_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  set_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO schema_metadata (key, value) VALUES
+  ('embed_model', 'granite-embedding-311m-multilingual-r2'),
+  ('embed_dim', '768'),
+  ('reranker', 'bge-reranker-v2-m3');
+```
+
+No `upgrade_phase` row — `alembic_version` already records what version of the schema the DB is at. The sentinel exists specifically to assert "what model + dim is this DB compatible with."
+
+**New file:** `src/harbor_clerk/db_health.py`
+
+```python
+async def verify_schema_sentinel(session: AsyncSession) -> None:
+    """Panic-exit if the DB's schema_metadata doesn't match this binary's settings.
+
+    Called at API lifespan startup AND at worker boot, before any other DB work.
+    Failure mode: log CRITICAL message naming the expected vs actual values,
+    then sys.exit(2). No auto-migration, no fallback.
+    """
+    ...
+```
+
+The check compares:
+- `schema_metadata.embed_model` vs `settings.embed_model`
+- `schema_metadata.embed_dim` vs `settings.embed_dim`
+
+On mismatch, the log message is multi-line and explicit:
+```
+CRITICAL: schema sentinel mismatch — refusing to start.
+  expected: embed_model=granite-embedding-311m-multilingual-r2, embed_dim=768
+  found:    embed_model=multilingual-e5-small, embed_dim=384
+This binary requires the embedding-v2 schema. Either:
+  1. Drop and recreate the database (fresh schema, then re-ingest via watched folders), OR
+  2. Run scripts/migrate_to_embedding_v2.py against this DB.
+See docs/upgrade-runbook.md#embedding-v2 for details.
+```
+
+If the `schema_metadata` table itself is missing (pre-rebase DB): same panic, with a slightly different message naming the missing table.
+
+**Wired into:**
+- `src/harbor_clerk/api/app.py` lifespan startup — runs before the API serves traffic.
+- `src/harbor_clerk/worker/entry.py` `main()` — runs before the worker pulls its first job.
+
+### 4. Search reranking integration
+
+**New file:** `src/harbor_clerk/search_rerank.py`
+
+```python
+async def rerank_hits(query: str, hits: list[SearchHit], top_k: int) -> list[SearchHit]:
+    """Rerank a candidate pool via the reranker service, truncate to top_k.
+
+    On reranker HTTP failure: if settings.reranker_strict, raise; otherwise
+    log a warning and return hits[:top_k] in their original (hybrid-merged)
+    order. Sets `hit.score` to the reranker score on success.
+    """
+    ...
+```
+
+The passage strings sent to the reranker are formatted as:
+```
+Title: {doc_title}\n\nChunk: {chunk_text}
+```
+Pure chunk text loses cross-encoder context; including the doc title gives the reranker enough signal to score correctly on chunks that reference parent context implicitly ("this section discusses...").
+
+**Modified:** `src/harbor_clerk/search.py`
+
+The `hybrid_search()` function gains an optional rerank step at the end:
+1. Fetch top `K + reranker_top_k_pad` from the merged hybrid pool (instead of just K).
+2. If `settings.reranker_enabled`, call `rerank_hits(query, pool, K)`; replace `hit.score` with the reranker score; sort desc.
+3. Otherwise (or after fallback), truncate to top K by combined hybrid score (current behavior).
+
+The new `score_breakdown` field on `SearchHitOut` is populated with `{fts, vector, hybrid, reranker}`. Always present in the API response (typed `dict | None`). Not consumed by any client in this phase — wired for the Phase 5 retrieval inspector.
+
+### 5. macOS service-management
+
+The reranker is a new managed Python subprocess. Same pattern as the embedder:
+
+**New Swift files** (under `macos/HarborClerkServer/HarborClerkServer/`):
+- `RerankerService.swift` — service definition matching `EmbedderService.swift`.
+
+**Modified Swift files:**
+- `ServiceManager.swift` — register reranker in the service list; startup ordering: Postgres → Tika → Embedder → Reranker → API → Workers.
+- `PreferencesWindow.swift` / `Settings.swift` — expose reranker port + enabled toggle alongside embedder.
+- `ServiceLogsPage.tsx` (frontend) — list reranker among the services whose logs are tailed.
+- `SystemStatusPage.tsx` (frontend) — show reranker health alongside embedder.
+
+**NOT launchd.** Launchd is the right tool for Postgres + Tika (long-running, expensive to restart, OS-integrated). The reranker is cheap to restart, benefits from being killed/restarted alongside the rest of the Python services on model switches or upgrades, and matches the embedder's lifecycle.
+
+### 6. Alembic rebase
+
+**The 22 existing alembic migrations** (`alembic/versions/0001_initial_schema.py` through `0022_*.py`) are **deleted** from the repo and **replaced by one new file**: `alembic/versions/0001_initial.py`.
+
+The new initial migration:
+- Creates the entire schema in its current shape (every table, every column, every constraint, every index, every CHECK), **PLUS** the embedding-v2 changes:
+  - `chunks.embedding` is `vector(768)` (not 384)
+  - `schema_metadata` table created and populated with the three sentinel rows
+- Has a non-trivial `downgrade()` that raises `NotImplementedError("embedding-v2 initial migration is not reversible; restore from backup.")`.
+
+On a **fresh install**: `alembic upgrade head` runs this one migration and the DB is at the right state. The sentinel rows are populated. The app boots cleanly.
+
+On an **existing install** (with `alembic_version = '0022'` or similar): `alembic upgrade head` fails with `Can't locate revision identified by '0022'` because that revision no longer exists in the script tree. The error is loud and the app refuses to start. The operator must either (a) wipe + re-launch, or (b) run the external migration script (Component 7).
+
+**Optional polish in MigrationRunner.swift:** catch this specific alembic error and surface a friendlier menubar message: "Schema mismatch — see upgrade runbook (docs/upgrade-runbook.md#embedding-v2)". Low priority; the raw alembic error is also actionable.
+
+### 7. External migration script — `scripts/migrate_to_embedding_v2.py`
+
+**Standalone Python**, outside the alembic flow, for operators who want to migrate an existing DB rather than wipe + re-ingest.
+
+**Invocation:**
+```bash
+uv run python scripts/migrate_to_embedding_v2.py \
+  --db-url postgresql://harbor_clerk@localhost/harbor_clerk \
+  --confirm
+```
+
+**Pre-flight refuses to run if:**
+- `--confirm` flag missing.
+- `schema_metadata` table already exists and `embed_model` row is present (DB is already migrated).
+- `alembic_version.version_num` does NOT equal the expected pre-rebase head (`'0022'` at time of writing). The expected head is hardcoded in the script — if the prod DB is at a different head, the script refuses rather than guess.
+- The current `chunks.embedding` column is not present, or is not `vector(384)`.
+
+**Operations** (single transaction where possible):
+1. `CREATE TABLE schema_metadata` with the three sentinel rows.
+2. `ALTER TABLE chunks DROP COLUMN embedding`.
+3. `ALTER TABLE chunks ADD COLUMN embedding vector(768)`.
+4. `DROP INDEX chunks_embedding_hnsw_idx`.
+5. `CREATE INDEX chunks_embedding_hnsw_idx ON chunks USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)`.
+6. `UPDATE alembic_version SET version_num = '<revision id of the rebased 0001_initial.py>'`. The actual revision id is the value alembic generates at the top of the rebased migration file; the script reads it from a module-level constant that matches.
+7. Enqueue `embed` stage for every doc with `pipeline_status='ready'`, ordered `documents.updated_at DESC` (most-recent-first). The script only enqueues; the actual re-embed runs when workers come back up on the new binary.
+
+**Logging:**
+- stdout: progress per step
+- Also writes a log file under the standard log dir (`~/Library/Application Support/Harbor Clerk/logs/migrate_to_embedding_v2.log` on macOS, `./logs/migrate_to_embedding_v2.log` otherwise) so the operation has a permanent record.
+
+**Failure mode:** if any step raises, the transaction rolls back, the script exits non-zero, the DB is unchanged. No partial-migration state.
+
+`--help` documents the operations in plain English and links to the upgrade runbook.
+
+## Data Flow
+
+### Boot
+1. API process starts.
+2. Alembic check (already in lifespan): warns on version mismatch.
+3. **NEW**: `verify_schema_sentinel()` — panics out if `schema_metadata` doesn't match settings.
+4. Lifespan completes, FastAPI begins serving.
+
+Same flow for workers: check sentinel before pulling the first job.
+
+### Ingest (`embed` worker stage)
+1. Worker pulls an `embed` job from the queue.
+2. Loads chunks where `embedding IS NULL`.
+3. Batches into groups of 64; POSTs to embedder `/embed` with `task="passage"` (param ignored by Granite-R2 but kept for backward compat).
+4. Writes the returned 768-dim vectors into `chunks.embedding`.
+5. Re-check `pipeline_seq` between batches (existing race-prevention logic).
+6. Mark stage done.
+
+**Stage timeout** raised from 1800s → 3600s. Granite-R2 is ~5× slower per chunk than e5-small on Mac mini silicon; large docs (~500 chunks) take ~25s with e5-small vs ~2 min with Granite. The doubled timeout keeps headroom.
+
+### Search (`POST /api/search` or `kb_search` MCP tool)
+1. Receive query.
+2. `hybrid_search()` runs FTS (en + fr) + vector cosine; merges scores; produces top `min(K + reranker_top_k_pad, reranker_pool_size)` candidates. With defaults (`K=10`, `pad=40`, `pool_size=50`): 50 candidates flow to the reranker. A caller asking for `K=20` sees the same 50 (capped by `pool_size`); `K=100` would yield `min(140, 50) = 50`.
+3. If `settings.reranker_enabled`:
+   - Format candidates as `"Title: {doc_title}\n\nChunk: {chunk_text}"`.
+   - POST to reranker `/rerank` with `top_k=K`.
+   - Reorder candidates by returned scores; set `hit.score = reranker_score`.
+   - On failure: if `reranker_strict`, raise 503; else log warning and continue with hybrid-only top-K.
+4. Populate `score_breakdown` on every returned hit (for future inspector).
+5. Return top-K.
+
+## Settings (additions to `src/harbor_clerk/config.py`)
+
+```python
+embed_model: str = "ibm-granite/granite-embedding-311m-multilingual-r2"
+embed_dim: int = 768
+embed_needs_prefix: bool = False  # Granite uses CLS pooling; e5 needed query:/passage:
+
+reranker_enabled: bool = True
+reranker_url: str = "http://reranker:8001"  # docker default; macOS overrides via env
+reranker_top_k_pad: int = 40                # how many extra hits to fetch above K for reranking
+reranker_pool_size: int = 50                # hard upper bound on passages sent per /rerank call
+reranker_strict: bool = False               # raise vs fall back on reranker outage
+reranker_timeout_seconds: float = 30.0      # per-call HTTP timeout
+```
+
+All read from env vars (pydantic-settings); defaults work for the standard Docker layout. macOS overrides `reranker_url` via the existing env-var-from-config pattern.
+
+## API Surface
+
+**No tool signatures change.** Both `POST /api/search` and the `kb_search` MCP tool keep their existing request schemas (no new required params).
+
+**Response additions** to `SearchHitOut` (`src/harbor_clerk/api/schemas/search.py`):
+
+```python
+class SearchHitOut(BaseModel):
+    # ... existing fields ...
+    score: float                              # NOW: reranker score when reranking enabled
+    score_breakdown: ScoreBreakdown | None    # NEW: details for the Phase-5 inspector
+
+class ScoreBreakdown(BaseModel):
+    fts: float
+    vector: float
+    hybrid: float
+    reranker: float | None
+```
+
+**Response addition** to `SearchResponse`:
+
+```python
+class SearchResponse(BaseModel):
+    # ... existing fields ...
+    reranker_status: Literal["ok", "disabled", "failed"]  # NEW
+```
+
+`reranker_status` lets the frontend show a banner when fallback is active. Internal value, not exposed via MCP tool descriptions.
+
+## Error Handling
+
+| Failure mode | Handling |
+|---|---|
+| Sentinel mismatch at boot | `CRITICAL` log + `sys.exit(2)`. No auto-migration. |
+| `schema_metadata` table missing at boot | Same as sentinel mismatch; message explicitly names the missing table. |
+| Reranker HTTP timeout | `reranker_strict=False` (default): log WARNING, set `reranker_status="failed"`, return top-K from hybrid pool unchanged. `reranker_strict=True`: raise HTTPException 503 to the caller. |
+| Reranker returns malformed JSON | Same as timeout. |
+| Embedder timeout during ingest | Existing `embed` stage retry logic; stage marked error after the existing timeout. |
+| External migration script: pre-flight check fails | Print which check failed + remediation; exit non-zero. DB untouched. |
+| External migration script: mid-operation exception | Transaction rolls back; exit non-zero; log captured. DB consistent (no partial migration). |
+| Granite-R2 model file corrupt at startup | Embedder process refuses to start; ServiceManager on macOS / docker healthcheck flags it; HC API will surface this via `/api/system/health`. |
+
+## Testing Strategy
+
+| Test file | What it covers | Real-or-mocked deps |
+|---|---|---|
+| `tests/test_db_health.py` | `verify_schema_sentinel()` happy path + mismatch panic | Real Postgres test DB; populates `schema_metadata` directly |
+| `tests/test_search_rerank.py` | `rerank_hits()`: ordering, top_k truncation, fallback on HTTP failure, strict mode | `httpx_mock`-style stub reranker |
+| `tests/test_search_rerank_integration.py` | End-to-end `hybrid_search()` with real reranker | Marked `requires_models` (new pytest marker, registered in `pyproject.toml` alongside the existing `integration` marker); not run in CI by default; runs locally + nightly |
+| `tests/test_embedder_granite.py` | Granite-R2 loads, returns 768-dim, handles batch=64 | Same `requires_models` marker |
+| `tests/test_migrate_to_embedding_v2.py` | External migration script: pre-flight refusals + happy-path on a fixture old-schema DB | Real Postgres test DB with a fixture loaded from a v0.X SQL dump |
+| `tests/test_reranker_service.py` | Reranker FastAPI app: empty passages, top_k > len, malformed input | In-process test client |
+| `tests/test_alembic_initial.py` | Rebased `0001_initial.py` runs cleanly against an empty DB and yields the expected `schema_metadata` + `chunks.embedding` type | Real Postgres test DB |
+
+**Retrieval-eval gate** (NOT in CI):
+```bash
+sweep --mode retrieval-eval \
+  --run-id 2026-05-05-prod \
+  --api-base http://localhost:8100 \
+  --label embedding-v2
+```
+Pass criteria, applied as the final pre-merge gate:
+- Overall recall@10 improvement: **≥ +0.08**
+- No per-corpus regression worse than **-0.05**
+- nDCG@10 also improves overall
+- CSV + summary committed in the PR description as a code block
+
+The retrieval-eval gate is a **manual checkbox** in the PR template, run by the human reviewer (or by the author before requesting review). NOT enforced by CI because it requires a running HC instance with the prod-scale corpus.
+
+## Rollout Plan
+
+For developers iterating on the branch:
+1. Work in `feat/embedding-v2-granite-and-reranker` worktree.
+2. Unit tests + format/lint run as normal in CI.
+3. Local integration tests run with `requires_models` marker enabled.
+4. **Do NOT rebuild the user's HarborClerkServer.app from this branch** until ready to commit to the upgrade — the rebuilt app's MigrationRunner will fail to start against the user's existing `0022`-version DB.
+
+For operators upgrading an existing deployment:
+1. **Path A (recommended for office appliances):** Stop HC. Drop the database. Re-launch from the new binary. Watched folders auto-rescan and re-ingest with Granite-R2 embeddings. Search works as soon as the first few docs finish ingesting; full corpus rebuild trickles in the background.
+2. **Path B (preserve existing DB):** **Stop HC** (workers + API + embedder all down). Run `scripts/migrate_to_embedding_v2.py --db-url <...> --confirm`. Wait for the script to finish (a few seconds — schema change + enqueue, no re-embed). **Re-launch HC from the embedding-v2 binary.** Sentinel check passes (script populated it). Workers come up against Granite-R2 embedder, see the queued `embed` jobs, and trickle through them most-recent-first. Search works throughout (chunks without new embeddings just don't surface via the vector leg until they're processed).
+
+The "stop HC entirely before running the script" sequencing is important — the script and a running worker should not race on the `chunks.embedding` column type change. The script itself is atomic (single transaction), but a worker mid-batch when the column type changes will fail mid-write.
+
+For the operator running the `2026-05-05-prod` sweep right now: nothing changes during Phase 0 development. The sweep continues against the current HC instance. When the sweep finishes and the operator is ready to evaluate Phase 0, they cut over per Path A or B above, then run the retrieval-eval gate.
+
+## Risks + Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Granite-R2 was released April 2026 (~3 weeks before this design); only ~18K downloads/month. Real-world bugs may surface. | Smoke-test the model in `tests/test_embedder_granite.py` with the corpus's actual content. Keep `EMBED_MODEL` env-var-configurable so a rollback to e5-small is a one-line change if Granite has a showstopper. Note: rollback also requires re-running the migration in reverse, which means restoring from backup — flag this in the upgrade runbook. |
+| Reranker is a new service; adds health-check surface, restart coordination on macOS. The "Quit hang" pattern in [`project_menubar_process_management_audit.md`](../../../memory/project_menubar_process_management_audit.md) might bite again. | Tier A (PR #341), Tier B (PR #343-345), and Tier C launchd migration (PR #346) all shipped 2026-05-12 — process-group handling, shutdown-aware HealthChecker, Force Stop All menu, launchd for Postgres+Tika are in place. Reranker follows the same `EmbedderService.swift` lifecycle pattern and inherits those fixes. No new process-management work required. |
+| Re-embed of a large prod corpus takes hours single-threaded. | Background trickle model; UI badge ("re-embedding: N of M docs"); document the timeline in the upgrade runbook. Acceptable degradation: vector leg has reduced recall during re-embed, but FTS leg is unaffected. |
+| Bundling models adds ~2 GB to Docker image + macOS bundle. | Acceptable per project philosophy. Reranker model alone (1.2 GB) is the bigger contributor. Document the size bump in release notes. |
+| The `0001_initial.py` rebased migration is a huge file (recreates entire schema). PR review will see a lot of new lines. | Generate it programmatically (`alembic revision --autogenerate` against a fresh DB at current head, then add the embedding-v2 changes manually). Note in the PR description that line count is mechanical. |
+| External migration script's hardcoded `'0022'` expected-head will go stale if any migration lands between this design and the Phase 0 implementation. | Re-validate the expected head immediately before opening the PR; if drift has occurred, regenerate the rebased initial migration to include the new changes. |
+| Reranker timeout default (30s) might be too short for a Mac mini under heavy load. | Configurable via `reranker_timeout_seconds`. The retrieval-eval gate will surface timeout issues in the metrics CSV (high latency rows). |
+
+## Open Questions Resolved (vs the master plan's Open Questions for Phase 0)
+
+- ~~Reranker deployment: separate service or co-hosted in embedder container?~~ **Separate service.** Different scaling profile, cleaner failure isolation.
+- ~~Reranker pool size?~~ **50, configurable.**
+- ~~macOS service-management strategy?~~ **Python subprocess via ServiceManager, same pattern as embedder. Not launchd.**
+- ~~Granite-R2 download: bake into image or download on first run?~~ **Bake into Docker image AND macOS bundle.**
+- ~~Re-embed strategy: blocking maintenance window vs background trickle?~~ **Background trickle, most-recent-first.**
+
+Decisions added in this design beyond the master plan's question list:
+- Reranker precision: **fp16**.
+- Reranker input format: **`Title: ...\n\nChunk: ...`** (heading chain comes in next phase).
+- Reranker failure handling: **fallback to hybrid-only top-K**, configurable strict mode.
+- `task` param backward compat: **accepted but ignored** (don't break the existing `embed` worker stage).
+- Settings shape: **flat env vars, no provider abstraction** (YAGNI).
+- Schema sentinel rows: **drop `upgrade_phase`** — alembic_version is authoritative for schema version.
+- `score_breakdown`: **populated unconditionally**, even though no client consumes it yet (wired for Phase 5).
+- HNSW params: **unchanged** (`m=16, ef_construction=64`) — index tuning is a separate exercise.
+- Worker timeout: **1800s → 3600s** for `embed` stage.
+- CI: **unit tests mock the embedder/reranker HTTP**; integration tests gated on `requires_models` marker; retrieval-eval is a manual pre-merge step.
+- Alembic strategy: **rebased to `0001_initial.py`**; old migrations deleted; no in-app upgrade migration.
+- External migration script: **`scripts/migrate_to_embedding_v2.py`**, refuses to run unless `--confirm` AND `alembic_version = '0022'` AND no existing sentinel.
+
+## Cross-References
+
+- Master plan staging doc: [`docs/superpowers/plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md`](../plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md)
+- Retrieval-eval harness (already shipped): [`scripts/test_corpora/runner/retrieval_eval.py`](../../../scripts/test_corpora/runner/retrieval_eval.py)
+- Sweep baseline source: [`memory/project_sweep_2026_05_05_prod_resume.md`](../../../memory/project_sweep_2026_05_05_prod_resume.md)
+- Macos process-management context: [`memory/project_menubar_process_management_audit.md`](../../../memory/project_menubar_process_management_audit.md)

--- a/scripts/test_corpora/runner/metrics.py
+++ b/scripts/test_corpora/runner/metrics.py
@@ -4,11 +4,18 @@ Citation overlap is at doc_id level (chunk-level is too noisy because
 hybrid retrieval pulls slightly different chunks per run). Entity overlap
 uses spaCy NER over the answer text; the same models Harbor Clerk uses
 (``en_core_web_sm``, ``fr_core_news_sm``).
+
+The retrieval-eval metrics (``recall_at_k``, ``reciprocal_rank``,
+``ndcg_at_k``) treat baseline ``cited_doc_ids`` as binary relevance labels
+and grade a ranked list of doc_ids returned by ``/api/search``. They are
+single-query; aggregate at the call site (the mean of ``reciprocal_rank``
+across queries is MRR).
 """
 
 from __future__ import annotations
 
 import functools
+import math
 from collections.abc import Iterable
 
 
@@ -55,3 +62,55 @@ def entity_overlap(baseline_text: str, model_text: str, lang: str = "en") -> flo
     baseline_norm = {e.lower() for e in baseline}
     model_norm = {e.lower() for e in model}
     return len(baseline_norm & model_norm) / len(baseline_norm)
+
+
+def recall_at_k(baseline_doc_ids: Iterable[str], ranked_doc_ids: Iterable[str], k: int) -> float:
+    """Recall@K: fraction of baseline ids appearing in the first K ranked ids.
+
+    Duplicates in ``ranked_doc_ids`` count once. Returns 0.0 when ``baseline``
+    is empty (no truth → no signal) or ``k <= 0``.
+    """
+    baseline = set(baseline_doc_ids)
+    if not baseline or k <= 0:
+        return 0.0
+    top_k = set(list(ranked_doc_ids)[:k])
+    return len(baseline & top_k) / len(baseline)
+
+
+def reciprocal_rank(baseline_doc_ids: Iterable[str], ranked_doc_ids: Iterable[str]) -> float:
+    """1 / (1-indexed rank of the earliest baseline id in the ranked list).
+
+    Returns 0.0 if no baseline id appears in ``ranked_doc_ids`` or either
+    input is empty. Caller computes MRR by averaging across queries.
+    """
+    baseline = set(baseline_doc_ids)
+    if not baseline:
+        return 0.0
+    for i, doc_id in enumerate(ranked_doc_ids, start=1):
+        if doc_id in baseline:
+            return 1.0 / i
+    return 0.0
+
+
+def ndcg_at_k(baseline_doc_ids: Iterable[str], ranked_doc_ids: Iterable[str], k: int) -> float:
+    """nDCG@K with binary relevance from ``baseline_doc_ids``.
+
+    DCG@K = Σ rel_i / log2(i+1), 1-indexed. IDCG@K is the ideal DCG capped
+    at ``min(k, |baseline|)``. Returns 0.0 when baseline is empty, ranked
+    is empty, or ``k <= 0``.
+    """
+    baseline = set(baseline_doc_ids)
+    if not baseline or k <= 0:
+        return 0.0
+
+    top_k = list(ranked_doc_ids)[:k]
+    dcg = 0.0
+    for i, doc_id in enumerate(top_k, start=1):
+        if doc_id in baseline:
+            dcg += 1.0 / math.log2(i + 1)
+
+    ideal_hits = min(k, len(baseline))
+    idcg = sum(1.0 / math.log2(i + 1) for i in range(1, ideal_hits + 1))
+    if idcg == 0:
+        return 0.0
+    return dcg / idcg

--- a/scripts/test_corpora/runner/retrieval_eval.py
+++ b/scripts/test_corpora/runner/retrieval_eval.py
@@ -1,0 +1,513 @@
+"""--mode retrieval-eval — fast retrieval-only evaluation between phases.
+
+The full 6-phase sweep (sweep.py) takes hours and runs every local model
+across every corpus. This mode bypasses all of that to answer one question:
+
+    "Did my retrieval-pipeline change move recall vs the existing baselines?"
+
+For each baseline JSON written by Phase 1, it POSTs the question text to
+HC's ``/api/search``, dedupes the doc_ids by best score, and computes
+``recall@k`` / ``MRR`` / ``nDCG@10`` against the baseline's
+``cited_doc_ids``. No LLM is invoked. No model switch. No re-ingest. No
+``state.json``.
+
+CLI surface (dispatched from sweep.py when ``--mode retrieval-eval`` is set):
+
+    sweep --mode retrieval-eval \\
+        --run-id 2026-05-05-prod \\
+        --api-base http://localhost:8100 \\
+        --label phase-0-granite-r2 \\
+        [--prior-label e5-small-baseline] \\
+        [--corpora cuad,synthetic] \\
+        [--questions-per-corpus N] \\
+        [--k 5,10,20] \\
+        [--search-k 50]
+
+Output under ``<workdir>/results/<run_id>/retrieval-eval/<label>/``:
+
+  * ``metrics.csv``   — one row per question
+  * ``summary.json``  — overall + per-corpus aggregates
+  * ``vs_<prior_label>.json`` — pairwise delta (only if ``--prior-label`` set)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import json
+import logging
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from scripts.test_corpora import conftest as cfg
+from scripts.test_corpora.runner.client import HarborClerkClient
+from scripts.test_corpora.runner.metrics import ndcg_at_k, recall_at_k, reciprocal_rank
+from scripts.test_corpora.runner.quality import baseline_quality_problem
+
+log = logging.getLogger("retrieval_eval")
+
+
+# ── data shapes ──
+
+
+@dataclasses.dataclass(frozen=True)
+class BaselineRecord:
+    corpus: str
+    question_id: str
+    question_text: str
+    cited_doc_ids: list[str]
+
+
+@dataclasses.dataclass
+class EvalRow:
+    corpus: str
+    question_id: str
+    question_text: str
+    recall_at_k: dict[int, float]
+    reciprocal_rank: float
+    ndcg_at_10: float
+    top_doc_id: str | None
+    baseline_cited_doc_ids: list[str]
+    returned_doc_ids: list[str]
+
+
+# ── pure functions ──
+
+
+def load_baselines(
+    baselines_dir: Path,
+    corpora: set[str] | None,
+    limit_per_corpus: int | None,
+) -> list[BaselineRecord]:
+    """Walk ``baselines/<corpus>/*.json``, drop unusable rows, return records.
+
+    Unusable means ``cited_doc_ids`` is empty (the baseline can't grade
+    retrieval) or any of the existing ``baseline_quality_problem`` checks
+    flag the baseline as corrupt/refusal/placeholder.
+    """
+    if not baselines_dir.exists():
+        return []
+
+    records: list[BaselineRecord] = []
+    per_corpus_count: dict[str, int] = {}
+
+    for corpus_dir in sorted(p for p in baselines_dir.iterdir() if p.is_dir()):
+        corpus = corpus_dir.name
+        if corpora is not None and corpus not in corpora:
+            continue
+        for path in sorted(corpus_dir.glob("*.json")):
+            data = json.loads(path.read_text())
+            cited = data.get("cited_doc_ids") or []
+            if not cited:
+                continue
+            if baseline_quality_problem(data):
+                continue
+            if limit_per_corpus is not None and per_corpus_count.get(corpus, 0) >= limit_per_corpus:
+                break
+            records.append(
+                BaselineRecord(
+                    corpus=corpus,
+                    question_id=data["question_id"],
+                    question_text=data["question"],
+                    cited_doc_ids=list(cited),
+                )
+            )
+            per_corpus_count[corpus] = per_corpus_count.get(corpus, 0) + 1
+
+    return records
+
+
+def score_one(baseline: BaselineRecord, ranked_doc_ids: list[str], ks: list[int]) -> EvalRow:
+    """Compute the per-question retrieval metrics."""
+    return EvalRow(
+        corpus=baseline.corpus,
+        question_id=baseline.question_id,
+        question_text=baseline.question_text,
+        recall_at_k={k: recall_at_k(baseline.cited_doc_ids, ranked_doc_ids, k) for k in ks},
+        reciprocal_rank=reciprocal_rank(baseline.cited_doc_ids, ranked_doc_ids),
+        ndcg_at_10=ndcg_at_k(baseline.cited_doc_ids, ranked_doc_ids, 10),
+        top_doc_id=ranked_doc_ids[0] if ranked_doc_ids else None,
+        baseline_cited_doc_ids=list(baseline.cited_doc_ids),
+        returned_doc_ids=list(ranked_doc_ids),
+    )
+
+
+def aggregate(rows: list[EvalRow], ks: list[int]) -> dict[str, Any]:
+    """Overall + per-corpus mean of each metric."""
+
+    def _summary(subset: list[EvalRow]) -> dict[str, Any]:
+        if not subset:
+            return {"n_questions": 0, "recall_at_k": {k: 0.0 for k in ks}, "mrr": 0.0, "ndcg_at_10": 0.0}
+        n = len(subset)
+        return {
+            "n_questions": n,
+            "recall_at_k": {k: sum(r.recall_at_k[k] for r in subset) / n for k in ks},
+            "mrr": sum(r.reciprocal_rank for r in subset) / n,
+            "ndcg_at_10": sum(r.ndcg_at_10 for r in subset) / n,
+        }
+
+    per_corpus: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        per_corpus.setdefault(r.corpus, []).append(r)
+    return {
+        "overall": _summary(rows),
+        "per_corpus": {c: _summary(rs) for c, rs in per_corpus.items()},
+    }
+
+
+def compute_diff(
+    current: list[EvalRow],
+    prior: list[EvalRow],
+    regression_threshold: float,
+) -> dict[str, Any]:
+    """Pairwise delta between two labeled eval runs.
+
+    A question whose ``recall_at_10`` drops by more than
+    ``regression_threshold`` is a regression. The same magnitude in the
+    other direction is an improvement. Questions only in one side are
+    bucketed separately so they don't look like noise.
+    """
+    by_key_current = {(r.corpus, r.question_id): r for r in current}
+    by_key_prior = {(r.corpus, r.question_id): r for r in prior}
+
+    common = set(by_key_current) & set(by_key_prior)
+    only_current = sorted(set(by_key_current) - set(by_key_prior))
+    only_prior = sorted(set(by_key_prior) - set(by_key_current))
+
+    regressions: list[dict[str, Any]] = []
+    improvements: list[dict[str, Any]] = []
+    for key in sorted(common):
+        cur = by_key_current[key]
+        pri = by_key_prior[key]
+        delta_recall = cur.recall_at_k[10] - pri.recall_at_k[10]
+        delta_mrr = cur.reciprocal_rank - pri.reciprocal_rank
+        delta_ndcg = cur.ndcg_at_10 - pri.ndcg_at_10
+        entry = {
+            "corpus": cur.corpus,
+            "question_id": cur.question_id,
+            "recall_at_10_current": cur.recall_at_k[10],
+            "recall_at_10_prior": pri.recall_at_k[10],
+            "recall_at_10_delta": delta_recall,
+            "mrr_delta": delta_mrr,
+            "ndcg_at_10_delta": delta_ndcg,
+        }
+        if delta_recall <= -regression_threshold:
+            regressions.append(entry)
+        elif delta_recall >= regression_threshold:
+            improvements.append(entry)
+
+    def _mean(rs, attr):
+        return sum(getattr(r, attr) for r in rs) / len(rs) if rs else 0.0
+
+    def _mean_recall(rs):
+        return sum(r.recall_at_k[10] for r in rs) / len(rs) if rs else 0.0
+
+    cur_common = [by_key_current[k] for k in common]
+    pri_common = [by_key_prior[k] for k in common]
+    overall_deltas = {
+        "recall_at_10": _mean_recall(cur_common) - _mean_recall(pri_common),
+        "mrr": _mean(cur_common, "reciprocal_rank") - _mean(pri_common, "reciprocal_rank"),
+        "ndcg_at_10": _mean(cur_common, "ndcg_at_10") - _mean(pri_common, "ndcg_at_10"),
+    }
+
+    return {
+        "regression_threshold": regression_threshold,
+        "n_common_questions": len(common),
+        "overall_deltas": overall_deltas,
+        "regressions": regressions,
+        "improvements": improvements,
+        "new_questions": [{"corpus": c, "question_id": q} for c, q in only_current],
+        "dropped_questions": [{"corpus": c, "question_id": q} for c, q in only_prior],
+    }
+
+
+# ── HTTP-calling pieces (thin wrappers, so the driver stays mockable) ──
+
+
+def search_doc_ids(client: HarborClerkClient, query: str, k: int) -> list[str]:
+    """POST ``/api/search`` with ``faceted=true`` and return doc_ids ordered
+    by best chunk score within each doc.
+
+    ``faceted=true`` groups hits by doc and sorts by top_score, which is
+    exactly the ranked list we want — one entry per doc_id, descending by
+    relevance. Falls back to per-chunk dedup if the server returns the
+    non-faceted shape for any reason.
+    """
+    r = client._client.post(
+        "/api/search",
+        json={"query": query, "k": k, "faceted": True},
+        timeout=30,
+    )
+    r.raise_for_status()
+    body = r.json()
+    if "documents" in body:
+        return [d["doc_id"] for d in body["documents"]]
+    # Non-faceted fallback — dedup by first appearance.
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for hit in body.get("hits", []):
+        did = hit.get("doc_id")
+        if did and did not in seen_set:
+            seen.append(did)
+            seen_set.add(did)
+    return seen
+
+
+# ── driver ──
+
+
+def _write_csv(rows: list[EvalRow], path: Path, ks: list[int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        w = csv.writer(f)
+        header = (
+            ["corpus", "question_id"]
+            + [f"recall_at_{k}" for k in ks]
+            + ["mrr", "ndcg_at_10", "top_doc_id", "n_baseline_cites", "n_returned"]
+        )
+        w.writerow(header)
+        for r in rows:
+            w.writerow(
+                [r.corpus, r.question_id]
+                + [f"{r.recall_at_k[k]:.3f}" for k in ks]
+                + [
+                    f"{r.reciprocal_rank:.3f}",
+                    f"{r.ndcg_at_10:.3f}",
+                    r.top_doc_id or "",
+                    len(r.baseline_cited_doc_ids),
+                    len(r.returned_doc_ids),
+                ]
+            )
+
+
+def _load_prior_label(eval_dir: Path, prior_label: str) -> list[EvalRow]:
+    """Reconstruct EvalRows from a prior label's metrics.csv.
+
+    We persist enough in the CSV to reconstruct the metric values; baseline
+    doc_ids and returned doc_ids aren't needed for diff math, so we leave
+    them empty in the reconstructed row.
+    """
+    path = eval_dir / prior_label / "metrics.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"prior label not found: {path}")
+    rows: list[EvalRow] = []
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        ks = sorted(int(c.split("_")[-1]) for c in reader.fieldnames or [] if c.startswith("recall_at_"))
+        for row in reader:
+            rows.append(
+                EvalRow(
+                    corpus=row["corpus"],
+                    question_id=row["question_id"],
+                    question_text="",
+                    recall_at_k={k: float(row[f"recall_at_{k}"]) for k in ks},
+                    reciprocal_rank=float(row["mrr"]),
+                    ndcg_at_10=float(row["ndcg_at_10"]),
+                    top_doc_id=row["top_doc_id"] or None,
+                    baseline_cited_doc_ids=[],
+                    returned_doc_ids=[],
+                )
+            )
+    return rows
+
+
+def run(
+    *,
+    workdir: Path,
+    run_id: str,
+    api_base: str,
+    label: str,
+    prior_label: str | None,
+    corpora: set[str] | None,
+    questions_per_corpus: int | None,
+    ks: list[int],
+    search_k: int,
+    insecure: bool,
+    regression_threshold: float = 0.05,
+    search_fn: Callable[[HarborClerkClient, str, int], list[str]] | None = None,
+) -> int:
+    """Main entry point. Returns process exit code."""
+    run_dir = workdir / cfg.RESULTS_DIR_NAME / run_id
+    baselines_dir = run_dir / "baselines"
+    eval_dir = run_dir / "retrieval-eval"
+    out_dir = eval_dir / label
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info("loading baselines from %s", baselines_dir)
+    records = load_baselines(baselines_dir, corpora=corpora, limit_per_corpus=questions_per_corpus)
+    if not records:
+        log.error(
+            "no usable baselines under %s (corpora filter=%s, limit=%s). Run phase 1 first, or check the path.",
+            baselines_dir,
+            sorted(corpora) if corpora else "all",
+            questions_per_corpus,
+        )
+        return 1
+    log.info("found %d usable baselines across %d corpora", len(records), len({r.corpus for r in records}))
+
+    if max(ks) > search_k:
+        log.error("--search-k=%d must be >= max(--k)=%d", search_k, max(ks))
+        return 2
+
+    # HC client + auth
+    hc = HarborClerkClient(api_base, verify=not insecure)
+    email = os.environ.get("HC_USERNAME")
+    password = os.environ.get("HC_PASSWORD")
+    if email and password:
+        hc.login(email, password)
+    else:
+        log.warning("no HC_USERNAME / HC_PASSWORD set — /api/search requires auth")
+
+    do_search = search_fn or search_doc_ids
+
+    rows: list[EvalRow] = []
+    for i, rec in enumerate(records, start=1):
+        try:
+            ranked = do_search(hc, rec.question_text, search_k)
+        except httpx.HTTPError as exc:
+            log.error("search failed for %s/%s: %r — recording zero metrics", rec.corpus, rec.question_id, exc)
+            ranked = []
+        row = score_one(rec, ranked, ks=ks)
+        rows.append(row)
+        if i % 10 == 0 or i == len(records):
+            log.info(
+                "  [%d/%d] %s/%s recall@10=%.2f mrr=%.2f",
+                i,
+                len(records),
+                rec.corpus,
+                rec.question_id,
+                row.recall_at_k.get(10, 0.0),
+                row.reciprocal_rank,
+            )
+
+    metrics_path = out_dir / "metrics.csv"
+    _write_csv(rows, metrics_path, ks=ks)
+    log.info("wrote per-question metrics → %s", metrics_path)
+
+    summary = aggregate(rows, ks=ks)
+    summary_path = out_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+    log.info("wrote summary → %s", summary_path)
+
+    overall = summary["overall"]
+    log.info(
+        "OVERALL  n=%d  recall@10=%.3f  mrr=%.3f  ndcg@10=%.3f",
+        overall["n_questions"],
+        overall["recall_at_k"].get(10, 0.0),
+        overall["mrr"],
+        overall["ndcg_at_10"],
+    )
+    for corpus, s in summary["per_corpus"].items():
+        log.info(
+            "  %-10s  n=%-3d  recall@10=%.3f  mrr=%.3f  ndcg@10=%.3f",
+            corpus,
+            s["n_questions"],
+            s["recall_at_k"].get(10, 0.0),
+            s["mrr"],
+            s["ndcg_at_10"],
+        )
+
+    if prior_label:
+        try:
+            prior_rows = _load_prior_label(eval_dir, prior_label)
+        except FileNotFoundError as exc:
+            log.error("--prior-label specified but not found: %s", exc)
+            return 3
+        diff = compute_diff(rows, prior_rows, regression_threshold=regression_threshold)
+        diff_path = out_dir / f"vs_{prior_label}.json"
+        diff_path.write_text(json.dumps(diff, indent=2))
+        log.info("wrote diff vs %s → %s", prior_label, diff_path)
+        log.info(
+            "DIFF vs %s  n_common=%d  Δrecall@10=%+.3f  Δmrr=%+.3f  regressions=%d  improvements=%d",
+            prior_label,
+            diff["n_common_questions"],
+            diff["overall_deltas"]["recall_at_10"],
+            diff["overall_deltas"]["mrr"],
+            len(diff["regressions"]),
+            len(diff["improvements"]),
+        )
+
+    return 0
+
+
+def add_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Attach retrieval-eval flags to an existing ArgumentParser.
+
+    Called by sweep.py to register these args alongside the main sweep flags
+    so users see them in --help. Most flags are ignored when --mode is unset.
+    """
+    g = parser.add_argument_group("retrieval-eval (only with --mode retrieval-eval)")
+    g.add_argument("--label", help="name this eval run (e.g. 'phase-0-granite-r2'); becomes the output dir name")
+    g.add_argument("--prior-label", help="prior eval label to diff against; produces vs_<prior_label>.json")
+    g.add_argument(
+        "--questions-per-corpus",
+        type=int,
+        default=None,
+        help="cap baselines per corpus (default: all). Useful for ~30s sanity-check runs between micro-phases.",
+    )
+    g.add_argument(
+        "--k",
+        default="5,10,20",
+        help="comma-separated K values for recall@K (default: 5,10,20). nDCG is always @10.",
+    )
+    g.add_argument(
+        "--search-k",
+        type=int,
+        default=50,
+        help="how many results to fetch from /api/search (must be >= max(--k)). Default: 50.",
+    )
+    g.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=0.05,
+        help="recall@10 delta below -threshold counts as a regression in vs_<prior>.json (default: 0.05).",
+    )
+
+
+def main_from_args(args: argparse.Namespace) -> int:
+    """Translate parsed args into a ``run()`` call. Caller validates ``args.mode``."""
+    if not args.label:
+        log.error("--mode retrieval-eval requires --label")
+        return 2
+
+    ks = sorted({int(x) for x in args.k.split(",") if x.strip()})
+    if not ks:
+        log.error("--k parsed to empty list")
+        return 2
+
+    corpora: set[str] | None = None
+    if args.corpora:
+        corpora = {c.strip() for c in args.corpora.split(",") if c.strip()}
+
+    return run(
+        workdir=Path(args.workdir).expanduser(),
+        run_id=args.run_id,
+        api_base=args.api_base,
+        label=args.label,
+        prior_label=args.prior_label,
+        corpora=corpora,
+        questions_per_corpus=args.questions_per_corpus,
+        ks=ks,
+        search_k=args.search_k,
+        insecure=args.insecure,
+        regression_threshold=args.regression_threshold,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    parser = argparse.ArgumentParser(prog="retrieval-eval")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--workdir", default=str(cfg.WORKDIR_DEFAULT))
+    parser.add_argument("--api-base", default=cfg.API_BASE)
+    parser.add_argument("--corpora", default="")
+    parser.add_argument("--insecure", action="store_true")
+    add_cli_args(parser)
+    parsed = parser.parse_args()
+    sys.exit(main_from_args(parsed))

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -284,6 +284,19 @@ def make_parser() -> argparse.ArgumentParser:
     p.add_argument("--workdir", default=str(cfg.WORKDIR_DEFAULT))
     p.add_argument("--api-base", default=cfg.API_BASE)
     p.add_argument(
+        "--mode",
+        choices=["retrieval-eval"],
+        default=None,
+        help=(
+            "alternate fast-path mode. With --mode retrieval-eval, the 6-phase "
+            "sweep is bypassed and a retrieval-only evaluation is run against "
+            "existing baselines (recall@K, MRR, nDCG@10). No LLM is invoked. "
+            "Use to gate retrieval-pipeline changes between phases without "
+            "rerunning the full Enron sweep. Requires --label; see "
+            "`retrieval_eval.py` for the full flag list."
+        ),
+    )
+    p.add_argument(
         "--resume",
         action="store_true",
         help="acknowledge that state.json already exists and continue from it. "
@@ -330,6 +343,12 @@ def make_parser() -> argparse.ArgumentParser:
             "Pass this flag on machines where the path doesn't apply."
         ),
     )
+    # Attach retrieval-eval flags. They're only meaningful when --mode
+    # retrieval-eval is set, but registering them on the main parser keeps
+    # --help discoverable.
+    from scripts.test_corpora.runner import retrieval_eval
+
+    retrieval_eval.add_cli_args(p)
     return p
 
 
@@ -693,6 +712,14 @@ def main(argv: list[str] | None = None) -> int:
             logging.StreamHandler(sys.stdout),
         ],
     )
+
+    # --mode retrieval-eval is a separate fast path: no state.json, no per-phase
+    # planning, no model switching, no LLM. Dispatch and return before the
+    # main sweep loop spins up clients or touches state.
+    if args.mode == "retrieval-eval":
+        from scripts.test_corpora.runner import retrieval_eval
+
+        return retrieval_eval.main_from_args(args)
 
     state_path = run_dir / "state.json"
     sf = StateFile(state_path)

--- a/scripts/test_corpora/tests/test_metrics.py
+++ b/scripts/test_corpora/tests/test_metrics.py
@@ -2,6 +2,9 @@ from scripts.test_corpora.runner.metrics import (
     citation_extra,
     citation_overlap,
     entity_overlap,
+    ndcg_at_k,
+    recall_at_k,
+    reciprocal_rank,
 )
 
 
@@ -36,3 +39,136 @@ def test_entity_overlap_english(monkeypatch):
 
 def test_entity_overlap_empty_returns_zero():
     assert entity_overlap("", "any text", lang="en") == 0.0
+
+
+# ── recall_at_k ──
+
+
+def test_recall_at_k_all_hits_in_top_k():
+    baseline = ["a", "b", "c"]
+    ranked = ["a", "b", "c", "x", "y"]
+    assert recall_at_k(baseline, ranked, k=3) == 1.0
+    assert recall_at_k(baseline, ranked, k=10) == 1.0
+
+
+def test_recall_at_k_partial_in_top_k():
+    baseline = ["a", "b", "c", "d"]
+    ranked = ["a", "x", "b", "y", "z"]  # a@1, b@3, no c, no d in top-5
+    assert recall_at_k(baseline, ranked, k=5) == 0.5
+
+
+def test_recall_at_k_zero_when_none_in_top_k():
+    baseline = ["a", "b"]
+    ranked = ["x", "y", "z", "a"]  # a is at position 4
+    assert recall_at_k(baseline, ranked, k=3) == 0.0
+
+
+def test_recall_at_k_empty_baseline_returns_zero():
+    assert recall_at_k([], ["a", "b"], k=5) == 0.0
+
+
+def test_recall_at_k_empty_ranked_returns_zero():
+    assert recall_at_k(["a"], [], k=5) == 0.0
+
+
+def test_recall_at_k_ranked_shorter_than_k():
+    baseline = ["a", "b"]
+    ranked = ["a"]
+    assert recall_at_k(baseline, ranked, k=10) == 0.5
+
+
+def test_recall_at_k_k_zero_returns_zero():
+    assert recall_at_k(["a"], ["a"], k=0) == 0.0
+
+
+def test_recall_at_k_dedup_in_ranked():
+    """Duplicate ranked ids must not double-count toward recall."""
+    baseline = ["a", "b"]
+    ranked = ["a", "a", "a", "x"]  # a appears thrice; b nowhere
+    assert recall_at_k(baseline, ranked, k=4) == 0.5
+
+
+# ── reciprocal_rank ──
+
+
+def test_reciprocal_rank_first_hit_at_top():
+    assert reciprocal_rank(["a", "b"], ["a", "x", "y"]) == 1.0
+
+
+def test_reciprocal_rank_first_hit_at_second():
+    assert reciprocal_rank(["a", "b"], ["x", "a", "y"]) == 0.5
+
+
+def test_reciprocal_rank_first_hit_at_fourth():
+    assert reciprocal_rank(["a"], ["x", "y", "z", "a"]) == 0.25
+
+
+def test_reciprocal_rank_no_hit_returns_zero():
+    assert reciprocal_rank(["a", "b"], ["x", "y", "z"]) == 0.0
+
+
+def test_reciprocal_rank_empty_baseline_returns_zero():
+    assert reciprocal_rank([], ["a"]) == 0.0
+
+
+def test_reciprocal_rank_empty_ranked_returns_zero():
+    assert reciprocal_rank(["a"], []) == 0.0
+
+
+def test_reciprocal_rank_uses_earliest_hit():
+    """If multiple baseline ids appear, rank of the earliest counts."""
+    # 'b' at position 2; 'a' at position 4. Earliest is 'b'.
+    assert reciprocal_rank(["a", "b"], ["x", "b", "y", "a"]) == 0.5
+
+
+# ── ndcg_at_k ──
+
+
+def test_ndcg_at_k_perfect_ordering_returns_one():
+    baseline = ["a", "b", "c"]
+    ranked = ["a", "b", "c", "x", "y"]
+    assert ndcg_at_k(baseline, ranked, k=3) == 1.0
+
+
+def test_ndcg_at_k_no_hits_returns_zero():
+    assert ndcg_at_k(["a", "b"], ["x", "y", "z"], k=10) == 0.0
+
+
+def test_ndcg_at_k_empty_baseline_returns_zero():
+    assert ndcg_at_k([], ["a"], k=5) == 0.0
+
+
+def test_ndcg_at_k_reverse_order_less_than_one():
+    """All baseline ids in top-K but reversed ordering scores lower than perfect."""
+    baseline = ["a", "b", "c"]
+    ideal = ndcg_at_k(baseline, ["a", "b", "c"], k=3)
+    reversed_ = ndcg_at_k(baseline, ["c", "b", "a"], k=3)
+    # Binary relevance: with all hits present, reversed still scores 1.0 because
+    # each position contributes equally to numerator and denominator. Test the
+    # weaker invariant: shoving a hit further down DOES reduce score.
+    assert ideal == 1.0
+    assert reversed_ == 1.0
+
+
+def test_ndcg_at_k_hit_further_down_scores_lower():
+    """Moving a hit from position 1 to position 5 must reduce nDCG."""
+    baseline = ["a"]
+    early = ndcg_at_k(baseline, ["a", "x", "y", "z", "w"], k=5)
+    late = ndcg_at_k(baseline, ["x", "y", "z", "w", "a"], k=5)
+    assert early > late
+    assert early == 1.0
+
+
+def test_ndcg_at_k_partial_recall():
+    """Two baseline hits, one in top-K and one outside."""
+    baseline = ["a", "b"]
+    # Only 'a' in top-3; ideal would place a@1 and b@2.
+    score = ndcg_at_k(baseline, ["a", "x", "y", "b"], k=3)
+    # DCG: 1/log2(2) = 1.0 (only 'a' contributes)
+    # IDCG@3 capped at |baseline|=2: 1/log2(2) + 1/log2(3) = 1.0 + 0.6309 ≈ 1.6309
+    # nDCG = 1.0 / 1.6309 ≈ 0.613
+    assert 0.6 < score < 0.62
+
+
+def test_ndcg_at_k_empty_ranked_returns_zero():
+    assert ndcg_at_k(["a"], [], k=5) == 0.0

--- a/scripts/test_corpora/tests/test_retrieval_eval.py
+++ b/scripts/test_corpora/tests/test_retrieval_eval.py
@@ -1,0 +1,285 @@
+"""Tests for the --mode retrieval-eval fast path.
+
+The HTTP-calling functions are tested with a stub search callable so these
+tests don't need a running HC. The pure-data functions (load_baselines,
+score_one, aggregate, compute_diff) are all unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.test_corpora.runner.retrieval_eval import (
+    BaselineRecord,
+    EvalRow,
+    aggregate,
+    compute_diff,
+    load_baselines,
+    score_one,
+)
+
+# ── load_baselines ──
+
+
+def _write_baseline(baselines_dir: Path, corpus: str, question_id: str, **fields) -> None:
+    d = baselines_dir / corpus
+    d.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "question_id": question_id,
+        "question": f"What about {question_id}?",
+        "answer": "an answer",
+        "cited_doc_ids": ["doc-a", "doc-b"],
+        "tool_call_count": 3,
+        "elapsed_seconds": 1.0,
+        "model": "claude-sonnet-4-6",
+        "timestamp": "2026-05-17T00:00:00Z",
+        **fields,
+    }
+    (d / f"{question_id}.json").write_text(json.dumps(payload))
+
+
+def test_load_baselines_reads_all_corpora_when_filter_is_none(tmp_path):
+    baselines = tmp_path / "baselines"
+    _write_baseline(baselines, "cuad", "cuad-ask-1")
+    _write_baseline(baselines, "enron", "enron-research-1")
+    _write_baseline(baselines, "synthetic", "syn-1")
+
+    records = load_baselines(baselines, corpora=None, limit_per_corpus=None)
+
+    by_corpus = {r.corpus for r in records}
+    assert by_corpus == {"cuad", "enron", "synthetic"}
+    assert len(records) == 3
+
+
+def test_load_baselines_corpus_filter_restricts(tmp_path):
+    baselines = tmp_path / "baselines"
+    _write_baseline(baselines, "cuad", "cuad-1")
+    _write_baseline(baselines, "enron", "enron-1")
+
+    records = load_baselines(baselines, corpora={"cuad"}, limit_per_corpus=None)
+
+    assert {r.corpus for r in records} == {"cuad"}
+    assert len(records) == 1
+
+
+def test_load_baselines_limit_per_corpus_caps_count(tmp_path):
+    baselines = tmp_path / "baselines"
+    for i in range(5):
+        _write_baseline(baselines, "cuad", f"cuad-{i}")
+
+    records = load_baselines(baselines, corpora=None, limit_per_corpus=2)
+
+    assert len(records) == 2
+    assert all(r.corpus == "cuad" for r in records)
+
+
+def test_load_baselines_returns_baseline_record_with_question_text(tmp_path):
+    baselines = tmp_path / "baselines"
+    _write_baseline(
+        baselines,
+        "cuad",
+        "cuad-1",
+        question="Specific question text here.",
+        cited_doc_ids=["x", "y"],
+    )
+
+    [rec] = load_baselines(baselines, corpora=None, limit_per_corpus=None)
+
+    assert isinstance(rec, BaselineRecord)
+    assert rec.corpus == "cuad"
+    assert rec.question_id == "cuad-1"
+    assert rec.question_text == "Specific question text here."
+    assert rec.cited_doc_ids == ["x", "y"]
+
+
+def test_load_baselines_skips_baselines_with_no_citations(tmp_path):
+    """An empty cited_doc_ids list means the baseline can't grade retrieval.
+    These are surfaced by the existing baseline_quality_problem check; the
+    eval should skip them so the metrics aren't polluted with 0.0 rows that
+    look like regressions."""
+    baselines = tmp_path / "baselines"
+    _write_baseline(baselines, "cuad", "cuad-1", cited_doc_ids=["a"])
+    _write_baseline(baselines, "cuad", "cuad-empty", cited_doc_ids=[])
+
+    records = load_baselines(baselines, corpora=None, limit_per_corpus=None)
+
+    assert [r.question_id for r in records] == ["cuad-1"]
+
+
+def test_load_baselines_handles_missing_baselines_dir(tmp_path):
+    """A missing baselines dir is not a crash — it's just zero records.
+
+    Lets retrieval-eval mode report 'no baselines yet' instead of blowing
+    up if invoked before phase 1 has populated the run dir.
+    """
+    records = load_baselines(tmp_path / "nope", corpora=None, limit_per_corpus=None)
+    assert records == []
+
+
+# ── score_one ──
+
+
+def test_score_one_perfect_retrieval():
+    baseline = BaselineRecord(
+        corpus="cuad",
+        question_id="q1",
+        question_text="?",
+        cited_doc_ids=["a", "b"],
+    )
+    ranked = ["a", "b", "x", "y", "z"]
+    row = score_one(baseline, ranked, ks=[5, 10])
+    assert row.recall_at_k == {5: 1.0, 10: 1.0}
+    assert row.reciprocal_rank == 1.0
+    assert row.ndcg_at_10 == 1.0
+    assert row.top_doc_id == "a"
+
+
+def test_score_one_no_hits_zero_metrics():
+    baseline = BaselineRecord(
+        corpus="cuad",
+        question_id="q1",
+        question_text="?",
+        cited_doc_ids=["a"],
+    )
+    row = score_one(baseline, ["x", "y", "z"], ks=[5, 10])
+    assert row.recall_at_k == {5: 0.0, 10: 0.0}
+    assert row.reciprocal_rank == 0.0
+    assert row.ndcg_at_10 == 0.0
+    assert row.top_doc_id == "x"
+
+
+def test_score_one_records_returned_ranked_and_baseline_cites():
+    """For the per-question CSV. Lets the operator inspect WHICH docs the
+    new pipeline surfaced vs what the baseline expected, without re-running."""
+    baseline = BaselineRecord(corpus="cuad", question_id="q1", question_text="?", cited_doc_ids=["a", "b"])
+    row = score_one(baseline, ["x", "a", "y"], ks=[5])
+    assert row.baseline_cited_doc_ids == ["a", "b"]
+    assert row.returned_doc_ids == ["x", "a", "y"]
+
+
+def test_score_one_empty_ranked_zero_metrics_no_top_doc():
+    baseline = BaselineRecord(corpus="cuad", question_id="q1", question_text="?", cited_doc_ids=["a"])
+    row = score_one(baseline, [], ks=[5, 10])
+    assert row.recall_at_k == {5: 0.0, 10: 0.0}
+    assert row.reciprocal_rank == 0.0
+    assert row.ndcg_at_10 == 0.0
+    assert row.top_doc_id is None
+
+
+# ── aggregate ──
+
+
+def _row(corpus, q, recall, rr, ndcg):
+    return EvalRow(
+        corpus=corpus,
+        question_id=q,
+        question_text="?",
+        recall_at_k={5: recall, 10: recall, 20: recall},
+        reciprocal_rank=rr,
+        ndcg_at_10=ndcg,
+        top_doc_id="x",
+        baseline_cited_doc_ids=["a"],
+        returned_doc_ids=["x"],
+    )
+
+
+def test_aggregate_overall_means():
+    rows = [
+        _row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0),
+        _row("cuad", "q2", recall=0.0, rr=0.0, ndcg=0.0),
+        _row("enron", "q1", recall=0.5, rr=0.5, ndcg=0.5),
+    ]
+    summary = aggregate(rows, ks=[5, 10, 20])
+    overall = summary["overall"]
+    assert overall["n_questions"] == 3
+    assert overall["recall_at_k"][10] == pytest.approx(0.5)
+    assert overall["mrr"] == pytest.approx(0.5)
+    assert overall["ndcg_at_10"] == pytest.approx(0.5)
+
+
+def test_aggregate_per_corpus_means():
+    rows = [
+        _row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0),
+        _row("cuad", "q2", recall=0.0, rr=0.0, ndcg=0.0),
+        _row("enron", "q1", recall=0.4, rr=0.4, ndcg=0.4),
+    ]
+    summary = aggregate(rows, ks=[5, 10, 20])
+    assert summary["per_corpus"]["cuad"]["n_questions"] == 2
+    assert summary["per_corpus"]["cuad"]["recall_at_k"][10] == pytest.approx(0.5)
+    assert summary["per_corpus"]["enron"]["recall_at_k"][10] == pytest.approx(0.4)
+
+
+def test_aggregate_empty_rows_returns_zero_n():
+    summary = aggregate([], ks=[5, 10])
+    assert summary["overall"]["n_questions"] == 0
+    assert summary["per_corpus"] == {}
+
+
+# ── compute_diff ──
+
+
+def test_compute_diff_detects_regression():
+    current = [_row("cuad", "q1", recall=0.5, rr=0.5, ndcg=0.5)]
+    prior = [_row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0)]
+    diff = compute_diff(current, prior, regression_threshold=0.05)
+    assert len(diff["regressions"]) == 1
+    reg = diff["regressions"][0]
+    assert reg["corpus"] == "cuad"
+    assert reg["question_id"] == "q1"
+    assert reg["recall_at_10_delta"] == pytest.approx(-0.5)
+
+
+def test_compute_diff_ignores_below_threshold_movements():
+    current = [_row("cuad", "q1", recall=0.95, rr=1.0, ndcg=1.0)]
+    prior = [_row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0)]
+    diff = compute_diff(current, prior, regression_threshold=0.10)
+    assert diff["regressions"] == []
+
+
+def test_compute_diff_lists_improvements():
+    current = [_row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0)]
+    prior = [_row("cuad", "q1", recall=0.0, rr=0.0, ndcg=0.0)]
+    diff = compute_diff(current, prior, regression_threshold=0.05)
+    assert len(diff["improvements"]) == 1
+    assert diff["improvements"][0]["recall_at_10_delta"] == pytest.approx(1.0)
+
+
+def test_compute_diff_reports_overall_deltas():
+    current = [
+        _row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0),
+        _row("cuad", "q2", recall=0.5, rr=0.5, ndcg=0.5),
+    ]
+    prior = [
+        _row("cuad", "q1", recall=0.5, rr=0.5, ndcg=0.5),
+        _row("cuad", "q2", recall=0.5, rr=0.5, ndcg=0.5),
+    ]
+    diff = compute_diff(current, prior, regression_threshold=0.05)
+    assert diff["overall_deltas"]["recall_at_10"] == pytest.approx(0.25)
+    assert diff["overall_deltas"]["mrr"] == pytest.approx(0.25)
+
+
+def test_compute_diff_handles_questions_only_in_current():
+    """A question added to current with no prior counterpart is reported as
+    'new', not as a regression."""
+    current = [
+        _row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0),
+        _row("cuad", "q-new", recall=0.5, rr=0.5, ndcg=0.5),
+    ]
+    prior = [_row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0)]
+    diff = compute_diff(current, prior, regression_threshold=0.05)
+    assert diff["new_questions"] == [{"corpus": "cuad", "question_id": "q-new"}]
+    assert diff["regressions"] == []
+
+
+def test_compute_diff_handles_questions_only_in_prior():
+    """A question removed from current is reported as 'dropped', not noise."""
+    current = [_row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0)]
+    prior = [
+        _row("cuad", "q1", recall=1.0, rr=1.0, ndcg=1.0),
+        _row("cuad", "q-gone", recall=0.5, rr=0.5, ndcg=0.5),
+    ]
+    diff = compute_diff(current, prior, regression_threshold=0.05)
+    assert diff["dropped_questions"] == [{"corpus": "cuad", "question_id": "q-gone"}]


### PR DESCRIPTION
## Summary

Two independent deliverables that set up the 6-phase retrieval/MCP upgrade:

**1. `--mode retrieval-eval` — fast retrieval-only evaluation harness** (`feat(test-corpora)`)

A new fast path on the test-corpora sweep that grades retrieval quality against existing baseline `cited_doc_ids` without invoking any LLM, model switch, or re-ingest. Built to gate retrieval-pipeline changes between upgrade phases without re-running the multi-hour full sweep.

- New pure metrics in `metrics.py`: `recall_at_k`, `reciprocal_rank`, `ndcg_at_k`.
- New `scripts/test_corpora/runner/retrieval_eval.py`: loads baselines, replays each question through `/api/search`, scores recall@K / MRR / nDCG@10, aggregates, and diffs against a prior labelled run.
- New CLI: `sweep --mode retrieval-eval --label <name> [--prior-label <name>]`.
- Output under `results/<run_id>/retrieval-eval/<label>/`: `metrics.csv`, `summary.json`, `vs_<prior_label>.json` (per-question regressions + improvements).
- 41 new tests, all green; lint clean.

**2. Retrieval/MCP upgrade planning docs** (`docs(superpowers)`)

- `docs/superpowers/plans/2026-05-17-retrieval-mcp-upgrade-master-plan.md` — the 6-phase staging plan (embedding swap → late chunking → metadata layer → knowledge graph → propositions → UI).
- `docs/superpowers/specs/2026-05-17-embedding-v2-design.md` — phase-1 design spec.
- `docs/superpowers/plans/2026-05-17-embedding-v2-implementation.md` — phase-1 bite-sized implementation plan.

## Why this is its own PR

The `--mode retrieval-eval` harness is the gating mechanism for every phase of the upgrade — including the embedding-v2 PR (#371), whose pre-merge checklist runs `sweep --mode retrieval-eval`. This branch needs to merge (or be available) before that gate can run.

## Test plan

- [x] 41 new tests for the metrics + harness — all pass.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
