### PR TITLE
fix(test-corpora): retry Anthropic 429/529 errors, don't crash sweep

### DIFF
--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -206,12 +206,14 @@ curl -X PUT "$HC_API_BASE/api/chat/models/<model_id>/activate"
 
 Then re-run the sweep with `--resume`. The harness's per-unit ConnectError handling waits up to 120s for HC to come back before incrementing the outage counter, so a brief restart usually doesn't cause unit losses.
 
-### Anthropic rate-limit storm
+### Anthropic rate-limit or overload storm
 
 Phase 1 baselines are sequential and Sonnet's rate limit allows them. If you hit 429s repeatedly, either:
 
 - Wait an hour and resume, or
 - Add `--rerun "phase=1,corpus=<one>"` to scope the retry
+
+On an HTTP 529 (Anthropic overloaded), the harness retries the affected baseline itself with exponential backoff — 60s, 120s, 240s, … capped at 10 min/attempt — for up to ~1 hr, so a transient overload needs no action. If the overload outlasts that budget the baseline is left PENDING and the sweep continues to the next unit; re-run with `--resume` once Anthropic recovers to fill in the overloaded baselines.
 
 ### A model is broken and won't progress
 

--- a/scripts/test_corpora/RUNBOOK.md
+++ b/scripts/test_corpora/RUNBOOK.md
@@ -208,12 +208,12 @@ Then re-run the sweep with `--resume`. The harness's per-unit ConnectError handl
 
 ### Anthropic rate-limit or overload storm
 
-Phase 1 baselines are sequential and Sonnet's rate limit allows them. If you hit 429s repeatedly, either:
+On an HTTP 429 (Anthropic rate-limited) or 529 (Anthropic overloaded), the harness retries the affected Phase 1 baseline itself with exponential backoff — 60s, 120s, 240s, … capped at 10 min/attempt — for up to ~1 hr, so a transient rate-limit or overload needs no action. If it outlasts that budget the baseline is left PENDING and the sweep continues to the next unit; re-run with `--resume` once Anthropic recovers to fill in the missing baselines.
+
+Phase 1 baselines are sequential and Sonnet's rate limit normally allows them. If 429s still persist across `--resume` attempts, either:
 
 - Wait an hour and resume, or
 - Add `--rerun "phase=1,corpus=<one>"` to scope the retry
-
-On an HTTP 529 (Anthropic overloaded), the harness retries the affected baseline itself with exponential backoff — 60s, 120s, 240s, … capped at 10 min/attempt — for up to ~1 hr, so a transient overload needs no action. If the overload outlasts that budget the baseline is left PENDING and the sweep continues to the next unit; re-run with `--resume` once Anthropic recovers to fill in the overloaded baselines.
 
 ### A model is broken and won't progress
 

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import anthropic
 import httpx
 import yaml
+from anthropic._exceptions import OverloadedError
 
 from scripts.test_corpora import conftest as cfg
 from scripts.test_corpora.corpora import cuad, enron, synthetic
@@ -81,6 +82,52 @@ HC_RECOVERY_WAIT_SECONDS = 120
 # of total wait before exit — well-suited to multi-hour runs where a
 # clean exit + --resume costs less than re-running cells.
 HC_UNREACHABLE_CONSECUTIVE_LIMIT = 3
+
+
+# Anthropic 529 (Overloaded) retry budget for Phase 1 baselines. The SDK's
+# built-in retries cover only ~5s, but a real overload can persist for many
+# minutes; once that window is exhausted the SDK raises OverloadedError and,
+# uncaught, it kills the whole multi-hour sweep. We retry the baseline with
+# exponential backoff, capping each sleep below the supervisor's 30-minute
+# "stuck" threshold so a long backoff is never mistaken for a hang.
+OVERLOAD_RETRY_BASE_SECONDS = 60
+OVERLOAD_RETRY_MAX_DELAY_SECONDS = 600
+OVERLOAD_RETRY_BUDGET_SECONDS = 3600
+
+
+def _with_overload_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = OVERLOAD_RETRY_BUDGET_SECONDS):
+    """Call ``fn(*args)``, retrying on Anthropic ``OverloadedError`` (HTTP 529).
+
+    An Anthropic overload routinely lasts longer than the SDK's built-in
+    ~5s retry window. Rather than let an uncaught ``OverloadedError`` abort
+    a multi-hour sweep, retry with exponential backoff (60s, 120s, 240s,
+    ... capped at 600s per attempt) until ``fn`` succeeds or the cumulative
+    backoff reaches ``max_total_seconds`` (~1 hr). On budget exhaustion the
+    ``OverloadedError`` is re-raised so the caller can leave the unit
+    PENDING for a later ``--resume``.
+
+    ``sleep`` is injectable so tests need not wait in real time.
+    """
+    attempt = 0
+    waited = 0.0
+    while True:
+        try:
+            return fn(*args)
+        except OverloadedError:
+            if waited >= max_total_seconds:
+                raise
+            delay = min(OVERLOAD_RETRY_BASE_SECONDS * 2**attempt, OVERLOAD_RETRY_MAX_DELAY_SECONDS)
+            delay = min(delay, max_total_seconds - waited)
+            log.warning(
+                "Anthropic 529 Overloaded — backing off %.0fs before retry (attempt %d, %.0fs of %ds budget used)",
+                delay,
+                attempt + 1,
+                waited,
+                max_total_seconds,
+            )
+            sleep(delay)
+            waited += delay
+            attempt += 1
 
 
 def _wait_for_hc_reachable(hc: HarborClerkClient, max_wait_seconds: int = HC_RECOVERY_WAIT_SECONDS) -> bool:
@@ -1132,7 +1179,9 @@ def main(argv: list[str] | None = None) -> int:
                                 error=f"unfilled placeholder: {placeholder}",
                             )
                             continue
-                        out = _phase1_baseline(anthro, mcp_session, u.corpus, u.question_id, text, run_dir)
+                        out = _with_overload_retry(
+                            _phase1_baseline, anthro, mcp_session, u.corpus, u.question_id, text, run_dir
+                        )
                     elif phase in (2, 3, 4, 5, 6):
                         owning_corpus = (
                             u.corpus
@@ -1345,6 +1394,26 @@ def main(argv: list[str] | None = None) -> int:
                                 f"({HC_RECOVERY_WAIT_SECONDS}s each); exiting cleanly so "
                                 "--resume picks up where we left off."
                             ) from exc
+                except OverloadedError:
+                    # Anthropic stayed overloaded (529) past the ~1 hr retry
+                    # budget. Not a unit-level failure — leave it PENDING (not
+                    # ERROR) so `--resume` re-runs it once Anthropic recovers,
+                    # and continue so the rest of the corpus still finishes.
+                    log.warning(
+                        "unit %s/%s/%s: Anthropic overloaded past the %ds retry budget; "
+                        "leaving PENDING for --resume and continuing",
+                        u.corpus,
+                        u.model,
+                        u.question_id,
+                        OVERLOAD_RETRY_BUDGET_SECONDS,
+                    )
+                    cur = sf.get(u.phase, u.corpus, u.model, u.question_id, u.depth)
+                    if cur is not None:
+                        cur.status = Status.PENDING
+                        cur.heartbeat = None
+                        cur.started_at = None
+                        cur.error = None
+                    sf.save()
                 except (httpx.HTTPError, RuntimeError, KeyError) as exc:
                     log.exception("unit failed: %s", u)
                     sf.set_status(u.phase, u.corpus, u.model, u.question_id, u.depth, Status.ERROR, error=str(exc))

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import anthropic
 import httpx
 import yaml
-from anthropic._exceptions import OverloadedError
+from anthropic._exceptions import OverloadedError, RateLimitError
 
 from scripts.test_corpora import conftest as cfg
 from scripts.test_corpora.corpora import cuad, enron, synthetic
@@ -84,27 +84,30 @@ HC_RECOVERY_WAIT_SECONDS = 120
 HC_UNREACHABLE_CONSECUTIVE_LIMIT = 3
 
 
-# Anthropic 529 (Overloaded) retry budget for Phase 1 baselines. The SDK's
-# built-in retries cover only ~5s, but a real overload can persist for many
-# minutes; once that window is exhausted the SDK raises OverloadedError and,
-# uncaught, it kills the whole multi-hour sweep. We retry the baseline with
-# exponential backoff, capping each sleep below the supervisor's 30-minute
-# "stuck" threshold so a long backoff is never mistaken for a hang.
-OVERLOAD_RETRY_BASE_SECONDS = 60
-OVERLOAD_RETRY_MAX_DELAY_SECONDS = 600
-OVERLOAD_RETRY_BUDGET_SECONDS = 3600
+# Anthropic 429 (rate-limited) / 529 (overloaded) retry budget for Phase 1
+# baselines. The SDK's built-in retries cover only ~5s, but a real rate-limit
+# window or Anthropic overload can persist for many minutes; once that window
+# is exhausted the SDK raises RateLimitError / OverloadedError and, uncaught,
+# it kills the whole multi-hour sweep. We retry the baseline with exponential
+# backoff, capping each sleep below the supervisor's 30-minute "stuck"
+# threshold so a long backoff is never mistaken for a hang.
+ANTHROPIC_RETRY_BASE_SECONDS = 60
+ANTHROPIC_RETRY_MAX_DELAY_SECONDS = 600
+ANTHROPIC_RETRY_BUDGET_SECONDS = 3600
 
 
-def _with_overload_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = OVERLOAD_RETRY_BUDGET_SECONDS):
-    """Call ``fn(*args)``, retrying on Anthropic ``OverloadedError`` (HTTP 529).
+def _with_anthropic_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = ANTHROPIC_RETRY_BUDGET_SECONDS):
+    """Call ``fn(*args)``, retrying on transient Anthropic API errors —
+    ``RateLimitError`` (HTTP 429) and ``OverloadedError`` (HTTP 529).
 
-    An Anthropic overload routinely lasts longer than the SDK's built-in
-    ~5s retry window. Rather than let an uncaught ``OverloadedError`` abort
-    a multi-hour sweep, retry with exponential backoff (60s, 120s, 240s,
-    ... capped at 600s per attempt) until ``fn`` succeeds or the cumulative
-    backoff reaches ``max_total_seconds`` (~1 hr). On budget exhaustion the
-    ``OverloadedError`` is re-raised so the caller can leave the unit
-    PENDING for a later ``--resume``.
+    A rate-limit window or Anthropic overload routinely lasts longer than the
+    SDK's built-in ~5s retry window. Rather than let an uncaught
+    ``RateLimitError`` / ``OverloadedError`` abort a multi-hour sweep, retry
+    with exponential backoff (60s, 120s, 240s, ... capped at 600s per attempt)
+    until ``fn`` succeeds or the cumulative backoff reaches
+    ``max_total_seconds`` (~1 hr). On budget exhaustion the original error is
+    re-raised so the caller can leave the unit PENDING for a later
+    ``--resume``.
 
     ``sleep`` is injectable so tests need not wait in real time.
     """
@@ -113,13 +116,15 @@ def _with_overload_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = O
     while True:
         try:
             return fn(*args)
-        except OverloadedError:
+        except (OverloadedError, RateLimitError) as exc:
             if waited >= max_total_seconds:
                 raise
-            delay = min(OVERLOAD_RETRY_BASE_SECONDS * 2**attempt, OVERLOAD_RETRY_MAX_DELAY_SECONDS)
+            delay = min(ANTHROPIC_RETRY_BASE_SECONDS * 2**attempt, ANTHROPIC_RETRY_MAX_DELAY_SECONDS)
             delay = min(delay, max_total_seconds - waited)
             log.warning(
-                "Anthropic 529 Overloaded — backing off %.0fs before retry (attempt %d, %.0fs of %ds budget used)",
+                "Anthropic API returned HTTP %s — backing off %.0fs before retry "
+                "(attempt %d, %.0fs of %ds budget used)",
+                exc.status_code,
                 delay,
                 attempt + 1,
                 waited,
@@ -1179,7 +1184,7 @@ def main(argv: list[str] | None = None) -> int:
                                 error=f"unfilled placeholder: {placeholder}",
                             )
                             continue
-                        out = _with_overload_retry(
+                        out = _with_anthropic_retry(
                             _phase1_baseline, anthro, mcp_session, u.corpus, u.question_id, text, run_dir
                         )
                     elif phase in (2, 3, 4, 5, 6):
@@ -1394,18 +1399,19 @@ def main(argv: list[str] | None = None) -> int:
                                 f"({HC_RECOVERY_WAIT_SECONDS}s each); exiting cleanly so "
                                 "--resume picks up where we left off."
                             ) from exc
-                except OverloadedError:
-                    # Anthropic stayed overloaded (529) past the ~1 hr retry
-                    # budget. Not a unit-level failure — leave it PENDING (not
-                    # ERROR) so `--resume` re-runs it once Anthropic recovers,
-                    # and continue so the rest of the corpus still finishes.
+                except (OverloadedError, RateLimitError):
+                    # Anthropic stayed rate-limited (429) or overloaded (529)
+                    # past the ~1 hr retry budget. Not a unit-level failure —
+                    # leave it PENDING (not ERROR) so `--resume` re-runs it
+                    # once Anthropic recovers, and continue so the rest of the
+                    # corpus still finishes.
                     log.warning(
-                        "unit %s/%s/%s: Anthropic overloaded past the %ds retry budget; "
+                        "unit %s/%s/%s: Anthropic rate-limited/overloaded past the %ds retry budget; "
                         "leaving PENDING for --resume and continuing",
                         u.corpus,
                         u.model,
                         u.question_id,
-                        OVERLOAD_RETRY_BUDGET_SECONDS,
+                        ANTHROPIC_RETRY_BUDGET_SECONDS,
                     )
                     cur = sf.get(u.phase, u.corpus, u.model, u.question_id, u.depth)
                     if cur is not None:

--- a/scripts/test_corpora/tests/test_sweep_overload_retry.py
+++ b/scripts/test_corpora/tests/test_sweep_overload_retry.py
@@ -1,10 +1,12 @@
-"""Tests for the harness's resilience to Anthropic HTTP 529 (Overloaded).
+"""Tests for the harness's resilience to transient Anthropic API errors —
+HTTP 429 (rate-limited) and HTTP 529 (overloaded).
 
-An Anthropic overload can persist for many minutes — far longer than the
-SDK's built-in ~5s retry window. Before the ``_with_overload_retry`` guard,
-an uncaught ``OverloadedError`` from a Phase 1 baseline call killed the
-whole multi-hour sweep. These tests pin down the backoff + give-up
-behaviour by simulating a 529 from the Anthropic client.
+A rate-limit window or Anthropic overload can persist for many minutes —
+far longer than the SDK's built-in ~5s retry window. Before the
+``_with_anthropic_retry`` guard, an uncaught ``RateLimitError`` /
+``OverloadedError`` from a Phase 1 baseline call killed the whole
+multi-hour sweep. These tests pin down the backoff + give-up behaviour by
+simulating 429s and 529s from the Anthropic client.
 """
 
 from __future__ import annotations
@@ -13,13 +15,13 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
-from anthropic._exceptions import OverloadedError
+from anthropic._exceptions import OverloadedError, RateLimitError
 
 from scripts.test_corpora.runner.sweep import (
-    OVERLOAD_RETRY_BUDGET_SECONDS,
-    OVERLOAD_RETRY_MAX_DELAY_SECONDS,
+    ANTHROPIC_RETRY_BUDGET_SECONDS,
+    ANTHROPIC_RETRY_MAX_DELAY_SECONDS,
     _phase1_baseline,
-    _with_overload_retry,
+    _with_anthropic_retry,
 )
 
 
@@ -30,7 +32,14 @@ def _make_overloaded_error() -> OverloadedError:
     return OverloadedError("Overloaded", response=response, body=None)
 
 
-def test_with_overload_retry_retries_then_succeeds():
+def _make_rate_limit_error() -> RateLimitError:
+    """Build the exact exception the Anthropic SDK raises on HTTP 429."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(429, request=request)
+    return RateLimitError("Rate limited", response=response, body=None)
+
+
+def test_with_anthropic_retry_retries_on_529_then_succeeds():
     """A transient 529 burst is absorbed: the call is retried with
     exponential backoff and its eventual success is returned."""
     calls: list[int] = []
@@ -42,14 +51,14 @@ def test_with_overload_retry_retries_then_succeeds():
             raise _make_overloaded_error()
         return "baseline-result"
 
-    result = _with_overload_retry(flaky, sleep=sleeps.append)
+    result = _with_anthropic_retry(flaky, sleep=sleeps.append)
 
     assert result == "baseline-result"
     assert len(calls) == 3  # two 529s, then success
     assert sleeps == [60, 120]  # exponential backoff between attempts
 
 
-def test_with_overload_retry_reraises_after_budget_exhausted():
+def test_with_anthropic_retry_reraises_529_after_budget_exhausted():
     """A sustained overload that outlasts the ~1 hr budget re-raises
     OverloadedError so the caller can leave the unit PENDING — but never
     sleeps past the budget, and never a single sleep long enough to trip
@@ -60,11 +69,11 @@ def test_with_overload_retry_reraises_after_budget_exhausted():
         raise _make_overloaded_error()
 
     with pytest.raises(OverloadedError):
-        _with_overload_retry(always_overloaded, sleep=sleeps.append)
+        _with_anthropic_retry(always_overloaded, sleep=sleeps.append)
 
     assert len(sleeps) >= 5  # retried many times before giving up
-    assert sum(sleeps) <= OVERLOAD_RETRY_BUDGET_SECONDS
-    assert all(s <= OVERLOAD_RETRY_MAX_DELAY_SECONDS for s in sleeps)
+    assert sum(sleeps) <= ANTHROPIC_RETRY_BUDGET_SECONDS
+    assert all(s <= ANTHROPIC_RETRY_MAX_DELAY_SECONDS for s in sleeps)
 
 
 def test_phase1_baseline_retry_recovers_from_anthropic_529(tmp_path):
@@ -82,7 +91,77 @@ def test_phase1_baseline_retry_recovers_from_anthropic_529(tmp_path):
     ]
     sleeps: list[float] = []
 
-    out = _with_overload_retry(
+    out = _with_anthropic_retry(
+        _phase1_baseline,
+        client,
+        None,  # mcp_session — None means no tools, single completion
+        "cuad",
+        "q1",
+        "What are the notice periods?",
+        tmp_path,
+        sleep=sleeps.append,
+    )
+
+    assert out["answer"] == "A thorough answer."
+    assert client.messages.create.call_count == 3
+    assert sleeps == [60, 120]
+    assert (tmp_path / "baselines" / "cuad" / "q1.json").exists()
+
+
+def test_with_anthropic_retry_retries_on_429_then_succeeds():
+    """A transient 429 rate-limit burst is absorbed exactly like a 529:
+    retried with exponential backoff, the eventual success returned. 429s
+    usually clear within the SDK's own retry window, but a storm that
+    outlasts it would otherwise propagate uncaught and kill the sweep."""
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) < 3:
+            raise _make_rate_limit_error()
+        return "baseline-result"
+
+    result = _with_anthropic_retry(flaky, sleep=sleeps.append)
+
+    assert result == "baseline-result"
+    assert len(calls) == 3  # two 429s, then success
+    assert sleeps == [60, 120]  # exponential backoff between attempts
+
+
+def test_with_anthropic_retry_reraises_429_after_budget_exhausted():
+    """A sustained 429 storm that outlasts the ~1 hr budget re-raises
+    RateLimitError specifically — the bare ``raise`` preserves the original
+    type — so the caller can leave the unit PENDING for a later --resume."""
+    sleeps: list[float] = []
+
+    def always_rate_limited():
+        raise _make_rate_limit_error()
+
+    with pytest.raises(RateLimitError):
+        _with_anthropic_retry(always_rate_limited, sleep=sleeps.append)
+
+    assert len(sleeps) >= 5  # retried many times before giving up
+    assert sum(sleeps) <= ANTHROPIC_RETRY_BUDGET_SECONDS
+    assert all(s <= ANTHROPIC_RETRY_MAX_DELAY_SECONDS for s in sleeps)
+
+
+def test_phase1_baseline_retry_recovers_from_anthropic_429(tmp_path):
+    """End-to-end: a Phase 1 baseline whose Anthropic client 429s twice
+    still produces a written baseline once the rate limit clears."""
+    response = MagicMock(
+        content=[MagicMock(text="A thorough answer.")],
+        stop_reason="end_turn",
+    )
+    client = MagicMock()
+    client.messages.create.side_effect = [
+        _make_rate_limit_error(),
+        _make_rate_limit_error(),
+        response,
+    ]
+    sleeps: list[float] = []
+
+    out = _with_anthropic_retry(
         _phase1_baseline,
         client,
         None,  # mcp_session — None means no tools, single completion

--- a/scripts/test_corpora/tests/test_sweep_overload_retry.py
+++ b/scripts/test_corpora/tests/test_sweep_overload_retry.py
@@ -1,0 +1,99 @@
+"""Tests for the harness's resilience to Anthropic HTTP 529 (Overloaded).
+
+An Anthropic overload can persist for many minutes — far longer than the
+SDK's built-in ~5s retry window. Before the ``_with_overload_retry`` guard,
+an uncaught ``OverloadedError`` from a Phase 1 baseline call killed the
+whole multi-hour sweep. These tests pin down the backoff + give-up
+behaviour by simulating a 529 from the Anthropic client.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from anthropic._exceptions import OverloadedError
+
+from scripts.test_corpora.runner.sweep import (
+    OVERLOAD_RETRY_BUDGET_SECONDS,
+    OVERLOAD_RETRY_MAX_DELAY_SECONDS,
+    _phase1_baseline,
+    _with_overload_retry,
+)
+
+
+def _make_overloaded_error() -> OverloadedError:
+    """Build the exact exception the Anthropic SDK raises on HTTP 529."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(529, request=request)
+    return OverloadedError("Overloaded", response=response, body=None)
+
+
+def test_with_overload_retry_retries_then_succeeds():
+    """A transient 529 burst is absorbed: the call is retried with
+    exponential backoff and its eventual success is returned."""
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) < 3:
+            raise _make_overloaded_error()
+        return "baseline-result"
+
+    result = _with_overload_retry(flaky, sleep=sleeps.append)
+
+    assert result == "baseline-result"
+    assert len(calls) == 3  # two 529s, then success
+    assert sleeps == [60, 120]  # exponential backoff between attempts
+
+
+def test_with_overload_retry_reraises_after_budget_exhausted():
+    """A sustained overload that outlasts the ~1 hr budget re-raises
+    OverloadedError so the caller can leave the unit PENDING — but never
+    sleeps past the budget, and never a single sleep long enough to trip
+    the supervisor's 30-minute 'stuck' alarm."""
+    sleeps: list[float] = []
+
+    def always_overloaded():
+        raise _make_overloaded_error()
+
+    with pytest.raises(OverloadedError):
+        _with_overload_retry(always_overloaded, sleep=sleeps.append)
+
+    assert len(sleeps) >= 5  # retried many times before giving up
+    assert sum(sleeps) <= OVERLOAD_RETRY_BUDGET_SECONDS
+    assert all(s <= OVERLOAD_RETRY_MAX_DELAY_SECONDS for s in sleeps)
+
+
+def test_phase1_baseline_retry_recovers_from_anthropic_529(tmp_path):
+    """End-to-end: a Phase 1 baseline whose Anthropic client 529s twice
+    still produces a written baseline once the overload clears."""
+    response = MagicMock(
+        content=[MagicMock(text="A thorough answer.")],
+        stop_reason="end_turn",
+    )
+    client = MagicMock()
+    client.messages.create.side_effect = [
+        _make_overloaded_error(),
+        _make_overloaded_error(),
+        response,
+    ]
+    sleeps: list[float] = []
+
+    out = _with_overload_retry(
+        _phase1_baseline,
+        client,
+        None,  # mcp_session — None means no tools, single completion
+        "cuad",
+        "q1",
+        "What are the notice periods?",
+        tmp_path,
+        sleep=sleeps.append,
+    )
+
+    assert out["answer"] == "A thorough answer."
+    assert client.messages.create.call_count == 3
+    assert sleeps == [60, 120]
+    assert (tmp_path / "baselines" / "cuad" / "q1.json").exists()


### PR DESCRIPTION
## Summary

The test-corpora sweep harness crashed on a transient Anthropic `529 Overloaded` instead of backing off — this aborted an overnight run. HTTP `429 Rate limited` had the identical latent gap, fixed here in the same PR.

Phase 1 baselines call Sonnet via the Anthropic SDK. On HTTP 429/529 the SDK's built-in retries cover only ~5s — far short of a real rate-limit window or overload, which can persist for many minutes. The exhausted `RateLimitError` / `OverloadedError` then propagated **uncaught** through the phase-1 unit loop (neither is an `httpx.HTTPError`, so the loop's `except (httpx.HTTPError, RuntimeError, KeyError)` clause missed it) and killed the entire multi-hour sweep.

- **`_with_anthropic_retry` helper** wraps the `_phase1_baseline` call and retries on `OverloadedError` (529) and `RateLimitError` (429) with exponential backoff — 60s, 120s, 240s, … capped at 10 min/attempt, ~1 hr total budget. Each sleep stays under `supervisor.py`'s 30-min "stuck" threshold so a long backoff isn't flagged as a hang.
- **`except (OverloadedError, RateLimitError)` clause** in the unit loop handles the budget-exhausted case: the unit is left **PENDING** (not ERROR), mirroring the existing `httpx.ConnectError` handler, so `--resume` re-runs just the affected baselines while the rest of the corpus still finishes.
- **RUNBOOK** updated under "Anthropic rate-limit or overload storm".

This is purely a harness-resilience fix; Harbor Clerk itself is unaffected.

## Test plan

- [x] `scripts/test_corpora/tests/test_sweep_overload_retry.py` — 6 tests simulating real `OverloadedError` (529) and `RateLimitError` (429) from the Anthropic client: retry-then-succeed, re-raise-after-budget (asserts it never sleeps past the budget or trips the stuck alarm), and end-to-end phase-1 baseline recovery — for each error type.
- [x] Full `scripts/test_corpora` suite — 267 passed.
- [x] `ruff check` + `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
