### PR TITLE
fix(research): every research citation rendered "page ?"

### DIFF
--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -606,7 +606,7 @@ def _ingest_hits(coverage: dict[str, dict], hits: list[dict], query_text: str) -
             coverage[cid] = {
                 "doc_id": hit.get("doc_id", ""),
                 "doc_title": hit.get("doc_title", ""),
-                "page": hit.get("page"),
+                "page": hit.get("pages"),
                 "score": hit.get("score", 0),
                 "snippet": hit.get("text", hit.get("snippet", ""))[:500],
                 "section": hit.get("section", ""),
@@ -745,11 +745,11 @@ async def _read_evidence(
             for passage in result.get("passages", []):
                 text = passage.get("text", "")
                 doc_title = passage.get("doc_title", "Unknown")
-                page = passage.get("page", "?")
+                pages = passage.get("pages", "?")
                 section = passage.get("section", "")
                 cid = passage.get("chunk_id")
 
-                entry = f"\n---\n**[{doc_title}, page {page}]**"
+                entry = f"\n---\n**[{doc_title}, page {pages}]**"
                 if section:
                     entry += f" — {section}"
                 # Note other drafts that were merged into this representative
@@ -774,7 +774,7 @@ async def _read_evidence(
                 if info and info.get("doc_id") and info["doc_id"] not in seen_evidence_docs:
                     seen_evidence_docs.add(info["doc_id"])
                     evidence_docs.append(
-                        {"doc_id": info["doc_id"], "doc_title": info.get("doc_title", ""), "page": passage.get("page")}
+                        {"doc_id": info["doc_id"], "doc_title": info.get("doc_title", ""), "page": passage.get("pages")}
                     )
 
         except Exception:

--- a/tests/test_research_engine.py
+++ b/tests/test_research_engine.py
@@ -137,11 +137,12 @@ async def test_read_evidence_returns_passages_and_evidence_docs():
         "c1": {"doc_id": "d1", "doc_title": "alpha", "page": 1, "score": 2.0, "snippet": "alpha text"},
         "c2": {"doc_id": "d2", "doc_title": "beta", "page": 3, "score": 1.5, "snippet": "beta text"},
     }
+    # read_passages emits the page span as ``pages`` (a string), not ``page``.
     read_result = json.dumps(
         {
             "passages": [
-                {"chunk_id": "c1", "text": "alpha body", "doc_title": "alpha", "page": 1},
-                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "page": 3},
+                {"chunk_id": "c1", "text": "alpha body", "doc_title": "alpha", "pages": "1"},
+                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "pages": "3-5"},
             ]
         }
     )
@@ -153,8 +154,8 @@ async def test_read_evidence_returns_passages_and_evidence_docs():
     by_id = {d["doc_id"]: d for d in evidence_docs}
     assert set(by_id) == {"d1", "d2"}
     assert by_id["d1"]["doc_title"] == "alpha"
-    assert by_id["d1"]["page"] == 1
-    assert by_id["d2"]["page"] == 3
+    assert by_id["d1"]["page"] == "1"
+    assert by_id["d2"]["page"] == "3-5"
 
 
 @pytest.mark.asyncio
@@ -170,8 +171,8 @@ async def test_read_evidence_excludes_budget_truncated_passages_from_evidence_do
     read_result = json.dumps(
         {
             "passages": [
-                {"chunk_id": "c1", "text": big, "doc_title": "alpha", "page": 1},
-                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "page": 2},
+                {"chunk_id": "c1", "text": big, "doc_title": "alpha", "pages": "1"},
+                {"chunk_id": "c2", "text": "beta body", "doc_title": "beta", "pages": "2"},
             ]
         }
     )
@@ -183,6 +184,24 @@ async def test_read_evidence_excludes_budget_truncated_passages_from_evidence_do
     assert big in passages_text
     assert "beta body" not in passages_text
     assert {d["doc_id"] for d in evidence_docs} == {"d1"}
+
+
+@pytest.mark.asyncio
+async def test_read_evidence_renders_real_page_in_passage_headers():
+    """The MCP read_passages tool emits the page span as ``pages`` (a string
+    like "3-5"). _read_evidence must surface it in the passage header that
+    feeds note extraction — a header reading "page ?" poisons every citation
+    the model is instructed to copy verbatim."""
+    coverage = {
+        "c1": {"doc_id": "d1", "doc_title": "alpha", "page": "3-5", "score": 2.0, "snippet": "a"},
+    }
+    read_result = json.dumps(
+        {"passages": [{"chunk_id": "c1", "text": "alpha body", "doc_title": "alpha", "pages": "3-5"}]}
+    )
+    with patch("harbor_clerk.llm.research.execute_tool", new=AsyncMock(return_value=read_result)):
+        passages_text, _ = await _read_evidence(coverage, user_id=None, max_passages=10, context_budget_chars=100_000)
+    assert "**[alpha, page 3-5]**" in passages_text
+    assert "page ?" not in passages_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The MCP `read_passages` and search tools emit a chunk's page span as **`pages`** (a string like `"3-5"`), but the research engine read **`page`** (singular) at three sites in `llm/research.py`:

- `_read_evidence` passage headers always rendered `**[Title, page ?]**`. The note-extraction prompt instructs the model to copy that citation **verbatim** — so every cited claim in every research report said "page ?".
- Every record in `state.citations` (the API `citations` array added by #369) had `page: null`.
- The coverage dict's documented `page` field was dead `None`.

The fix reads `pages` at all three sites. `citations` is an untyped JSON list, so the string span stores fine.

## How it slipped past CI
`tests/test_research_engine.py` mocked `read_passages` output with the `page` key — matching the buggy code, not the real MCP shape. The mocks are corrected to the real `pages` key (which makes them fail against the old code), and a new test asserts the rendered passage header.

## Test plan
- [x] `tests/test_research_engine.py` — 12 passed
- [ ] CI green

Found by an audit of the post-#369 research loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)