### PR TITLE
feat(eval): answer-level eval (--mode answer-eval), phase 1

### DIFF
--- a/scripts/test_corpora/groundtruth/cuad.yaml
+++ b/scripts/test_corpora/groundtruth/cuad.yaml
@@ -1,0 +1,101 @@
+# CUAD answer-eval ground-truth set -- frozen, version-controlled.
+#
+# Curated 2026-05-22 from CUAD master_clauses.csv (Atticus Project expert
+# annotations) via groundtruth/generate_cuad.py. 15 items across 7 contracts:
+# value-category lookups (Governing Law, Parties, Agreement/Expiration Date)
+# carry the verbatim CUAD span; clause-presence categories are phrased as
+# yes/no questions, with negatives drawn from CUAD's explicit "No" labels.
+# Regenerate only by explicitly re-running the generator and re-curating --
+# never as a side effect of an eval run.
+corpus: cuad
+items:
+- id: cuad-gt-gl-arca
+  question: What is the governing law of the ArcaUsTreasuryFund_20200207_N-2_EX-99.K5_11971930_EX-99.K5_Development Agreement agreement?
+  clause_category: Governing Law
+  gold_doc: ArcaUsTreasuryFund_20200207_N-2_EX-99.K5_11971930_EX-99.K5_Development Agreement
+  answer_key: New York
+  type: lookup
+- id: cuad-gt-gl-berkshire
+  question: What is the governing law of the BerkshireHillsBancorpInc_20120809_10-Q_EX-10.16_7708169_EX-10.16_Endorsement Agreement agreement?
+  clause_category: Governing Law
+  gold_doc: BerkshireHillsBancorpInc_20120809_10-Q_EX-10.16_7708169_EX-10.16_Endorsement Agreement
+  answer_key: Connecticut
+  type: lookup
+- id: cuad-gt-gl-clickstream
+  question: What is the governing law of the ClickstreamCorp_20200330_1-A_EX1A-6 MAT CTRCT_12089935_EX1A-6 MAT CTRCT_Development Agreement agreement?
+  clause_category: Governing Law
+  gold_doc: ClickstreamCorp_20200330_1-A_EX1A-6 MAT CTRCT_12089935_EX1A-6 MAT CTRCT_Development Agreement
+  answer_key: Florida
+  type: lookup
+- id: cuad-gt-gl-cns
+  question: What is the governing law of the CnsPharmaceuticalsInc_20200326_8-K_EX-10.1_12079626_EX-10.1_Development Agreement agreement?
+  clause_category: Governing Law
+  gold_doc: CnsPharmaceuticalsInc_20200326_8-K_EX-10.1_12079626_EX-10.1_Development Agreement
+  answer_key: Texas
+  type: lookup
+- id: cuad-gt-parties-2themart
+  question: Who are the parties to the 2ThemartComInc_19990826_10-12G_EX-10.10_6700288_EX-10.10_Co-Branding Agreement_ Agency Agreement agreement?
+  clause_category: Parties
+  gold_doc: 2ThemartComInc_19990826_10-12G_EX-10.10_6700288_EX-10.10_Co-Branding Agreement_ Agency Agreement
+  answer_key: I-ESCROW, INC.  ("i-Escrow" ); 2THEMART.COM, INC. ("2TheMart")
+  type: lookup
+- id: cuad-gt-parties-berkshire
+  question: Who are the parties to the BerkshireHillsBancorpInc_20120809_10-Q_EX-10.16_7708169_EX-10.16_Endorsement Agreement agreement?
+  clause_category: Parties
+  gold_doc: BerkshireHillsBancorpInc_20120809_10-Q_EX-10.16_7708169_EX-10.16_Endorsement Agreement
+  answer_key: Geno Auriemma (Auriemma); Berkshire Bank (Berkshire)("Party" or "Parties")
+  type: lookup
+- id: cuad-gt-parties-bizzingo
+  question: Who are the parties to the BizzingoInc_20120322_8-K_EX-10.17_7504499_EX-10.17_Endorsement Agreement agreement?
+  clause_category: Parties
+  gold_doc: BizzingoInc_20120322_8-K_EX-10.17_7504499_EX-10.17_Endorsement Agreement
+  answer_key: Bizzingo, Inc ("Bizzingo"); Joseph Theismann ("Theismann")
+  type: lookup
+- id: cuad-gt-agreementdate-2themart
+  question: What is the agreement date of the 2ThemartComInc_19990826_10-12G_EX-10.10_6700288_EX-10.10_Co-Branding Agreement_ Agency Agreement agreement?
+  clause_category: Agreement Date
+  gold_doc: 2ThemartComInc_19990826_10-12G_EX-10.10_6700288_EX-10.10_Co-Branding Agreement_ Agency Agreement
+  answer_key: 6/21/99
+  type: lookup
+- id: cuad-gt-agreementdate-clickstream
+  question: What is the agreement date of the ClickstreamCorp_20200330_1-A_EX1A-6 MAT CTRCT_12089935_EX1A-6 MAT CTRCT_Development Agreement agreement?
+  clause_category: Agreement Date
+  gold_doc: ClickstreamCorp_20200330_1-A_EX1A-6 MAT CTRCT_12089935_EX1A-6 MAT CTRCT_Development Agreement
+  answer_key: 3/20/20
+  type: lookup
+- id: cuad-gt-expirationdate-berkshire
+  question: What is the expiration date of the BerkshireHillsBancorpInc_20120809_10-Q_EX-10.16_7708169_EX-10.16_Endorsement Agreement agreement?
+  clause_category: Expiration Date
+  gold_doc: BerkshireHillsBancorpInc_20120809_10-Q_EX-10.16_7708169_EX-10.16_Endorsement Agreement
+  answer_key: 5/31/16
+  type: lookup
+- id: cuad-gt-expirationdate-bizzingo
+  question: What is the expiration date of the BizzingoInc_20120322_8-K_EX-10.17_7504499_EX-10.17_Endorsement Agreement agreement?
+  clause_category: Expiration Date
+  gold_doc: BizzingoInc_20120322_8-K_EX-10.17_7504499_EX-10.17_Endorsement Agreement
+  answer_key: 3/1/13
+  type: lookup
+- id: cuad-gt-noncompete-aimmune
+  question: Does the AimmuneTherapeuticsInc_20200205_8-K_EX-10.3_11967170_EX-10.3_Development Agreement agreement contain a non-compete clause?
+  clause_category: Non-Compete
+  gold_doc: AimmuneTherapeuticsInc_20200205_8-K_EX-10.3_11967170_EX-10.3_Development Agreement
+  answer_key: 'Yes'
+  type: lookup
+- id: cuad-gt-mfn-neg-arca
+  question: Does the ArcaUsTreasuryFund_20200207_N-2_EX-99.K5_11971930_EX-99.K5_Development Agreement agreement contain a most-favored-nation clause?
+  clause_category: Most Favored Nation
+  gold_doc: ArcaUsTreasuryFund_20200207_N-2_EX-99.K5_11971930_EX-99.K5_Development Agreement
+  answer_key: null
+  type: negative
+- id: cuad-gt-cap-neg-bizzingo
+  question: Does the BizzingoInc_20120322_8-K_EX-10.17_7504499_EX-10.17_Endorsement Agreement agreement contain a clause that limits or caps liability?
+  clause_category: Cap On Liability
+  gold_doc: BizzingoInc_20120322_8-K_EX-10.17_7504499_EX-10.17_Endorsement Agreement
+  answer_key: null
+  type: negative
+- id: cuad-gt-exclusivity-neg-2themart
+  question: Does the 2ThemartComInc_19990826_10-12G_EX-10.10_6700288_EX-10.10_Co-Branding Agreement_ Agency Agreement agreement contain an exclusivity clause?
+  clause_category: Exclusivity
+  gold_doc: 2ThemartComInc_19990826_10-12G_EX-10.10_6700288_EX-10.10_Co-Branding Agreement_ Agency Agreement
+  answer_key: null
+  type: negative

--- a/scripts/test_corpora/groundtruth/generate_cuad.py
+++ b/scripts/test_corpora/groundtruth/generate_cuad.py
@@ -1,0 +1,117 @@
+# scripts/test_corpora/groundtruth/generate_cuad.py
+"""Generate the CUAD answer-eval ground-truth set from master_clauses.csv.
+
+CUAD ships expert clause labels (Atticus Project). master_clauses.csv has, per
+contract, a `<Category>` column and a `<Category>-Answer` column; the -Answer
+cell is a Python-list-repr string of the extracted clause text(s), or "[]" when
+the clause is absent. We turn a fixed set of (contract, category) pairs into
+ground-truth Q&A: lookups (clause present) and negatives (clause absent).
+
+Run explicitly; the output is curated once by a human and committed. It is
+never regenerated as a side effect of an eval run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import yaml
+
+# Clause category -> question template. {name} is filled with the contract's
+# filename stem. Categories chosen for crisp, checkable answers.
+CATEGORIES: dict[str, str] = {
+    "Governing Law": "What is the governing law of the {name} agreement?",
+    "Parties": "Who are the parties to the {name} agreement?",
+    "Agreement Date": "What is the agreement date of the {name} agreement?",
+    "Expiration Date": "What is the expiration date of the {name} agreement?",
+    "Cap On Liability": "What is the cap on liability in the {name} agreement?",
+    "Exclusivity": "What exclusivity clause does the {name} agreement contain?",
+    "Most Favored Nation": "Does the {name} agreement contain a most-favored-nation clause?",
+    "Non-Compete": "What non-compete clause does the {name} agreement contain?",
+}
+
+
+def _parse_answer(cell: str | None) -> str | None:
+    """Rough extraction from a master_clauses.csv -Answer cell — a
+    Python-list-repr string like "['Delaware']", or "[]" when the clause is
+    absent. Returns the answer text, or None when absent. Deliberately crude
+    (no code evaluation): the generated set is finalized by a human curation
+    pass before being committed, so first-pass roughness is acceptable.
+    """
+    cell = (cell or "").strip()
+    if cell in ("", "[]"):
+        return None
+    inner = cell.strip("[]").strip()
+    # First quoted element, surrounding quote stripped.
+    first = inner.split("',")[0].split('",')[0].strip()
+    return first.strip("'\"").strip() or None
+
+
+def generate(master_csv: Path, ingest_dir: Path, out_path: Path, per_category: int = 2) -> int:
+    """Emit the ground-truth YAML. Returns the number of items written.
+
+    Selects up to `per_category` lookup items per category, plus one negative
+    per category where one exists (a contract where CUAD labeled the clause
+    absent). Contracts not present in `ingest_dir` (i.e. not in the sampled set
+    HC actually holds) are skipped. Deterministic by sorted filename.
+    """
+    sampled = {p.stem for p in sorted(ingest_dir.glob("*.pdf"))}
+    rows = sorted(csv.DictReader(master_csv.open()), key=lambda r: r.get("Filename", ""))
+
+    items: list[dict] = []
+    for category, template in CATEGORIES.items():
+        answer_col = f"{category}-Answer"
+        lookups: list[dict] = []
+        negatives: list[dict] = []
+        for row in rows:
+            filename = (row.get("Filename") or "").strip()
+            stem = filename[:-4] if filename.lower().endswith(".pdf") else filename
+            if stem not in sampled:
+                continue
+            answer = _parse_answer(row.get(answer_col))
+            if answer is not None and len(lookups) < per_category:
+                lookups.append(
+                    {
+                        "id": f"cuad-gt-{category.lower().replace(' ', '-')}-{len(lookups) + 1}",
+                        "question": template.format(name=stem),
+                        "clause_category": category,
+                        "gold_doc": stem,
+                        "answer_key": answer,
+                        "type": "lookup",
+                    }
+                )
+            elif answer is None and len(negatives) < 1:
+                negatives.append(
+                    {
+                        "id": f"cuad-gt-{category.lower().replace(' ', '-')}-neg",
+                        "question": template.format(name=stem),
+                        "clause_category": category,
+                        "gold_doc": stem,
+                        "answer_key": None,
+                        "type": "negative",
+                    }
+                )
+        items.extend(lookups + negatives)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(yaml.safe_dump({"corpus": "cuad", "items": items}, sort_keys=False))
+    return len(items)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Generate the CUAD answer-eval ground-truth set.")
+    ap.add_argument("--master-csv", type=Path, required=True, help="CUAD master_clauses.csv")
+    ap.add_argument("--ingest-dir", type=Path, required=True, help="CUAD ingest dir (sampled PDFs)")
+    ap.add_argument("--out", type=Path, required=True, help="output cuad.yaml")
+    ap.add_argument("--per-category", type=int, default=2)
+    a = ap.parse_args(argv)
+    n = generate(master_csv=a.master_csv, ingest_dir=a.ingest_dir, out_path=a.out, per_category=a.per_category)
+    print(f"wrote {n} ground-truth items -> {a.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_corpora/groundtruth/generate_cuad.py
+++ b/scripts/test_corpora/groundtruth/generate_cuad.py
@@ -59,7 +59,8 @@ def generate(master_csv: Path, ingest_dir: Path, out_path: Path, per_category: i
     HC actually holds) are skipped. Deterministic by sorted filename.
     """
     sampled = {p.stem for p in sorted(ingest_dir.glob("*.pdf"))}
-    rows = sorted(csv.DictReader(master_csv.open()), key=lambda r: r.get("Filename", ""))
+    with master_csv.open(newline="") as fh:
+        rows = sorted(csv.DictReader(fh), key=lambda r: r.get("Filename", ""))
 
     items: list[dict] = []
     for category, template in CATEGORIES.items():

--- a/scripts/test_corpora/runner/answer_eval.py
+++ b/scripts/test_corpora/runner/answer_eval.py
@@ -1,0 +1,243 @@
+# scripts/test_corpora/runner/answer_eval.py
+"""--mode answer-eval — run a frontier model through HC's MCP over a
+ground-truth set and score answers for correctness / groundedness /
+completeness against expert labels.
+
+Mirrors retrieval_eval.py. Artifacts are model-keyed and reused by default:
+  <workdir>/answer-eval/captures/<corpus>/<model>/<id>.json   (model+MCP run)
+  <workdir>/answer-eval/verdicts/<corpus>/<model>/<id>.json   (judge verdict)
+  <workdir>/answer-eval/reports/<label>/summary.json          (per-run report)
+Regeneration is explicit: --refresh re-runs captures, --rejudge re-runs the
+judge. The ground-truth set itself is a frozen, version-controlled file.
+
+scope_folder_ids classification (Task 1): pre-ranking. A folder-scoped API key
+restricts the candidate set before ranking — scope.apply_key_scope() builds the
+in-scope doc-id set and search.py spreads Chunk.doc_id.in_(doc_ids) into both
+the FTS and vector WHERE clauses ahead of ORDER BY/LIMIT. A scoped search over
+the 3-corpus index is therefore equivalent to a single-corpus index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+import yaml
+
+from scripts.test_corpora.runner.answer_judge import AnswerJudge, AnswerVerdict
+
+log = logging.getLogger("answer_eval")
+
+GROUNDTRUTH_DIR = Path(__file__).resolve().parents[1] / "groundtruth"
+
+
+@dataclasses.dataclass(frozen=True)
+class GTItem:
+    id: str
+    question: str
+    clause_category: str
+    gold_doc: str
+    answer_key: str | None
+    type: str
+
+
+def load_groundtruth(path: Path) -> list[GTItem]:
+    data = yaml.safe_load(path.read_text())
+    return [
+        GTItem(
+            id=i["id"],
+            question=i["question"],
+            clause_category=i["clause_category"],
+            gold_doc=i["gold_doc"],
+            answer_key=i.get("answer_key"),
+            type=i["type"],
+        )
+        for i in data["items"]
+    ]
+
+
+def aggregate(rows: list[tuple[str, str, AnswerVerdict]]) -> dict:
+    """rows = [(item_id, type, verdict)]. Means overall and by type."""
+
+    def _means(group: list[AnswerVerdict]) -> dict:
+        n = len(group)
+        if n == 0:
+            return {"n": 0}
+        return {
+            "n": n,
+            "correctness": sum(v.correctness for v in group) / n,
+            "groundedness": sum(v.groundedness for v in group) / n,
+            "completeness": sum(v.completeness for v in group) / n,
+        }
+
+    by_type: dict[str, list[AnswerVerdict]] = {}
+    for _id, qtype, v in rows:
+        by_type.setdefault(qtype, []).append(v)
+    return {
+        "overall": _means([v for _, _, v in rows]),
+        "by_type": {t: _means(g) for t, g in by_type.items()},
+    }
+
+
+def _cited_text(capture: dict) -> str:
+    """Compact rendering of the cited evidence for the judge."""
+    titles = capture.get("cited_doc_titles") or []
+    transcript = capture.get("tool_transcript") or []
+    lines = [f"cited docs: {', '.join(t for t in titles if t)}"]
+    for call in transcript:
+        lines.append(f"[{call.get('tool')}] {str(call.get('result_summary'))[:400]}")
+    return "\n".join(lines)
+
+
+def run(
+    *,
+    workdir: Path,
+    corpus: str,
+    model: str,
+    label: str,
+    api_base: str,
+    refresh: bool,
+    rejudge: bool,
+    insecure: bool,
+    groundtruth_path: Path | None = None,
+    capture_fn: Callable[[GTItem], dict] | None = None,
+    judge: AnswerJudge | None = None,
+) -> int:
+    """Returns an exit code (0 = success). `capture_fn` and `judge` are
+    injectable for tests; in production they default to a live model+MCP run
+    and a live AnswerJudge."""
+    gt_path = groundtruth_path or (GROUNDTRUTH_DIR / f"{corpus}.yaml")
+    if not gt_path.exists():
+        log.error("ground-truth set not found: %s", gt_path)
+        return 2
+    items = load_groundtruth(gt_path)
+    log.info("loaded %d ground-truth items from %s", len(items), gt_path)
+
+    cap_dir = workdir / "answer-eval" / "captures" / corpus / model
+    ver_dir = workdir / "answer-eval" / "verdicts" / corpus / model
+    cap_dir.mkdir(parents=True, exist_ok=True)
+    ver_dir.mkdir(parents=True, exist_ok=True)
+
+    if capture_fn is None:
+        capture_fn = _live_capture_fn(api_base=api_base, corpus=corpus, model=model, insecure=insecure)
+    if judge is None:
+        judge = AnswerJudge()
+
+    rows: list[tuple[str, str, AnswerVerdict]] = []
+    for item in items:
+        cap_path = cap_dir / f"{item.id}.json"
+        if cap_path.exists() and not refresh:
+            capture = json.loads(cap_path.read_text())
+        else:
+            log.info("capturing %s via model+MCP", item.id)
+            capture = capture_fn(item)
+            cap_path.write_text(json.dumps(capture, indent=2))
+
+        ver_path = ver_dir / f"{item.id}.json"
+        if ver_path.exists() and not rejudge and not refresh:
+            verdict = AnswerVerdict(**json.loads(ver_path.read_text()))
+        else:
+            verdict = judge.judge_answer(
+                question=item.question,
+                model_answer=capture.get("answer", ""),
+                cited=_cited_text(capture),
+                answer_key=item.answer_key,
+                qtype=item.type,
+            )
+            ver_path.write_text(json.dumps(dataclasses.asdict(verdict), indent=2))
+        log.info(
+            "  %s correctness=%d grounded=%d complete=%d",
+            item.id,
+            verdict.correctness,
+            verdict.groundedness,
+            verdict.completeness,
+        )
+        rows.append((item.id, item.type, verdict))
+
+    summary = aggregate(rows)
+    report_dir = workdir / "answer-eval" / "reports" / label
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+    (report_dir / "detail.json").write_text(
+        json.dumps([{"id": i, "type": t, **dataclasses.asdict(v)} for i, t, v in rows], indent=2)
+    )
+    o = summary["overall"]
+    log.info(
+        "OVERALL n=%d correctness=%.2f groundedness=%.2f completeness=%.2f",
+        o["n"],
+        o["correctness"],
+        o["groundedness"],
+        o["completeness"],
+    )
+    return 0
+
+
+def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) -> Callable[[GTItem], dict]:
+    """Build the production capture function: a model+MCP run per item.
+
+    Reuses the phase-1 machinery — SyncMcpSession for the MCP tool calls,
+    BaselineGenerator for the agentic loop. The MCP session MUST be
+    authenticated with a corpus-scoped API key so HC's search is restricted to
+    `corpus`: set HC_API_KEY to that scoped key. Falls back to a
+    HC_USERNAME/HC_PASSWORD login, which yields an UNSCOPED (full-index)
+    session — correct only when `corpus` is the lone corpus loaded.
+    """
+    import anthropic
+
+    from scripts.test_corpora.runner.claude_baseline import BaselineGenerator
+    from scripts.test_corpora.runner.client import HarborClerkClient, SyncMcpSession
+
+    token = os.environ.get("HC_API_KEY")
+    if not token:
+        user, password = os.environ.get("HC_USERNAME"), os.environ.get("HC_PASSWORD")
+        if not (user and password):
+            raise RuntimeError(
+                "answer-eval needs HC_API_KEY (a corpus-scoped key) or HC_USERNAME + HC_PASSWORD in the environment"
+            )
+        hc = HarborClerkClient(api_base, verify=not insecure)
+        hc.login(user, password)
+        token = hc.get_bearer_token()
+        log.warning("HC_API_KEY unset — using an unscoped login; search is NOT corpus-restricted")
+
+    mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
+    mcp = SyncMcpSession(url=mcp_url, headers={"Authorization": f"Bearer {token}"})
+    anthro = anthropic.Anthropic()
+
+    def capture(item: GTItem) -> dict:
+        gen = BaselineGenerator(client=anthro, mcp_session=mcp, model=model)
+        res = gen.run_question(question=item.question, question_id=item.id, corpus=corpus)
+        return dataclasses.asdict(res)
+
+    return capture
+
+
+def add_cli_args(p: argparse.ArgumentParser) -> None:
+    """Register answer-eval-only flags. --label / --run-id / --workdir /
+    --api-base / --corpora / --models / --insecure already exist on the sweep
+    parser (the last set via retrieval_eval.add_cli_args)."""
+    g = p.add_argument_group("answer-eval (only with --mode answer-eval)")
+    g.add_argument("--refresh", action="store_true", help="re-run model+MCP captures even if present")
+    g.add_argument("--rejudge", action="store_true", help="re-run the judge even if verdicts are present")
+
+
+def main_from_args(args: argparse.Namespace) -> int:
+    corpus = args.corpora.split(",")[0].strip() if args.corpora else "cuad"
+    model = args.models.split(",")[0].strip() if args.models else "claude-sonnet-4-6"
+    if not args.label:
+        log.error("--label is required for --mode answer-eval")
+        return 2
+    return run(
+        workdir=Path(args.workdir),
+        corpus=corpus,
+        model=model,
+        label=args.label,
+        api_base=args.api_base,
+        refresh=args.refresh,
+        rejudge=args.rejudge,
+        insecure=args.insecure,
+    )

--- a/scripts/test_corpora/runner/answer_eval.py
+++ b/scripts/test_corpora/runner/answer_eval.py
@@ -118,15 +118,17 @@ def run(
     items = load_groundtruth(gt_path)
     log.info("loaded %d ground-truth items from %s", len(items), gt_path)
 
-    cap_dir = workdir / "answer-eval" / "captures" / corpus / model
-    ver_dir = workdir / "answer-eval" / "verdicts" / corpus / model
-    cap_dir.mkdir(parents=True, exist_ok=True)
-    ver_dir.mkdir(parents=True, exist_ok=True)
-
+    # Build the model/judge clients before creating any output directories, so
+    # a missing credential fails fast without leaving empty dirs behind.
     if capture_fn is None:
         capture_fn = _live_capture_fn(api_base=api_base, corpus=corpus, model=model, insecure=insecure)
     if judge is None:
         judge = AnswerJudge()
+
+    cap_dir = workdir / "answer-eval" / "captures" / corpus / model
+    ver_dir = workdir / "answer-eval" / "verdicts" / corpus / model
+    cap_dir.mkdir(parents=True, exist_ok=True)
+    ver_dir.mkdir(parents=True, exist_ok=True)
 
     rows: list[tuple[str, str, AnswerVerdict]] = []
     for item in items:
@@ -244,14 +246,15 @@ def main_from_args(args: argparse.Namespace) -> int:
             corpus,
             model,
         )
-    if not args.label:
+    label = getattr(args, "label", None)
+    if not label:
         log.error("--label is required for --mode answer-eval")
         return 2
     return run(
         workdir=Path(args.workdir),
         corpus=corpus,
         model=model,
-        label=args.label,
+        label=label,
         api_base=args.api_base,
         refresh=args.refresh,
         rejudge=args.rejudge,

--- a/scripts/test_corpora/runner/answer_eval.py
+++ b/scripts/test_corpora/runner/answer_eval.py
@@ -65,14 +65,14 @@ def aggregate(rows: list[tuple[str, str, AnswerVerdict]]) -> dict:
     """rows = [(item_id, type, verdict)]. Means overall and by type."""
 
     def _means(group: list[AnswerVerdict]) -> dict:
+        # Always returns the full four-key shape (zeros when the group is empty)
+        # so callers — including the OVERALL log line — can index every key.
         n = len(group)
-        if n == 0:
-            return {"n": 0}
         return {
             "n": n,
-            "correctness": sum(v.correctness for v in group) / n,
-            "groundedness": sum(v.groundedness for v in group) / n,
-            "completeness": sum(v.completeness for v in group) / n,
+            "correctness": sum(v.correctness for v in group) / n if n else 0.0,
+            "groundedness": sum(v.groundedness for v in group) / n if n else 0.0,
+            "completeness": sum(v.completeness for v in group) / n if n else 0.0,
         }
 
     by_type: dict[str, list[AnswerVerdict]] = {}
@@ -131,17 +131,25 @@ def run(
     rows: list[tuple[str, str, AnswerVerdict]] = []
     for item in items:
         cap_path = cap_dir / f"{item.id}.json"
+        capture: dict | None = None
         if cap_path.exists() and not refresh:
-            capture = json.loads(cap_path.read_text())
-        else:
+            try:
+                capture = json.loads(cap_path.read_text())
+            except json.JSONDecodeError as e:
+                log.warning("  %s: unreadable capture %s (%s) — re-running", item.id, cap_path, e)
+        if capture is None:
             log.info("capturing %s via model+MCP", item.id)
             capture = capture_fn(item)
             cap_path.write_text(json.dumps(capture, indent=2))
 
         ver_path = ver_dir / f"{item.id}.json"
+        verdict: AnswerVerdict | None = None
         if ver_path.exists() and not rejudge and not refresh:
-            verdict = AnswerVerdict(**json.loads(ver_path.read_text()))
-        else:
+            try:
+                verdict = AnswerVerdict(**json.loads(ver_path.read_text()))
+            except (json.JSONDecodeError, TypeError) as e:
+                log.warning("  %s: unreadable verdict %s (%s) — re-judging", item.id, ver_path, e)
+        if verdict is None:
             verdict = judge.judge_answer(
                 question=item.question,
                 model_answer=capture.get("answer", ""),
@@ -202,6 +210,8 @@ def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) 
         hc = HarborClerkClient(api_base, verify=not insecure)
         hc.login(user, password)
         token = hc.get_bearer_token()
+        if not token:
+            raise RuntimeError("HC login did not yield a bearer token — check HC_USERNAME / HC_PASSWORD")
         log.warning("HC_API_KEY unset — using an unscoped login; search is NOT corpus-restricted")
 
     mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
@@ -228,6 +238,12 @@ def add_cli_args(p: argparse.ArgumentParser) -> None:
 def main_from_args(args: argparse.Namespace) -> int:
     corpus = args.corpora.split(",")[0].strip() if args.corpora else "cuad"
     model = args.models.split(",")[0].strip() if args.models else "claude-sonnet-4-6"
+    if (args.corpora and "," in args.corpora) or (args.models and "," in args.models):
+        log.warning(
+            "answer-eval is single-corpus/single-model in phase 1; using corpus=%s model=%s, ignoring the rest",
+            corpus,
+            model,
+        )
     if not args.label:
         log.error("--label is required for --mode answer-eval")
         return 2

--- a/scripts/test_corpora/runner/answer_judge.py
+++ b/scripts/test_corpora/runner/answer_judge.py
@@ -1,0 +1,89 @@
+# scripts/test_corpora/runner/answer_judge.py
+"""LLM-as-judge for the answer-eval. Scores a model answer against an external
+ground-truth key (CUAD expert label) on correctness, groundedness, and
+completeness. Independence is not a concern: the judge adjudicates against the
+label, it is not itself the source of truth.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+
+import anthropic
+
+JUDGE_MODEL = "claude-sonnet-4-6"
+
+_PROMPT = """You are scoring an answer produced by a document-search assistant.
+
+QUESTION:
+{question}
+
+GROUND-TRUTH ANSWER KEY (expert-labeled; the source of truth):
+{answer_key}
+
+QUESTION TYPE: {qtype}
+(For type "negative", the ground-truth answer key is "NONE" — the clause does
+not exist in the document, and a correct answer says so.)
+
+THE ASSISTANT'S ANSWER:
+{model_answer}
+
+THE PASSAGES THE ASSISTANT CITED:
+{cited}
+
+Score three dimensions, each an integer 0-5:
+- correctness: does the answer agree with the ground-truth key? (negative type:
+  full marks only if it correctly says the clause is absent.)
+- groundedness: is every claim supported by a cited passage? 5 = fully
+  grounded, 0 = key claims uncited or contradicted by the citation.
+- completeness: does the answer cover what the key contains, without burying it
+  in irrelevant text?
+
+Reply with ONLY a JSON object:
+{{"correctness": <0-5>, "groundedness": <0-5>, "completeness": <0-5>, "rationale": "<one sentence>"}}
+"""
+
+
+@dataclasses.dataclass
+class AnswerVerdict:
+    correctness: int
+    groundedness: int
+    completeness: int
+    rationale: str
+
+
+def _extract_json(text: str) -> dict:
+    fence = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
+    raw = fence.group(1) if fence else text[text.find("{") : text.rfind("}") + 1]
+    return json.loads(raw)
+
+
+class AnswerJudge:
+    def __init__(self, client: anthropic.Anthropic | None = None, model: str = JUDGE_MODEL):
+        self._client = client or anthropic.Anthropic()
+        self._model = model
+
+    def judge_answer(
+        self, *, question: str, model_answer: str, cited: str, answer_key: str | None, qtype: str
+    ) -> AnswerVerdict:
+        prompt = _PROMPT.format(
+            question=question,
+            answer_key="NONE" if answer_key is None else answer_key,
+            qtype=qtype,
+            model_answer=model_answer or "(empty)",
+            cited=cited or "(no passages cited)",
+        )
+        msg = self._client.messages.create(
+            model=self._model,
+            max_tokens=600,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        data = _extract_json(msg.content[0].text)
+        return AnswerVerdict(
+            correctness=int(data["correctness"]),
+            groundedness=int(data["groundedness"]),
+            completeness=int(data["completeness"]),
+            rationale=str(data.get("rationale", "")),
+        )

--- a/scripts/test_corpora/runner/answer_judge.py
+++ b/scripts/test_corpora/runner/answer_judge.py
@@ -56,8 +56,12 @@ class AnswerVerdict:
 
 def _extract_json(text: str) -> dict:
     fence = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
-    raw = fence.group(1) if fence else text[text.find("{") : text.rfind("}") + 1]
-    return json.loads(raw)
+    if fence:
+        return json.loads(fence.group(1))
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end == -1:
+        raise ValueError("no JSON object in judge response")
+    return json.loads(text[start : end + 1])
 
 
 class AnswerJudge:

--- a/scripts/test_corpora/runner/answer_judge.py
+++ b/scripts/test_corpora/runner/answer_judge.py
@@ -55,13 +55,16 @@ class AnswerVerdict:
 
 
 def _extract_json(text: str) -> dict:
+    """Pull the score JSON object out of the judge reply, tolerating a ```json
+    fence and any prose after the object's closing brace."""
     fence = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
     if fence:
-        return json.loads(fence.group(1))
-    start, end = text.find("{"), text.rfind("}")
-    if start == -1 or end == -1:
+        text = fence.group(1)
+    start = text.find("{")
+    if start == -1:
         raise ValueError("no JSON object in judge response")
-    return json.loads(text[start : end + 1])
+    obj, _ = json.JSONDecoder().raw_decode(text, start)
+    return obj
 
 
 class AnswerJudge:

--- a/scripts/test_corpora/runner/claude_baseline.py
+++ b/scripts/test_corpora/runner/claude_baseline.py
@@ -165,10 +165,14 @@ class BaselineGenerator:
                     )
             messages.append({"role": "user", "content": tool_results})
 
-        # Final answer is the last text block in the assistant turn
+        # Final answer is the last text block in the assistant turn — scan from
+        # the end so a leading non-text block (e.g. tool_use) is skipped.
         final = ""
-        if resp and resp.content and hasattr(resp.content[0], "text"):
-            final = resp.content[0].text
+        if resp and resp.content:
+            for block in reversed(resp.content):
+                if hasattr(block, "text"):
+                    final = block.text
+                    break
 
         return BaselineResult(
             question_id=question_id,

--- a/scripts/test_corpora/runner/claude_baseline.py
+++ b/scripts/test_corpora/runner/claude_baseline.py
@@ -45,6 +45,9 @@ class BaselineResult:
     # carried no title.
     cited_doc_titles: list[str]
     tool_call_count: int
+    # Per-call record [{tool, args, result_summary}] in call order — for
+    # groundedness scoring and tool-use auditing.
+    tool_transcript: list[dict]
     elapsed_seconds: float
     model: str
     timestamp: str
@@ -122,6 +125,7 @@ class BaselineGenerator:
         tools = self._list_tools()
         messages: list[dict] = [{"role": "user", "content": question}]
         tool_call_count = 0
+        tool_transcript: list[dict] = []
         resp = None
 
         while True:
@@ -145,6 +149,13 @@ class BaselineGenerator:
                 if getattr(block, "type", None) == "tool_use":
                     tool_call_count += 1
                     out = self._exec_tool(block.name, block.input)
+                    tool_transcript.append(
+                        {
+                            "tool": block.name,
+                            "args": dict(block.input),
+                            "result_summary": out[:600],
+                        }
+                    )
                     tool_results.append(
                         {
                             "type": "tool_result",
@@ -166,6 +177,7 @@ class BaselineGenerator:
             cited_doc_ids=list(self._cited.keys()),
             cited_doc_titles=list(self._cited.values()),
             tool_call_count=tool_call_count,
+            tool_transcript=tool_transcript,
             elapsed_seconds=time.time() - started,
             model=self._model,
             timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -337,15 +337,17 @@ def make_parser() -> argparse.ArgumentParser:
     p.add_argument("--api-base", default=cfg.API_BASE)
     p.add_argument(
         "--mode",
-        choices=["retrieval-eval"],
+        choices=["retrieval-eval", "answer-eval"],
         default=None,
         help=(
             "alternate fast-path mode. With --mode retrieval-eval, the 6-phase "
             "sweep is bypassed and a retrieval-only evaluation is run against "
             "existing baselines (recall@K, MRR, nDCG@10). No LLM is invoked. "
-            "Use to gate retrieval-pipeline changes between phases without "
-            "rerunning the full Enron sweep. Requires --label; see "
-            "`retrieval_eval.py` for the full flag list."
+            "With --mode answer-eval, a model is run through HC's MCP over a "
+            "ground-truth set and its answers are scored for correctness, "
+            "groundedness, and completeness against expert labels. Both modes "
+            "require --label; see `retrieval_eval.py` / `answer_eval.py` for "
+            "the full flag list."
         ),
     )
     p.add_argument(
@@ -406,9 +408,10 @@ def make_parser() -> argparse.ArgumentParser:
     # Attach retrieval-eval flags. They're only meaningful when --mode
     # retrieval-eval is set, but registering them on the main parser keeps
     # --help discoverable.
-    from scripts.test_corpora.runner import retrieval_eval
+    from scripts.test_corpora.runner import answer_eval, retrieval_eval
 
     retrieval_eval.add_cli_args(p)
+    answer_eval.add_cli_args(p)
     return p
 
 
@@ -780,6 +783,11 @@ def main(argv: list[str] | None = None) -> int:
         from scripts.test_corpora.runner import retrieval_eval
 
         return retrieval_eval.main_from_args(args)
+
+    if args.mode == "answer-eval":
+        from scripts.test_corpora.runner import answer_eval
+
+        return answer_eval.main_from_args(args)
 
     state_path = run_dir / "state.json"
     sf = StateFile(state_path)

--- a/scripts/test_corpora/tests/test_answer_eval.py
+++ b/scripts/test_corpora/tests/test_answer_eval.py
@@ -109,3 +109,93 @@ def test_run_reuses_captures_and_verdicts_by_default(tmp_path: Path):
 
     summary = json.loads((tmp_path / "answer-eval" / "reports" / "r4" / "summary.json").read_text())
     assert summary["overall"]["n"] == 1
+
+
+def test_run_handles_empty_groundtruth(tmp_path: Path):
+    """An empty ground-truth set yields a zeroed report, not a KeyError crash."""
+    gt = tmp_path / "cuad.yaml"
+    gt.write_text(yaml.safe_dump({"corpus": "cuad", "items": []}))
+
+    def no_capture(item):
+        raise AssertionError("capture_fn must not be called for an empty ground-truth set")
+
+    class FakeJudge:
+        def judge_answer(self, **kw):
+            raise AssertionError("judge must not be called for an empty ground-truth set")
+
+    rc = run(
+        workdir=tmp_path,
+        corpus="cuad",
+        model="m1",
+        label="empty",
+        api_base="http://x",
+        refresh=False,
+        rejudge=False,
+        insecure=True,
+        groundtruth_path=gt,
+        capture_fn=no_capture,
+        judge=FakeJudge(),
+    )
+    assert rc == 0
+    summary = json.loads((tmp_path / "answer-eval" / "reports" / "empty" / "summary.json").read_text())
+    assert summary["overall"] == {"n": 0, "correctness": 0.0, "groundedness": 0.0, "completeness": 0.0}
+
+
+def test_run_rejudges_when_verdict_file_is_corrupt(tmp_path: Path):
+    """A good capture plus a corrupt verdict file: the capture is reused, but the
+    unreadable verdict is discarded and re-judged rather than crashing."""
+    gt = tmp_path / "cuad.yaml"
+    gt.write_text(
+        yaml.safe_dump(
+            {
+                "corpus": "cuad",
+                "items": [
+                    {
+                        "id": "g1",
+                        "question": "q1",
+                        "clause_category": "Governing Law",
+                        "gold_doc": "DocA",
+                        "answer_key": "Delaware",
+                        "type": "lookup",
+                    }
+                ],
+            }
+        )
+    )
+    cap_dir = tmp_path / "answer-eval" / "captures" / "cuad" / "m1"
+    ver_dir = tmp_path / "answer-eval" / "verdicts" / "cuad" / "m1"
+    cap_dir.mkdir(parents=True)
+    ver_dir.mkdir(parents=True)
+    (cap_dir / "g1.json").write_text(json.dumps({"answer": "Delaware.", "cited_doc_titles": [], "tool_transcript": []}))
+    (ver_dir / "g1.json").write_text("{ this is not valid json")
+
+    captures = {"n": 0}
+
+    def counting_capture(item):
+        captures["n"] += 1
+        return {"answer": "x", "cited_doc_titles": [], "tool_transcript": []}
+
+    judged = {"n": 0}
+
+    class FakeJudge:
+        def judge_answer(self, **kw):
+            judged["n"] += 1
+            return AnswerVerdict(4, 4, 4, "re-judged")
+
+    rc = run(
+        workdir=tmp_path,
+        corpus="cuad",
+        model="m1",
+        label="rj",
+        api_base="http://x",
+        refresh=False,
+        rejudge=False,
+        insecure=True,
+        groundtruth_path=gt,
+        capture_fn=counting_capture,
+        judge=FakeJudge(),
+    )
+    assert rc == 0
+    assert captures["n"] == 0  # the good capture was reused
+    assert judged["n"] == 1  # the corrupt verdict was discarded and re-judged
+    assert json.loads((ver_dir / "g1.json").read_text())["correctness"] == 4

--- a/scripts/test_corpora/tests/test_answer_eval.py
+++ b/scripts/test_corpora/tests/test_answer_eval.py
@@ -1,0 +1,111 @@
+# scripts/test_corpora/tests/test_answer_eval.py
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.test_corpora.runner.answer_eval import aggregate, load_groundtruth, run
+from scripts.test_corpora.runner.answer_judge import AnswerVerdict
+
+
+def test_load_groundtruth(tmp_path: Path):
+    gt = tmp_path / "cuad.yaml"
+    gt.write_text(
+        yaml.safe_dump(
+            {
+                "corpus": "cuad",
+                "items": [
+                    {
+                        "id": "g1",
+                        "question": "q1",
+                        "clause_category": "Governing Law",
+                        "gold_doc": "AcmeCo",
+                        "answer_key": "Delaware",
+                        "type": "lookup",
+                    },
+                    {
+                        "id": "g2",
+                        "question": "q2",
+                        "clause_category": "Most Favored Nation",
+                        "gold_doc": "BetaCo",
+                        "answer_key": None,
+                        "type": "negative",
+                    },
+                ],
+            }
+        )
+    )
+    items = load_groundtruth(gt)
+    assert [i.id for i in items] == ["g1", "g2"]
+    assert items[0].answer_key == "Delaware"
+    assert items[1].answer_key is None and items[1].type == "negative"
+
+
+def test_aggregate_means_overall_and_by_type():
+    rows = [
+        ("g1", "lookup", AnswerVerdict(5, 4, 5, "")),
+        ("g2", "lookup", AnswerVerdict(3, 2, 3, "")),
+        ("g3", "negative", AnswerVerdict(5, 5, 5, "")),
+    ]
+    summary = aggregate(rows)
+    assert summary["overall"]["n"] == 3
+    assert summary["overall"]["correctness"] == 13 / 3
+    assert summary["by_type"]["lookup"]["n"] == 2
+    assert summary["by_type"]["negative"]["correctness"] == 5.0
+
+
+def test_run_reuses_captures_and_verdicts_by_default(tmp_path: Path):
+    """run() reuses an existing capture+verdict; --refresh re-runs the model,
+    --rejudge re-runs the judge. Captures/verdicts are keyed by corpus/model/id
+    (not by label), so they carry across runs with different labels."""
+    gt = tmp_path / "cuad.yaml"
+    gt.write_text(
+        yaml.safe_dump(
+            {
+                "corpus": "cuad",
+                "items": [
+                    {
+                        "id": "g1",
+                        "question": "q1",
+                        "clause_category": "Governing Law",
+                        "gold_doc": "DocA",
+                        "answer_key": "Delaware",
+                        "type": "lookup",
+                    },
+                ],
+            }
+        )
+    )
+
+    captures = {"n": 0}
+
+    def fake_capture(item):
+        captures["n"] += 1
+        return {"answer": "Delaware.", "cited_doc_titles": ["DocA"], "tool_transcript": []}
+
+    judged = {"n": 0}
+
+    class FakeJudge:
+        def judge_answer(self, **kw):
+            judged["n"] += 1
+            return AnswerVerdict(5, 5, 5, "ok")
+
+    common = dict(workdir=tmp_path, corpus="cuad", model="m1", api_base="http://x", insecure=True, groundtruth_path=gt)
+
+    rc = run(**common, label="r1", refresh=False, rejudge=False, capture_fn=fake_capture, judge=FakeJudge())
+    assert rc == 0 and captures["n"] == 1 and judged["n"] == 1
+
+    # second run, different label: capture + verdict both reused
+    run(**common, label="r2", refresh=False, rejudge=False, capture_fn=fake_capture, judge=FakeJudge())
+    assert captures["n"] == 1 and judged["n"] == 1
+
+    # --refresh re-runs the model (and re-judges the fresh capture)
+    run(**common, label="r3", refresh=True, rejudge=False, capture_fn=fake_capture, judge=FakeJudge())
+    assert captures["n"] == 2 and judged["n"] == 2
+
+    # --rejudge re-runs only the judge
+    run(**common, label="r4", refresh=False, rejudge=True, capture_fn=fake_capture, judge=FakeJudge())
+    assert captures["n"] == 2 and judged["n"] == 3
+
+    summary = json.loads((tmp_path / "answer-eval" / "reports" / "r4" / "summary.json").read_text())
+    assert summary["overall"]["n"] == 1

--- a/scripts/test_corpora/tests/test_answer_judge.py
+++ b/scripts/test_corpora/tests/test_answer_judge.py
@@ -63,3 +63,10 @@ def test_extract_json_rejects_response_without_json():
     """A judge reply with no JSON object raises a clear error, not a JSONDecodeError."""
     with pytest.raises(ValueError, match="no JSON object"):
         _extract_json("the model refused and returned only prose")
+
+
+def test_extract_json_ignores_trailing_prose():
+    """raw_decode stops at the JSON object's closing brace, ignoring trailing
+    commentary even when that commentary itself contains braces."""
+    txt = '{"correctness": 5, "groundedness": 5, "completeness": 5, "rationale": "ok"}\n\nNote: see {4.2}.'
+    assert _extract_json(txt)["correctness"] == 5

--- a/scripts/test_corpora/tests/test_answer_judge.py
+++ b/scripts/test_corpora/tests/test_answer_judge.py
@@ -2,7 +2,9 @@
 import json
 from unittest.mock import MagicMock
 
-from scripts.test_corpora.runner.answer_judge import AnswerJudge, AnswerVerdict
+import pytest
+
+from scripts.test_corpora.runner.answer_judge import AnswerJudge, AnswerVerdict, _extract_json
 
 
 def _fake_client(payload: dict) -> MagicMock:
@@ -55,3 +57,9 @@ def test_judge_tolerates_fenced_json():
     )
     v = AnswerJudge(client=c).judge_answer(question="q", model_answer="a", cited="", answer_key="k", qtype="lookup")
     assert v.correctness == 0
+
+
+def test_extract_json_rejects_response_without_json():
+    """A judge reply with no JSON object raises a clear error, not a JSONDecodeError."""
+    with pytest.raises(ValueError, match="no JSON object"):
+        _extract_json("the model refused and returned only prose")

--- a/scripts/test_corpora/tests/test_answer_judge.py
+++ b/scripts/test_corpora/tests/test_answer_judge.py
@@ -1,0 +1,57 @@
+# scripts/test_corpora/tests/test_answer_judge.py
+import json
+from unittest.mock import MagicMock
+
+from scripts.test_corpora.runner.answer_judge import AnswerJudge, AnswerVerdict
+
+
+def _fake_client(payload: dict) -> MagicMock:
+    c = MagicMock()
+    c.messages.create.return_value = MagicMock(content=[MagicMock(text=json.dumps(payload))])
+    return c
+
+
+def test_judge_parses_scores():
+    payload = {
+        "correctness": 5,
+        "groundedness": 4,
+        "completeness": 5,
+        "rationale": "states Delaware, cites the contract",
+    }
+    j = AnswerJudge(client=_fake_client(payload))
+    v = j.judge_answer(
+        question="What is the governing law?",
+        model_answer="Delaware.",
+        cited="contract X, p2: governed by Delaware law",
+        answer_key="Delaware",
+        qtype="lookup",
+    )
+    assert isinstance(v, AnswerVerdict)
+    assert (v.correctness, v.groundedness, v.completeness) == (5, 4, 5)
+    assert v.rationale
+
+
+def test_judge_handles_negative_item():
+    payload = {"correctness": 5, "groundedness": 5, "completeness": 5, "rationale": "correctly declined"}
+    j = AnswerJudge(client=_fake_client(payload))
+    v = j.judge_answer(
+        question="Does it contain an MFN clause?",
+        model_answer="No most-favored-nation clause is present.",
+        cited="contract Y full text",
+        answer_key=None,
+        qtype="negative",
+    )
+    assert v.correctness == 5
+
+
+def test_judge_tolerates_fenced_json():
+    c = MagicMock()
+    c.messages.create.return_value = MagicMock(
+        content=[
+            MagicMock(
+                text='```json\n{"correctness": 0, "groundedness": 0, "completeness": 0, "rationale": "wrong"}\n```'
+            )
+        ]
+    )
+    v = AnswerJudge(client=c).judge_answer(question="q", model_answer="a", cited="", answer_key="k", qtype="lookup")
+    assert v.correctness == 0

--- a/scripts/test_corpora/tests/test_baseline.py
+++ b/scripts/test_corpora/tests/test_baseline.py
@@ -82,3 +82,22 @@ def test_run_question_records_tool_transcript():
     assert call["tool"] == "kb_search"
     assert call["args"] == {"query": "x"}
     assert "doc_id" in call["result_summary"]
+
+
+def test_run_question_extracts_last_text_block_not_first():
+    """The final answer is the last text block of the assistant turn, even when
+    the turn's first content block is a non-text block."""
+    from unittest.mock import MagicMock
+
+    from scripts.test_corpora.runner.claude_baseline import BaselineGenerator
+
+    non_text = MagicMock(spec=["type", "id"])  # spec'd: has no .text attribute
+    non_text.type = "tool_use"
+    text_block = MagicMock(text="the real answer")
+    fake = MagicMock()
+    fake.messages.create.return_value = MagicMock(content=[non_text, text_block], stop_reason="end_turn")
+
+    gen = BaselineGenerator(client=fake, mcp_session=None)
+    res = gen.run_question(question="q", question_id="q1", corpus="cuad")
+
+    assert res.answer == "the real answer"

--- a/scripts/test_corpora/tests/test_baseline.py
+++ b/scripts/test_corpora/tests/test_baseline.py
@@ -55,3 +55,30 @@ def test_collect_doc_ids_upgrades_empty_title_on_later_mention():
     gen._collect_doc_ids({"doc_id": "uuid-x"})  # titleless first
     gen._collect_doc_ids({"doc_id": "uuid-x", "doc_title": "real title"})  # titled later
     assert gen._cited == {"uuid-x": "real title"}
+
+
+def test_run_question_records_tool_transcript():
+    """Each tool call is recorded in BaselineResult.tool_transcript."""
+    from unittest.mock import MagicMock
+
+    from scripts.test_corpora.runner.claude_baseline import BaselineGenerator
+
+    fake = MagicMock()
+    tool_block = MagicMock(type="tool_use", id="t1", input={"query": "x"})
+    tool_block.name = "kb_search"  # MagicMock(name=...) sets display name, not .name attr
+    fake.messages.create.side_effect = [
+        MagicMock(content=[tool_block], stop_reason="tool_use"),
+        MagicMock(content=[MagicMock(text="final answer", type="text")], stop_reason="end_turn"),
+    ]
+    mcp = MagicMock()
+    mcp.list_tools.return_value = []
+    mcp.call_tool.return_value = MagicMock(content=[MagicMock(text='{"doc_id": "d1"}')])
+
+    gen = BaselineGenerator(client=fake, mcp_session=mcp)
+    res = gen.run_question(question="q", question_id="q1", corpus="cuad")
+
+    assert len(res.tool_transcript) == 1
+    call = res.tool_transcript[0]
+    assert call["tool"] == "kb_search"
+    assert call["args"] == {"query": "x"}
+    assert "doc_id" in call["result_summary"]

--- a/scripts/test_corpora/tests/test_generate_cuad.py
+++ b/scripts/test_corpora/tests/test_generate_cuad.py
@@ -1,0 +1,73 @@
+# scripts/test_corpora/tests/test_generate_cuad.py
+import csv
+from pathlib import Path
+
+import yaml
+
+from scripts.test_corpora.groundtruth.generate_cuad import generate
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+
+def test_generate_emits_lookup_and_negative_items(tmp_path: Path):
+    master = tmp_path / "master_clauses.csv"
+    _write_csv(
+        master,
+        [
+            {
+                "Filename": "AcmeCo_Distributor Agreement.pdf",
+                "Governing Law-Answer": "['Delaware']",
+                "Most Favored Nation-Answer": "[]",
+            },
+            {
+                "Filename": "BetaCo_License Agreement.pdf",
+                "Governing Law-Answer": "['New York']",
+                "Most Favored Nation-Answer": "['Section 4.2 grants MFN pricing']",
+            },
+        ],
+    )
+    ingest = tmp_path / "ingest"
+    ingest.mkdir()
+    (ingest / "AcmeCo_Distributor Agreement.pdf").write_text("x")
+    (ingest / "BetaCo_License Agreement.pdf").write_text("x")
+    out = tmp_path / "cuad.yaml"
+
+    n = generate(master_csv=master, ingest_dir=ingest, out_path=out, per_category=2)
+
+    assert n >= 3
+    data = yaml.safe_load(out.read_text())
+    assert data["corpus"] == "cuad"
+    by_type = {}
+    for item in data["items"]:
+        by_type.setdefault(item["type"], []).append(item)
+        assert item["gold_doc"]  # filename stem, no .pdf
+        assert not item["gold_doc"].endswith(".pdf")
+    assert "lookup" in by_type and "negative" in by_type
+    neg = by_type["negative"][0]
+    assert neg["answer_key"] is None  # CUAD labeled the clause absent
+    law = next(i for i in by_type["lookup"] if i["clause_category"] == "Governing Law")
+    assert law["answer_key"] == "Delaware"
+    assert law["gold_doc"] in {"AcmeCo_Distributor Agreement", "BetaCo_License Agreement"}
+
+
+def test_generate_skips_contracts_not_in_ingest(tmp_path: Path):
+    master = tmp_path / "master_clauses.csv"
+    _write_csv(
+        master,
+        [
+            {"Filename": "NotSampled_Agreement.pdf", "Governing Law-Answer": "['Texas']"},
+        ],
+    )
+    ingest = tmp_path / "ingest"
+    ingest.mkdir()  # empty -- NotSampled is not present
+    out = tmp_path / "cuad.yaml"
+
+    n = generate(master_csv=master, ingest_dir=ingest, out_path=out, per_category=2)
+
+    assert n == 0
+    assert yaml.safe_load(out.read_text())["items"] == []

--- a/scripts/test_corpora/tests/test_sweep_ingest.py
+++ b/scripts/test_corpora/tests/test_sweep_ingest.py
@@ -311,3 +311,36 @@ def test_no_ingest_flag_never_calls_ingest_corpus(tmp_path: Path) -> None:
 
     assert rc == 0, "main() should exit 0 with --no-ingest"
     mock_ingest.assert_not_called(), "_ingest_corpus must never be called with --no-ingest"
+
+
+def test_mode_answer_eval_is_accepted_and_dispatches(monkeypatch, tmp_path):
+    """--mode answer-eval parses on the sweep parser and dispatches to
+    answer_eval.main_from_args before the main sweep loop spins up."""
+    from scripts.test_corpora.runner import answer_eval, sweep
+
+    called = {}
+
+    def fake_main_from_args(args):
+        called["args"] = args
+        return 0
+
+    monkeypatch.setattr(answer_eval, "main_from_args", fake_main_from_args)
+    rc = sweep.main(
+        [
+            "--run-id",
+            "test-answer-eval",
+            "--workdir",
+            str(tmp_path),
+            "--mode",
+            "answer-eval",
+            "--label",
+            "lbl",
+            "--corpora",
+            "cuad",
+            "--models",
+            "claude-sonnet-4-6",
+        ]
+    )
+    assert rc == 0
+    assert called["args"].mode == "answer-eval"
+    assert called["args"].label == "lbl"


### PR DESCRIPTION
## Summary

Builds `--mode answer-eval` for the `scripts/test_corpora/` harness — a repeatable eval that runs a frontier model through Harbor Clerk's MCP over a CUAD ground-truth set and scores each answer for **correctness, groundedness, and completeness** against expert clause labels.

This addresses a structural gap in the existing retrieval-eval: that eval treats the frontier model's own citations as the gold standard (circular — it validates retrieval-vs-agent-intent, never answer correctness). The answer-eval scores against *external* expert ground truth (CUAD's Atticus-Project clause annotations), so it actually measures whether HC's MCP lets a model produce complete, correct, grounded answers.

Design + plan: `docs/superpowers/specs/2026-05-22-real-eval-phase1-design.md` and `docs/superpowers/plans/2026-05-22-real-eval-phase1.md` (PR #378).

## What's in it

- **Ground-truth generator** (`groundtruth/generate_cuad.py`) — turns CUAD's `master_clauses.csv` expert annotations into a ground-truth YAML.
- **Frozen ground-truth set** (`groundtruth/cuad.yaml`) — 15 hand-curated items across 7 contracts: 12 lookups (Governing Law, Parties, Agreement/Expiration Date, Non-Compete) + 3 negatives (MFN, Cap on Liability, Exclusivity).
- **`AnswerJudge`** (`runner/answer_judge.py`) — LLM-as-judge scoring an answer against the ground-truth key on three 0–5 dimensions.
- **Answer-eval runner** (`runner/answer_eval.py`) — loads the ground truth, runs the model via MCP, persists **model-keyed** captures + judge verdicts (reused by default; `--refresh` / `--rejudge` to regenerate), writes a labeled report.
- **Tool-transcript persistence** — `BaselineResult` now records each MCP tool call, needed for groundedness scoring.
- **Sweep wiring** — `--mode answer-eval` registered alongside `--mode retrieval-eval`.

Investigation finding (Task 1): a folder-scoped API key (`scope_folder_ids`) filters **pre-ranking** in `search.py`, so the planned 3-corpus eval bed is viable.

## Test plan

- [x] `uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/` — 281 passing (1 pre-existing unrelated failure: `test_entity_overlap_english`, missing spaCy model in the harness venv).
- [x] `ruff check` + `ruff format` clean.
- [x] Built TDD, task-by-task, with per-task spec + code-quality review and a final unconstrained branch review.
- [ ] **Task 8 — the live end-to-end run is NOT yet done.** It needs a running HC instance, the three corpora ingested as watched folders, folder-scoped API keys minted, and Anthropic API budget. The runbook is Task 8 of the plan. `_live_capture_fn` (the model+MCP wiring) is unit-tested via dependency injection but unverified against a live MCP until that run.

## Known limitations / follow-ups

- The generator is a rough first-pass tool; its output is always hand-curated before freezing. It (a) mis-types clause-presence categories — CUAD's `<Category>-Answer` is a bare Yes/No for Cap on Liability / Exclusivity / MFN / Non-Compete, not a verbatim span, so `cuad.yaml` was curated to re-phrase those as yes/no questions; (b) selects contracts by first-N-sorted order (alphabetical clustering, low diversity); (c) emits unstable sequential IDs. A content-aware generator is possible future work; phase 1 relies on the curation pass.
- Synthesis/stats question types, Enron + synthetic ground-truth sets, multi-model runs, and tool-use trajectory auditing are later phases (spec §15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
