### PR TITLE
fix(build): fetch embedding-v2 models via snapshot_download

### DIFF
--- a/docker/embedder.Dockerfile
+++ b/docker/embedder.Dockerfile
@@ -20,7 +20,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN /app/.venv/bin/python -c "from huggingface_hub import snapshot_download; \
   snapshot_download(repo_id='ibm-granite/granite-embedding-311m-multilingual-r2', \
                     local_dir='/models/granite-embedding-311m-multilingual-r2', \
-                    local_dir_use_symlinks=False)"
+                    local_dir_use_symlinks=False, \
+                    ignore_patterns=['onnx/*', 'openvino/*', 'openvino_model.*'])"
 
 # ── Runtime ──
 FROM python:3.12-slim

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -48,8 +48,9 @@ spacy-models: venv
 
 # ── Models ──
 # MODEL_DIR must match paths in EmbedderService.swift and RerankerService.swift ("model/<name>")
+# Depends on venv: download-model.sh runs huggingface_hub from the venv's Python.
 
-model:
+model: venv
 	@echo "==> Downloading embedding + reranker models"
 	MODEL_DIR=$(BUILD)/model VENV_DIR=$(BUILD)/venv BUILD_DIR=$(BUILD) bash $(SCRIPTS)/download-model.sh
 

--- a/macos/scripts/download-model.sh
+++ b/macos/scripts/download-model.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
-# Download the embedding and reranker models for Harbor Clerk.
+# Download the embedding + reranker models for Harbor Clerk's macOS bundle.
+#
+# Both models are fetched with huggingface_hub.snapshot_download into
+# MODEL_DIR/<name>. The <name> directories must match the paths the Swift
+# services load (EmbedderService.swift, RerankerService.swift) and the names
+# the Docker images use. snapshot_download writes real files into local_dir
+# (huggingface_hub 1.x has no symlink-into-cache mode), so the resulting tree
+# is safe to bundle into a relocatable .app.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -16,42 +23,35 @@ fi
 
 mkdir -p "$MODEL_DIR"
 
-# ── Granite-R2 embedder (~700 MB) ──────────────────────────────────────────
-GRANITE_DEST="$MODEL_DIR/granite-embedding-311m-multilingual-r2"
-echo "==> Downloading Granite-R2 embedder model"
-"$PYTHON" -c "
-from sentence_transformers import SentenceTransformer
-import os
+# download_model <hf-repo-id> <local-dir-name> [ignore-pattern ...]
+download_model() {
+    local repo_id="$1"
+    local name="$2"
+    shift 2
+    local dest="$MODEL_DIR/$name"
+    echo "==> Downloading ${repo_id}"
+    # Re-fetch into a clean directory: makes the result deterministic and
+    # stops ignore_patterns from leaving stale files behind on a rebuild.
+    rm -rf "$dest"
+    "$PYTHON" - "$repo_id" "$dest" "$@" <<'PY'
+import sys
 
-model_name = 'ibm-granite/granite-embedding-311m-multilingual-r2'
-dest = '${GRANITE_DEST}'
+from huggingface_hub import snapshot_download
 
-print(f'Loading model {model_name}...')
-model = SentenceTransformer(model_name)
-print(f'Saving to {dest}...')
-model.save(dest)
-print('Done.')
-"
-echo "==> Granite-R2 saved to ${GRANITE_DEST}"
-echo "==> Size: $(du -sh "$GRANITE_DEST" | cut -f1)"
+repo_id, dest, *ignore = sys.argv[1:]
+snapshot_download(repo_id=repo_id, local_dir=dest, ignore_patterns=ignore or None)
+print(f"==> {repo_id} saved to {dest}")
+PY
+    echo "==> Size: $(du -sh "$dest" | cut -f1)"
+}
 
-# ── bge-reranker-v2-m3 cross-encoder (~1.2 GB) ────────────────────────────
-BGE_DEST="$MODEL_DIR/bge-reranker-v2-m3"
-echo "==> Downloading bge-reranker-v2-m3 reranker model"
-"$PYTHON" -c "
-from sentence_transformers import CrossEncoder
-import os
+# Granite-R2 embedder — EmbedderService.swift loads model/granite-embedding-311m-multilingual-r2.
+# Skip the onnx/ + openvino/ variants (~3 GB): the embedder loads the PyTorch backend only.
+download_model "ibm-granite/granite-embedding-311m-multilingual-r2" \
+    "granite-embedding-311m-multilingual-r2" \
+    "onnx/*" "openvino/*" "openvino_model.*"
 
-model_name = 'BAAI/bge-reranker-v2-m3'
-dest = '${BGE_DEST}'
+# bge-reranker-v2-m3 cross-encoder — RerankerService.swift loads model/bge-reranker-v2-m3
+download_model "BAAI/bge-reranker-v2-m3" "bge-reranker-v2-m3"
 
-print(f'Loading model {model_name}...')
-model = CrossEncoder(model_name)
-# Save underlying HuggingFace model + tokenizer
-model.model.save_pretrained(dest)
-model.tokenizer.save_pretrained(dest)
-print(f'Saved to {dest}')
-print('Done.')
-"
-echo "==> bge-reranker-v2-m3 saved to ${BGE_DEST}"
-echo "==> Size: $(du -sh "$BGE_DEST" | cut -f1)"
+echo "==> All models downloaded to ${MODEL_DIR}"


### PR DESCRIPTION
## Summary

The macOS `make model` step never produced a verified embedding-v2 bundle. PR #371 repointed `download-model.sh` at Granite-R2 + bge-reranker but used `SentenceTransformer.save()` / `CrossEncoder` internals and **never ran the build** (its "build the embedding-v2 stack" checklist item is unchecked). The build machine's models had been placed by hand, so a clean `make all` produced a bundle whose embedder/reranker could not start.

- **`download-model.sh`** — rewritten to use `huggingface_hub.snapshot_download` (the mechanism the Docker images use), producing the `model/<name>` directory layout `EmbedderService.swift` / `RerankerService.swift` expect.
- **`Makefile`** — the `model` target now depends on `venv` (matching `spacy-models: venv`) so the script runs `huggingface_hub` from the venv's Python rather than a happenstance system `python3`.
- **onnx/openvino trim** — the Granite repo ships `onnx/` + `openvino/` variants (~3.3 GB) the embedder never loads (it uses the PyTorch backend). `ignore_patterns` skips them in both the macOS script and `docker/embedder.Dockerfile`. Granite drops **3.8 GB to 628 MB**.
- e5-small is intentionally not bundled (Docker doesn't bundle it either; an e5 rollback needs a full DB rebuild — dims differ, 768 vs 384). The runtime `EMBED_NEEDS_PREFIX` rollback hook is untouched.

## Test plan

- [x] `bash -n download-model.sh` — clean
- [x] Clean `make model` — fetches `build/model/granite-embedding-311m-multilingual-r2` (628 MB) + `build/model/bge-reranker-v2-m3` (2.1 GB)
- [x] Trimmed Granite dir contains only the 12 PyTorch-backend files — no onnx/openvino
- [x] `harbor-clerk-embedder` + `harbor-clerk-reranker` boot healthy against `build/model/` — 768-dim embeddings; bge-reranker ranks the relevant passage 0.9998 vs 0.0
- [ ] Full `make apps` (Xcode bundle assembly) — not run; `package.sh`'s model step is an unchanged `cp -R build/model` into `Resources/model`
- [ ] Docker embedder image build — not run; the `ignore_patterns` are the exact patterns verified on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
