### PR TITLE
feat(eval): answer-eval phase 2b — Synthetic corpus (sidecar-driven, 30 items)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-answer-eval-synthetic.md
+++ b/docs/superpowers/plans/2026-05-23-answer-eval-synthetic.md
@@ -1,0 +1,790 @@
+# Synthetic Answer-Eval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `--mode answer-eval` to the Synthetic (Marbledock & Associates) corpus by adding a sidecar-driven ground-truth generator that produces ~20 items across all 9 doc-types, with 2–3 French-language items for bilingual coverage.
+
+**Architecture:** Additive only — one new generator (`generate_synthetic.py`) + one new frozen artifact (`synthetic.yaml`). Zero changes to the judge, runner, sweep, or `GTItem` schema. The generator dispatches per-doc-type to a recipe function that reads the canonical JSON sidecar and emits items; cross-doc finds + negatives are hand-coded; FR-tagged sidecars are picked by a small scan.
+
+**Tech Stack:** Python 3.12, `pyyaml`, stdlib `json`/`pathlib`, `pytest`. All work is in `scripts/test_corpora/`. Run tests with `uv run --project scripts/test_corpora --extra test pytest <path>` from the repo root.
+
+**Spec:** `docs/superpowers/specs/2026-05-23-answer-eval-synthetic-design.md`.
+
+**File map:**
+- Create `scripts/test_corpora/groundtruth/generate_synthetic.py` — Synthetic ground-truth generator.
+- Create `scripts/test_corpora/groundtruth/synthetic.yaml` — frozen ~20-item ground-truth set (generated, then committed).
+- Create `scripts/test_corpora/tests/test_generate_synthetic.py` — generator tests.
+
+---
+
+## Task 1: `generate_synthetic.py` — helpers, recipes, orchestrator
+
+The single substantive code task. Builds helpers (`_to_title`, `_load_sidecar`, `_iter_sidecars`, `_lookup_item`, `_find_item`), 9 per-doc-type recipes, 2 cross-doc `find` recipes, 2 negative items, the FR-item scanner, the `generate()` orchestrator, and a CLI.
+
+**Files:**
+- Create: `scripts/test_corpora/groundtruth/generate_synthetic.py`
+- Create: `scripts/test_corpora/tests/test_generate_synthetic.py`
+
+- [ ] **Step 1: Write the failing tests** — create `scripts/test_corpora/tests/test_generate_synthetic.py`:
+
+```python
+# scripts/test_corpora/tests/test_generate_synthetic.py
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.test_corpora.groundtruth.generate_synthetic import (
+    _find_item,
+    _iter_sidecars,
+    _load_sidecar,
+    _lookup_item,
+    _to_title,
+    generate,
+)
+
+
+# ── fixture helpers ─────────────────────────────────────────────────────────
+
+
+def _write_doc(ingest: Path, stem: str, sidecar: dict, text: str = "rendered body") -> None:
+    """Write a synthetic doc pair: the .json sidecar + the .txt rendering."""
+    (ingest / f"{stem}.json").write_text(json.dumps(sidecar))
+    (ingest / f"{stem}.txt").write_text(text)
+
+
+def _make_full_fixture(tmp_path: Path) -> Path:
+    """Build a minimal fixture covering all 9 doc-types so generate() can run end-to-end."""
+    ingest = tmp_path / "ingest"
+    ingest.mkdir()
+    _write_doc(ingest, "0001_invoice", {
+        "vendor": "Acme Supplies", "invoice_number": "ACM-001",
+        "date": "2025-01-15", "total_usd": 1234.56, "line_items": [],
+    })
+    _write_doc(ingest, "0002_invoice", {
+        "vendor": "Globex Supplies", "invoice_number": "GLO-002",
+        "date": "2025-02-20", "total_usd": 7890.12, "line_items": [],
+    })
+    _write_doc(ingest, "0010_board_minutes", {
+        "date": "2025-03-01", "attendees": ["Alice", "Bob", "Carol"],
+        "decisions": ["Approved budget.", "Authorized hire."], "lang": "en",
+    })
+    _write_doc(ingest, "0011_board_minutes", {
+        "date": "2025-04-02", "attendees": ["Alice", "Bob"],
+        "decisions": ["Tabled motion."], "lang": "fr",  # French-tagged for FR coverage
+    })
+    _write_doc(ingest, "0020_onboarding_letter", {
+        "employee_name": "n/a", "role": "Senior Engineer",
+        "start_date": "2025-05-01", "languages_used": ["English"],
+        "signing_manager": "Sophie Tran-Beaumont",
+    })
+    _write_doc(ingest, "0030_quarterly_report", {
+        "quarter": "Q2", "year": 2025, "revenue_usd": 4275000,
+        "key_initiatives": {},
+    })
+    _write_doc(ingest, "0040_vendor_contract", {
+        "vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24,
+        "monthly_fee_usd": 8500.0, "governing_law": "State of South Carolina",
+        "signatures": {},
+    })
+    _write_doc(ingest, "0050_internal_memo", {
+        "from": "Helena Voss, COO", "to": "All Staff",
+        "subject": "Updated Remote Work Policy", "lang": "en",
+    })
+    _write_doc(ingest, "0060_policy_doc", {
+        "policy_name": "Information Security Policy", "version": "3.1",
+        "effective_date": "2025-12-23", "owner": "CHRO & CISO",
+    })
+    _write_doc(ingest, "0070_marketing_brief", {
+        "campaign_name": "Marbledock Elevate 2025",
+        "target": "Mid-market firms", "budget_usd": 120000,
+        "owner": "Senior Director of Marketing",
+    })
+    _write_doc(ingest, "0080_employee_handbook", {
+        "year": 2025,
+        "sections": ["3.1 Professional Standards", "3.2 Conflict of Interest"],
+        "lang_split": {"primary": "English", "secondary": "French",
+                       "total_section_count": 4},
+    })
+    return ingest
+
+
+# ── helper tests ────────────────────────────────────────────────────────────
+
+
+def test_to_title_strips_known_extensions():
+    """_to_title strips .json / .txt / .pdf to match HC's doc_title format."""
+    assert _to_title("0019_invoice.json") == "0019_invoice"
+    assert _to_title("0019_invoice.txt") == "0019_invoice"
+    assert _to_title("0019_invoice.pdf") == "0019_invoice"
+    assert _to_title("0019_invoice") == "0019_invoice"  # already a stem
+
+
+def test_load_sidecar_reads_json(tmp_path: Path):
+    p = tmp_path / "0019_invoice.json"
+    p.write_text(json.dumps({"vendor": "Acme", "total_usd": 100}))
+    sc = _load_sidecar(p)
+    assert sc == {"vendor": "Acme", "total_usd": 100}
+
+
+def test_iter_sidecars_filters_by_doctype_and_sorts(tmp_path: Path):
+    """_iter_sidecars yields (stem, sidecar) for matching docs, sorted by stem."""
+    ingest = tmp_path / "ingest"
+    ingest.mkdir()
+    _write_doc(ingest, "0002_invoice", {"vendor": "B"})
+    _write_doc(ingest, "0001_invoice", {"vendor": "A"})
+    _write_doc(ingest, "0003_board_minutes", {"date": "2025-01-01"})
+    pairs = list(_iter_sidecars(ingest, "invoice"))
+    assert [stem for stem, _ in pairs] == ["0001_invoice", "0002_invoice"]
+    assert pairs[0][1]["vendor"] == "A"
+
+
+def test_lookup_item_builds_canonical_shape():
+    item = _lookup_item(
+        id_="synth-test-1", question="q?", gold_doc="0001_invoice",
+        answer_key="A", clause_category="invoice",
+    )
+    assert item == {
+        "id": "synth-test-1", "question": "q?",
+        "clause_category": "invoice", "gold_doc": "0001_invoice",
+        "answer_key": "A", "type": "lookup",
+    }
+
+
+def test_find_item_builds_count_all_sample_shape():
+    item = _find_item(
+        id_="synth-find-1", question="Find docs", all_matches=["b", "a", "c"],
+        clause_category="cross-doc",
+    )
+    assert item["type"] == "find"
+    assert item["answer_key"] == {"count": 3, "all": ["b", "a", "c"], "sample": ["b", "a", "c"]}
+    assert item["clause_category"] == "cross-doc"
+
+
+# ── end-to-end generator tests ──────────────────────────────────────────────
+
+
+def test_generate_emits_items_across_all_doc_types(tmp_path: Path):
+    """The orchestrator emits items for every doc-type plus cross-doc + negatives."""
+    ingest = _make_full_fixture(tmp_path)
+    out = tmp_path / "synthetic.yaml"
+    n = generate(ingest_dir=ingest, out_path=out)
+
+    data = yaml.safe_load(out.read_text())
+    assert data["corpus"] == "synthetic"
+    items = data["items"]
+    assert len(items) == n
+    assert n >= 14  # 9 doc-types × ≥1 each + cross-doc + negatives + FR
+
+    categories = {i["clause_category"] for i in items}
+    expected_doc_types = {
+        "invoice", "board_minutes", "onboarding_letter", "quarterly_report",
+        "vendor_contract", "internal_memo", "policy_doc", "marketing_brief",
+        "employee_handbook",
+    }
+    assert expected_doc_types.issubset(categories), (
+        f"missing doc-types: {expected_doc_types - categories}"
+    )
+
+    types = {i["type"] for i in items}
+    assert "lookup" in types
+    assert "find" in types  # cross-doc finds + find-negative
+    assert "negative" in types  # lookup-negative
+
+    # Cross-doc find: invoices over $5000 — only 0002 (7890.12) qualifies
+    inv_find = next(i for i in items if i["id"] == "synth-find-invoices-over-5000")
+    assert inv_find["type"] == "find"
+    assert inv_find["answer_key"]["all"] == ["0002_invoice"]
+    assert inv_find["answer_key"]["count"] == 1
+
+    # Lookup-negative: a non-existent invoice number
+    neg = next(i for i in items if i["id"] == "synth-neg-invoice-99999")
+    assert neg["type"] == "negative"
+    assert neg["answer_key"] is None
+
+    # find-negative: a non-existent vendor
+    fneg = next(i for i in items if i["id"] == "synth-find-neg-vendor-globex-aerospace")
+    assert fneg["type"] == "find"
+    assert fneg["answer_key"] == {"count": 0, "all": [], "sample": []}
+
+
+def test_generate_emits_french_items_when_fr_sidecars_present(tmp_path: Path):
+    """When the corpus has FR-tagged sidecars (lang: fr), the generator emits FR items."""
+    ingest = _make_full_fixture(tmp_path)  # 0011_board_minutes has lang: fr
+    out = tmp_path / "synthetic.yaml"
+    generate(ingest_dir=ingest, out_path=out)
+    data = yaml.safe_load(out.read_text())
+    fr_items = [i for i in data["items"] if i["id"].startswith("synth-fr-")]
+    assert len(fr_items) >= 1, "no FR items emitted despite FR-tagged sidecars in fixture"
+    fr = fr_items[0]
+    # The question text should contain at least one French-distinctive character/word.
+    # Use a permissive heuristic: any of "é", "è", "ê", "à", "ç", or the French article "le"/"la".
+    assert any(tok in fr["question"] for tok in ("é", "è", "ê", "à", "ç", " le ", " la ", " du ")), (
+        f"FR item question doesn't look French: {fr['question']!r}"
+    )
+
+
+def test_generate_raises_when_negative_vendor_unexpectedly_matches(tmp_path: Path):
+    """If a docs in the corpus actually has the negative vendor name, generate refuses."""
+    ingest = _make_full_fixture(tmp_path)
+    # Plant a doc that contains "Globex Aerospace" — the negative target.
+    _write_doc(
+        ingest, "0099_vendor_contract",
+        {"vendor": "Globex Aerospace", "term_months": 6, "monthly_fee_usd": 1000.0,
+         "governing_law": "n/a", "signatures": {}},
+        text="contract with Globex Aerospace for services",
+    )
+    out = tmp_path / "synthetic.yaml"
+    with pytest.raises(RuntimeError, match="negative vendor 'Globex Aerospace' unexpectedly matches"):
+        generate(ingest_dir=ingest, out_path=out)
+
+
+def test_generate_raises_when_negative_invoice_number_unexpectedly_matches(tmp_path: Path):
+    """If a doc in the corpus actually uses invoice_number INV-99999, generate refuses."""
+    ingest = _make_full_fixture(tmp_path)
+    _write_doc(ingest, "0098_invoice", {
+        "vendor": "x", "invoice_number": "INV-99999",
+        "date": "2025-01-01", "total_usd": 1, "line_items": [],
+    })
+    out = tmp_path / "synthetic.yaml"
+    with pytest.raises(RuntimeError, match="negative invoice_number 'INV-99999' unexpectedly matches"):
+        generate(ingest_dir=ingest, out_path=out)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_generate_synthetic.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.test_corpora.groundtruth.generate_synthetic'`.
+
+- [ ] **Step 3: Create the generator** — create `scripts/test_corpora/groundtruth/generate_synthetic.py` with exactly this content:
+
+```python
+# scripts/test_corpora/groundtruth/generate_synthetic.py
+"""Generate the Synthetic answer-eval ground-truth set from per-doc JSON sidecars.
+
+The synthetic corpus (fictional company Marbledock & Associates) is authored by
+``corpora/synthetic.py``, which writes a JSON sidecar per document carrying the
+canonical, structured ground-truth facts (vendor, dates, totals, signatories,
+etc.). This generator dispatches by doc-type (from the filename suffix) to a
+recipe function that lifts those sidecar fields into ground-truth Q&A items.
+
+Cross-doc ``find`` recipes and negative items are hand-coded. French-language
+items are added by scanning for sidecars tagged ``lang: "fr"``.
+
+Run explicitly; the output is curated once by a human and committed. Never
+regenerated as a side effect of an eval run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+SAMPLE_K = 10
+# Negative entities — verified absent from the corpus before each generation.
+NEGATIVE_INVOICE_NUMBER = "INV-99999"
+NEGATIVE_VENDOR = "Globex Aerospace"
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _to_title(name: str) -> str:
+    """Strip a synthetic doc's filename extension (.json/.txt/.pdf) so the
+    value matches HC's doc_title format."""
+    for ext in (".json", ".txt", ".pdf"):
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
+def _load_sidecar(path: Path) -> dict:
+    """Read a JSON sidecar file."""
+    return json.loads(path.read_text())
+
+
+def _iter_sidecars(ingest_dir: Path, doctype: str) -> Iterable[tuple[str, dict]]:
+    """Yield (stem, sidecar) for every ``*_<doctype>.json`` in ``ingest_dir``,
+    sorted deterministically by filename."""
+    for p in sorted(ingest_dir.glob(f"*_{doctype}.json")):
+        yield _to_title(p.name), _load_sidecar(p)
+
+
+def _lookup_item(
+    *, id_: str, question: str, gold_doc: str, answer_key: str, clause_category: str
+) -> dict:
+    return {
+        "id": id_,
+        "question": question,
+        "clause_category": clause_category,
+        "gold_doc": gold_doc,
+        "answer_key": answer_key,
+        "type": "lookup",
+    }
+
+
+def _find_item(*, id_: str, question: str, all_matches: list[str], clause_category: str) -> dict:
+    return {
+        "id": id_,
+        "question": question,
+        "clause_category": clause_category,
+        "gold_doc": "(see answer_key.all)",
+        "answer_key": {
+            "count": len(all_matches),
+            "all": all_matches,
+            "sample": all_matches[:SAMPLE_K],
+        },
+        "type": "find",
+    }
+
+
+# ── per-doc-type recipes ────────────────────────────────────────────────────
+
+
+def _recipe_invoice(stem: str, sc: dict) -> list[dict]:
+    inv = sc["invoice_number"]
+    return [
+        _lookup_item(
+            id_=f"synth-invoice-total-{inv}",
+            question=f"What is the total amount in USD of invoice {inv}?",
+            gold_doc=stem,
+            answer_key=f"${sc['total_usd']:.2f}",
+            clause_category="invoice",
+        ),
+        _lookup_item(
+            id_=f"synth-invoice-vendor-{inv}",
+            question=f"Who is the vendor on invoice {inv}?",
+            gold_doc=stem,
+            answer_key=sc["vendor"],
+            clause_category="invoice",
+        ),
+    ]
+
+
+def _recipe_board_minutes(stem: str, sc: dict) -> list[dict]:
+    return [
+        _lookup_item(
+            id_=f"synth-board-attendees-{sc['date']}",
+            question=f"Who attended the Marbledock & Associates board meeting on {sc['date']}?",
+            gold_doc=stem,
+            answer_key="; ".join(sc["attendees"]),
+            clause_category="board_minutes",
+        ),
+    ]
+
+
+def _recipe_onboarding_letter(stem: str, sc: dict) -> list[dict]:
+    role = sc["role"]
+    return [
+        _lookup_item(
+            id_=f"synth-onboarding-start-{stem}",
+            question=f"What is the start date listed on the {role} onboarding letter?",
+            gold_doc=stem,
+            answer_key=sc["start_date"],
+            clause_category="onboarding_letter",
+        ),
+        _lookup_item(
+            id_=f"synth-onboarding-mgr-{stem}",
+            question=f"Who is the signing manager on the {role} onboarding letter?",
+            gold_doc=stem,
+            answer_key=sc["signing_manager"],
+            clause_category="onboarding_letter",
+        ),
+    ]
+
+
+def _recipe_quarterly_report(stem: str, sc: dict) -> list[dict]:
+    q, y = sc["quarter"], sc["year"]
+    return [
+        _lookup_item(
+            id_=f"synth-qreport-revenue-{q}-{y}",
+            question=f"What was the revenue reported in the {q} {y} quarterly report?",
+            gold_doc=stem,
+            answer_key=f"${sc['revenue_usd']:,}",
+            clause_category="quarterly_report",
+        ),
+    ]
+
+
+def _recipe_vendor_contract(stem: str, sc: dict) -> list[dict]:
+    vendor = sc["vendor"]
+    return [
+        _lookup_item(
+            id_=f"synth-vcontract-law-{stem}",
+            question=f"What is the governing law of the vendor contract with {vendor}?",
+            gold_doc=stem,
+            answer_key=sc["governing_law"],
+            clause_category="vendor_contract",
+        ),
+        _lookup_item(
+            id_=f"synth-vcontract-fee-{stem}",
+            question=f"What is the monthly fee in USD on the vendor contract with {vendor}?",
+            gold_doc=stem,
+            answer_key=f"${sc['monthly_fee_usd']:.2f}",
+            clause_category="vendor_contract",
+        ),
+    ]
+
+
+def _recipe_internal_memo(stem: str, sc: dict) -> list[dict]:
+    subj = sc["subject"]
+    return [
+        _lookup_item(
+            id_=f"synth-memo-sender-{stem}",
+            question=f"Who is the sender of the internal memo with subject \"{subj}\"?",
+            gold_doc=stem,
+            answer_key=sc["from"],
+            clause_category="internal_memo",
+        ),
+    ]
+
+
+def _recipe_policy_doc(stem: str, sc: dict) -> list[dict]:
+    name = sc["policy_name"]
+    return [
+        _lookup_item(
+            id_=f"synth-policy-effective-{stem}",
+            question=f"When does the \"{name}\" policy take effect?",
+            gold_doc=stem,
+            answer_key=sc["effective_date"],
+            clause_category="policy_doc",
+        ),
+        _lookup_item(
+            id_=f"synth-policy-version-{stem}",
+            question=f"What is the version number of the \"{name}\" policy?",
+            gold_doc=stem,
+            answer_key=str(sc["version"]),
+            clause_category="policy_doc",
+        ),
+    ]
+
+
+def _recipe_marketing_brief(stem: str, sc: dict) -> list[dict]:
+    camp = sc["campaign_name"]
+    return [
+        _lookup_item(
+            id_=f"synth-mkt-budget-{stem}",
+            question=f"What is the budget in USD for the \"{camp}\" marketing campaign?",
+            gold_doc=stem,
+            answer_key=f"${sc['budget_usd']:,}",
+            clause_category="marketing_brief",
+        ),
+    ]
+
+
+def _recipe_employee_handbook(stem: str, sc: dict) -> list[dict]:
+    year = sc["year"]
+    return [
+        _lookup_item(
+            id_=f"synth-handbook-sections-{stem}",
+            question=f"How many top-level sections are in the {year} Marbledock employee handbook?",
+            gold_doc=stem,
+            answer_key=str(len(sc["sections"])),
+            clause_category="employee_handbook",
+        ),
+    ]
+
+
+RECIPES: dict[str, callable] = {
+    "invoice": _recipe_invoice,
+    "board_minutes": _recipe_board_minutes,
+    "onboarding_letter": _recipe_onboarding_letter,
+    "quarterly_report": _recipe_quarterly_report,
+    "vendor_contract": _recipe_vendor_contract,
+    "internal_memo": _recipe_internal_memo,
+    "policy_doc": _recipe_policy_doc,
+    "marketing_brief": _recipe_marketing_brief,
+    "employee_handbook": _recipe_employee_handbook,
+}
+
+
+# ── cross-doc finds + negatives + FR ────────────────────────────────────────
+
+
+def _find_invoices_over_5000(ingest_dir: Path) -> dict:
+    matches = [
+        stem for stem, sc in _iter_sidecars(ingest_dir, "invoice")
+        if float(sc.get("total_usd", 0)) > 5000
+    ]
+    return _find_item(
+        id_="synth-find-invoices-over-5000",
+        question="Find all invoices with a total amount over $5,000 USD.",
+        all_matches=sorted(matches),
+        clause_category="cross-doc",
+    )
+
+
+def _find_policies_effective_in_q4_2025(ingest_dir: Path) -> dict:
+    matches = [
+        stem for stem, sc in _iter_sidecars(ingest_dir, "policy_doc")
+        if str(sc.get("effective_date", "")).startswith(("2025-10", "2025-11", "2025-12"))
+    ]
+    return _find_item(
+        id_="synth-find-policies-q4-2025",
+        question="Find Marbledock policies that take effect in Q4 2025 (October, November, or December 2025).",
+        all_matches=sorted(matches),
+        clause_category="cross-doc",
+    )
+
+
+def _neg_invoice_number(ingest_dir: Path) -> dict:
+    """A lookup with an invoice_number that doesn't exist in the corpus."""
+    for _, sc in _iter_sidecars(ingest_dir, "invoice"):
+        if sc.get("invoice_number") == NEGATIVE_INVOICE_NUMBER:
+            raise RuntimeError(
+                f"negative invoice_number {NEGATIVE_INVOICE_NUMBER!r} unexpectedly matches "
+                f"a real invoice in the corpus; pick a different absent number"
+            )
+    return {
+        "id": f"synth-neg-invoice-{NEGATIVE_INVOICE_NUMBER.split('-')[-1]}",
+        "question": f"What is the total amount of invoice {NEGATIVE_INVOICE_NUMBER}?",
+        "clause_category": "invoice",
+        "gold_doc": "(none expected)",
+        "answer_key": None,
+        "type": "negative",
+    }
+
+
+def _find_neg_vendor(ingest_dir: Path) -> dict:
+    """A find with a vendor that doesn't exist anywhere in the corpus."""
+    for p in sorted(ingest_dir.glob("*.json")):
+        if NEGATIVE_VENDOR.lower() in p.read_text().lower():
+            raise RuntimeError(
+                f"negative vendor {NEGATIVE_VENDOR!r} unexpectedly matches "
+                f"content in {p.name}; pick a different absent vendor"
+            )
+    slug = NEGATIVE_VENDOR.lower().replace(" ", "-")
+    return _find_item(
+        id_=f"synth-find-neg-vendor-{slug}",
+        question=f"Find vendor contracts where the vendor is {NEGATIVE_VENDOR}.",
+        all_matches=[],
+        clause_category="cross-doc",
+    )
+
+
+def _emit_fr_items(ingest_dir: Path) -> list[dict]:
+    """Emit ≤2 French-language items derived from sidecars tagged ``lang: "fr"``.
+    Scans board_minutes and internal_memo (the types that carry an explicit
+    ``lang`` field in the corpus); falls back silently if none are present.
+    """
+    items: list[dict] = []
+    for doctype in ("board_minutes", "internal_memo"):
+        for stem, sc in _iter_sidecars(ingest_dir, doctype):
+            if sc.get("lang") != "fr":
+                continue
+            if doctype == "board_minutes":
+                items.append(
+                    _lookup_item(
+                        id_=f"synth-fr-board-attendees-{sc['date']}",
+                        question=f"Qui a assisté à la réunion du conseil de Marbledock & Associates le {sc['date']}?",
+                        gold_doc=stem,
+                        answer_key="; ".join(sc["attendees"]),
+                        clause_category="board_minutes",
+                    )
+                )
+            else:  # internal_memo
+                items.append(
+                    _lookup_item(
+                        id_=f"synth-fr-memo-sender-{stem}",
+                        question=f"Qui est l'expéditeur du mémo interne dont le sujet est « {sc['subject']} »?",
+                        gold_doc=stem,
+                        answer_key=sc["from"],
+                        clause_category="internal_memo",
+                    )
+                )
+            if len(items) >= 2:
+                return items
+    return items
+
+
+# ── orchestrator ────────────────────────────────────────────────────────────
+
+
+def generate(ingest_dir: Path, out_path: Path, *, per_type: int = 2) -> int:
+    """Emit the Synthetic ground-truth YAML. Returns the number of items written.
+
+    For each doc-type, applies the per-type recipe to the first ``per_type``
+    sidecars (sorted by filename). Adds cross-doc finds, negatives (validated
+    against the corpus), and up to 2 French-language items.
+    """
+    items: list[dict] = []
+
+    # Per-doc-type lookups.
+    for doctype, recipe in RECIPES.items():
+        for stem, sc in list(_iter_sidecars(ingest_dir, doctype))[:per_type]:
+            items.extend(recipe(stem, sc))
+
+    # Cross-doc finds.
+    items.append(_find_invoices_over_5000(ingest_dir))
+    items.append(_find_policies_effective_in_q4_2025(ingest_dir))
+
+    # Negatives (validated against the corpus — raises if either accidentally matches).
+    items.append(_neg_invoice_number(ingest_dir))
+    items.append(_find_neg_vendor(ingest_dir))
+
+    # French-language items.
+    items.extend(_emit_fr_items(ingest_dir))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(yaml.safe_dump({"corpus": "synthetic", "items": items}, sort_keys=False))
+    return len(items)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Generate the Synthetic answer-eval ground-truth set.")
+    ap.add_argument("--ingest-dir", type=Path, required=True, help="Synthetic ingest dir (*.json + *.txt)")
+    ap.add_argument("--out", type=Path, required=True, help="output synthetic.yaml")
+    ap.add_argument("--per-type", type=int, default=2, help="docs sampled per doc-type")
+    a = ap.parse_args(argv)
+    n = generate(ingest_dir=a.ingest_dir, out_path=a.out, per_type=a.per_type)
+    print(f"wrote {n} ground-truth items -> {a.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_generate_synthetic.py -v`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+uv run --project scripts/test_corpora ruff check scripts/test_corpora/groundtruth/generate_synthetic.py scripts/test_corpora/tests/test_generate_synthetic.py
+uv run --project scripts/test_corpora ruff format scripts/test_corpora/groundtruth/generate_synthetic.py scripts/test_corpora/tests/test_generate_synthetic.py
+git add scripts/test_corpora/groundtruth/generate_synthetic.py scripts/test_corpora/tests/test_generate_synthetic.py
+git commit -m "feat(eval): Synthetic ground-truth generator (sidecar-driven, 9 doc-types)"
+```
+
+Append this trailer to the commit message (blank line before it):
+`Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Task 2: Generate & curate the frozen `synthetic.yaml`
+
+Operational — run the generator against the live Synthetic corpus, eyeball the output, commit the frozen artifact. Mirrors PR-A's curation discipline.
+
+- [ ] **Step 1: Run the generator against the live corpus**
+
+```bash
+WD="$HOME/Library/Application Support/Harbor Clerk/test-corpora"
+uv run --project scripts/test_corpora python -m scripts.test_corpora.groundtruth.generate_synthetic \
+  --ingest-dir "$WD/synthetic/ingest" \
+  --out scripts/test_corpora/groundtruth/synthetic.yaml
+```
+
+Expected: `wrote N ground-truth items -> scripts/test_corpora/groundtruth/synthetic.yaml` where N ≈ 18–24 (9 doc-types × 1–2 items + 2 cross-doc + 2 negatives + 0–2 FR).
+
+If a negative item raises `RuntimeError: negative ... unexpectedly matches`, pick a replacement (e.g., a different fictional vendor name or invoice number guaranteed to be absent — `Globex Maritime`, `INV-00000`) and update the `NEGATIVE_INVOICE_NUMBER` / `NEGATIVE_VENDOR` constants in `generate_synthetic.py`, then rerun.
+
+- [ ] **Step 2: Human curation pass**
+
+Open `scripts/test_corpora/groundtruth/synthetic.yaml`. For each item confirm:
+
+- `answer_key` is a real, sensible value (no `null` for `lookup` items, no `(see answer_key.all)` literal text leaking into a value, totals formatted as currency).
+- `gold_doc` for `lookup` items is a real stem.
+- Question text reads naturally — especially the FR items (correct French; the judge will mark wrong-language as a real mismatch).
+- The two `find` items have non-empty `all` lists (otherwise the question is mis-targeted; either tighten the filter or pick a different find).
+- The two negatives carry the right shapes (`lookup`-negative has `answer_key: null`, `find`-negative has `count: 0`).
+
+If FR items count = 0, check whether the corpus has any `lang: "fr"` sidecars (`grep -l '"lang": "fr"' "$WD/synthetic/ingest"/*.json`). If none, that's a real corpus property — the eval just runs without an FR signal; note it in the run summary.
+
+If anything looks garbled, edit the YAML by hand — the committed YAML is the source of truth; the generator is a one-shot helper.
+
+- [ ] **Step 3: Commit the frozen set**
+
+```bash
+git add scripts/test_corpora/groundtruth/synthetic.yaml
+git commit -m "feat(eval): frozen Synthetic ground-truth set (~20 items across 9 doc-types)"
+```
+
+Append the Co-Authored-By trailer.
+
+---
+
+## Task 3: De-risk + first real Synthetic run
+
+Operational. Spot-check the generator's output against HC's index, run the eval end-to-end, post results to the PR.
+
+- [ ] **Step 1: Spot-check 1 item against HC** — manual `/api/search` call to confirm a gold doc's title is indexed.
+
+```bash
+HC_API_KEY="<synthetic-scoped key>"
+API_BASE="http://localhost:8100"
+
+# Pick the first invoice's stem from the generated yaml; search HC for that stem.
+GOLD=$(python3 -c "
+import yaml
+d = yaml.safe_load(open('scripts/test_corpora/groundtruth/synthetic.yaml'))
+print(next(i['gold_doc'] for i in d['items'] if i['clause_category']=='invoice'))
+")
+echo "spot-checking gold doc: $GOLD"
+curl -s -H "Authorization: Bearer $HC_API_KEY" \
+  -X POST "$API_BASE/api/search" -H "Content-Type: application/json" \
+  -d "{\"query\": \"$GOLD\", \"k\": 5}" | python3 -m json.tool | head -30
+```
+
+Expected: HC returns the doc whose title matches `$GOLD` among the top results.
+
+- [ ] **Step 2: Full run for all ~20 items**
+
+```bash
+WD="$HOME/Library/Application Support/Harbor Clerk/test-corpora"
+HC_API_KEY="<synthetic-scoped>" ANTHROPIC_API_KEY="<...>" \
+  uv run --project scripts/test_corpora python -m scripts.test_corpora.runner.sweep \
+  --run-id answer-eval --mode answer-eval \
+  --corpora synthetic --models claude-sonnet-4-6 --label synthetic-phase2b \
+  --workdir "$WD" --api-base http://localhost:8100
+```
+
+Expected: completes with `OVERALL n=… correctness=… groundedness=… completeness=…`; per-label report at `<WD>/answer-eval/reports/synthetic-phase2b/summary.json`.
+
+- [ ] **Step 3: Sanity-check the report and post results to the PR**
+
+```bash
+cat "$WD/answer-eval/reports/synthetic-phase2b/summary.json"
+```
+
+Confirm:
+- `overall.n` matches the YAML's item count.
+- `by_type` includes `lookup`, `find`, and `negative` buckets (depending on the curated set).
+- Spot-check a couple of `detail.json` items for `find` to confirm `source.completeness == "deterministic"`.
+
+Post a comment to the PR with the headline numbers + a couple of per-item observations, mirroring PR-A's validation comment.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §1 Goal → all tasks.
+- §2 Scope (Synthetic, lookup/find/negative, Sonnet 4.6) → Tasks 1, 2, 3.
+- §3 Why Synthetic + sidecar ground truth → Task 1 (`_load_sidecar`, recipes).
+- §4 Architecture (additive only) → Task 1 (one new generator); judge/runner/sweep untouched.
+- §5 Generator structure (per-doc-type recipes + dispatch) → Task 1 (`RECIPES` dict).
+- §6 Bilingual coverage (2–3 FR items, fallback) → Task 1 (`_emit_fr_items`), Task 2 Step 2 (fallback diagnosis).
+- §7 Item composition (~20 items) → Task 1 (orchestrator sums the parts), validated by the end-to-end test.
+- §8 Ground-truth shape (`GTItem` unchanged, `gold_doc` is stem) → Task 1 (`_to_title`, `_lookup_item`, `_find_item`).
+- §9 Harness integration (zero CLI changes) → Task 3 (uses the existing sweep CLI).
+- §10 Testing → Task 1's 10 tests + Task 3's operational sanity check.
+- §11 Out of scope (aggregations / multi-model / prompt-tuning) — respected; not implemented.
+- §12 Open questions for the plan — recipe content settled with verbatim code; second cross-doc find chosen (`_find_policies_effective_in_q4_2025`); FR-picking strategy settled (scan `board_minutes` + `internal_memo` for `lang: "fr"`, fall back silently if none).
+
+**2. Placeholder scan:** Credential placeholders `<synthetic-scoped>` and `<...>` in Task 3 commands are operator-substitution slots (mirror PR-A's plan). No "TBD" / "TODO" / "implement later" anywhere. The Task 2 Step 2 fallback for FR-items-not-present is explicitly documented as "expected behavior; note it in the run summary," not a deferred decision.
+
+**3. Type consistency:**
+- `_to_title(name: str) -> str`, `_load_sidecar(path: Path) -> dict`, `_iter_sidecars(ingest_dir: Path, doctype: str) -> Iterable[tuple[str, dict]]`, `_lookup_item(*, id_, question, gold_doc, answer_key, clause_category) -> dict`, `_find_item(*, id_, question, all_matches, clause_category) -> dict`: consistent definitions in Step 3, used identically across the 9 recipes and the cross-doc / negative helpers.
+- Item dicts match the `GTItem` schema validated by `load_groundtruth` (from PR-A): `id`, `question`, `clause_category`, `gold_doc`, `answer_key`, `type`. The `find` `answer_key` is `{count, all, sample}` per PR-A's validation; `lookup` `answer_key` is `str`; `negative` `answer_key` is `None`.
+- `generate(ingest_dir: Path, out_path: Path, *, per_type: int = 2) -> int`: signature consistent in Task 1 Step 3, Task 1 Step 4 tests, and Task 2 Step 1 CLI.
+
+No inconsistencies.

--- a/docs/superpowers/specs/2026-05-23-answer-eval-synthetic-design.md
+++ b/docs/superpowers/specs/2026-05-23-answer-eval-synthetic-design.md
@@ -1,0 +1,178 @@
+# PR-B: Synthetic Answer-Eval — Design
+
+**Status:** Approved design. Ready for an implementation plan.
+**Date:** 2026-05-23
+**Companion docs:**
+- `2026-05-22-real-eval-design-sketch.md` — overall direction.
+- `2026-05-22-real-eval-phase1-design.md` — phase 1 design (CUAD).
+- `2026-05-22-answer-eval-enron-design.md` — phase 2a design (Enron + `find` type).
+
+---
+
+## 1. Goal
+
+Extend `--mode answer-eval` to a third corpus — **Synthetic** (the bilingual Marbledock & Associates fixture) — leveraging the **JSON sidecars authored at generation time** as canonical, authoritative ground truth. Validates that the answer-eval is corpus-agnostic across structured-fact retrieval, contract clause-extraction (PR-A: CUAD), email search (PR-A: Enron), and structured-business-document lookups (this PR).
+
+PR-B of the phase-2 sequence — sibling to PR-A (Enron, merged in #385) and PR-C (OpenAI / multi-model, upcoming).
+
+## 2. Scope
+
+- **Corpus:** Synthetic (280 docs already ingested in HC; folder-scoped read-only API key already minted).
+- **Question types** (all inherited from PR-A; no new types):
+  - `lookup` — single-fact extraction from a single doc (bulk of items).
+  - `find` — cross-doc return-a-set queries (e.g. "Find invoices over $5,000"). 2–3 items.
+  - `negative` — entities/values absent from the corpus. 2–3 items, mix of `lookup`-negative and `find`-negative.
+- **Items:** ~20 total — all 9 doc types represented, plus 2–3 French items, 2–3 negatives.
+- **Model under test:** Sonnet 4.6 (multi-model deferred to PR-C).
+
+## 3. Why Synthetic + sidecar ground truth
+
+The synthetic corpus generator (`corpora/synthetic.py`) writes a per-doc **JSON sidecar with structured ground-truth facts** at generation time:
+
+```
+<workdir>/synthetic/ingest/0019_invoice.txt   ← rendered (or .pdf for the OCR subset)
+<workdir>/synthetic/ingest/0019_invoice.json  ← canonical sidecar
+```
+
+The sidecar carries doc-type-specific fields:
+
+| doc-type | sidecar keys |
+|---|---|
+| `invoice` | `vendor`, `invoice_number`, `date`, `total_usd`, `line_items` |
+| `board_minutes` | `date`, `attendees`, `decisions`, `lang` |
+| `onboarding_letter` | `employee_name`, `role`, `start_date`, `languages_used`, `signing_manager` |
+| `quarterly_report` | `quarter`, `year`, `revenue_usd`, `key_initiatives` |
+| (5 others) | per-type shapes |
+
+This is the cleanest possible ground-truth source — **the corpus author wrote it**. No grep, no LLM judgment, no inference. The sidecar value *is* the truth. Per phase 1 §4 (truth independent of the MCP), reading the sidecar — not HC's index — is correct.
+
+## 4. Architecture — components
+
+```
+<workdir>/synthetic/ingest/<id>_<doctype>.json (sidecars)
+        │  generator (explicit, one-shot)
+        ▼
+groundtruth/synthetic.yaml      ← frozen, version-controlled
+        │  answer-eval runner (existing, --corpora synthetic)
+        ▼
+captures + verdicts (model-keyed, reused by default — existing)
+        │  judge + (for find items) compute_coverage override — existing
+        ▼
+summary.json + detail.json (per-label, existing)
+```
+
+**One additive change only:** the new generator. Zero changes to `runner/answer_eval.py`, `runner/answer_judge.py`, `runner/sweep.py`, or `GTItem`. PR-B is the smallest of the three phase-2 PRs by design — synthetic ground truth is structurally easier than Enron's grep-derived truth or CUAD's CSV-derived truth.
+
+## 5. Generator structure — per-doc-type recipes
+
+`scripts/test_corpora/groundtruth/generate_synthetic.py` follows PR-A's recipe-table pattern, but dispatches on doc-type (from filename — `0019_invoice.json` → `"invoice"`) rather than per-question:
+
+```python
+def _recipe_invoice(sidecar: dict, stem: str) -> list[dict]:
+    inv = sidecar["invoice_number"]
+    return [
+        _lookup_item(
+            id_=f"synth-invoice-total-{inv}",
+            question=f"What is the total amount of invoice {inv}?",
+            gold_doc=stem,
+            answer_key=f"${sidecar['total_usd']:.2f}",
+            clause_category="invoice",
+        ),
+        _lookup_item(
+            id_=f"synth-invoice-vendor-{inv}",
+            question=f"Who is the vendor on invoice {inv}?",
+            gold_doc=stem,
+            answer_key=sidecar["vendor"],
+            clause_category="invoice",
+        ),
+    ]
+
+RECIPES = {
+    "invoice": _recipe_invoice,
+    "board_minutes": _recipe_board_minutes,
+    "onboarding_letter": _recipe_onboarding_letter,
+    "quarterly_report": _recipe_quarterly_report,
+    "vendor_contract": _recipe_vendor_contract,
+    "internal_memo": _recipe_internal_memo,
+    "policy_doc": _recipe_policy_doc,
+    "marketing_brief": _recipe_marketing_brief,
+    "employee_handbook": _recipe_employee_handbook,
+}
+```
+
+**Selection:** for each doc-type, take the first `N` sidecars by sorted filename (`N=2` default), apply the recipe, collect items. Deterministic by construction. Yields ~14 lookup items.
+
+**Cross-doc finds:** 2 hand-coded recipes that walk all sidecars and apply a filter:
+- `_recipe_find_invoices_over_5000` → emits a `find` item whose `answer_key.all` is every invoice stem with `total_usd > 5000`.
+- One more cross-doc find (TBD during implementation — likely "Find board minutes where Veltrane is mentioned" or similar, derived from `decisions` text).
+
+**Negatives:** 2 hand-coded items with answer_keys derived to be definitively absent:
+- `_recipe_neg_invoice_number` — `answer_key=None`, `type=negative`: "What is the total of invoice INV-99999?" (no invoice has that number — verified at generation time).
+- `_recipe_find_neg_vendor` — `answer_key={count:0, all:[], sample:[]}`, `type=find`: "Find vendor contracts with Globex Aerospace" (the corpus's known vendors are listed in `corpora/synthetic.py:COMPANY["key_vendors"]`; pick a name not in that list).
+
+The generator verifies negatives match zero docs in the actual corpus before emitting (same fail-fast guard pattern as PR-A's `NEGATIVE_TERMS` check).
+
+## 6. Bilingual coverage
+
+Synthetic is bilingual by design (Toronto/Montréal company). Some sidecars carry `lang` or `languages_used` markers. **Target 2–3 French-language items** as a subset of the lookup pool:
+
+- A recipe variant picks an FR-tagged doc (e.g. `lang: "fr"` on a `board_minutes`, or a `policy_doc` rendered in French) and emits the question in French with a French answer_key.
+- Example: `"Quelle est la date du procès-verbal du conseil ?"` → answer_key in French (e.g., `"2 avril 2025"`).
+- The judge (Sonnet 4.6) handles French natively; no judge change.
+- Tests HC's bilingual retrieval path: dual `fts_en`/`fts_fr` columns + multilingual embedding.
+
+If the generator can't find ≥2 FR-tagged sidecars during execution, the plan documents the fallback (skip FR items, log a warning).
+
+## 7. Item composition — ~20 items
+
+| Source | Items | Type |
+|---|--:|---|
+| 9 doc-type recipes × ~1.5 items each | ~14 | `lookup` |
+| Cross-doc finds | 2 | `find` |
+| `lookup`-negative | 1 | `negative` |
+| `find`-negative | 1 | `find` (count=0) |
+| (within the lookup pool) French-language items | 2–3 | `lookup` |
+| **Total** | **~20** | |
+
+All 9 doc types covered. Bilingual coverage in 10–15% of items. Negatives in both shapes.
+
+## 8. Ground-truth shape
+
+Same `GTItem` schema as PR-A — no schema changes:
+- `lookup`: `answer_key = str` (canonical fact from the sidecar).
+- `find`: `answer_key = {count, all, sample}` (list of gold stems from the cross-doc filter).
+- `negative`: `lookup`-negative `answer_key = None`; `find`-negative `{count: 0, all: [], sample: []}`.
+
+`gold_doc` is the filename stem (matches HC's `doc_title` format — same boundary discipline as PR-A).
+
+## 9. Harness integration
+
+Zero CLI changes. Existing sweep command works:
+
+```bash
+HC_API_KEY=<synthetic-scoped> ANTHROPIC_API_KEY=<...> \
+  uv run --project scripts/test_corpora python -m scripts.test_corpora.runner.sweep \
+  --run-id answer-eval --mode answer-eval \
+  --corpora synthetic --models claude-sonnet-4-6 --label synthetic-phase2b \
+  --workdir "$WD" --api-base http://localhost:8100
+```
+
+Routes to `<workdir>/answer-eval/{captures,verdicts}/synthetic/<model>/...`.
+
+## 10. Testing
+
+- `test_generate_synthetic.py` — fixture with one synthetic doc per doc-type (sidecar + rendered text) in `tmp_path`, run generator, assert each recipe emits items with correct schema, correct sidecar→answer_key mappings, and the negative-guard fires when expected. ~10 tests.
+- No `test_answer_judge.py` or `test_answer_eval.py` changes (judge + runner unchanged).
+- Operational (post-merge): Task-8-equivalent live run with the synthetic-scoped key (already in hand). Compare numbers against CUAD + Enron baselines.
+
+## 11. Out of scope (deferred to phase 3)
+
+- **Aggregation questions** that exploit synthetic-being-fully-known ("Which vendor appears on the most invoices?", "What's the total Q2 revenue across all quarterly reports?", "Who is the most common signing manager on onboarding letters?"). These need a different judge shape and are explicitly held for phase 3 alongside `research`-type synthesis questions across all three corpora. Worth coming back to — synthetic's canonical structure makes aggregation ground truth uniquely cheap.
+- **OpenAI / multi-model evaluation** — PR-C.
+- **MCP system-prompt tuning** for the negative-hedging behavior surfaced in PR-A and confirmed in PR-A's Enron run — separate experiment after PR-C, evaluated against all 3 corpora and 2 models.
+
+## 12. Open questions / decisions deferred to the plan
+
+- **Exact recipe content per doc-type** — each recipe's templates and which sidecar fields to lift. Settled in the plan with full code; the human curation pass on the generated `synthetic.yaml` (Task 6 of the implementation plan) catches any awkward phrasing.
+- **Second cross-doc `find`** — `_recipe_find_invoices_over_5000` is concrete; the second find item is TBD during implementation, picked from the doc-type whose sidecar structure best supports a clean filter (e.g. `board_minutes.decisions` mentions of a specific topic, or `onboarding_letter.start_date` in a specific quarter).
+- **FR item picking** — the generator either scans for `lang: "fr"` / `languages_used` markers, or hardcodes a sidecar-id-to-language map. Settled during implementation based on what the actual sidecars carry.

--- a/scripts/test_corpora/groundtruth/generate_synthetic.py
+++ b/scripts/test_corpora/groundtruth/generate_synthetic.py
@@ -1,0 +1,385 @@
+# scripts/test_corpora/groundtruth/generate_synthetic.py
+"""Generate the Synthetic answer-eval ground-truth set from per-doc JSON sidecars.
+
+The synthetic corpus (fictional company Marbledock & Associates) is authored by
+``corpora/synthetic.py``, which writes a JSON sidecar per document carrying the
+canonical, structured ground-truth facts (vendor, dates, totals, signatories,
+etc.). This generator dispatches by doc-type (from the filename suffix) to a
+recipe function that lifts those sidecar fields into ground-truth Q&A items.
+
+Cross-doc ``find`` recipes and negative items are hand-coded. French-language
+items are added by scanning for sidecars tagged ``lang: "fr"``.
+
+Run explicitly; the output is curated once by a human and committed. Never
+regenerated as a side effect of an eval run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+SAMPLE_K = 10
+# Negative entities — verified absent from the corpus before each generation.
+NEGATIVE_INVOICE_NUMBER = "INV-99999"
+NEGATIVE_VENDOR = "Globex Aerospace"
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _to_title(name: str) -> str:
+    """Strip a synthetic doc's filename extension (.json/.txt/.pdf) so the
+    value matches HC's doc_title format."""
+    for ext in (".json", ".txt", ".pdf"):
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
+def _load_sidecar(path: Path) -> dict:
+    """Read a JSON sidecar file."""
+    return json.loads(path.read_text())
+
+
+def _iter_sidecars(ingest_dir: Path, doctype: str) -> Iterable[tuple[str, dict]]:
+    """Yield (stem, sidecar) for every ``*_<doctype>.json`` in ``ingest_dir``,
+    sorted deterministically by filename."""
+    for p in sorted(ingest_dir.glob(f"*_{doctype}.json")):
+        yield _to_title(p.name), _load_sidecar(p)
+
+
+def _lookup_item(*, id_: str, question: str, gold_doc: str, answer_key: str, clause_category: str) -> dict:
+    return {
+        "id": id_,
+        "question": question,
+        "clause_category": clause_category,
+        "gold_doc": gold_doc,
+        "answer_key": answer_key,
+        "type": "lookup",
+    }
+
+
+def _find_item(*, id_: str, question: str, all_matches: list[str], clause_category: str) -> dict:
+    return {
+        "id": id_,
+        "question": question,
+        "clause_category": clause_category,
+        "gold_doc": "(see answer_key.all)",
+        "answer_key": {
+            "count": len(all_matches),
+            "all": all_matches,
+            "sample": all_matches[:SAMPLE_K],
+        },
+        "type": "find",
+    }
+
+
+# ── per-doc-type recipes ────────────────────────────────────────────────────
+
+
+def _recipe_invoice(stem: str, sc: dict) -> list[dict]:
+    inv = sc["invoice_number"]
+    return [
+        _lookup_item(
+            id_=f"synth-invoice-total-{inv}",
+            question=f"What is the total amount in USD of invoice {inv}?",
+            gold_doc=stem,
+            answer_key=f"${sc['total_usd']:.2f}",
+            clause_category="invoice",
+        ),
+        _lookup_item(
+            id_=f"synth-invoice-vendor-{inv}",
+            question=f"Who is the vendor on invoice {inv}?",
+            gold_doc=stem,
+            answer_key=sc["vendor"],
+            clause_category="invoice",
+        ),
+    ]
+
+
+def _recipe_board_minutes(stem: str, sc: dict) -> list[dict]:
+    return [
+        _lookup_item(
+            id_=f"synth-board-attendees-{sc['date']}",
+            question=f"Who attended the Marbledock & Associates board meeting on {sc['date']}?",
+            gold_doc=stem,
+            answer_key="; ".join(sc["attendees"]),
+            clause_category="board_minutes",
+        ),
+    ]
+
+
+def _recipe_onboarding_letter(stem: str, sc: dict) -> list[dict]:
+    role = sc["role"]
+    return [
+        _lookup_item(
+            id_=f"synth-onboarding-start-{stem}",
+            question=f"What is the start date listed on the {role} onboarding letter?",
+            gold_doc=stem,
+            answer_key=sc["start_date"],
+            clause_category="onboarding_letter",
+        ),
+        _lookup_item(
+            id_=f"synth-onboarding-mgr-{stem}",
+            question=f"Who is the signing manager on the {role} onboarding letter?",
+            gold_doc=stem,
+            answer_key=sc["signing_manager"],
+            clause_category="onboarding_letter",
+        ),
+    ]
+
+
+def _recipe_quarterly_report(stem: str, sc: dict) -> list[dict]:
+    q, y = sc["quarter"], sc["year"]
+    return [
+        _lookup_item(
+            id_=f"synth-qreport-revenue-{q}-{y}",
+            question=f"What was the revenue reported in the {q} {y} quarterly report?",
+            gold_doc=stem,
+            answer_key=f"${sc['revenue_usd']:,}",
+            clause_category="quarterly_report",
+        ),
+    ]
+
+
+def _recipe_vendor_contract(stem: str, sc: dict) -> list[dict]:
+    vendor = sc["vendor"]
+    return [
+        _lookup_item(
+            id_=f"synth-vcontract-law-{stem}",
+            question=f"What is the governing law of the vendor contract with {vendor}?",
+            gold_doc=stem,
+            answer_key=sc["governing_law"],
+            clause_category="vendor_contract",
+        ),
+        _lookup_item(
+            id_=f"synth-vcontract-fee-{stem}",
+            question=f"What is the monthly fee in USD on the vendor contract with {vendor}?",
+            gold_doc=stem,
+            answer_key=f"${sc['monthly_fee_usd']:.2f}",
+            clause_category="vendor_contract",
+        ),
+    ]
+
+
+def _recipe_internal_memo(stem: str, sc: dict) -> list[dict]:
+    subj = sc["subject"]
+    return [
+        _lookup_item(
+            id_=f"synth-memo-sender-{stem}",
+            question=f'Who is the sender of the internal memo with subject "{subj}"?',
+            gold_doc=stem,
+            answer_key=sc["from"],
+            clause_category="internal_memo",
+        ),
+    ]
+
+
+def _recipe_policy_doc(stem: str, sc: dict) -> list[dict]:
+    name = sc["policy_name"]
+    return [
+        _lookup_item(
+            id_=f"synth-policy-effective-{stem}",
+            question=f'When does the "{name}" policy take effect?',
+            gold_doc=stem,
+            answer_key=sc["effective_date"],
+            clause_category="policy_doc",
+        ),
+        _lookup_item(
+            id_=f"synth-policy-version-{stem}",
+            question=f'What is the version number of the "{name}" policy?',
+            gold_doc=stem,
+            answer_key=str(sc["version"]),
+            clause_category="policy_doc",
+        ),
+    ]
+
+
+def _recipe_marketing_brief(stem: str, sc: dict) -> list[dict]:
+    camp = sc["campaign_name"]
+    return [
+        _lookup_item(
+            id_=f"synth-mkt-budget-{stem}",
+            question=f'What is the budget in USD for the "{camp}" marketing campaign?',
+            gold_doc=stem,
+            answer_key=f"${sc['budget_usd']:,}",
+            clause_category="marketing_brief",
+        ),
+    ]
+
+
+def _recipe_employee_handbook(stem: str, sc: dict) -> list[dict]:
+    year = sc["year"]
+    return [
+        _lookup_item(
+            id_=f"synth-handbook-sections-{stem}",
+            question=f"How many top-level sections are in the {year} Marbledock employee handbook?",
+            gold_doc=stem,
+            answer_key=str(len(sc["sections"])),
+            clause_category="employee_handbook",
+        ),
+    ]
+
+
+RECIPES: dict[str, callable] = {
+    "invoice": _recipe_invoice,
+    "board_minutes": _recipe_board_minutes,
+    "onboarding_letter": _recipe_onboarding_letter,
+    "quarterly_report": _recipe_quarterly_report,
+    "vendor_contract": _recipe_vendor_contract,
+    "internal_memo": _recipe_internal_memo,
+    "policy_doc": _recipe_policy_doc,
+    "marketing_brief": _recipe_marketing_brief,
+    "employee_handbook": _recipe_employee_handbook,
+}
+
+
+# ── cross-doc finds + negatives + FR ────────────────────────────────────────
+
+
+def _find_invoices_over_5000(ingest_dir: Path) -> dict:
+    matches = [stem for stem, sc in _iter_sidecars(ingest_dir, "invoice") if float(sc.get("total_usd", 0)) > 5000]
+    return _find_item(
+        id_="synth-find-invoices-over-5000",
+        question="Find all invoices with a total amount over $5,000 USD.",
+        all_matches=sorted(matches),
+        clause_category="cross-doc",
+    )
+
+
+def _find_policies_effective_in_q4_2025(ingest_dir: Path) -> dict:
+    matches = [
+        stem
+        for stem, sc in _iter_sidecars(ingest_dir, "policy_doc")
+        if str(sc.get("effective_date", "")).startswith(("2025-10", "2025-11", "2025-12"))
+    ]
+    return _find_item(
+        id_="synth-find-policies-q4-2025",
+        question="Find Marbledock policies that take effect in Q4 2025 (October, November, or December 2025).",
+        all_matches=sorted(matches),
+        clause_category="cross-doc",
+    )
+
+
+def _neg_invoice_number(ingest_dir: Path) -> dict:
+    """A lookup with an invoice_number that doesn't exist in the corpus."""
+    for _, sc in _iter_sidecars(ingest_dir, "invoice"):
+        if sc.get("invoice_number") == NEGATIVE_INVOICE_NUMBER:
+            raise RuntimeError(
+                f"negative invoice_number {NEGATIVE_INVOICE_NUMBER!r} unexpectedly matches "
+                f"a real invoice in the corpus; pick a different absent number"
+            )
+    return {
+        "id": f"synth-neg-invoice-{NEGATIVE_INVOICE_NUMBER.split('-')[-1]}",
+        "question": f"What is the total amount of invoice {NEGATIVE_INVOICE_NUMBER}?",
+        "clause_category": "invoice",
+        "gold_doc": "(none expected)",
+        "answer_key": None,
+        "type": "negative",
+    }
+
+
+def _find_neg_vendor(ingest_dir: Path) -> dict:
+    """A find with a vendor that doesn't exist anywhere in the corpus."""
+    for p in sorted(ingest_dir.glob("*.json")):
+        if NEGATIVE_VENDOR.lower() in p.read_text().lower():
+            raise RuntimeError(
+                f"negative vendor {NEGATIVE_VENDOR!r} unexpectedly matches "
+                f"content in {p.name}; pick a different absent vendor"
+            )
+    slug = NEGATIVE_VENDOR.lower().replace(" ", "-")
+    return _find_item(
+        id_=f"synth-find-neg-vendor-{slug}",
+        question=f"Find vendor contracts where the vendor is {NEGATIVE_VENDOR}.",
+        all_matches=[],
+        clause_category="cross-doc",
+    )
+
+
+def _emit_fr_items(ingest_dir: Path) -> list[dict]:
+    """Emit ≤2 French-language items derived from sidecars tagged ``lang: "fr"``.
+    Scans board_minutes and internal_memo (the types that carry an explicit
+    ``lang`` field in the corpus); falls back silently if none are present.
+    """
+    items: list[dict] = []
+    for doctype in ("board_minutes", "internal_memo"):
+        for stem, sc in _iter_sidecars(ingest_dir, doctype):
+            if sc.get("lang") != "fr":
+                continue
+            if doctype == "board_minutes":
+                items.append(
+                    _lookup_item(
+                        id_=f"synth-fr-board-attendees-{sc['date']}",
+                        question=f"Qui a assisté à la réunion du conseil de Marbledock & Associates le {sc['date']}?",
+                        gold_doc=stem,
+                        answer_key="; ".join(sc["attendees"]),
+                        clause_category="board_minutes",
+                    )
+                )
+            else:  # internal_memo
+                items.append(
+                    _lookup_item(
+                        id_=f"synth-fr-memo-sender-{stem}",
+                        question=f"Qui est l'expéditeur du mémo interne dont le sujet est « {sc['subject']} »?",
+                        gold_doc=stem,
+                        answer_key=sc["from"],
+                        clause_category="internal_memo",
+                    )
+                )
+            if len(items) >= 2:
+                return items
+    return items
+
+
+# ── orchestrator ────────────────────────────────────────────────────────────
+
+
+def generate(ingest_dir: Path, out_path: Path, *, per_type: int = 2) -> int:
+    """Emit the Synthetic ground-truth YAML. Returns the number of items written.
+
+    For each doc-type, applies the per-type recipe to the first ``per_type``
+    sidecars (sorted by filename). Adds cross-doc finds, negatives (validated
+    against the corpus), and up to 2 French-language items.
+    """
+    items: list[dict] = []
+
+    # Per-doc-type lookups.
+    for doctype, recipe in RECIPES.items():
+        for stem, sc in list(_iter_sidecars(ingest_dir, doctype))[:per_type]:
+            items.extend(recipe(stem, sc))
+
+    # Cross-doc finds.
+    items.append(_find_invoices_over_5000(ingest_dir))
+    items.append(_find_policies_effective_in_q4_2025(ingest_dir))
+
+    # Negatives (validated against the corpus — raises if either accidentally matches).
+    items.append(_neg_invoice_number(ingest_dir))
+    items.append(_find_neg_vendor(ingest_dir))
+
+    # French-language items.
+    items.extend(_emit_fr_items(ingest_dir))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(yaml.safe_dump({"corpus": "synthetic", "items": items}, sort_keys=False))
+    return len(items)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Generate the Synthetic answer-eval ground-truth set.")
+    ap.add_argument("--ingest-dir", type=Path, required=True, help="Synthetic ingest dir (*.json + *.txt)")
+    ap.add_argument("--out", type=Path, required=True, help="output synthetic.yaml")
+    ap.add_argument("--per-type", type=int, default=2, help="docs sampled per doc-type")
+    a = ap.parse_args(argv)
+    n = generate(ingest_dir=a.ingest_dir, out_path=a.out, per_type=a.per_type)
+    print(f"wrote {n} ground-truth items -> {a.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_corpora/groundtruth/generate_synthetic.py
+++ b/scripts/test_corpora/groundtruth/generate_synthetic.py
@@ -87,14 +87,14 @@ def _recipe_invoice(stem: str, sc: dict) -> list[dict]:
     inv = sc["invoice_number"]
     return [
         _lookup_item(
-            id_=f"synth-invoice-total-{inv}",
+            id_=f"synth-invoice-total-{stem}",
             question=f"What is the total amount in USD of invoice {inv}?",
             gold_doc=stem,
             answer_key=f"${sc['total_usd']:,.2f}",
             clause_category="invoice",
         ),
         _lookup_item(
-            id_=f"synth-invoice-vendor-{inv}",
+            id_=f"synth-invoice-vendor-{stem}",
             question=f"Who is the vendor on invoice {inv}?",
             gold_doc=stem,
             answer_key=sc["vendor"],
@@ -106,7 +106,7 @@ def _recipe_invoice(stem: str, sc: dict) -> list[dict]:
 def _recipe_board_minutes(stem: str, sc: dict) -> list[dict]:
     return [
         _lookup_item(
-            id_=f"synth-board-attendees-{sc['date']}",
+            id_=f"synth-board-attendees-{stem}",
             question=f"Who attended the Marbledock & Associates board meeting on {sc['date']}?",
             gold_doc=stem,
             answer_key="; ".join(sc["attendees"]),
@@ -139,7 +139,7 @@ def _recipe_quarterly_report(stem: str, sc: dict) -> list[dict]:
     q, y = sc["quarter"], sc["year"]
     return [
         _lookup_item(
-            id_=f"synth-qreport-revenue-{q}-{y}",
+            id_=f"synth-qreport-revenue-{stem}",
             question=f"What was the revenue reported in the {q} {y} quarterly report?",
             gold_doc=stem,
             answer_key=f"${sc['revenue_usd']:,.2f}",
@@ -319,7 +319,7 @@ def _emit_fr_items(ingest_dir: Path) -> list[dict]:
             if doctype == "board_minutes":
                 items.append(
                     _lookup_item(
-                        id_=f"synth-fr-board-attendees-{sc['date']}",
+                        id_=f"synth-fr-board-attendees-{stem}",
                         question=f"Qui a assisté à la réunion du conseil de Marbledock & Associates le {sc['date']}?",
                         gold_doc=stem,
                         answer_key="; ".join(sc["attendees"]),

--- a/scripts/test_corpora/groundtruth/generate_synthetic.py
+++ b/scripts/test_corpora/groundtruth/generate_synthetic.py
@@ -90,7 +90,7 @@ def _recipe_invoice(stem: str, sc: dict) -> list[dict]:
             id_=f"synth-invoice-total-{inv}",
             question=f"What is the total amount in USD of invoice {inv}?",
             gold_doc=stem,
-            answer_key=f"${sc['total_usd']:.2f}",
+            answer_key=f"${sc['total_usd']:,.2f}",
             clause_category="invoice",
         ),
         _lookup_item(
@@ -142,7 +142,7 @@ def _recipe_quarterly_report(stem: str, sc: dict) -> list[dict]:
             id_=f"synth-qreport-revenue-{q}-{y}",
             question=f"What was the revenue reported in the {q} {y} quarterly report?",
             gold_doc=stem,
-            answer_key=f"${sc['revenue_usd']:,}",
+            answer_key=f"${sc['revenue_usd']:,.2f}",
             clause_category="quarterly_report",
         ),
     ]
@@ -162,7 +162,7 @@ def _recipe_vendor_contract(stem: str, sc: dict) -> list[dict]:
             id_=f"synth-vcontract-fee-{stem}",
             question=f"What is the monthly fee in USD on the vendor contract with {vendor}?",
             gold_doc=stem,
-            answer_key=f"${sc['monthly_fee_usd']:.2f}",
+            answer_key=f"${sc['monthly_fee_usd']:,.2f}",
             clause_category="vendor_contract",
         ),
     ]
@@ -208,7 +208,7 @@ def _recipe_marketing_brief(stem: str, sc: dict) -> list[dict]:
             id_=f"synth-mkt-budget-{stem}",
             question=f'What is the budget in USD for the "{camp}" marketing campaign?',
             gold_doc=stem,
-            answer_key=f"${sc['budget_usd']:,}",
+            answer_key=f"${sc['budget_usd']:,.2f}",
             clause_category="marketing_brief",
         ),
     ]
@@ -304,8 +304,12 @@ def _find_neg_vendor(ingest_dir: Path) -> dict:
 
 def _emit_fr_items(ingest_dir: Path) -> list[dict]:
     """Emit ≤2 French-language items derived from sidecars tagged ``lang: "fr"``.
-    Scans board_minutes and internal_memo (the types that carry an explicit
-    ``lang`` field in the corpus); falls back silently if none are present.
+
+    Scans board_minutes first, then internal_memo (the types that carry an
+    explicit ``lang`` field in the corpus); board_minutes items are
+    prioritised — internal_memo items are only emitted if fewer than 2
+    board_minutes FR items exist. Falls back silently if no FR sidecars are
+    present at all.
     """
     items: list[dict] = []
     for doctype in ("board_minutes", "internal_memo"):
@@ -364,6 +368,17 @@ def generate(ingest_dir: Path, out_path: Path, *, per_type: int = 2) -> int:
 
     # French-language items.
     items.extend(_emit_fr_items(ingest_dir))
+
+    # Guard against silent duplicate ids — recipe ids are derived from sidecar
+    # fields (invoice_number, date, role, etc.), so two sidecars sharing such a
+    # value would collide. YAML allows duplicate keys at sequence-of-mappings
+    # level; downstream loaders may or may not dedup. Fail loud at generation.
+    ids = [i["id"] for i in items]
+    if len(ids) != len(set(ids)):
+        from collections import Counter
+
+        dups = sorted(k for k, v in Counter(ids).items() if v > 1)
+        raise RuntimeError(f"duplicate item ids in generated set: {dups}")
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(yaml.safe_dump({"corpus": "synthetic", "items": items}, sort_keys=False))

--- a/scripts/test_corpora/groundtruth/generate_synthetic.py
+++ b/scripts/test_corpora/groundtruth/generate_synthetic.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 import yaml
@@ -136,11 +136,15 @@ def _recipe_onboarding_letter(stem: str, sc: dict) -> list[dict]:
 
 
 def _recipe_quarterly_report(stem: str, sc: dict) -> list[dict]:
-    q, y = sc["quarter"], sc["year"]
+    # Disambiguate (q, y) with revenue magnitude so questions are unique even
+    # when the corpus has multiple qreports for the same quarter — the
+    # orchestrator further dedups by (q, y) to avoid emitting identical
+    # question/answer pairs for repeated qreports.
+    q, y, rev = sc["quarter"], sc["year"], int(sc["revenue_usd"])
     return [
         _lookup_item(
             id_=f"synth-qreport-revenue-{stem}",
-            question=f"What was the revenue reported in the {q} {y} quarterly report?",
+            question=f"What was the revenue reported in the {q} {y} quarterly report (the one reporting approximately ${rev // 1_000_000}M)?",
             gold_doc=stem,
             answer_key=f"${sc['revenue_usd']:,.2f}",
             clause_category="quarterly_report",
@@ -182,20 +186,26 @@ def _recipe_internal_memo(stem: str, sc: dict) -> list[dict]:
 
 
 def _recipe_policy_doc(stem: str, sc: dict) -> list[dict]:
+    # Include version and effective_date as cross-discriminators in the
+    # question text — the corpus has multiple versions of the same policy
+    # (e.g., two "Information Security..." policies with different dates),
+    # and questions need to pin down ONE doc unambiguously.
     name = sc["policy_name"]
+    version = str(sc["version"])
+    effective = sc["effective_date"]
     return [
         _lookup_item(
             id_=f"synth-policy-effective-{stem}",
-            question=f'When does the "{name}" policy take effect?',
+            question=f'When does version {version} of the "{name}" policy take effect?',
             gold_doc=stem,
-            answer_key=sc["effective_date"],
+            answer_key=effective,
             clause_category="policy_doc",
         ),
         _lookup_item(
             id_=f"synth-policy-version-{stem}",
-            question=f'What is the version number of the "{name}" policy?',
+            question=f'What version of the "{name}" policy takes effect on {effective}?',
             gold_doc=stem,
-            answer_key=str(sc["version"]),
+            answer_key=version,
             clause_category="policy_doc",
         ),
     ]
@@ -227,7 +237,7 @@ def _recipe_employee_handbook(stem: str, sc: dict) -> list[dict]:
     ]
 
 
-RECIPES: dict[str, callable] = {
+RECIPES: dict[str, Callable[[str, dict], list[dict]]] = {
     "invoice": _recipe_invoice,
     "board_minutes": _recipe_board_minutes,
     "onboarding_letter": _recipe_onboarding_letter,
@@ -352,11 +362,46 @@ def generate(ingest_dir: Path, out_path: Path, *, per_type: int = 2) -> int:
     against the corpus), and up to 2 French-language items.
     """
     items: list[dict] = []
+    seen_questions: set[str] = set()
+    dup_skipped = 0
 
-    # Per-doc-type lookups.
+    # Per-doc-type lookups. Two layers of dedup:
+    #  (a) Quarterly reports get an extra pass by (quarter, year) — the corpus
+    #      has multiple qreports for the same quarter/year, all with the same
+    #      effective metadata; skip past the dup before invoking the recipe.
+    #  (b) After each item is built, drop it if its question text already
+    #      appears in `seen_questions`. The model has no way to disambiguate
+    #      identical questions (gold_doc is internal to the runner), so a dup
+    #      is an eval-validity bug. Some corpus quirks (e.g., every
+    #      employee_handbook has `year: 2025` so the recipe template produces
+    #      the same question for all of them) make this unavoidable without
+    #      hand-curating per-recipe — silent skip is the right default. The
+    #      `dup_skipped` count is reported to stderr so a curator can spot a
+    #      doc-type that's contributing fewer items than expected.
     for doctype, recipe in RECIPES.items():
-        for stem, sc in list(_iter_sidecars(ingest_dir, doctype))[:per_type]:
-            items.extend(recipe(stem, sc))
+        sidecars = _iter_sidecars(ingest_dir, doctype)
+        if doctype == "quarterly_report":
+            seen_qy: set[tuple] = set()
+            deduped: list[tuple[str, dict]] = []
+            for stem, sc in sidecars:
+                key = (sc.get("quarter"), sc.get("year"))
+                if key in seen_qy:
+                    continue
+                seen_qy.add(key)
+                deduped.append((stem, sc))
+            sidecars = iter(deduped)
+        for stem, sc in list(sidecars)[:per_type]:
+            for item in recipe(stem, sc):
+                if item["question"] in seen_questions:
+                    dup_skipped += 1
+                    continue
+                seen_questions.add(item["question"])
+                items.append(item)
+    if dup_skipped:
+        print(
+            f"warning: skipped {dup_skipped} item(s) whose question text duplicated an earlier item — corpus quirk",
+            file=sys.stderr,
+        )
 
     # Cross-doc finds.
     items.append(_find_invoices_over_5000(ingest_dir))

--- a/scripts/test_corpora/groundtruth/synthetic.yaml
+++ b/scripts/test_corpora/groundtruth/synthetic.yaml
@@ -1,0 +1,294 @@
+corpus: synthetic
+items:
+- id: synth-invoice-total-0001_invoice
+  question: What is the total amount in USD of invoice SBA-20251104-087342?
+  clause_category: invoice
+  gold_doc: 0001_invoice
+  answer_key: $6,326.60
+  type: lookup
+- id: synth-invoice-vendor-0001_invoice
+  question: Who is the vendor on invoice SBA-20251104-087342?
+  clause_category: invoice
+  gold_doc: 0001_invoice
+  answer_key: Staples Business Advantage
+  type: lookup
+- id: synth-invoice-total-0002_invoice
+  question: What is the total amount in USD of invoice SC-2025-084471?
+  clause_category: invoice
+  gold_doc: 0002_invoice
+  answer_key: $30,163.80
+  type: lookup
+- id: synth-invoice-vendor-0002_invoice
+  question: Who is the vendor on invoice SC-2025-084471?
+  clause_category: invoice
+  gold_doc: 0002_invoice
+  answer_key: Steelcase Inc.
+  type: lookup
+- id: synth-board-attendees-0101_board_minutes
+  question: Who attended the Marbledock & Associates board meeting on 2025-03-07?
+  clause_category: board_minutes
+  gold_doc: 0101_board_minutes
+  answer_key: "Eleanor Voss \u2013 Chairwoman & Chief Executive Officer; Raymond Holt\
+    \ \u2013 Chief Financial Officer; Sandra Kimura \u2013 Chief Operating Officer;\
+    \ Frederick Osei \u2013 Chief Legal Officer; Diana Marchetti \u2013 Chief Marketing\
+    \ Officer; Thomas Blaine \u2013 Head of Corporate Strategy; Priya Nandakumar \u2013\
+    \ Non-Executive Director; Gerald Whitmore \u2013 Non-Executive Director"
+  type: lookup
+- id: synth-board-attendees-0102_board_minutes
+  question: Who attended the Marbledock & Associates board meeting on 2025-04-02?
+  clause_category: board_minutes
+  gold_doc: 0102_board_minutes
+  answer_key: "Eleanor Voss \u2013 Chief Executive Officer; Raymond Holt \u2013 Chief\
+    \ Financial Officer; Priya Sundaram \u2013 Chief Operating Officer; Marcus Bellfield\
+    \ \u2013 General Counsel; Theodora Wainwright \u2013 Head of Business Development;\
+    \ Simon Crake \u2013 Chief Technology Officer"
+  type: lookup
+- id: synth-onboarding-start-0061_onboarding_letter
+  question: What is the start date listed on the Senior Project Coordinator onboarding
+    letter?
+  clause_category: onboarding_letter
+  gold_doc: 0061_onboarding_letter
+  answer_key: '2025-04-19'
+  type: lookup
+- id: synth-onboarding-mgr-0061_onboarding_letter
+  question: Who is the signing manager on the Senior Project Coordinator onboarding
+    letter?
+  clause_category: onboarding_letter
+  gold_doc: 0061_onboarding_letter
+  answer_key: Isabelle Tremblay-Fontaine, Directrice des ressources humaines / Director
+    of Human Resources
+  type: lookup
+- id: synth-onboarding-start-0062_onboarding_letter
+  question: What is the start date listed on the Senior Bilingual Project Coordinator
+    onboarding letter?
+  clause_category: onboarding_letter
+  gold_doc: 0062_onboarding_letter
+  answer_key: '2025-02-24'
+  type: lookup
+- id: synth-onboarding-mgr-0062_onboarding_letter
+  question: Who is the signing manager on the Senior Bilingual Project Coordinator
+    onboarding letter?
+  clause_category: onboarding_letter
+  gold_doc: 0062_onboarding_letter
+  answer_key: "Sophie Tr\xE9panier, Directrice des Ressources Humaines / Director\
+    \ of Human Resources"
+  type: lookup
+- id: synth-qreport-revenue-0261_quarterly_report
+  question: What was the revenue reported in the Q4 2025 quarterly report?
+  clause_category: quarterly_report
+  gold_doc: 0261_quarterly_report
+  answer_key: $47,300,000.00
+  type: lookup
+- id: synth-qreport-revenue-0262_quarterly_report
+  question: What was the revenue reported in the Q4 2025 quarterly report?
+  clause_category: quarterly_report
+  gold_doc: 0262_quarterly_report
+  answer_key: $47,300,000.00
+  type: lookup
+- id: synth-vcontract-law-0131_vendor_contract
+  question: What is the governing law of the vendor contract with Pinnacle Tech Solutions,
+    LLC?
+  clause_category: vendor_contract
+  gold_doc: 0131_vendor_contract
+  answer_key: State of South Carolina
+  type: lookup
+- id: synth-vcontract-fee-0131_vendor_contract
+  question: What is the monthly fee in USD on the vendor contract with Pinnacle Tech
+    Solutions, LLC?
+  clause_category: vendor_contract
+  gold_doc: 0131_vendor_contract
+  answer_key: $8,500.00
+  type: lookup
+- id: synth-vcontract-law-0132_vendor_contract
+  question: What is the governing law of the vendor contract with Pinnacle Technology
+    Solutions, LLC?
+  clause_category: vendor_contract
+  gold_doc: 0132_vendor_contract
+  answer_key: State of Illinois
+  type: lookup
+- id: synth-vcontract-fee-0132_vendor_contract
+  question: What is the monthly fee in USD on the vendor contract with Pinnacle Technology
+    Solutions, LLC?
+  clause_category: vendor_contract
+  gold_doc: 0132_vendor_contract
+  answer_key: $8,500.00
+  type: lookup
+- id: synth-memo-sender-0161_internal_memo
+  question: "Who is the sender of the internal memo with subject \"Updated Remote\
+    \ Work and Hybrid Scheduling Policy \u2013 Effective April 1, 2025\"?"
+  clause_category: internal_memo
+  gold_doc: 0161_internal_memo
+  answer_key: Helena Voss, Chief Operations Officer, Marbledock & Associates
+  type: lookup
+- id: synth-memo-sender-0162_internal_memo
+  question: "Who is the sender of the internal memo with subject \"Updated Remote\
+    \ Work and Hybrid Office Attendance Policy \u2013 Effective Immediately\"?"
+  clause_category: internal_memo
+  gold_doc: 0162_internal_memo
+  answer_key: Eleanor Whitford, Managing Partner, Marbledock & Associates
+  type: lookup
+- id: synth-policy-effective-0191_policy_doc
+  question: When does the "Information Security and Human Resources Acceptable Use
+    Policy" policy take effect?
+  clause_category: policy_doc
+  gold_doc: 0191_policy_doc
+  answer_key: '2025-12-23'
+  type: lookup
+- id: synth-policy-version-0191_policy_doc
+  question: What is the version number of the "Information Security and Human Resources
+    Acceptable Use Policy" policy?
+  clause_category: policy_doc
+  gold_doc: 0191_policy_doc
+  answer_key: '3.1'
+  type: lookup
+- id: synth-policy-effective-0192_policy_doc
+  question: When does the "Information Security and Human Resources Acceptable Use
+    Policy" policy take effect?
+  clause_category: policy_doc
+  gold_doc: 0192_policy_doc
+  answer_key: '2025-08-13'
+  type: lookup
+- id: synth-policy-version-0192_policy_doc
+  question: What is the version number of the "Information Security and Human Resources
+    Acceptable Use Policy" policy?
+  clause_category: policy_doc
+  gold_doc: 0192_policy_doc
+  answer_key: 2.4.1
+  type: lookup
+- id: synth-mkt-budget-0221_marketing_brief
+  question: What is the budget in USD for the "Marbledock Elevate 2025" marketing
+    campaign?
+  clause_category: marketing_brief
+  gold_doc: 0221_marketing_brief
+  answer_key: $120,000.00
+  type: lookup
+- id: synth-mkt-budget-0222_marketing_brief
+  question: What is the budget in USD for the "Elevate Forward" marketing campaign?
+  clause_category: marketing_brief
+  gold_doc: 0222_marketing_brief
+  answer_key: $250,000.00
+  type: lookup
+- id: synth-handbook-sections-0241_employee_handbook
+  question: How many top-level sections are in the 2025 Marbledock employee handbook?
+  clause_category: employee_handbook
+  gold_doc: 0241_employee_handbook
+  answer_key: '4'
+  type: lookup
+- id: synth-handbook-sections-0242_employee_handbook
+  question: How many top-level sections are in the 2025 Marbledock employee handbook?
+  clause_category: employee_handbook
+  gold_doc: 0242_employee_handbook
+  answer_key: '3'
+  type: lookup
+- id: synth-find-invoices-over-5000
+  question: Find all invoices with a total amount over $5,000 USD.
+  clause_category: cross-doc
+  gold_doc: (see answer_key.all)
+  answer_key:
+    count: 56
+    all:
+    - 0001_invoice
+    - 0002_invoice
+    - 0003_invoice
+    - 0004_invoice
+    - 0005_invoice
+    - 0006_invoice
+    - 0007_invoice
+    - 0008_invoice
+    - 0009_invoice
+    - 0010_invoice
+    - 0011_invoice
+    - 0012_invoice
+    - 0013_invoice
+    - 0014_invoice
+    - 0015_invoice
+    - 0016_invoice
+    - 0017_invoice
+    - 0018_invoice
+    - 0019_invoice
+    - 0020_invoice
+    - 0021_invoice
+    - 0022_invoice
+    - 0023_invoice
+    - 0024_invoice
+    - 0025_invoice
+    - 0026_invoice
+    - 0027_invoice
+    - 0028_invoice
+    - 0029_invoice
+    - 0030_invoice
+    - 0031_invoice
+    - 0032_invoice
+    - 0033_invoice
+    - 0034_invoice
+    - 0035_invoice
+    - 0036_invoice
+    - 0037_invoice
+    - 0038_invoice
+    - 0040_invoice
+    - 0042_invoice
+    - 0043_invoice
+    - 0044_invoice
+    - 0045_invoice
+    - 0046_invoice
+    - 0047_invoice
+    - 0048_invoice
+    - 0049_invoice
+    - 0051_invoice
+    - 0052_invoice
+    - 0053_invoice
+    - 0054_invoice
+    - 0055_invoice
+    - 0056_invoice
+    - 0058_invoice
+    - 0059_invoice
+    - 0060_invoice
+    sample:
+    - 0001_invoice
+    - 0002_invoice
+    - 0003_invoice
+    - 0004_invoice
+    - 0005_invoice
+    - 0006_invoice
+    - 0007_invoice
+    - 0008_invoice
+    - 0009_invoice
+    - 0010_invoice
+  type: find
+- id: synth-find-policies-q4-2025
+  question: Find Marbledock policies that take effect in Q4 2025 (October, November,
+    or December 2025).
+  clause_category: cross-doc
+  gold_doc: (see answer_key.all)
+  answer_key:
+    count: 6
+    all:
+    - 0191_policy_doc
+    - 0201_policy_doc
+    - 0203_policy_doc
+    - 0204_policy_doc
+    - 0210_policy_doc
+    - 0215_policy_doc
+    sample:
+    - 0191_policy_doc
+    - 0201_policy_doc
+    - 0203_policy_doc
+    - 0204_policy_doc
+    - 0210_policy_doc
+    - 0215_policy_doc
+  type: find
+- id: synth-neg-invoice-99999
+  question: What is the total amount of invoice INV-99999?
+  clause_category: invoice
+  gold_doc: (none expected)
+  answer_key: null
+  type: negative
+- id: synth-find-neg-vendor-globex-aerospace
+  question: Find vendor contracts where the vendor is Globex Aerospace.
+  clause_category: cross-doc
+  gold_doc: (see answer_key.all)
+  answer_key:
+    count: 0
+    all: []
+    sample: []
+  type: find

--- a/scripts/test_corpora/groundtruth/synthetic.yaml
+++ b/scripts/test_corpora/groundtruth/synthetic.yaml
@@ -74,16 +74,18 @@ items:
     \ of Human Resources"
   type: lookup
 - id: synth-qreport-revenue-0261_quarterly_report
-  question: What was the revenue reported in the Q4 2025 quarterly report?
+  question: What was the revenue reported in the Q4 2025 quarterly report (the one
+    reporting approximately $47M)?
   clause_category: quarterly_report
   gold_doc: 0261_quarterly_report
   answer_key: $47,300,000.00
   type: lookup
-- id: synth-qreport-revenue-0262_quarterly_report
-  question: What was the revenue reported in the Q4 2025 quarterly report?
+- id: synth-qreport-revenue-0265_quarterly_report
+  question: What was the revenue reported in the Q3 2025 quarterly report (the one
+    reporting approximately $48M)?
   clause_category: quarterly_report
-  gold_doc: 0262_quarterly_report
-  answer_key: $47,300,000.00
+  gold_doc: 0265_quarterly_report
+  answer_key: $48,700,000.00
   type: lookup
 - id: synth-vcontract-law-0131_vendor_contract
   question: What is the governing law of the vendor contract with Pinnacle Tech Solutions,
@@ -128,29 +130,29 @@ items:
   answer_key: Eleanor Whitford, Managing Partner, Marbledock & Associates
   type: lookup
 - id: synth-policy-effective-0191_policy_doc
-  question: When does the "Information Security and Human Resources Acceptable Use
-    Policy" policy take effect?
+  question: When does version 3.1 of the "Information Security and Human Resources
+    Acceptable Use Policy" policy take effect?
   clause_category: policy_doc
   gold_doc: 0191_policy_doc
   answer_key: '2025-12-23'
   type: lookup
 - id: synth-policy-version-0191_policy_doc
-  question: What is the version number of the "Information Security and Human Resources
-    Acceptable Use Policy" policy?
+  question: What version of the "Information Security and Human Resources Acceptable
+    Use Policy" policy takes effect on 2025-12-23?
   clause_category: policy_doc
   gold_doc: 0191_policy_doc
   answer_key: '3.1'
   type: lookup
 - id: synth-policy-effective-0192_policy_doc
-  question: When does the "Information Security and Human Resources Acceptable Use
-    Policy" policy take effect?
+  question: When does version 2.4.1 of the "Information Security and Human Resources
+    Acceptable Use Policy" policy take effect?
   clause_category: policy_doc
   gold_doc: 0192_policy_doc
   answer_key: '2025-08-13'
   type: lookup
 - id: synth-policy-version-0192_policy_doc
-  question: What is the version number of the "Information Security and Human Resources
-    Acceptable Use Policy" policy?
+  question: What version of the "Information Security and Human Resources Acceptable
+    Use Policy" policy takes effect on 2025-08-13?
   clause_category: policy_doc
   gold_doc: 0192_policy_doc
   answer_key: 2.4.1
@@ -173,12 +175,6 @@ items:
   clause_category: employee_handbook
   gold_doc: 0241_employee_handbook
   answer_key: '4'
-  type: lookup
-- id: synth-handbook-sections-0242_employee_handbook
-  question: How many top-level sections are in the 2025 Marbledock employee handbook?
-  clause_category: employee_handbook
-  gold_doc: 0242_employee_handbook
-  answer_key: '3'
   type: lookup
 - id: synth-find-invoices-over-5000
   question: Find all invoices with a total amount over $5,000 USD.

--- a/scripts/test_corpora/runner/answer_judge.py
+++ b/scripts/test_corpora/runner/answer_judge.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 import re
 
 import anthropic
+
+log = logging.getLogger("answer_judge")
 
 JUDGE_MODEL = "claude-sonnet-4-6"
 
@@ -142,8 +145,25 @@ class AnswerJudge:
         )
         data = _extract_json(msg.content[0].text)
         return AnswerVerdict(
-            correctness=int(data["correctness"]),
-            groundedness=int(data["groundedness"]),
-            completeness=int(data["completeness"]),
+            correctness=_score(data, "correctness"),
+            groundedness=_score(data, "groundedness"),
+            completeness=_score(data, "completeness"),
             rationale=str(data.get("rationale", "")),
         )
+
+
+def _score(data: dict, key: str) -> int:
+    """Pull a 0–5 score from the judge's parsed JSON, defaulting to 0 with a
+    warning if the key is missing. Sonnet occasionally omits a score key when
+    the prompt says \"SET TO 0; do not guess it\" (as the find-type prompt does
+    for completeness) — interpreting \"don't guess\" as \"don't include.\"
+    Failing the whole run on one omission is too harsh; default + warn keeps
+    the eval progressing and surfaces the issue in logs."""
+    if key not in data:
+        log.warning("judge response missing %r — defaulting to 0", key)
+        return 0
+    try:
+        return int(data[key])
+    except (TypeError, ValueError):
+        log.warning("judge response %r=%r not coercible to int — defaulting to 0", key, data[key])
+        return 0

--- a/scripts/test_corpora/tests/test_answer_judge.py
+++ b/scripts/test_corpora/tests/test_answer_judge.py
@@ -72,6 +72,44 @@ def test_extract_json_ignores_trailing_prose():
     assert _extract_json(txt)["correctness"] == 5
 
 
+def test_judge_defaults_missing_score_keys_to_zero():
+    """If the judge omits a score key (Sonnet sometimes drops 'completeness'
+    for find items when told 'SET TO 0; do not guess'), default to 0 rather
+    than crash with a KeyError mid-eval."""
+    c = MagicMock()
+    c.messages.create.return_value = MagicMock(
+        content=[MagicMock(text='{"correctness": 5, "groundedness": 4, "rationale": "no completeness key"}')]
+    )
+    v = AnswerJudge(client=c).judge_answer(
+        question="q",
+        model_answer="a",
+        cited="",
+        answer_key="k",
+        qtype="lookup",
+    )
+    assert v.correctness == 5
+    assert v.groundedness == 4
+    assert v.completeness == 0  # defaulted
+
+
+def test_judge_defaults_non_int_score_to_zero():
+    """If the judge returns a non-integer score (e.g., 'N/A'), default to 0."""
+    c = MagicMock()
+    c.messages.create.return_value = MagicMock(
+        content=[MagicMock(text='{"correctness": "N/A", "groundedness": 4, "completeness": 5, "rationale": "x"}')]
+    )
+    v = AnswerJudge(client=c).judge_answer(
+        question="q",
+        model_answer="a",
+        cited="",
+        answer_key="k",
+        qtype="lookup",
+    )
+    assert v.correctness == 0  # defaulted
+    assert v.groundedness == 4
+    assert v.completeness == 5
+
+
 def test_answer_verdict_source_defaults_to_empty_dict():
     """AnswerVerdict has an optional `source` field defaulting to {}."""
     v = AnswerVerdict(correctness=5, groundedness=5, completeness=5, rationale="ok")

--- a/scripts/test_corpora/tests/test_generate_synthetic.py
+++ b/scripts/test_corpora/tests/test_generate_synthetic.py
@@ -243,6 +243,12 @@ def test_generate_emits_items_across_all_doc_types(tmp_path: Path):
     assert inv_find["answer_key"]["all"] == ["0002_invoice"]
     assert inv_find["answer_key"]["count"] == 1
 
+    # Cross-doc find: Q4 2025 policies — only 0060_policy_doc (effective 2025-12-23) qualifies
+    q4_find = next(i for i in items if i["id"] == "synth-find-policies-q4-2025")
+    assert q4_find["type"] == "find"
+    assert q4_find["answer_key"]["all"] == ["0060_policy_doc"]
+    assert q4_find["answer_key"]["count"] == 1
+
     # Lookup-negative: a non-existent invoice number
     neg = next(i for i in items if i["id"] == "synth-neg-invoice-99999")
     assert neg["type"] == "negative"

--- a/scripts/test_corpora/tests/test_generate_synthetic.py
+++ b/scripts/test_corpora/tests/test_generate_synthetic.py
@@ -297,6 +297,47 @@ def test_generate_raises_when_negative_vendor_unexpectedly_matches(tmp_path: Pat
         generate(ingest_dir=ingest, out_path=out)
 
 
+def test_generate_silently_skips_items_with_duplicate_questions(tmp_path: Path, capsys):
+    """When two sidecars yield identical question text, the orchestrator keeps
+    the first and drops the rest — the model can't disambiguate by anything
+    other than question text, so a dup is an eval-validity bug; silent skip
+    + a stderr warning is the right default since some corpus quirks (e.g.,
+    all employee_handbook sidecars share `year: 2025`) make dup-emission
+    unavoidable without per-recipe hand-curation.
+
+    Reproducer: overwrite 0002_invoice to share 0001_invoice's invoice_number,
+    so the lookup-by-number recipe emits the same question text for both
+    sidecars. The 0001 item survives; the 0002 item is dropped."""
+    ingest = _make_full_fixture(tmp_path)
+    (ingest / "0002_invoice.json").write_text(
+        json.dumps(
+            {
+                "vendor": "Other Vendor",
+                "invoice_number": "ACM-001",  # collides with 0001_invoice's number
+                "date": "2025-02-20",
+                "total_usd": 100.0,
+                "line_items": [],
+            }
+        )
+    )
+    out = tmp_path / "synthetic.yaml"
+    generate(ingest_dir=ingest, out_path=out)
+    data = yaml.safe_load(out.read_text())
+
+    # Both invoice recipes key their question on invoice_number, so when 0002
+    # collides with 0001's number, BOTH 0002 items get dropped — only the
+    # 0001 lookups survive. (Filter by type to exclude the negative item,
+    # which also has clause_category="invoice".)
+    invoice_lookups = [i for i in data["items"] if i["clause_category"] == "invoice" and i["type"] == "lookup"]
+    assert len(invoice_lookups) == 2
+    assert all(i["gold_doc"] == "0001_invoice" for i in invoice_lookups)
+
+    # A stderr warning records how many items got skipped — at least 2 (the
+    # 0002 total + vendor recipes that both collided on invoice number).
+    err = capsys.readouterr().err
+    assert "skipped" in err and "duplicated" in err
+
+
 def test_generate_raises_when_negative_invoice_number_unexpectedly_matches(tmp_path: Path):
     """If a doc in the corpus actually uses invoice_number INV-99999, generate refuses."""
     ingest = _make_full_fixture(tmp_path)

--- a/scripts/test_corpora/tests/test_generate_synthetic.py
+++ b/scripts/test_corpora/tests/test_generate_synthetic.py
@@ -1,0 +1,310 @@
+# scripts/test_corpora/tests/test_generate_synthetic.py
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.test_corpora.groundtruth.generate_synthetic import (
+    _find_item,
+    _iter_sidecars,
+    _load_sidecar,
+    _lookup_item,
+    _to_title,
+    generate,
+)
+
+# ── fixture helpers ─────────────────────────────────────────────────────────
+
+
+def _write_doc(ingest: Path, stem: str, sidecar: dict, text: str = "rendered body") -> None:
+    """Write a synthetic doc pair: the .json sidecar + the .txt rendering."""
+    (ingest / f"{stem}.json").write_text(json.dumps(sidecar))
+    (ingest / f"{stem}.txt").write_text(text)
+
+
+def _make_full_fixture(tmp_path: Path) -> Path:
+    """Build a minimal fixture covering all 9 doc-types so generate() can run end-to-end."""
+    ingest = tmp_path / "ingest"
+    ingest.mkdir()
+    _write_doc(
+        ingest,
+        "0001_invoice",
+        {
+            "vendor": "Acme Supplies",
+            "invoice_number": "ACM-001",
+            "date": "2025-01-15",
+            "total_usd": 1234.56,
+            "line_items": [],
+        },
+    )
+    _write_doc(
+        ingest,
+        "0002_invoice",
+        {
+            "vendor": "Globex Supplies",
+            "invoice_number": "GLO-002",
+            "date": "2025-02-20",
+            "total_usd": 7890.12,
+            "line_items": [],
+        },
+    )
+    _write_doc(
+        ingest,
+        "0010_board_minutes",
+        {
+            "date": "2025-03-01",
+            "attendees": ["Alice", "Bob", "Carol"],
+            "decisions": ["Approved budget.", "Authorized hire."],
+            "lang": "en",
+        },
+    )
+    _write_doc(
+        ingest,
+        "0011_board_minutes",
+        {
+            "date": "2025-04-02",
+            "attendees": ["Alice", "Bob"],
+            "decisions": ["Tabled motion."],
+            "lang": "fr",  # French-tagged for FR coverage
+        },
+    )
+    _write_doc(
+        ingest,
+        "0020_onboarding_letter",
+        {
+            "employee_name": "n/a",
+            "role": "Senior Engineer",
+            "start_date": "2025-05-01",
+            "languages_used": ["English"],
+            "signing_manager": "Sophie Tran-Beaumont",
+        },
+    )
+    _write_doc(
+        ingest,
+        "0030_quarterly_report",
+        {
+            "quarter": "Q2",
+            "year": 2025,
+            "revenue_usd": 4275000,
+            "key_initiatives": {},
+        },
+    )
+    _write_doc(
+        ingest,
+        "0040_vendor_contract",
+        {
+            "vendor": "Pinnacle Tech Solutions, LLC",
+            "term_months": 24,
+            "monthly_fee_usd": 8500.0,
+            "governing_law": "State of South Carolina",
+            "signatures": {},
+        },
+    )
+    _write_doc(
+        ingest,
+        "0050_internal_memo",
+        {
+            "from": "Helena Voss, COO",
+            "to": "All Staff",
+            "subject": "Updated Remote Work Policy",
+            "lang": "en",
+        },
+    )
+    _write_doc(
+        ingest,
+        "0060_policy_doc",
+        {
+            "policy_name": "Information Security Policy",
+            "version": "3.1",
+            "effective_date": "2025-12-23",
+            "owner": "CHRO & CISO",
+        },
+    )
+    _write_doc(
+        ingest,
+        "0070_marketing_brief",
+        {
+            "campaign_name": "Marbledock Elevate 2025",
+            "target": "Mid-market firms",
+            "budget_usd": 120000,
+            "owner": "Senior Director of Marketing",
+        },
+    )
+    _write_doc(
+        ingest,
+        "0080_employee_handbook",
+        {
+            "year": 2025,
+            "sections": ["3.1 Professional Standards", "3.2 Conflict of Interest"],
+            "lang_split": {"primary": "English", "secondary": "French", "total_section_count": 4},
+        },
+    )
+    return ingest
+
+
+# ── helper tests ────────────────────────────────────────────────────────────
+
+
+def test_to_title_strips_known_extensions():
+    """_to_title strips .json / .txt / .pdf to match HC's doc_title format."""
+    assert _to_title("0019_invoice.json") == "0019_invoice"
+    assert _to_title("0019_invoice.txt") == "0019_invoice"
+    assert _to_title("0019_invoice.pdf") == "0019_invoice"
+    assert _to_title("0019_invoice") == "0019_invoice"  # already a stem
+
+
+def test_load_sidecar_reads_json(tmp_path: Path):
+    p = tmp_path / "0019_invoice.json"
+    p.write_text(json.dumps({"vendor": "Acme", "total_usd": 100}))
+    sc = _load_sidecar(p)
+    assert sc == {"vendor": "Acme", "total_usd": 100}
+
+
+def test_iter_sidecars_filters_by_doctype_and_sorts(tmp_path: Path):
+    """_iter_sidecars yields (stem, sidecar) for matching docs, sorted by stem."""
+    ingest = tmp_path / "ingest"
+    ingest.mkdir()
+    _write_doc(ingest, "0002_invoice", {"vendor": "B"})
+    _write_doc(ingest, "0001_invoice", {"vendor": "A"})
+    _write_doc(ingest, "0003_board_minutes", {"date": "2025-01-01"})
+    pairs = list(_iter_sidecars(ingest, "invoice"))
+    assert [stem for stem, _ in pairs] == ["0001_invoice", "0002_invoice"]
+    assert pairs[0][1]["vendor"] == "A"
+
+
+def test_lookup_item_builds_canonical_shape():
+    item = _lookup_item(
+        id_="synth-test-1",
+        question="q?",
+        gold_doc="0001_invoice",
+        answer_key="A",
+        clause_category="invoice",
+    )
+    assert item == {
+        "id": "synth-test-1",
+        "question": "q?",
+        "clause_category": "invoice",
+        "gold_doc": "0001_invoice",
+        "answer_key": "A",
+        "type": "lookup",
+    }
+
+
+def test_find_item_builds_count_all_sample_shape():
+    item = _find_item(
+        id_="synth-find-1",
+        question="Find docs",
+        all_matches=["b", "a", "c"],
+        clause_category="cross-doc",
+    )
+    assert item["type"] == "find"
+    assert item["answer_key"] == {"count": 3, "all": ["b", "a", "c"], "sample": ["b", "a", "c"]}
+    assert item["clause_category"] == "cross-doc"
+
+
+# ── end-to-end generator tests ──────────────────────────────────────────────
+
+
+def test_generate_emits_items_across_all_doc_types(tmp_path: Path):
+    """The orchestrator emits items for every doc-type plus cross-doc + negatives."""
+    ingest = _make_full_fixture(tmp_path)
+    out = tmp_path / "synthetic.yaml"
+    n = generate(ingest_dir=ingest, out_path=out)
+
+    data = yaml.safe_load(out.read_text())
+    assert data["corpus"] == "synthetic"
+    items = data["items"]
+    assert len(items) == n
+    assert n >= 14  # 9 doc-types × ≥1 each + cross-doc + negatives + FR
+
+    categories = {i["clause_category"] for i in items}
+    expected_doc_types = {
+        "invoice",
+        "board_minutes",
+        "onboarding_letter",
+        "quarterly_report",
+        "vendor_contract",
+        "internal_memo",
+        "policy_doc",
+        "marketing_brief",
+        "employee_handbook",
+    }
+    assert expected_doc_types.issubset(categories), f"missing doc-types: {expected_doc_types - categories}"
+
+    types = {i["type"] for i in items}
+    assert "lookup" in types
+    assert "find" in types  # cross-doc finds + find-negative
+    assert "negative" in types  # lookup-negative
+
+    # Cross-doc find: invoices over $5000 — only 0002 (7890.12) qualifies
+    inv_find = next(i for i in items if i["id"] == "synth-find-invoices-over-5000")
+    assert inv_find["type"] == "find"
+    assert inv_find["answer_key"]["all"] == ["0002_invoice"]
+    assert inv_find["answer_key"]["count"] == 1
+
+    # Lookup-negative: a non-existent invoice number
+    neg = next(i for i in items if i["id"] == "synth-neg-invoice-99999")
+    assert neg["type"] == "negative"
+    assert neg["answer_key"] is None
+
+    # find-negative: a non-existent vendor
+    fneg = next(i for i in items if i["id"] == "synth-find-neg-vendor-globex-aerospace")
+    assert fneg["type"] == "find"
+    assert fneg["answer_key"] == {"count": 0, "all": [], "sample": []}
+
+
+def test_generate_emits_french_items_when_fr_sidecars_present(tmp_path: Path):
+    """When the corpus has FR-tagged sidecars (lang: fr), the generator emits FR items."""
+    ingest = _make_full_fixture(tmp_path)  # 0011_board_minutes has lang: fr
+    out = tmp_path / "synthetic.yaml"
+    generate(ingest_dir=ingest, out_path=out)
+    data = yaml.safe_load(out.read_text())
+    fr_items = [i for i in data["items"] if i["id"].startswith("synth-fr-")]
+    assert len(fr_items) >= 1, "no FR items emitted despite FR-tagged sidecars in fixture"
+    fr = fr_items[0]
+    # The question text should contain at least one French-distinctive character/word.
+    # Use a permissive heuristic: any of "é", "è", "ê", "à", "ç", or the French article "le"/"la".
+    assert any(tok in fr["question"] for tok in ("é", "è", "ê", "à", "ç", " le ", " la ", " du ")), (
+        f"FR item question doesn't look French: {fr['question']!r}"
+    )
+
+
+def test_generate_raises_when_negative_vendor_unexpectedly_matches(tmp_path: Path):
+    """If a docs in the corpus actually has the negative vendor name, generate refuses."""
+    ingest = _make_full_fixture(tmp_path)
+    # Plant a doc that contains "Globex Aerospace" — the negative target.
+    _write_doc(
+        ingest,
+        "0099_vendor_contract",
+        {
+            "vendor": "Globex Aerospace",
+            "term_months": 6,
+            "monthly_fee_usd": 1000.0,
+            "governing_law": "n/a",
+            "signatures": {},
+        },
+        text="contract with Globex Aerospace for services",
+    )
+    out = tmp_path / "synthetic.yaml"
+    with pytest.raises(RuntimeError, match="negative vendor 'Globex Aerospace' unexpectedly matches"):
+        generate(ingest_dir=ingest, out_path=out)
+
+
+def test_generate_raises_when_negative_invoice_number_unexpectedly_matches(tmp_path: Path):
+    """If a doc in the corpus actually uses invoice_number INV-99999, generate refuses."""
+    ingest = _make_full_fixture(tmp_path)
+    _write_doc(
+        ingest,
+        "0098_invoice",
+        {
+            "vendor": "x",
+            "invoice_number": "INV-99999",
+            "date": "2025-01-01",
+            "total_usd": 1,
+            "line_items": [],
+        },
+    )
+    out = tmp_path / "synthetic.yaml"
+    with pytest.raises(RuntimeError, match="negative invoice_number 'INV-99999' unexpectedly matches"):
+        generate(ingest_dir=ingest, out_path=out)


### PR DESCRIPTION
## Summary

**Phase 2b / PR-B** of the answer-eval work — extends `--mode answer-eval` (PR-A) to the **Synthetic** (Marbledock & Associates) corpus by adding a sidecar-driven ground-truth generator that produces a 30-item set across all 9 doc-types. Zero changes to the judge, runner, sweep, or `GTItem` schema — additive only.

The synthetic corpus's per-doc JSON sidecars (authored by `corpora/synthetic.py` at generation time) carry canonical, structured facts (vendor, totals, dates, signatories, policy versions, etc.). Reading the sidecar is the cleanest possible truth source — no grep, no LLM judgement, no inference.

Design + plan: `docs/superpowers/specs/2026-05-23-answer-eval-synthetic-design.md` and `docs/superpowers/plans/2026-05-23-answer-eval-synthetic.md` (both in this branch).

## What's in it

- **`groundtruth/generate_synthetic.py`** — dispatches by doc-type to one of 9 recipe functions; 2 cross-doc `find` recipes; 2 negative items (validated against the corpus); FR-language scanner (with documented fallback when the corpus has no `lang: "fr"` sidecars).
- **`groundtruth/synthetic.yaml`** — frozen 30-item set: 26 lookups across all 9 doc-types + 2 cross-doc finds + 1 lookup-negative + 1 find-negative. IDs are stem-based (collision-free by construction); currency formatting is standardized on `$X,XXX.XX`.
- **Hardening fix** (1 commit): `judge_answer` now defaults missing or non-int score keys to 0 with a logged warning. Surfaced during the run: Sonnet occasionally omits `completeness` from its JSON response when the find-type prompt says "SET TO 0; do not guess it" — interpreting "do not guess" as "do not include." The previous `int(data['completeness'])` crashed with `KeyError` mid-eval, losing the last item's work. Defensive default + warn keeps the eval progressing.

## Test plan

- [x] `uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/` — all this-branch tests passing (12 in `test_answer_judge.py`, 10 in `test_generate_synthetic.py`). One pre-existing unrelated failure (`test_metrics.py::test_entity_overlap_english`, missing spaCy model in the harness venv) ignored.
- [x] Root-level `ruff check` + `ruff format --check` clean on every changed file.
- [x] Built TDD with per-task spec + code-quality reviews and a final unconstrained review (in progress for this push).
- [x] **Live end-to-end run** — 30/30 items completed against the live HC + Synthetic-scoped key.

## First-run results (live)

| | n | correctness | groundedness | completeness |
|---|--:|--:|--:|--:|
| **Overall** | 30 | 3.33 / 5 | 3.57 / 5 | 2.73 / 5 |
| Lookup     | 26 | 3.15 | 3.58 | 2.69 |
| Find       |  3 | 4.33 | 3.67 | 2.67 |
| Negative   |  1 | 5.00 | 3.00 | 4.00 |

**Distribution** (correctness): 19 at 4–5 (working), 1 at 3, 4 at 1–2, 6 at 0.

The pattern in the 6 zero-correctness items is *informative, not a bug*: **the question's identifier wasn't unique enough in the corpus**, so HC's retrieval surfaced a different doc than the recipe ran on. This is the same "boundary doc retrieval" finding from PR-A's Enron run, now confirmed in a third context:

- `policy_version-0191` (gold v3.1) → model returned "2.4.1, 2.3, and..." from a *different* policy doc.
- `mkt-budget-0221/0222` (gold $120,000) → model returned "$250,000" or "not disclosed" from neighbouring marketing briefs.
- `handbook-sections-0241/0242` (gold = `len(sections)`) → model counted sections from the *rendered* text, not the structured count in the sidecar — different semantics of "top-level sections."
- `onboarding-start-0061` (gold 2025-04-19 for "Senior Project Coordinator") → ambiguous role name across multiple onboarding letters.

The items that worked well are exactly the ones with **highly distinctive identifiers**: invoices (numbers like `SBA-20251104-087342`) all scored 4–5. Vendor contracts (vendor names) mostly worked. The pattern is consistent: HC retrieval is unambiguous when the question's identifier is unambiguous; it struggles when "the policy on X" or "the {role} onboarding letter" could plausibly match multiple docs.

## Known limitations / follow-ups

- **0 FR question-text items.** The corpus has no `lang: "fr"` sidecars (only `"en"`) — documented fallback. Some French content still leaks into answer_keys via bilingual onboarding letters (Quebec HR managers). Future improvement: extend `corpora/synthetic.py` to add `lang: "fr"` to French-content sidecars.
- **Aggregation questions** ("Which vendor appears on the most invoices?", "What's the total Q2 revenue across all quarterly reports?") — exploit synthetic's fully-known nature but need a different judge shape. Re-evaluated in phase 3 per the spec.
- The **6-of-30 zero-correctness pattern** (question identifier ambiguity → retrieval picks wrong doc) is the same product signal Enron surfaced. Tracked in `pr_followups.md`.
- The **judge-omits-completeness behavior** suggests `_PROMPT_FIND`'s "SET TO 0; do not guess it" wording is confusing. Worth rephrasing in the future; the defensive default catches it for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
