### PR TITLE
feat(eval): answer-eval phase 2c — multi-model via Provider protocol

### DIFF
--- a/docs/superpowers/plans/2026-05-23-answer-eval-multi-model.md
+++ b/docs/superpowers/plans/2026-05-23-answer-eval-multi-model.md
@@ -1,0 +1,1720 @@
+# PR-C Answer-Eval Multi-Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a second baseline model (`gpt-4o`) to `--mode answer-eval` via a pluggable Provider protocol, without breaking any existing Sonnet wiring.
+
+**Architecture:** New `scripts/test_corpora/runner/providers/` package holds (1) `base.py` with the `Provider` typing.Protocol + `BaselineResult` dataclass + `DEFAULT_SYSTEM_PROMPT`, (2) `anthropic_provider.py` with `AnthropicProvider`, (3) `openai_provider.py` with `OpenAIProvider`, (4) `factory.py` with `make_provider(model, *, mcp_session)`. The old `claude_baseline.py` becomes a 5-line re-export shim so `sweep.py`'s import sites stay untouched.
+
+**Tech Stack:** Python 3.12, `anthropic>=0.43` (already installed), `openai>=1.50` (added in Task 9), `pytest`, MCP tool sessions via `SyncMcpSession`.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md`
+
+---
+
+## File Structure
+
+**New files (this PR):**
+- `scripts/test_corpora/runner/providers/__init__.py` — re-exports
+- `scripts/test_corpora/runner/providers/base.py` — Protocol + BaselineResult + DEFAULT_SYSTEM_PROMPT
+- `scripts/test_corpora/runner/providers/anthropic_provider.py` — AnthropicProvider
+- `scripts/test_corpora/runner/providers/openai_provider.py` — OpenAIProvider
+- `scripts/test_corpora/runner/providers/factory.py` — make_provider
+- `scripts/test_corpora/tests/test_providers_base.py` — Protocol + BaselineResult smoke tests
+- `scripts/test_corpora/tests/test_providers_factory.py` — factory dispatch tests
+- `scripts/test_corpora/tests/test_openai_provider.py` — OpenAI provider tests
+
+**Modified files (this PR):**
+- `scripts/test_corpora/runner/claude_baseline.py` — collapses to a 5-line shim
+- `scripts/test_corpora/runner/answer_eval.py` — `_live_capture_fn` uses `make_provider`
+- `scripts/test_corpora/runner/sweep.py` — generalizes `_with_anthropic_retry` to handle both providers
+- `scripts/test_corpora/tests/test_sweep_overload_retry.py` — extends to cover OpenAI exceptions
+- `scripts/test_corpora/pyproject.toml` — adds `openai>=1.50` dependency
+
+**Untouched:** `runner/answer_judge.py`, ground-truth YAMLs, all other tests.
+
+---
+
+## Task 1: Provider Protocol + BaselineResult + DEFAULT_SYSTEM_PROMPT in `providers/base.py`
+
+**Files:**
+- Create: `scripts/test_corpora/runner/providers/__init__.py` (empty for now; populated in Task 6)
+- Create: `scripts/test_corpora/runner/providers/base.py`
+- Create: `scripts/test_corpora/tests/test_providers_base.py`
+
+- [ ] **Step 1: Write the failing test for the Protocol + dataclass shape**
+
+Create `scripts/test_corpora/tests/test_providers_base.py`:
+
+```python
+# scripts/test_corpora/tests/test_providers_base.py
+"""Smoke tests for the Provider Protocol + BaselineResult dataclass."""
+import dataclasses
+
+from scripts.test_corpora.runner.providers.base import (
+    BaselineResult,
+    DEFAULT_SYSTEM_PROMPT,
+    Provider,
+)
+
+
+def test_baseline_result_is_a_dataclass_with_expected_fields():
+    """BaselineResult is the universal return shape from every Provider."""
+    assert dataclasses.is_dataclass(BaselineResult)
+    fields = {f.name for f in dataclasses.fields(BaselineResult)}
+    assert fields == {
+        "question_id",
+        "question",
+        "answer",
+        "cited_doc_ids",
+        "cited_doc_titles",
+        "tool_call_count",
+        "tool_transcript",
+        "elapsed_seconds",
+        "model",
+        "timestamp",
+    }
+
+
+def test_default_system_prompt_mentions_corpus_and_mcp_tools():
+    """DEFAULT_SYSTEM_PROMPT scopes the model to MCP-only retrieval."""
+    assert "MCP" in DEFAULT_SYSTEM_PROMPT or "mcp" in DEFAULT_SYSTEM_PROMPT
+    assert "corpus" in DEFAULT_SYSTEM_PROMPT.lower()
+
+
+def test_provider_is_a_protocol_with_run_question():
+    """Provider is a Protocol; any class with run_question matching the
+    signature satisfies it (duck-typed at runtime via @runtime_checkable)."""
+
+    class _FakeProvider:
+        def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+            return BaselineResult(
+                question_id=question_id,
+                question=question,
+                answer="",
+                cited_doc_ids=[],
+                cited_doc_titles=[],
+                tool_call_count=0,
+                tool_transcript=[],
+                elapsed_seconds=0.0,
+                model="fake",
+                timestamp="2026-05-23T00:00:00Z",
+            )
+
+    # @runtime_checkable Protocol allows isinstance() against duck-typed classes
+    assert isinstance(_FakeProvider(), Provider)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_base.py -v
+```
+
+Expected: ImportError — `scripts.test_corpora.runner.providers.base` does not exist yet.
+
+- [ ] **Step 3: Create the providers/ package**
+
+```bash
+mkdir -p /Users/alex/mcp-gateway/scripts/test_corpora/runner/providers
+```
+
+Create `scripts/test_corpora/runner/providers/__init__.py`:
+
+```python
+# scripts/test_corpora/runner/providers/__init__.py
+"""Multi-provider abstraction for the answer-eval baseline.
+
+See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md for
+the design rationale (Provider protocol + factory dispatch by model-name
+prefix). Public exports are populated in Task 6.
+"""
+```
+
+- [ ] **Step 4: Implement `providers/base.py`**
+
+Create `scripts/test_corpora/runner/providers/base.py`:
+
+```python
+# scripts/test_corpora/runner/providers/base.py
+"""Provider Protocol + universal BaselineResult dataclass.
+
+Every concrete provider (AnthropicProvider, OpenAIProvider, ...) exposes the
+same `run_question(question, question_id, corpus) -> BaselineResult` method.
+BaselineResult is the canonical serialization shape under
+`workdir/answer-eval/captures/<corpus>/<model>/<question_id>.json` — same
+fields across providers so the judging loop in answer_eval.py is provider-blind.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol, runtime_checkable
+
+
+DEFAULT_SYSTEM_PROMPT = """You are answering a user's question about a specific document corpus.
+You have access to the corpus only through the provided MCP tools (kb_search,
+kb_read_passages, kb_get_document, kb_find_related, etc.). Use them as
+needed. Cite specific documents in your answer by doc_id.
+
+Be thorough — your answer is the gold-standard reference for evaluating
+local models. Spend tool calls liberally."""
+
+
+@dataclasses.dataclass
+class BaselineResult:
+    """Universal return shape from every Provider's `run_question`.
+
+    Fields mirror the pre-refactor `claude_baseline.BaselineResult` so the
+    file-on-disk format and downstream consumers (judge, metrics roll-up)
+    don't need to change.
+    """
+
+    question_id: str
+    question: str
+    answer: str
+    cited_doc_ids: list[str]
+    # Stable, ingest-independent identifiers for the cited docs, parallel to
+    # cited_doc_ids (same order). doc_id is a random per-ingest UUID, so a
+    # baseline's cited_doc_ids never intersect a phase-4 response's doc_ids
+    # unless both ran against the exact same ingest. doc_title (the filename
+    # stem) is stable across re-ingests, so citation_overlap computed on
+    # titles stays correct even when baseline and response come from
+    # different ingests. Empty string for any cited doc whose tool result
+    # carried no title.
+    cited_doc_titles: list[str]
+    tool_call_count: int
+    # Per-call record [{tool, args, result_summary}] in call order — for
+    # groundedness scoring and tool-use auditing.
+    tool_transcript: list[dict]
+    elapsed_seconds: float
+    model: str
+    timestamp: str
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """The narrow protocol every baseline provider satisfies.
+
+    Implementations: AnthropicProvider, OpenAIProvider. Use
+    `providers.factory.make_provider(model, *, mcp_session)` to construct
+    one by model name.
+    """
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+        ...
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_base.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/providers/__init__.py scripts/test_corpora/runner/providers/base.py scripts/test_corpora/tests/test_providers_base.py && git commit -m "feat(eval): Provider Protocol + BaselineResult in providers/base.py" -m "First task in PR-C's multi-model arc — adds the universal return shape and the Protocol every provider satisfies. Empty providers/__init__.py for now (populated in Task 6 after all concrete providers + factory exist)." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: AnthropicProvider in `providers/anthropic_provider.py`
+
+**Files:**
+- Create: `scripts/test_corpora/runner/providers/anthropic_provider.py`
+- Read: `scripts/test_corpora/runner/claude_baseline.py:1-195` (source for the loop body)
+
+- [ ] **Step 1: Write the failing test that imports AnthropicProvider from the new path**
+
+Append to `scripts/test_corpora/tests/test_providers_base.py`:
+
+```python
+def test_anthropic_provider_class_is_importable_from_new_path():
+    """AnthropicProvider lives at providers.anthropic_provider — this is the
+    canonical path; claude_baseline.py becomes a shim in Task 3."""
+    from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+
+    assert AnthropicProvider.__name__ == "AnthropicProvider"
+    # AnthropicProvider satisfies the Provider Protocol (structural check)
+    from scripts.test_corpora.runner.providers.base import Provider
+
+    # AnthropicProvider needs a real client+mcp_session to instantiate, so we
+    # use a structural check via hasattr rather than isinstance against an
+    # instance. Provider is @runtime_checkable, but structural duck-typing
+    # against the class itself reads more clearly.
+    assert hasattr(AnthropicProvider, "run_question")
+    assert callable(AnthropicProvider.run_question)
+    _ = Provider  # silence unused-import warning
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_base.py::test_anthropic_provider_class_is_importable_from_new_path -v
+```
+
+Expected: ModuleNotFoundError on `providers.anthropic_provider`.
+
+- [ ] **Step 3: Implement `providers/anthropic_provider.py`**
+
+Create `scripts/test_corpora/runner/providers/anthropic_provider.py`:
+
+```python
+# scripts/test_corpora/runner/providers/anthropic_provider.py
+"""AnthropicProvider — Sonnet (or any claude-* model) + Harbor Clerk MCP.
+
+Body is the pre-refactor BaselineGenerator.run_question loop, lifted out of
+claude_baseline.py verbatim. claude_baseline.py becomes a thin re-export
+shim in Task 3 so sweep.py's existing import sites stay untouched.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import anthropic
+
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
+)
+
+
+class AnthropicProvider:
+    """Runs a Sonnet (or other claude-*) model + Harbor Clerk MCP for one question.
+
+    Constructor accepts `client=None` for back-compat with the pre-refactor
+    `BaselineGenerator(client=..., mcp_session=...)` call signature in
+    sweep.py — when not provided, the factory's convenience role lazily
+    constructs `anthropic.Anthropic()` (which reads ANTHROPIC_API_KEY from
+    env). Tests pass a mock client explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_session: Any,
+        model: str = "claude-sonnet-4-6",
+        client: anthropic.Anthropic | None = None,
+        doc_ids_seen: list[str] | None = None,
+    ):
+        self._client = client if client is not None else anthropic.Anthropic()
+        self._mcp = mcp_session
+        self._model = model
+        # Ordered map doc_id -> doc_title, in first-seen order. dict preserves
+        # insertion order (3.7+), so cited_doc_ids and cited_doc_titles stay
+        # parallel. For tests: pre-seed via doc_ids_seen (titles default to "").
+        self._cited: dict[str, str] = {did: "" for did in doc_ids_seen} if doc_ids_seen else {}
+
+    def _list_tools(self) -> list[dict]:
+        """Discover MCP tools and convert to Anthropic's tool schema."""
+        if self._mcp is None:
+            return []
+        # mcp.types.Tool has .name, .description, .inputSchema
+        tools = self._mcp.list_tools()  # sync wrapper expected
+        return [{"name": t.name, "description": t.description or "", "input_schema": t.inputSchema} for t in tools]
+
+    def _exec_tool(self, name: str, args: dict) -> str:
+        """Execute one MCP tool call, capture any doc_ids in the result."""
+        result = self._mcp.call_tool(name, args)
+        # Collect text content; capture doc_ids if present in the JSON
+        text_chunks: list[str] = []
+        for block in result.content:
+            if hasattr(block, "text"):
+                text_chunks.append(block.text)
+                # Greedy extraction: if the tool returned JSON containing
+                # doc_id fields, harvest them. Robust to nested structures.
+                try:
+                    parsed = json.loads(block.text)
+                    self._collect_doc_ids(parsed)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return "\n".join(text_chunks) or "(empty)"
+
+    def _collect_doc_ids(self, obj: Any) -> None:
+        if isinstance(obj, dict):
+            doc_id = obj.get("doc_id")
+            if isinstance(doc_id, str):
+                # Pair the doc_id with its title from the SAME dict. MCP tool
+                # results (kb_search etc.) emit doc_id + doc_title together;
+                # fall back to "title" then "". First-seen title wins — if a
+                # later result re-mentions the doc with a title where the
+                # first had none, upgrade the stored value.
+                title = obj.get("doc_title") or obj.get("title") or ""
+                if doc_id not in self._cited or (title and not self._cited[doc_id]):
+                    self._cited[doc_id] = title
+            for v in obj.values():
+                self._collect_doc_ids(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                self._collect_doc_ids(v)
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+        started = time.time()
+        tools = self._list_tools()
+        messages: list[dict] = [{"role": "user", "content": question}]
+        tool_call_count = 0
+        tool_transcript: list[dict] = []
+        resp = None
+
+        while True:
+            resp = self._client.messages.create(
+                model=self._model,
+                max_tokens=8000,
+                system=DEFAULT_SYSTEM_PROMPT,
+                tools=tools,
+                messages=messages,
+            )
+            messages.append({"role": "assistant", "content": resp.content})
+
+            if resp.stop_reason == "end_turn":
+                break
+            if resp.stop_reason != "tool_use":
+                break  # safety
+
+            # Execute each tool_use block, send results back as user message
+            tool_results: list[dict] = []
+            for block in resp.content:
+                if getattr(block, "type", None) == "tool_use":
+                    tool_call_count += 1
+                    out = self._exec_tool(block.name, block.input)
+                    tool_transcript.append(
+                        {
+                            "tool": block.name,
+                            "args": dict(block.input),
+                            "result_summary": out[:600],
+                        }
+                    )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": out,
+                        }
+                    )
+            messages.append({"role": "user", "content": tool_results})
+
+        # Final answer is the last text block in the assistant turn — scan from
+        # the end so a leading non-text block (e.g. tool_use) is skipped.
+        final = ""
+        if resp and resp.content:
+            for block in reversed(resp.content):
+                if hasattr(block, "text"):
+                    final = block.text
+                    break
+
+        return BaselineResult(
+            question_id=question_id,
+            question=question,
+            answer=final,
+            cited_doc_ids=list(self._cited.keys()),
+            cited_doc_titles=list(self._cited.values()),
+            tool_call_count=tool_call_count,
+            tool_transcript=tool_transcript,
+            elapsed_seconds=time.time() - started,
+            model=self._model,
+            timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        )
+
+    @staticmethod
+    def write(result: BaselineResult, results_dir: Path, corpus: str) -> Path:
+        """Write a BaselineResult JSON under results_dir/baselines/<corpus>/.
+
+        Kept as a @staticmethod (not a free function) for shim compatibility:
+        the sweep.py phase-1 baseline calls `BaselineGenerator.write(...)`,
+        which the shim re-exports as `AnthropicProvider.write`.
+        """
+        out = results_dir / "baselines" / corpus / f"{result.question_id}.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(dataclasses.asdict(result), indent=2))
+        return out
+```
+
+- [ ] **Step 4: Run the new test + verify existing baseline tests still pass via direct import (shim comes in Task 3)**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_base.py -v
+```
+
+Expected: 4 passed.
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_baseline.py -v
+```
+
+Expected: still passes — claude_baseline.py is unchanged in this task; the new file is additive.
+
+- [ ] **Step 5: Lint + format**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/runner/providers/anthropic_provider.py && uv run ruff format --check scripts/test_corpora/runner/providers/anthropic_provider.py
+```
+
+Expected: clean. If `format --check` fails, run `uv run ruff format scripts/test_corpora/runner/providers/anthropic_provider.py` and re-check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/providers/anthropic_provider.py scripts/test_corpora/tests/test_providers_base.py && git commit -m "feat(eval): AnthropicProvider — Sonnet + MCP, satisfies Provider Protocol" -m "Body lifted from claude_baseline.py verbatim (Task 3 collapses claude_baseline.py to a shim re-exporting AnthropicProvider as BaselineGenerator). Constructor takes mcp_session as keyword-only with client=None default — when client is None, anthropic.Anthropic() is constructed lazily (reads ANTHROPIC_API_KEY)." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Shim `claude_baseline.py` to re-export from new package
+
+**Files:**
+- Modify: `scripts/test_corpora/runner/claude_baseline.py` (collapse 195 lines → ~12-line shim)
+
+- [ ] **Step 1: Verify the existing baseline tests still pass before the change (regression baseline)**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_baseline.py -v
+```
+
+Expected: all baseline tests pass (they're hitting the pre-shim implementation).
+
+- [ ] **Step 2: Rewrite `claude_baseline.py` as a shim**
+
+Overwrite `scripts/test_corpora/runner/claude_baseline.py` with:
+
+```python
+# scripts/test_corpora/runner/claude_baseline.py
+"""Back-compat shim — the real code lives in providers/anthropic_provider.py.
+
+`BaselineGenerator` is exported as an alias for `AnthropicProvider` so that
+`sweep.py`'s 30+ import sites (and `tests/test_baseline.py`) continue to
+work unchanged. A follow-up PR can migrate `sweep.py` to use
+`make_provider()` directly; that's a larger blast radius — deferred.
+
+See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md
+for the design rationale.
+"""
+
+from __future__ import annotations
+
+from scripts.test_corpora.runner.providers.anthropic_provider import (
+    AnthropicProvider as BaselineGenerator,
+)
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT as SYSTEM_PROMPT,
+    BaselineResult,
+)
+
+__all__ = ["BaselineGenerator", "BaselineResult", "SYSTEM_PROMPT"]
+```
+
+- [ ] **Step 3: Run baseline tests + new providers tests to verify nothing broke**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_baseline.py scripts/test_corpora/tests/test_providers_base.py -v
+```
+
+Expected: all green. The existing tests now exercise `AnthropicProvider` via the shim's `BaselineGenerator` alias — no behavioral change.
+
+- [ ] **Step 4: Run the broader test suite to catch any indirect import breakage**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/ -q
+```
+
+Expected: same pass/fail count as before (1 pre-existing failure for `test_entity_overlap_english` is the spaCy-model-missing baseline; everything else green).
+
+- [ ] **Step 5: Lint + format**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/runner/claude_baseline.py && uv run ruff format --check scripts/test_corpora/runner/claude_baseline.py
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/claude_baseline.py && git commit -m "refactor(eval): collapse claude_baseline.py to a re-export shim" -m "All real code now lives in providers/anthropic_provider.py (Task 2). sweep.py's 30+ import sites (and tests/test_baseline.py) continue to work unchanged. A follow-up PR can migrate sweep.py to make_provider() directly; that's a larger blast radius — deferred." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `make_provider` factory in `providers/factory.py`
+
+**Files:**
+- Create: `scripts/test_corpora/runner/providers/factory.py`
+- Create: `scripts/test_corpora/tests/test_providers_factory.py`
+
+- [ ] **Step 1: Write the failing tests for prefix-based dispatch**
+
+Create `scripts/test_corpora/tests/test_providers_factory.py`:
+
+```python
+# scripts/test_corpora/tests/test_providers_factory.py
+"""make_provider() — string-prefix dispatch on model name."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+from scripts.test_corpora.runner.providers.factory import make_provider
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+
+def test_factory_dispatches_claude_to_anthropic():
+    """Any name starting with 'claude-' → AnthropicProvider."""
+    p = make_provider("claude-sonnet-4-6", mcp_session=MagicMock())
+    assert isinstance(p, AnthropicProvider)
+
+
+def test_factory_dispatches_claude_3_5_to_anthropic():
+    """Legacy claude- names still dispatch correctly."""
+    p = make_provider("claude-3-5-sonnet-20241022", mcp_session=MagicMock())
+    assert isinstance(p, AnthropicProvider)
+
+
+def test_factory_dispatches_gpt_to_openai():
+    """Any name starting with 'gpt-' → OpenAIProvider."""
+    p = make_provider("gpt-4o", mcp_session=MagicMock())
+    assert isinstance(p, OpenAIProvider)
+
+
+def test_factory_dispatches_o1_to_openai():
+    """Any name starting with 'o1-' → OpenAIProvider."""
+    p = make_provider("o1-preview", mcp_session=MagicMock())
+    assert isinstance(p, OpenAIProvider)
+
+
+def test_factory_dispatches_o3_to_openai():
+    """Any name starting with 'o3-' → OpenAIProvider."""
+    p = make_provider("o3-mini", mcp_session=MagicMock())
+    assert isinstance(p, OpenAIProvider)
+
+
+def test_factory_raises_value_error_on_unknown_model():
+    """An unknown prefix raises ValueError with the supported list in the message."""
+    with pytest.raises(ValueError, match=r"unknown model.*supported prefixes.*claude-.*gpt-"):
+        make_provider("llama-3.1-70b", mcp_session=MagicMock())
+
+
+def test_factory_forwards_doc_ids_seen_kwarg_to_anthropic():
+    """doc_ids_seen pre-seeds the provider's cited-doc map for test scenarios."""
+    p = make_provider("claude-sonnet-4-6", mcp_session=MagicMock(), doc_ids_seen=["doc-a", "doc-b"])
+    assert isinstance(p, AnthropicProvider)
+    # cited starts pre-seeded with the two doc ids (titles default to "")
+    assert list(p._cited.keys()) == ["doc-a", "doc-b"]
+
+
+def test_factory_forwards_doc_ids_seen_kwarg_to_openai():
+    """doc_ids_seen works the same way for the OpenAI provider."""
+    p = make_provider("gpt-4o", mcp_session=MagicMock(), doc_ids_seen=["doc-x"])
+    assert isinstance(p, OpenAIProvider)
+    assert list(p._cited.keys()) == ["doc-x"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_factory.py -v
+```
+
+Expected: ImportError on `providers.factory` AND on `providers.openai_provider` (OpenAI provider isn't created until Task 5; that import failure is expected here — fix in Task 5).
+
+- [ ] **Step 3: Implement `providers/factory.py`**
+
+Create `scripts/test_corpora/runner/providers/factory.py`:
+
+```python
+# scripts/test_corpora/runner/providers/factory.py
+"""make_provider — single dispatch point that maps model name → Provider.
+
+String matching by prefix:
+  claude-*           -> AnthropicProvider
+  gpt-* / o1-* / o3-* -> OpenAIProvider
+
+Unknown prefixes raise ValueError with the supported list. The factory
+lazily constructs the underlying client (anthropic.Anthropic() or
+openai.OpenAI()) inside the matched branch via the provider's own
+constructor — both read API keys from the standard env vars
+(ANTHROPIC_API_KEY, OPENAI_API_KEY).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+from scripts.test_corpora.runner.providers.base import Provider
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+
+_ANTHROPIC_PREFIXES = ("claude-",)
+_OPENAI_PREFIXES = ("gpt-", "o1-", "o3-")
+
+
+def make_provider(
+    model: str,
+    *,
+    mcp_session: Any,
+    doc_ids_seen: list[str] | None = None,
+) -> Provider:
+    """Construct a Provider for `model` wired to `mcp_session`.
+
+    `doc_ids_seen` pre-seeds the cited-doc map (used by tests + by callers
+    that want to anchor citations to a known starting set).
+    """
+    if model.startswith(_ANTHROPIC_PREFIXES):
+        return AnthropicProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
+    if model.startswith(_OPENAI_PREFIXES):
+        return OpenAIProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
+    supported = ", ".join(_ANTHROPIC_PREFIXES + _OPENAI_PREFIXES)
+    raise ValueError(f"unknown model {model!r}; supported prefixes: {supported}")
+```
+
+- [ ] **Step 4: Run factory tests — they will still fail on the OpenAIProvider import**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_factory.py -v
+```
+
+Expected: ModuleNotFoundError on `providers.openai_provider`. Defer green test until Task 5. (Skipping ahead to make factory work without OpenAI provider would entail dead code in factory.py — better to keep the import + let Task 5 close it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/providers/factory.py scripts/test_corpora/tests/test_providers_factory.py && git commit -m "feat(eval): make_provider factory + factory tests (OpenAI provider Task 5)" -m "Dispatch by model-name prefix: claude-* -> AnthropicProvider, gpt-*/o1-*/o3-* -> OpenAIProvider, unknown -> ValueError with supported list. Factory tests created here but fail until Task 5 lands OpenAIProvider; left intentionally red so the next commit goes green." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: OpenAIProvider in `providers/openai_provider.py`
+
+**Files:**
+- Modify: `scripts/test_corpora/pyproject.toml` (add `openai>=1.50`)
+- Create: `scripts/test_corpora/runner/providers/openai_provider.py`
+- Create: `scripts/test_corpora/tests/test_openai_provider.py`
+
+- [ ] **Step 1: Add openai dependency**
+
+Edit `scripts/test_corpora/pyproject.toml`. Find the `dependencies = [...]` block and add `"openai>=1.50",` alphabetically near `"anthropic>=0.43",`:
+
+```toml
+dependencies = [
+    "httpx>=0.28",
+    "anthropic>=0.43",
+    "openai>=1.50",
+    "mcp>=1.9",
+    "pyyaml>=6",
+    "tenacity>=9",
+    "pypdfium2>=4",
+    "Pillow>=12",
+    "spacy>=3.7",
+    "huggingface_hub>=0.25",
+    "pyarrow>=21",
+]
+```
+
+Then sync:
+
+```bash
+cd /Users/alex/mcp-gateway && uv sync --project scripts/test_corpora --extra test 2>&1 | tail -5
+```
+
+Expected: openai installed successfully.
+
+- [ ] **Step 2: Write the failing tests for the OpenAI provider's tool loop**
+
+Create `scripts/test_corpora/tests/test_openai_provider.py`:
+
+```python
+# scripts/test_corpora/tests/test_openai_provider.py
+"""OpenAIProvider — gpt-4o + Harbor Clerk MCP via OpenAI's chat/completions
+tool_calls loop. Mirrors AnthropicProvider's shape but speaks OpenAI's API.
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from scripts.test_corpora.runner.providers.base import BaselineResult
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+
+def _mk_resp(*, finish_reason: str, text: str = "", tool_calls=None):
+    """Build a minimal OpenAI-style ChatCompletion response object.
+
+    OpenAI SDK returns `resp.choices[0].finish_reason` and
+    `resp.choices[0].message.{content, tool_calls}`. tool_calls is a list of
+    objects with `.id`, `.type='function'`, `.function.name`, `.function.arguments`
+    (JSON string).
+    """
+    msg = SimpleNamespace(content=text, tool_calls=tool_calls)
+    choice = SimpleNamespace(finish_reason=finish_reason, message=msg)
+    return SimpleNamespace(choices=[choice])
+
+
+def _mk_tool_call(*, id: str, name: str, args: dict):
+    fn = SimpleNamespace(name=name, arguments=json.dumps(args))
+    return SimpleNamespace(id=id, type="function", function=fn)
+
+
+def test_openai_provider_parses_simple_end_turn_answer():
+    """A single response with finish_reason='stop' returns its content as the final answer."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _mk_resp(
+        finish_reason="stop", text="The answer is 42."
+    )
+    p = OpenAIProvider(mcp_session=None, model="gpt-4o", client=client)
+    res = p.run_question(question="What is the answer?", question_id="q1", corpus="cuad")
+    assert isinstance(res, BaselineResult)
+    assert res.answer == "The answer is 42."
+    assert res.tool_call_count == 0
+    assert res.cited_doc_ids == []
+    assert res.model == "gpt-4o"
+
+
+def test_openai_provider_tool_loop_captures_cited_docs():
+    """A tool_calls round followed by an end-turn round — cited_doc_ids
+    are harvested from the MCP result and the final answer is the second
+    response's content."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [
+        SimpleNamespace(name="kb_search", description="search", inputSchema={"type": "object"})
+    ]
+    # First MCP call returns one block with JSON containing a doc_id+doc_title pair
+    mcp.call_tool.return_value = SimpleNamespace(
+        content=[SimpleNamespace(text='{"doc_id": "doc-abc", "doc_title": "Acme Contract", "snippet": "..."}')]
+    )
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[_mk_tool_call(id="call-1", name="kb_search", args={"query": "acme"})],
+        ),
+        _mk_resp(finish_reason="stop", text="Per doc-abc, the answer is found."),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="Find acme.", question_id="q2", corpus="cuad")
+    assert res.tool_call_count == 1
+    assert res.cited_doc_ids == ["doc-abc"]
+    assert res.cited_doc_titles == ["Acme Contract"]
+    assert res.answer == "Per doc-abc, the answer is found."
+
+
+def test_openai_provider_transcript_records_each_call():
+    """tool_transcript has one entry per tool_call with tool, args, result_summary."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [
+        SimpleNamespace(name="kb_search", description="", inputSchema={"type": "object"})
+    ]
+    mcp.call_tool.return_value = SimpleNamespace(
+        content=[SimpleNamespace(text='{"doc_id": "x"}')]
+    )
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[_mk_tool_call(id="c1", name="kb_search", args={"query": "alpha"})],
+        ),
+        _mk_resp(finish_reason="stop", text="done"),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q3", corpus="cuad")
+    assert len(res.tool_transcript) == 1
+    entry = res.tool_transcript[0]
+    assert entry["tool"] == "kb_search"
+    assert entry["args"] == {"query": "alpha"}
+    assert entry["result_summary"].startswith('{"doc_id":')
+
+
+def test_openai_provider_treats_length_finish_as_end_turn():
+    """finish_reason='length' (response truncated) returns the partial answer
+    with a logged warning rather than crashing. PR-B's _score() in the judge
+    set this defensive precedent — Anthropic's API rarely hits this; OpenAI's
+    max_tokens semantics are subtly different and we may hit it."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _mk_resp(
+        finish_reason="length", text="The answer begins with the very long preamble"
+    )
+    p = OpenAIProvider(mcp_session=None, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q4", corpus="cuad")
+    assert res.answer.startswith("The answer begins")
+    assert res.tool_call_count == 0
+
+
+def test_openai_provider_falls_back_when_mcp_returns_empty_content():
+    """When a tool result has no text content, the loop sends '(empty)' so the
+    model doesn't choke on a literal empty string in the tool response."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [
+        SimpleNamespace(name="kb_search", description="", inputSchema={"type": "object"})
+    ]
+    mcp.call_tool.return_value = SimpleNamespace(content=[])  # empty
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[_mk_tool_call(id="c1", name="kb_search", args={"q": "x"})],
+        ),
+        _mk_resp(finish_reason="stop", text="nothing found"),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q5", corpus="cuad")
+    assert res.tool_transcript[0]["result_summary"] == "(empty)"
+    # Verify the tool result message sent back to the model contained "(empty)"
+    call_args_list = client.chat.completions.create.call_args_list
+    assert len(call_args_list) == 2
+    second_call_messages = call_args_list[1].kwargs["messages"]
+    tool_msg = next(m for m in second_call_messages if m.get("role") == "tool")
+    assert tool_msg["content"] == "(empty)"
+```
+
+- [ ] **Step 3: Run tests to verify they fail with ImportError**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_openai_provider.py -v
+```
+
+Expected: ImportError on `providers.openai_provider`.
+
+- [ ] **Step 4: Implement `providers/openai_provider.py`**
+
+Create `scripts/test_corpora/runner/providers/openai_provider.py`:
+
+```python
+# scripts/test_corpora/runner/providers/openai_provider.py
+"""OpenAIProvider — gpt-* (and o1-*/o3-*) + Harbor Clerk MCP.
+
+Structurally mirrors AnthropicProvider but speaks OpenAI's chat.completions
+tool_calls protocol:
+  1. Send user message + tools list.
+  2. Receive a response with `finish_reason`:
+     - "stop"        -> done, return final assistant text
+     - "tool_calls"  -> execute each tool, send results back, loop
+     - "length"      -> response truncated; treat as end-of-turn (logged warn)
+  3. Tool result messages have role="tool", tool_call_id=<call id>.
+
+Constructor accepts client=None for symmetry with AnthropicProvider; when
+None, openai.OpenAI() reads OPENAI_API_KEY from env.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import openai
+
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
+)
+
+log = logging.getLogger("openai_provider")
+
+
+class OpenAIProvider:
+    """Runs a gpt-* (or o1-*/o3-*) model + Harbor Clerk MCP for one question."""
+
+    def __init__(
+        self,
+        *,
+        mcp_session: Any,
+        model: str = "gpt-4o",
+        client: openai.OpenAI | None = None,
+        doc_ids_seen: list[str] | None = None,
+    ):
+        self._client = client if client is not None else openai.OpenAI()
+        self._mcp = mcp_session
+        self._model = model
+        self._cited: dict[str, str] = {did: "" for did in doc_ids_seen} if doc_ids_seen else {}
+
+    def _list_tools(self) -> list[dict]:
+        """Discover MCP tools and convert to OpenAI's `tools` schema.
+
+        OpenAI shape: [{"type": "function", "function": {"name", "description",
+        "parameters"}}]. The MCP tool's `inputSchema` slots directly into
+        `function.parameters` (both are JSON Schema).
+        """
+        if self._mcp is None:
+            return []
+        tools = self._mcp.list_tools()
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description or "",
+                    "parameters": t.inputSchema,
+                },
+            }
+            for t in tools
+        ]
+
+    def _exec_tool(self, name: str, args: dict) -> str:
+        """Execute one MCP tool call, capture any doc_ids in the result."""
+        result = self._mcp.call_tool(name, args)
+        text_chunks: list[str] = []
+        for block in result.content:
+            if hasattr(block, "text"):
+                text_chunks.append(block.text)
+                try:
+                    parsed = json.loads(block.text)
+                    self._collect_doc_ids(parsed)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return "\n".join(text_chunks) or "(empty)"
+
+    def _collect_doc_ids(self, obj: Any) -> None:
+        if isinstance(obj, dict):
+            doc_id = obj.get("doc_id")
+            if isinstance(doc_id, str):
+                title = obj.get("doc_title") or obj.get("title") or ""
+                if doc_id not in self._cited or (title and not self._cited[doc_id]):
+                    self._cited[doc_id] = title
+            for v in obj.values():
+                self._collect_doc_ids(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                self._collect_doc_ids(v)
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+        started = time.time()
+        tools = self._list_tools()
+        messages: list[dict] = [
+            {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ]
+        tool_call_count = 0
+        tool_transcript: list[dict] = []
+        final_text = ""
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": 8000,
+                "messages": messages,
+            }
+            if tools:
+                kwargs["tools"] = tools
+                kwargs["tool_choice"] = "auto"
+            resp = self._client.chat.completions.create(**kwargs)
+            choice = resp.choices[0]
+            msg = choice.message
+            finish = choice.finish_reason
+
+            # Persist the assistant message before loop-deciding so subsequent
+            # tool results pair with it correctly. OpenAI requires the
+            # assistant message that contained the tool_calls to be in the
+            # history before the tool-result messages.
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": msg.content or ""}
+            if msg.tool_calls:
+                assistant_msg["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                    }
+                    for tc in msg.tool_calls
+                ]
+            messages.append(assistant_msg)
+
+            if finish == "tool_calls" and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_call_count += 1
+                    try:
+                        args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+                    except json.JSONDecodeError:
+                        args = {}
+                    out = self._exec_tool(tc.function.name, args)
+                    tool_transcript.append(
+                        {
+                            "tool": tc.function.name,
+                            "args": args,
+                            "result_summary": out[:600],
+                        }
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": out,
+                        }
+                    )
+                continue  # loop to next assistant turn
+
+            # finish in {"stop", "length", "content_filter", "function_call", ...}
+            if finish == "length":
+                log.warning(
+                    "openai response truncated (finish_reason=length) — returning partial answer"
+                )
+            final_text = msg.content or ""
+            break
+
+        return BaselineResult(
+            question_id=question_id,
+            question=question,
+            answer=final_text,
+            cited_doc_ids=list(self._cited.keys()),
+            cited_doc_titles=list(self._cited.values()),
+            tool_call_count=tool_call_count,
+            tool_transcript=tool_transcript,
+            elapsed_seconds=time.time() - started,
+            model=self._model,
+            timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        )
+```
+
+- [ ] **Step 5: Run OpenAI provider tests + factory tests + base tests — all should now pass**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_openai_provider.py scripts/test_corpora/tests/test_providers_factory.py scripts/test_corpora/tests/test_providers_base.py -v
+```
+
+Expected: 5 openai + 8 factory + 4 base = 17 passed.
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/runner/providers/ scripts/test_corpora/tests/test_openai_provider.py scripts/test_corpora/tests/test_providers_factory.py && uv run ruff format --check scripts/test_corpora/runner/providers/ scripts/test_corpora/tests/test_openai_provider.py scripts/test_corpora/tests/test_providers_factory.py
+```
+
+Expected: clean. Fix and re-check if needed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/pyproject.toml scripts/test_corpora/uv.lock scripts/test_corpora/runner/providers/openai_provider.py scripts/test_corpora/tests/test_openai_provider.py && git commit -m "feat(eval): OpenAIProvider — gpt-4o + MCP, satisfies Provider Protocol" -m "Mirrors AnthropicProvider's shape: same BaselineResult, same MCP tool execution path, same cited-doc harvesting. Adapts to OpenAI's chat.completions tool_calls protocol (role=tool messages with tool_call_id, parameters schema instead of input_schema). finish_reason='length' treated as soft end-of-turn with a logged warning (defensive precedent set by PR-B's _score() helper)." -m "openai>=1.50 added to scripts/test_corpora/pyproject.toml." -m "Closes the factory tests that were left red in Task 4." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Populate `providers/__init__.py` with the public API
+
+**Files:**
+- Modify: `scripts/test_corpora/runner/providers/__init__.py`
+
+- [ ] **Step 1: Write the smoke test for the package's public exports**
+
+Append to `scripts/test_corpora/tests/test_providers_base.py`:
+
+```python
+def test_providers_package_exports_canonical_api():
+    """The providers package re-exports the canonical API for callers."""
+    from scripts.test_corpora.runner import providers
+
+    assert providers.BaselineResult.__name__ == "BaselineResult"
+    assert providers.DEFAULT_SYSTEM_PROMPT  # non-empty string
+    assert callable(providers.make_provider)
+    assert providers.Provider.__name__ == "Provider"
+    assert providers.AnthropicProvider.__name__ == "AnthropicProvider"
+    assert providers.OpenAIProvider.__name__ == "OpenAIProvider"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_base.py::test_providers_package_exports_canonical_api -v
+```
+
+Expected: AttributeError on `providers.BaselineResult` (the __init__.py is empty).
+
+- [ ] **Step 3: Populate `providers/__init__.py`**
+
+Overwrite `scripts/test_corpora/runner/providers/__init__.py`:
+
+```python
+# scripts/test_corpora/runner/providers/__init__.py
+"""Multi-provider abstraction for the answer-eval baseline.
+
+Public API:
+  Provider              — typing.Protocol every provider satisfies
+  BaselineResult        — universal dataclass returned by every provider
+  DEFAULT_SYSTEM_PROMPT — shared system prompt across providers
+  AnthropicProvider     — Sonnet (or any claude-* model) + MCP
+  OpenAIProvider        — gpt-4o (or any gpt-*/o1-*/o3-* model) + MCP
+  make_provider         — factory: dispatch by model-name prefix
+
+See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md.
+"""
+
+from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
+    Provider,
+)
+from scripts.test_corpora.runner.providers.factory import make_provider
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+__all__ = [
+    "AnthropicProvider",
+    "BaselineResult",
+    "DEFAULT_SYSTEM_PROMPT",
+    "OpenAIProvider",
+    "Provider",
+    "make_provider",
+]
+```
+
+- [ ] **Step 4: Run smoke test + all package tests**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_providers_base.py scripts/test_corpora/tests/test_providers_factory.py scripts/test_corpora/tests/test_openai_provider.py -v
+```
+
+Expected: all 18 passed (4 base + 1 new export test + 8 factory + 5 openai).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/providers/__init__.py scripts/test_corpora/tests/test_providers_base.py && git commit -m "feat(eval): populate providers/__init__.py with canonical public API" -m "Re-exports Provider, BaselineResult, DEFAULT_SYSTEM_PROMPT, AnthropicProvider, OpenAIProvider, and make_provider so callers can do 'from scripts.test_corpora.runner.providers import make_provider'." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Wire factory into `answer_eval._live_capture_fn`
+
+**Files:**
+- Modify: `scripts/test_corpora/runner/answer_eval.py:231-269` (the `_live_capture_fn` function)
+
+- [ ] **Step 1: Read the current implementation**
+
+```bash
+cd /Users/alex/mcp-gateway && cat -n scripts/test_corpora/runner/answer_eval.py | sed -n '231,269p'
+```
+
+Expected: shows the current `_live_capture_fn` that imports `BaselineGenerator` directly and constructs `anthropic.Anthropic()`.
+
+- [ ] **Step 2: Rewrite `_live_capture_fn` to use `make_provider`**
+
+Edit `scripts/test_corpora/runner/answer_eval.py` — find the function `_live_capture_fn` and replace its body:
+
+```python
+def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) -> Callable[[GTItem], dict]:
+    """Build the production capture function: a model+MCP run per item.
+
+    Uses make_provider() to dispatch on model name (claude-* -> AnthropicProvider,
+    gpt-* / o1-* / o3-* -> OpenAIProvider). The MCP session MUST be
+    authenticated with a corpus-scoped API key so HC's search is restricted to
+    `corpus`: set HC_API_KEY to that scoped key. Falls back to a
+    HC_USERNAME/HC_PASSWORD login, which yields an UNSCOPED (full-index)
+    session — correct only when `corpus` is the lone corpus loaded.
+
+    The provider's underlying API client (anthropic.Anthropic() or
+    openai.OpenAI()) is lazily constructed inside the provider; both read
+    their API keys from env (ANTHROPIC_API_KEY / OPENAI_API_KEY).
+    """
+    from scripts.test_corpora.runner.client import HarborClerkClient, SyncMcpSession
+    from scripts.test_corpora.runner.providers import make_provider
+
+    token = os.environ.get("HC_API_KEY")
+    if not token:
+        user, password = os.environ.get("HC_USERNAME"), os.environ.get("HC_PASSWORD")
+        if not (user and password):
+            raise RuntimeError(
+                "answer-eval needs HC_API_KEY (a corpus-scoped key) or HC_USERNAME + HC_PASSWORD in the environment"
+            )
+        hc = HarborClerkClient(api_base, verify=not insecure)
+        hc.login(user, password)
+        token = hc.get_bearer_token()
+        if not token:
+            raise RuntimeError("HC login did not yield a bearer token — check HC_USERNAME / HC_PASSWORD")
+        log.warning("HC_API_KEY unset — using an unscoped login; search is NOT corpus-restricted")
+
+    mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
+    mcp = SyncMcpSession(url=mcp_url, headers={"Authorization": f"Bearer {token}"})
+
+    def capture(item: GTItem) -> dict:
+        provider = make_provider(model, mcp_session=mcp)
+        res = provider.run_question(question=item.question, question_id=item.id, corpus=corpus)
+        return dataclasses.asdict(res)
+
+    return capture
+```
+
+- [ ] **Step 3: Verify the existing answer-eval tests still pass**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_answer_eval.py -v
+```
+
+Expected: all green. The tests inject `capture_fn` directly, so they bypass `_live_capture_fn` — this change doesn't affect them. The change is exercised by Task 10's live run.
+
+- [ ] **Step 4: Lint + format**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/runner/answer_eval.py && uv run ruff format --check scripts/test_corpora/runner/answer_eval.py
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/answer_eval.py && git commit -m "feat(eval): answer-eval _live_capture_fn uses make_provider() dispatch" -m "Replaces the direct BaselineGenerator(client=anthropic.Anthropic(), ...) wiring with make_provider(model, mcp_session=mcp). Now answer-eval supports any model name the factory recognizes (claude-* and gpt-*/o1-*/o3-*) — the underlying API client is constructed lazily inside the provider." -m "Existing unit tests inject capture_fn directly so they bypass this code path; live exercise comes from the gpt-4o run against synthetic." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Provider-aware retry in `sweep._with_anthropic_retry`
+
+**Files:**
+- Modify: `scripts/test_corpora/runner/sweep.py:99-145` (the `_with_anthropic_retry` function and constants)
+- Modify: `scripts/test_corpora/tests/test_sweep_overload_retry.py` (extend to cover OpenAI exceptions)
+
+- [ ] **Step 1: Inspect current retry helper + its existing tests**
+
+```bash
+cd /Users/alex/mcp-gateway && cat -n scripts/test_corpora/runner/sweep.py | sed -n '85,150p'
+```
+
+```bash
+cd /Users/alex/mcp-gateway && cat -n scripts/test_corpora/tests/test_sweep_overload_retry.py | head -80
+```
+
+- [ ] **Step 2: Write the failing tests for OpenAI exception classes**
+
+Append to `scripts/test_corpora/tests/test_sweep_overload_retry.py`:
+
+```python
+def test_retry_handles_openai_rate_limit_error():
+    """OpenAI's RateLimitError triggers backoff via _with_provider_retry."""
+    from unittest.mock import MagicMock
+
+    import openai
+
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    # Build a minimal openai.RateLimitError (it requires message + response + body)
+    fake_resp = MagicMock()
+    fake_resp.status_code = 429
+    err = openai.RateLimitError("rate limited", response=fake_resp, body=None)
+
+    call_count = {"n": 0}
+
+    def fn():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise err
+        return "ok"
+
+    sleeps = []
+    result = _with_provider_retry(fn, client_kind="openai", sleep=sleeps.append, max_total_seconds=3600)
+    assert result == "ok"
+    assert call_count["n"] == 2
+    assert len(sleeps) == 1  # one backoff before the successful retry
+
+
+def test_retry_handles_openai_api_status_error_503():
+    """OpenAI's APIStatusError 503 (overloaded) triggers backoff."""
+    from unittest.mock import MagicMock
+
+    import openai
+
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 503
+    err = openai.APIStatusError("overloaded", response=fake_resp, body=None)
+
+    call_count = {"n": 0}
+
+    def fn():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise err
+        return "ok"
+
+    sleeps = []
+    result = _with_provider_retry(fn, client_kind="openai", sleep=sleeps.append, max_total_seconds=3600)
+    assert result == "ok"
+    assert call_count["n"] == 2
+
+
+def test_retry_with_anthropic_kind_still_works():
+    """Back-compat: _with_provider_retry(client_kind='anthropic') matches the
+    legacy _with_anthropic_retry behavior."""
+    from anthropic._exceptions import RateLimitError as AnthropicRateLimitError
+
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    call_count = {"n": 0}
+
+    def fn():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            # AnthropicRateLimitError requires (message, *, response, body) too
+            from unittest.mock import MagicMock
+
+            fake_resp = MagicMock()
+            fake_resp.status_code = 429
+            raise AnthropicRateLimitError("rate limited", response=fake_resp, body=None)
+        return "ok"
+
+    sleeps = []
+    result = _with_provider_retry(fn, client_kind="anthropic", sleep=sleeps.append, max_total_seconds=3600)
+    assert result == "ok"
+
+
+def test_with_anthropic_retry_legacy_alias_still_callable():
+    """The old _with_anthropic_retry name remains as a back-compat alias."""
+    from scripts.test_corpora.runner.sweep import _with_anthropic_retry
+
+    # Just verify it's callable and forwards to _with_provider_retry
+    result = _with_anthropic_retry(lambda: "ok")
+    assert result == "ok"
+```
+
+- [ ] **Step 3: Run tests to verify the new ones fail**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_sweep_overload_retry.py -v
+```
+
+Expected: existing tests pass; the four new tests fail with `ImportError: cannot import name '_with_provider_retry'`.
+
+- [ ] **Step 4: Generalize the retry helper in `sweep.py`**
+
+Edit `scripts/test_corpora/runner/sweep.py`. Find lines around 94-145 (the constants + `_with_anthropic_retry` function) and replace with:
+
+```python
+ANTHROPIC_RETRY_BASE_SECONDS = 60
+ANTHROPIC_RETRY_MAX_DELAY_SECONDS = 600
+ANTHROPIC_RETRY_BUDGET_SECONDS = 3600
+
+# Per-provider exception tuples for the unified retry helper. Imports are
+# inside the helper to keep openai optional at module import time (the
+# package is in scripts/test_corpora/pyproject.toml but isn't imported
+# until a provider asks for it).
+
+
+def _retryable_exceptions(client_kind: str) -> tuple[type[BaseException], ...]:
+    """Return the exception classes treated as transient for `client_kind`."""
+    if client_kind == "anthropic":
+        return (OverloadedError, RateLimitError)
+    if client_kind == "openai":
+        import openai
+
+        # openai.RateLimitError covers 429; openai.APIStatusError covers other
+        # transient statuses (502/503). We narrow to "transient" inside the
+        # retry loop based on .status_code.
+        return (openai.RateLimitError, openai.APIStatusError)
+    raise ValueError(f"unknown client_kind {client_kind!r}; supported: anthropic, openai")
+
+
+def _with_provider_retry(
+    fn,
+    *args,
+    client_kind: str = "anthropic",
+    sleep=time.sleep,
+    max_total_seconds: int = ANTHROPIC_RETRY_BUDGET_SECONDS,
+):
+    """Call ``fn(*args)``, retrying on transient API errors from `client_kind`.
+
+    `client_kind` ∈ {"anthropic", "openai"} — picks the exception classes to
+    catch. Backoff schedule is the same across providers: 60s, 120s, 240s,
+    capped at 600s/attempt, with a cumulative budget of `max_total_seconds`
+    (~1 hr default). On budget exhaustion the original exception is re-raised
+    so the caller can leave the unit PENDING for a later --resume.
+
+    ``sleep`` is injectable so tests need not wait in real time.
+    """
+    transient = _retryable_exceptions(client_kind)
+    attempt = 0
+    waited = 0.0
+    while True:
+        try:
+            return fn(*args)
+        except transient as exc:
+            # For openai.APIStatusError, narrow to truly transient statuses;
+            # a 400 bad-request shouldn't be retried.
+            status = getattr(exc, "status_code", None)
+            if client_kind == "openai" and status is not None and status not in (429, 500, 502, 503, 504):
+                raise
+            if waited >= max_total_seconds:
+                raise
+            delay = min(ANTHROPIC_RETRY_BASE_SECONDS * 2**attempt, ANTHROPIC_RETRY_MAX_DELAY_SECONDS)
+            delay = min(delay, max_total_seconds - waited)
+            log.warning(
+                "%s API returned HTTP %s — backing off %.0fs before retry "
+                "(attempt %d, %.0fs of %ds budget used)",
+                client_kind,
+                status,
+                delay,
+                attempt + 1,
+                waited,
+                max_total_seconds,
+            )
+            sleep(delay)
+            waited += delay
+            attempt += 1
+
+
+def _with_anthropic_retry(
+    fn,
+    *args,
+    sleep=time.sleep,
+    max_total_seconds: int = ANTHROPIC_RETRY_BUDGET_SECONDS,
+):
+    """Back-compat alias for callers that haven't yet switched to
+    _with_provider_retry. Functionally identical to
+    _with_provider_retry(client_kind='anthropic', ...).
+    """
+    return _with_provider_retry(
+        fn,
+        *args,
+        client_kind="anthropic",
+        sleep=sleep,
+        max_total_seconds=max_total_seconds,
+    )
+```
+
+- [ ] **Step 5: Run the overload-retry test file**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/test_sweep_overload_retry.py -v
+```
+
+Expected: all tests (existing + 4 new) pass.
+
+- [ ] **Step 6: Run the full test suite to catch any regressions in sweep callers**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/ -q
+```
+
+Expected: same pass count as the pre-PR baseline plus the new tests (4 base + 8 factory + 5 openai + 4 retry = 21 new tests), and the same 1 pre-existing `test_entity_overlap_english` failure.
+
+- [ ] **Step 7: Lint + format**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/runner/sweep.py scripts/test_corpora/tests/test_sweep_overload_retry.py && uv run ruff format --check scripts/test_corpora/runner/sweep.py scripts/test_corpora/tests/test_sweep_overload_retry.py
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/runner/sweep.py scripts/test_corpora/tests/test_sweep_overload_retry.py && git commit -m "feat(eval): provider-aware retry in sweep — handles openai exceptions" -m "Generalizes _with_anthropic_retry to _with_provider_retry(client_kind=...) so OpenAI's RateLimitError (429) and APIStatusError (502/503/504) get the same exponential backoff. _with_anthropic_retry stays as a back-compat alias — callers that target only Anthropic keep working unchanged." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Full-suite regression sanity check
+
+**No new files or code — just verification.**
+
+- [ ] **Step 1: Run the full test_corpora suite**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/ -q 2>&1 | tail -10
+```
+
+Expected: One pre-existing failure (`test_entity_overlap_english` — missing spaCy model in test venv); everything else green. Roughly 21 new tests for PR-C land on top of the 317 baseline.
+
+- [ ] **Step 2: Root-level ruff check + format check on all changed files**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/ && uv run ruff format --check scripts/test_corpora/
+```
+
+Expected: clean across the whole `scripts/test_corpora/` tree.
+
+- [ ] **Step 3: No commit needed — this is a verification gate**
+
+If any of the above failed, return to the relevant earlier task and fix; don't proceed to Task 10 (live run) on a yellow signal.
+
+---
+
+## Task 10: Live end-to-end run — gpt-4o against synthetic
+
+**Prerequisites:**
+- HC must be up + responsive at `https://localhost:8100`.
+- `OPENAI_API_KEY` env var must be set to a valid OpenAI key.
+- `HC_API_KEY` must be a Synthetic-scoped HC API key.
+- PR-B's frozen `scripts/test_corpora/groundtruth/synthetic.yaml` must be on disk (it ships in PR-B's branch; this branch is based on main so it WON'T have it yet — fetch it from PR-B's branch first).
+
+- [ ] **Step 1: Verify HC is reachable**
+
+```bash
+cd /Users/alex/mcp-gateway && curl -sk https://localhost:8100/api/system/health | head -50
+```
+
+Expected: JSON health response. If HC is down, restart the menubar app and re-run.
+
+- [ ] **Step 2: Fetch the synthetic.yaml from PR-B's branch**
+
+PR-B's frozen synthetic.yaml isn't on this branch yet. Cherry-pick it (or copy from the worktree) so the live eval has ground truth:
+
+```bash
+cd /Users/alex/mcp-gateway && git fetch origin feat/answer-eval-synthetic --quiet && git checkout origin/feat/answer-eval-synthetic -- scripts/test_corpora/groundtruth/synthetic.yaml && ls -la scripts/test_corpora/groundtruth/synthetic.yaml
+```
+
+Expected: file present, ~29 items long.
+
+- [ ] **Step 3: Commit the ground-truth fetch on this branch**
+
+```bash
+cd /Users/alex/mcp-gateway && git add scripts/test_corpora/groundtruth/synthetic.yaml && git commit -m "chore(eval): pull synthetic.yaml from PR-B branch for live gpt-4o run" -m "PR-B (feat/answer-eval-synthetic) is the canonical source of this file; we copy it here so PR-C's live validation has ground truth to score against. When PR-B merges into main, this commit becomes a no-op and can be rebased away." -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Run the live eval against gpt-4o (LLM spend authorized)**
+
+The user authorized LLM spend for this run. Substitute the env vars (DON'T commit them — the values live only in your shell):
+
+```bash
+cd /Users/alex/mcp-gateway && OPENAI_API_KEY="$OPENAI_API_KEY" \
+    HC_API_KEY="$SYNTHETIC_HC_API_KEY" \
+    uv run --project scripts/test_corpora python -m scripts.test_corpora.runner.sweep \
+    --mode answer-eval \
+    --corpora synthetic \
+    --models gpt-4o \
+    --label pr-c-synthetic-gpt4o \
+    --workdir "$HOME/Library/Application Support/Harbor Clerk/test-corpora" \
+    --api-base https://localhost:8100 \
+    --insecure 2>&1 | tee /tmp/pr-c-gpt4o-run.log
+```
+
+Expected: 29 items captured + judged. Each item logs `correctness=N grounded=N complete=N`; final line is `OVERALL n=29 correctness=... groundedness=... completeness=...`.
+
+If the run dies partway, re-run the same command — captures and verdicts are reused by default (the answer-eval runner reads existing `captures/<corpus>/<model>/<id>.json` and skips re-capture).
+
+- [ ] **Step 5: Save the summary table for the PR comment**
+
+```bash
+cd /Users/alex/mcp-gateway && cat "$HOME/Library/Application Support/Harbor Clerk/test-corpora/answer-eval/reports/pr-c-synthetic-gpt4o/summary.json"
+```
+
+Expected: JSON with `overall` + `by_type` sub-blocks of `n / correctness / groundedness / completeness`.
+
+- [ ] **Step 6: Optional — also re-run Sonnet for head-to-head**
+
+If the user wants a head-to-head comparison (LLM spend already authorized), run the same command with `--models claude-sonnet-4-6 --label pr-c-synthetic-sonnet`. Outputs land in a sibling directory. Skip for now if you want to ship PR-C faster — Sonnet's PR-B numbers are already in PR #386's description.
+
+---
+
+## Task 11: Self-review, fresh-eyes code review, open PR, post results
+
+- [ ] **Step 1: Diff summary against `main`**
+
+```bash
+cd /Users/alex/mcp-gateway && git fetch origin main --quiet && git log --oneline origin/main..HEAD && echo "---" && git diff --stat origin/main..HEAD
+```
+
+Expected: ~8 commits, touching the files listed in the spec's File Structure section.
+
+- [ ] **Step 2: Final lint + format pass on all changed files**
+
+```bash
+cd /Users/alex/mcp-gateway && uv run ruff check scripts/test_corpora/ && uv run ruff format --check scripts/test_corpora/
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Dispatch fresh-eyes code review subagent** (per MEMORY.md standing directive — minimal prompt, no carve-outs)
+
+Use the Agent tool with `subagent_type: feature-dev:code-reviewer` and a minimal prompt: "Review the diff `git diff origin/main..HEAD` on branch `feat/answer-eval-multi-model`. Spec is at `docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md`. Identify bugs, security issues, design problems with ≥80 confidence."
+
+Address ≥80-confidence findings inline before opening the PR.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+cd /Users/alex/mcp-gateway && git push -u origin feat/answer-eval-multi-model 2>&1 | tail -5
+```
+
+Already pushed in the brainstorm phase; this is a no-op `Everything up-to-date` or a fast-forward push of the new commits.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+cd /Users/alex/mcp-gateway && gh pr create --base main --head feat/answer-eval-multi-model --title "feat(eval): answer-eval phase 2c — multi-model via Provider protocol" --body "$(cat <<'EOF'
+## Summary
+
+**Phase 2c / PR-C** of the answer-eval work — adds a second baseline model (`gpt-4o`) to `--mode answer-eval` via a pluggable Provider protocol. Spec: `docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md`. Plan: `docs/superpowers/plans/2026-05-23-answer-eval-multi-model.md`.
+
+Zero changes to the judge, runner loop, ground-truth schemas, or `--label`/`--workdir` machinery — additive only.
+
+## What's in it
+
+- **`providers/` package** — `Provider` Protocol + `BaselineResult` dataclass + `DEFAULT_SYSTEM_PROMPT` in `base.py`; concrete `AnthropicProvider` and `OpenAIProvider`; `make_provider(model, *, mcp_session)` factory dispatching by model-name prefix (`claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` → OpenAI).
+- **`claude_baseline.py` collapsed to a 12-line shim** re-exporting `AnthropicProvider as BaselineGenerator` — `sweep.py`'s 30+ import sites stay untouched.
+- **`answer_eval._live_capture_fn` uses `make_provider`** — pass any supported model name via `--models`.
+- **Provider-aware retry** — `_with_provider_retry(fn, *, client_kind=...)` generalizes `_with_anthropic_retry` to handle OpenAI's `RateLimitError` (429) + `APIStatusError` (502/503/504). Legacy `_with_anthropic_retry` kept as an alias.
+- **21 new tests** (4 base + 8 factory + 5 openai + 4 retry); pre-existing 317 still pass.
+
+## Test plan
+
+- [x] `uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/` — all green except the pre-existing `test_entity_overlap_english` failure (spaCy model missing in test venv).
+- [x] Root-level `ruff check` + `ruff format --check` clean on every changed file.
+- [x] Built TDD with per-task spec + code-quality reviews and a final unconstrained fresh-eyes review.
+- [x] **Live end-to-end run** — `gpt-4o` against synthetic (29 items). Results below.
+
+## First-run results (live)
+
+REPLACE-WITH-METRICS-FROM-STEP-5
+
+## Comparison with Sonnet (PR-B baseline)
+
+For head-to-head context, here are PR-B's first-run Sonnet numbers against the same 30-item synthetic set (one item was dropped during PR-B's post-review fix — gpt-4o ran against the 29-item version):
+
+| | n | correctness | groundedness | completeness |
+|---|--:|--:|--:|--:|
+| Sonnet (PR-B)  | 30 | 3.33 | 3.57 | 2.73 |
+| GPT-4o (this PR) | 29 | TBD | TBD | TBD |
+
+Headline read: REPLACE-WITH-OBSERVATION.
+
+## Known limitations / follow-ups
+
+- The shim is intentional for this PR — a follow-up can migrate `sweep.py`'s `BaselineGenerator(...)` call sites to `make_provider(model)` directly, but that's a larger blast radius.
+- Cross-provider judge bias: Sonnet judging gpt-4o introduces a same-family-vs-cross-family asymmetry. Future "swap the judge to gpt-4o" experiment for sensitivity analysis.
+- Lifting the Provider protocol into `harbor_clerk` proper (for the "bring your own cloud LLM" use case in HC chat/research) is a separate effort.
+- Prompt-tuning experiment is next on the queue — addresses the negative-hedging finding now confirmed across CUAD, Enron, and synthetic.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Then capture the PR URL from the output.
+
+- [ ] **Step 6: Edit the PR body with the actual metrics from Step 5**
+
+Replace `REPLACE-WITH-METRICS-FROM-STEP-5` and the `TBD` cells with the values from `summary.json`. Use `gh pr edit <N> --body "$(cat <<EOF ... EOF)"` or `gh pr comment` if simpler.
+
+- [ ] **Step 7: Mark PR-C done in the task tracker.**
+
+Mark task BC2 (PR-C spec + plan + execution) completed.
+
+---
+
+## Self-Review Notes (for the agentic worker)
+
+1. **Spec coverage:** Every section/requirement in `2026-05-23-answer-eval-multi-model-design.md` has a corresponding task:
+   - Provider Protocol + BaselineResult → Task 1
+   - AnthropicProvider → Task 2
+   - claude_baseline shim → Task 3
+   - make_provider factory → Task 4
+   - OpenAIProvider + openai dep → Task 5
+   - providers/__init__.py exports → Task 6
+   - answer_eval wiring → Task 7
+   - sweep retry generalization → Task 8
+   - Validation + ruff → Task 9
+   - Live gpt-4o run → Task 10
+   - PR + fresh-eyes review → Task 11
+
+2. **Placeholder scan:** No `TBD` / "TODO" / "implement later" in any code step. The PR body in Task 11 has two `REPLACE-WITH-...` placeholders by design — they get filled in Step 6 of Task 11 with real numbers from the live run.
+
+3. **Type consistency:**
+   - `BaselineResult` field set is identical in Task 1's definition, Task 2's import, Task 5's import, and Task 6's re-export.
+   - `make_provider`'s signature `(model, *, mcp_session, doc_ids_seen=None)` is consistent in Task 4 (definition), Task 6 (re-export), and Task 7 (call site).
+   - `_with_provider_retry`'s `client_kind` parameter values are consistent (`"anthropic"` / `"openai"`) in Task 8's definition and Task 8's tests.
+   - `AnthropicProvider`/`OpenAIProvider` constructors both take `(*, mcp_session, model=..., client=None, doc_ids_seen=None)` — kwargs-only, same shape, swappable through the factory.

--- a/docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md
+++ b/docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md
@@ -194,7 +194,7 @@ scripts/test_corpora/runner/
   "openai"]` parameter; dispatches the exception classes accordingly. Existing
   call sites stay the same (the kind is derived from the model name).
 
-- **`scripts/test_corpora/tests/test_claude_baseline.py`** — tests stay; they
+- **`scripts/test_corpora/tests/test_baseline.py`** — tests stay; they
   exercise the shim's re-exports, which in turn exercise `AnthropicProvider`.
   Imports remain `from scripts.test_corpora.runner.claude_baseline import ...`.
 
@@ -260,7 +260,7 @@ based on judge's `_score()` precedent from PR-B's post-eval hardening.)
 | `test_openai_provider.py` | `test_openai_provider_transcript_records_each_call` | tool_transcript has one entry per tool_call with `tool`, `args`, `result_summary` |
 | `test_openai_provider.py` | `test_openai_provider_treats_length_finish_as_end_turn` | `finish_reason == "length"` returns the partial answer without crashing |
 | `test_openai_provider.py` | `test_openai_provider_falls_back_when_mcp_returns_no_content` | empty tool result → `(empty)` literal |
-| `test_claude_baseline.py` | (existing tests, unchanged) | shim re-exports work; `BaselineGenerator` is still importable from old path |
+| `test_baseline.py` | (existing tests, unchanged) | shim re-exports work; `BaselineGenerator` is still importable from old path |
 
 Live validation: one end-to-end run against `synthetic` with `gpt-4o`,
 re-using PR-B's frozen `synthetic.yaml`, expected to complete 29 items.

--- a/docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md
+++ b/docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md
@@ -1,0 +1,293 @@
+# PR-C — Answer-eval multi-model support (Provider protocol)
+
+**Status:** spec — awaiting user review before plan + implementation
+**Author:** Claude (with Alex)
+**Companion docs:** [PR-A spec](2026-05-22-answer-eval-enron-design.md), [PR-B spec](2026-05-23-answer-eval-synthetic-design.md), [eval sketch](2026-05-19-real-eval-sketch.md)
+
+## Goal
+
+Extend `--mode answer-eval` to support a **second baseline model** (`gpt-4o`)
+alongside Sonnet, so each PR-A/B corpus eval can be re-run head-to-head across
+two frontier providers without forking the runner. Architecturally: introduce a
+narrow **Provider protocol** under
+`scripts/test_corpora/runner/providers/` (new package), refactor the existing
+`claude_baseline.py` into a concrete `AnthropicProvider` implementing it, add a
+parallel `OpenAIProvider`, and select the implementation via the model name in
+the existing `--models` flag. Output paths already key on model
+(`workdir/answer-eval/{captures,verdicts}/<corpus>/<model>/`), so reuse-by-default
+keeps the Sonnet baselines from PR-A/B intact and GPT-4o results land in a
+sibling directory.
+
+This is the third piece in the answer-eval phase 2 arc:
+
+- **PR-A** (Enron, merged in #385): extended `--mode answer-eval` to Enron + added the `find` qtype + deterministic coverage scoring.
+- **PR-B** (Synthetic, in #386): extended to the synthetic corpus via sidecar-driven generator.
+- **PR-C** (this PR): extends to a second frontier model via a Provider protocol so PR-A/B numbers can be reproduced head-to-head with GPT-4o.
+
+## Non-goals
+
+- **No judge changes.** The judge stays Sonnet-only across all providers — same
+  judge means comparable scores. (Future: cross-judge eval is its own PR.)
+- **No multi-provider runs in a single invocation.** The runner stays
+  single-model per invocation. Multi-model is achieved by running the harness
+  twice with different `--models` values. Answer-eval's existing per-model
+  directory layout (`workdir/answer-eval/{captures,verdicts}/<corpus>/<model>/`)
+  keeps parallel runs from clobbering each other; no path changes needed.
+- **No HC chat/research integration.** The Provider protocol is designed to be
+  reusable for the future "bring your own cloud LLM key" use case in HC's
+  chat/research path, but THIS PR only ships the abstraction inside
+  `scripts/test_corpora`. Lifting it into `harbor_clerk` proper is a separate
+  effort with its own design review.
+- **No model routing or fallback.** One provider per run; if the API errors, the
+  run fails. (The existing `_with_anthropic_retry` retry budget extends to the
+  Anthropic provider; an analogous `_with_openai_retry` is in scope for the
+  OpenAI provider.)
+- **No tool-schema convergence work.** Each provider translates the MCP tool
+  list to its own native schema (Anthropic's `input_schema`, OpenAI's
+  `parameters`). The tool *executions* go through the same `SyncMcpSession`.
+
+## Why this architecture (Option 2: pluggable Provider protocol)
+
+Two architecturally-distinct options were considered (transcript: user
+explicitly chose Option 2 after confirming the abstraction is reusable for the
+future HC cloud-LLM use case):
+
+- **Option 1 — fork-and-extend `claude_baseline.py`:** Copy the file to
+  `openai_baseline.py`, swap `anthropic` for `openai`, hand-edit the tool-call
+  loop. Fastest to ship; bad once we want a third provider; locks PR-C's value
+  to the eval harness specifically.
+
+- **Option 2 — Provider protocol + concrete implementations:** Define
+  `Provider` as a small Python `Protocol` (`run_question(...) -> BaselineResult`),
+  refactor `claude_baseline.py` into `anthropic_provider.py` implementing it,
+  add `openai_provider.py` as a peer. One factory function maps model name →
+  provider instance. New providers (Gemini, Bedrock, Azure) become drop-in.
+  More work up-front; pays back the moment we need a third provider OR want to
+  lift the abstraction into HC's chat/research path.
+
+The user confirmed Option 2 is reusable for the future HC cloud-LLM use case,
+so the engineering investment is paid back in two places.
+
+## Architecture
+
+```
+scripts/test_corpora/runner/
+├── providers/
+│   ├── __init__.py              # exports: Provider, BaselineResult, make_provider
+│   ├── base.py                  # Protocol + BaselineResult dataclass (moved from claude_baseline.py)
+│   ├── anthropic_provider.py    # AnthropicProvider — refactored from claude_baseline.py
+│   ├── openai_provider.py       # OpenAIProvider — new, mirrors Anthropic's shape
+│   └── factory.py               # make_provider(model: str, *, mcp_session) -> Provider
+├── answer_eval.py               # _live_capture_fn uses make_provider() instead of importing BaselineGenerator directly
+├── claude_baseline.py           # shim: re-exports BaselineResult + BaselineGenerator for back-compat (sweep.py)
+└── sweep.py                     # unchanged — imports through the shim
+```
+
+**Key design decisions:**
+
+1. **`Provider` is a `typing.Protocol`, not an ABC.** Duck-typed mocks in tests
+   stay simple; no inheritance required. Mirrors how `AnswerJudge`'s client
+   parameter is duck-typed today.
+
+2. **`BaselineResult` dataclass stays as the universal return type.** Every
+   provider returns the same shape: `answer`, `cited_doc_ids`, `cited_doc_titles`,
+   `tool_call_count`, `tool_transcript`, `elapsed_seconds`, `model`, `timestamp`.
+   This is what `answer_eval.py`'s judging loop reads, and what gets serialized
+   to `baselines/<corpus>/<question_id>.json`. Zero schema change.
+
+3. **`make_provider(model, *, mcp_session)` is the single dispatch point.**
+   String matching: any model name starting with `claude-` → Anthropic; any name
+   starting with `gpt-` or `o1-`/`o3-` → OpenAI. Unknown prefixes raise a clear
+   `ValueError` with the list of supported prefixes. No registry config file —
+   the prefix list is hand-curated and lives in `factory.py`. The factory
+   constructs the underlying client (`anthropic.Anthropic()` or
+   `openai.OpenAI()`) lazily inside the matched branch, so callers don't have to
+   know which client class to instantiate. Both clients read their API keys from
+   the standard env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) — same pattern
+   as today's `_live_capture_fn`.
+
+   For back-compat with `sweep.py`'s existing `BaselineGenerator(client=...,
+   mcp_session=..., model=..., doc_ids_seen=...)` call sites, both provider
+   classes accept a `client=None` keyword: when supplied, the factory's
+   convenience role is bypassed and the caller-built client is used verbatim.
+   This is how the shim keeps sweep.py untouched.
+
+4. **`claude_baseline.py` becomes a thin re-export shim** to avoid touching
+   `sweep.py`'s 30+ import sites in this PR. The sweep keeps importing
+   `BaselineGenerator` from `claude_baseline`; the shim re-exports it from the
+   new `providers.anthropic_provider` module. (A follow-up PR can migrate
+   `sweep.py` to use `make_provider` directly, but that's a much larger blast
+   radius — better to defer.)
+
+5. **`SYSTEM_PROMPT` is shared.** Currently inlined in `claude_baseline.py`;
+   moves to `providers/base.py` as `DEFAULT_SYSTEM_PROMPT`. Both providers use it
+   verbatim. (The prompt-tuning experiment queued after PR-C may parameterize
+   this; out of scope here.)
+
+6. **OpenAI tool-call loop mirrors Anthropic's structurally** but uses OpenAI's
+   message+tool_calls format. Both loops:
+   1. Send the user question + tool list.
+   2. Receive a response; check `finish_reason` (`stop` = done, `tool_calls` =
+      execute tools).
+   3. Execute each tool via the shared `SyncMcpSession`.
+   4. Append `tool` role messages with results, loop back.
+
+7. **Error handling** — both providers expose the same retry surface: a
+   provider-specific `_with_<provider>_retry()` helper in `sweep.py`. Existing
+   `_with_anthropic_retry` is renamed to `_with_provider_retry(client_kind, fn, ...)`
+   that dispatches on the model name. (See "Failure paths" below for the
+   error-class mapping.)
+
+## File-by-file changes
+
+### Created
+
+- **`scripts/test_corpora/runner/providers/__init__.py`** — re-exports
+  `Provider`, `BaselineResult`, `make_provider`, `DEFAULT_SYSTEM_PROMPT`.
+- **`scripts/test_corpora/runner/providers/base.py`** — `Provider` Protocol
+  (single method: `run_question(question, question_id, corpus) -> BaselineResult`),
+  `BaselineResult` dataclass, `DEFAULT_SYSTEM_PROMPT` constant.
+- **`scripts/test_corpora/runner/providers/anthropic_provider.py`** —
+  `AnthropicProvider` class; constructor takes `(*, mcp_session, model="claude-sonnet-4-6",
+  client=None, doc_ids_seen=None)` (client defaults to `anthropic.Anthropic()`
+  on first use); body is the existing `BaselineGenerator.run_question` loop moved
+  here verbatim. Keeps `.write()` as a `@staticmethod` for shim compatibility.
+- **`scripts/test_corpora/runner/providers/openai_provider.py`** —
+  `OpenAIProvider` class; constructor takes `(*, mcp_session, model="gpt-4o",
+  client=None, doc_ids_seen=None)` (client defaults to `openai.OpenAI()`);
+  tool-call loop adapted to OpenAI's API shape.
+- **`scripts/test_corpora/runner/providers/factory.py`** — `make_provider(model,
+  *, mcp_session, doc_ids_seen=None) -> Provider`; prefix-based dispatch;
+  raises `ValueError` on unknown.
+- **`scripts/test_corpora/tests/test_providers_factory.py`** — unit tests for
+  factory dispatch + unknown-model handling.
+- **`scripts/test_corpora/tests/test_openai_provider.py`** — unit tests
+  mirroring the existing `claude_baseline` tests (mock the OpenAI client, test
+  tool-loop + cited-doc capture + transcript shape + empty `(empty)` fallback).
+
+### Modified
+
+- **`scripts/test_corpora/runner/claude_baseline.py`** — becomes a 5-line shim:
+  ```python
+  """Back-compat shim — see providers/anthropic_provider.py."""
+  from scripts.test_corpora.runner.providers.anthropic_provider import (
+      AnthropicProvider as BaselineGenerator,
+  )
+  from scripts.test_corpora.runner.providers.base import (
+      BaselineResult,
+      DEFAULT_SYSTEM_PROMPT as SYSTEM_PROMPT,
+  )
+  __all__ = ["BaselineGenerator", "BaselineResult", "SYSTEM_PROMPT"]
+  ```
+  The shim preserves all existing imports in `sweep.py` and tests. The
+  `AnthropicProvider` class keeps `.write()` as a `@staticmethod` for the same
+  reason.
+
+- **`scripts/test_corpora/runner/answer_eval.py`** — `_live_capture_fn` switches
+  from `BaselineGenerator(client=anthro, mcp_session=mcp, model=model)` to
+  `make_provider(model, mcp_session=mcp)`. The Anthropic client construction
+  moves into the Anthropic provider's own factory branch; the OpenAI client
+  construction lives in its branch.
+
+- **`scripts/test_corpora/runner/sweep.py`** — `_with_anthropic_retry` renamed
+  to `_with_provider_retry`; signature gains a `client_kind: Literal["anthropic",
+  "openai"]` parameter; dispatches the exception classes accordingly. Existing
+  call sites stay the same (the kind is derived from the model name).
+
+- **`scripts/test_corpora/tests/test_claude_baseline.py`** — tests stay; they
+  exercise the shim's re-exports, which in turn exercise `AnthropicProvider`.
+  Imports remain `from scripts.test_corpora.runner.claude_baseline import ...`.
+
+### Untouched
+
+- `runner/answer_judge.py` — judge stays Sonnet-only.
+- `runner/sampler.py`, `runner/state.py`, `runner/metrics.py`, etc. — no changes.
+- All ground-truth YAML files and generators.
+- All other tests except the two new provider test files.
+
+## CLI surface
+
+No new flags. `--models gpt-4o` Just Works:
+
+```bash
+# Same harness invocation as PR-A/B, just with a different model name
+uv run --project scripts/test_corpora python -m scripts.test_corpora.runner.sweep \
+    --mode answer-eval \
+    --corpora synthetic \
+    --models gpt-4o \
+    --label pr-c-synthetic-gpt4o \
+    --workdir "$HC_WORKDIR" \
+    --api-base "$HC_API_BASE"
+```
+
+Multi-model runs are two sequential invocations with different `--models` and
+`--label` values. Captures and verdicts already key on model
+(`workdir/answer-eval/captures/<corpus>/<model>/<question_id>.json`,
+`workdir/answer-eval/verdicts/<corpus>/<model>/<question_id>.json`) — no path
+changes needed for parallel runs. Per-label reports live under
+`workdir/answer-eval/reports/<label>/`.
+
+## Failure paths
+
+The OpenAI provider needs the same defensive surface as the Anthropic one:
+
+| Failure | Anthropic today | OpenAI in PR-C |
+|---|---|---|
+| Rate limit | `RateLimitError` → backoff via `_with_anthropic_retry` | `openai.RateLimitError` → backoff via `_with_provider_retry` |
+| Overloaded | `OverloadedError` → backoff | `openai.APIStatusError` (502/503) → backoff |
+| Bad request | bubble up | bubble up |
+| Tool call returns empty content | `(empty)` literal | same `(empty)` literal |
+| Tool call raises | uncaught (bubbles to sweep retry budget) | same |
+| Model omits tool args | `KeyError` → fix in judge-style defensive pattern | same |
+| `finish_reason == "length"` (response truncated mid-tool-call) | not currently handled | log + treat as `end_turn` (best-effort answer) |
+
+The truncation case is a new wrinkle for OpenAI — Anthropic's API rarely hits
+context limits with our 8000-token cap, but GPT-4o's `max_tokens` semantics are
+subtly different. PR-C's OpenAI provider treats `finish_reason == "length"` as a
+soft end-of-turn with a logged warning, rather than crashing. (Spec'd defensively
+based on judge's `_score()` precedent from PR-B's post-eval hardening.)
+
+## Tests
+
+| File | New test | Asserts |
+|---|---|---|
+| `test_providers_factory.py` | `test_factory_dispatches_claude_to_anthropic` | `make_provider("claude-sonnet-4-6", ...)` returns `AnthropicProvider` instance |
+| `test_providers_factory.py` | `test_factory_dispatches_gpt_to_openai` | `make_provider("gpt-4o", ...)` returns `OpenAIProvider` |
+| `test_providers_factory.py` | `test_factory_dispatches_o1_to_openai` | `make_provider("o1-preview", ...)` returns `OpenAIProvider` |
+| `test_providers_factory.py` | `test_factory_raises_on_unknown_model` | unknown prefix → `ValueError` with supported prefixes in message |
+| `test_openai_provider.py` | `test_openai_provider_parses_simple_answer` | mock OpenAI client → end_turn on first response → returns final text |
+| `test_openai_provider.py` | `test_openai_provider_tool_loop_captures_cited_docs` | mock client emits one tool_calls round → cited_doc_ids harvested from MCP result |
+| `test_openai_provider.py` | `test_openai_provider_transcript_records_each_call` | tool_transcript has one entry per tool_call with `tool`, `args`, `result_summary` |
+| `test_openai_provider.py` | `test_openai_provider_treats_length_finish_as_end_turn` | `finish_reason == "length"` returns the partial answer without crashing |
+| `test_openai_provider.py` | `test_openai_provider_falls_back_when_mcp_returns_no_content` | empty tool result → `(empty)` literal |
+| `test_claude_baseline.py` | (existing tests, unchanged) | shim re-exports work; `BaselineGenerator` is still importable from old path |
+
+Live validation: one end-to-end run against `synthetic` with `gpt-4o`,
+re-using PR-B's frozen `synthetic.yaml`, expected to complete 29 items.
+
+## Open questions / follow-ups
+
+- **OpenAI's tool-call concurrency.** GPT-4o sometimes emits multiple
+  `tool_calls` in parallel. PR-C executes them sequentially (same as Anthropic
+  today). If `gpt-4o`'s parallel tool calling materially helps end-to-end speed,
+  consider a `concurrent.futures` thread pool in a follow-up.
+- **Cross-provider judge bias.** Sonnet judging GPT-4o's answers introduces a
+  potential same-family bias against the cross-family case. Worth a future "swap
+  the judge to GPT-4o" experiment for sensitivity analysis — out of scope here.
+- **Lifting the Provider protocol into `harbor_clerk` proper.** The eval-harness
+  Provider can serve as the proof-of-concept; once it's been used for 2+
+  providers in the eval, lift it into `src/harbor_clerk/llm/providers/` for the
+  "bring your own cloud LLM" use case.
+- **Prompt-tuning experiment.** Queued after PR-C: tune HC's MCP system prompt
+  to fix the negative-hedging finding that's now confirmed across CUAD, Enron,
+  and synthetic. PR-C does NOT change the system prompt; that's the experiment's
+  job.
+
+## Validation plan
+
+- All 317 existing tests pass + new tests pass.
+- Ruff clean on every changed file.
+- Live end-to-end: `gpt-4o` against synthetic (29 items), captured + judged +
+  metrics rolled up. Results comment on the PR; absolute numbers are a
+  one-shot reference point (not a benchmark — Sonnet remains the gold
+  baseline).

--- a/scripts/test_corpora/groundtruth/synthetic.yaml
+++ b/scripts/test_corpora/groundtruth/synthetic.yaml
@@ -1,0 +1,290 @@
+corpus: synthetic
+items:
+- id: synth-invoice-total-0001_invoice
+  question: What is the total amount in USD of invoice SBA-20251104-087342?
+  clause_category: invoice
+  gold_doc: 0001_invoice
+  answer_key: $6,326.60
+  type: lookup
+- id: synth-invoice-vendor-0001_invoice
+  question: Who is the vendor on invoice SBA-20251104-087342?
+  clause_category: invoice
+  gold_doc: 0001_invoice
+  answer_key: Staples Business Advantage
+  type: lookup
+- id: synth-invoice-total-0002_invoice
+  question: What is the total amount in USD of invoice SC-2025-084471?
+  clause_category: invoice
+  gold_doc: 0002_invoice
+  answer_key: $30,163.80
+  type: lookup
+- id: synth-invoice-vendor-0002_invoice
+  question: Who is the vendor on invoice SC-2025-084471?
+  clause_category: invoice
+  gold_doc: 0002_invoice
+  answer_key: Steelcase Inc.
+  type: lookup
+- id: synth-board-attendees-0101_board_minutes
+  question: Who attended the Marbledock & Associates board meeting on 2025-03-07?
+  clause_category: board_minutes
+  gold_doc: 0101_board_minutes
+  answer_key: "Eleanor Voss \u2013 Chairwoman & Chief Executive Officer; Raymond Holt\
+    \ \u2013 Chief Financial Officer; Sandra Kimura \u2013 Chief Operating Officer;\
+    \ Frederick Osei \u2013 Chief Legal Officer; Diana Marchetti \u2013 Chief Marketing\
+    \ Officer; Thomas Blaine \u2013 Head of Corporate Strategy; Priya Nandakumar \u2013\
+    \ Non-Executive Director; Gerald Whitmore \u2013 Non-Executive Director"
+  type: lookup
+- id: synth-board-attendees-0102_board_minutes
+  question: Who attended the Marbledock & Associates board meeting on 2025-04-02?
+  clause_category: board_minutes
+  gold_doc: 0102_board_minutes
+  answer_key: "Eleanor Voss \u2013 Chief Executive Officer; Raymond Holt \u2013 Chief\
+    \ Financial Officer; Priya Sundaram \u2013 Chief Operating Officer; Marcus Bellfield\
+    \ \u2013 General Counsel; Theodora Wainwright \u2013 Head of Business Development;\
+    \ Simon Crake \u2013 Chief Technology Officer"
+  type: lookup
+- id: synth-onboarding-start-0061_onboarding_letter
+  question: What is the start date listed on the Senior Project Coordinator onboarding
+    letter?
+  clause_category: onboarding_letter
+  gold_doc: 0061_onboarding_letter
+  answer_key: '2025-04-19'
+  type: lookup
+- id: synth-onboarding-mgr-0061_onboarding_letter
+  question: Who is the signing manager on the Senior Project Coordinator onboarding
+    letter?
+  clause_category: onboarding_letter
+  gold_doc: 0061_onboarding_letter
+  answer_key: Isabelle Tremblay-Fontaine, Directrice des ressources humaines / Director
+    of Human Resources
+  type: lookup
+- id: synth-onboarding-start-0062_onboarding_letter
+  question: What is the start date listed on the Senior Bilingual Project Coordinator
+    onboarding letter?
+  clause_category: onboarding_letter
+  gold_doc: 0062_onboarding_letter
+  answer_key: '2025-02-24'
+  type: lookup
+- id: synth-onboarding-mgr-0062_onboarding_letter
+  question: Who is the signing manager on the Senior Bilingual Project Coordinator
+    onboarding letter?
+  clause_category: onboarding_letter
+  gold_doc: 0062_onboarding_letter
+  answer_key: "Sophie Tr\xE9panier, Directrice des Ressources Humaines / Director\
+    \ of Human Resources"
+  type: lookup
+- id: synth-qreport-revenue-0261_quarterly_report
+  question: What was the revenue reported in the Q4 2025 quarterly report (the one
+    reporting approximately $47M)?
+  clause_category: quarterly_report
+  gold_doc: 0261_quarterly_report
+  answer_key: $47,300,000.00
+  type: lookup
+- id: synth-qreport-revenue-0265_quarterly_report
+  question: What was the revenue reported in the Q3 2025 quarterly report (the one
+    reporting approximately $48M)?
+  clause_category: quarterly_report
+  gold_doc: 0265_quarterly_report
+  answer_key: $48,700,000.00
+  type: lookup
+- id: synth-vcontract-law-0131_vendor_contract
+  question: What is the governing law of the vendor contract with Pinnacle Tech Solutions,
+    LLC?
+  clause_category: vendor_contract
+  gold_doc: 0131_vendor_contract
+  answer_key: State of South Carolina
+  type: lookup
+- id: synth-vcontract-fee-0131_vendor_contract
+  question: What is the monthly fee in USD on the vendor contract with Pinnacle Tech
+    Solutions, LLC?
+  clause_category: vendor_contract
+  gold_doc: 0131_vendor_contract
+  answer_key: $8,500.00
+  type: lookup
+- id: synth-vcontract-law-0132_vendor_contract
+  question: What is the governing law of the vendor contract with Pinnacle Technology
+    Solutions, LLC?
+  clause_category: vendor_contract
+  gold_doc: 0132_vendor_contract
+  answer_key: State of Illinois
+  type: lookup
+- id: synth-vcontract-fee-0132_vendor_contract
+  question: What is the monthly fee in USD on the vendor contract with Pinnacle Technology
+    Solutions, LLC?
+  clause_category: vendor_contract
+  gold_doc: 0132_vendor_contract
+  answer_key: $8,500.00
+  type: lookup
+- id: synth-memo-sender-0161_internal_memo
+  question: "Who is the sender of the internal memo with subject \"Updated Remote\
+    \ Work and Hybrid Scheduling Policy \u2013 Effective April 1, 2025\"?"
+  clause_category: internal_memo
+  gold_doc: 0161_internal_memo
+  answer_key: Helena Voss, Chief Operations Officer, Marbledock & Associates
+  type: lookup
+- id: synth-memo-sender-0162_internal_memo
+  question: "Who is the sender of the internal memo with subject \"Updated Remote\
+    \ Work and Hybrid Office Attendance Policy \u2013 Effective Immediately\"?"
+  clause_category: internal_memo
+  gold_doc: 0162_internal_memo
+  answer_key: Eleanor Whitford, Managing Partner, Marbledock & Associates
+  type: lookup
+- id: synth-policy-effective-0191_policy_doc
+  question: When does version 3.1 of the "Information Security and Human Resources
+    Acceptable Use Policy" policy take effect?
+  clause_category: policy_doc
+  gold_doc: 0191_policy_doc
+  answer_key: '2025-12-23'
+  type: lookup
+- id: synth-policy-version-0191_policy_doc
+  question: What version of the "Information Security and Human Resources Acceptable
+    Use Policy" policy takes effect on 2025-12-23?
+  clause_category: policy_doc
+  gold_doc: 0191_policy_doc
+  answer_key: '3.1'
+  type: lookup
+- id: synth-policy-effective-0192_policy_doc
+  question: When does version 2.4.1 of the "Information Security and Human Resources
+    Acceptable Use Policy" policy take effect?
+  clause_category: policy_doc
+  gold_doc: 0192_policy_doc
+  answer_key: '2025-08-13'
+  type: lookup
+- id: synth-policy-version-0192_policy_doc
+  question: What version of the "Information Security and Human Resources Acceptable
+    Use Policy" policy takes effect on 2025-08-13?
+  clause_category: policy_doc
+  gold_doc: 0192_policy_doc
+  answer_key: 2.4.1
+  type: lookup
+- id: synth-mkt-budget-0221_marketing_brief
+  question: What is the budget in USD for the "Marbledock Elevate 2025" marketing
+    campaign?
+  clause_category: marketing_brief
+  gold_doc: 0221_marketing_brief
+  answer_key: $120,000.00
+  type: lookup
+- id: synth-mkt-budget-0222_marketing_brief
+  question: What is the budget in USD for the "Elevate Forward" marketing campaign?
+  clause_category: marketing_brief
+  gold_doc: 0222_marketing_brief
+  answer_key: $250,000.00
+  type: lookup
+- id: synth-handbook-sections-0241_employee_handbook
+  question: How many top-level sections are in the 2025 Marbledock employee handbook?
+  clause_category: employee_handbook
+  gold_doc: 0241_employee_handbook
+  answer_key: '4'
+  type: lookup
+- id: synth-find-invoices-over-5000
+  question: Find all invoices with a total amount over $5,000 USD.
+  clause_category: cross-doc
+  gold_doc: (see answer_key.all)
+  answer_key:
+    count: 56
+    all:
+    - 0001_invoice
+    - 0002_invoice
+    - 0003_invoice
+    - 0004_invoice
+    - 0005_invoice
+    - 0006_invoice
+    - 0007_invoice
+    - 0008_invoice
+    - 0009_invoice
+    - 0010_invoice
+    - 0011_invoice
+    - 0012_invoice
+    - 0013_invoice
+    - 0014_invoice
+    - 0015_invoice
+    - 0016_invoice
+    - 0017_invoice
+    - 0018_invoice
+    - 0019_invoice
+    - 0020_invoice
+    - 0021_invoice
+    - 0022_invoice
+    - 0023_invoice
+    - 0024_invoice
+    - 0025_invoice
+    - 0026_invoice
+    - 0027_invoice
+    - 0028_invoice
+    - 0029_invoice
+    - 0030_invoice
+    - 0031_invoice
+    - 0032_invoice
+    - 0033_invoice
+    - 0034_invoice
+    - 0035_invoice
+    - 0036_invoice
+    - 0037_invoice
+    - 0038_invoice
+    - 0040_invoice
+    - 0042_invoice
+    - 0043_invoice
+    - 0044_invoice
+    - 0045_invoice
+    - 0046_invoice
+    - 0047_invoice
+    - 0048_invoice
+    - 0049_invoice
+    - 0051_invoice
+    - 0052_invoice
+    - 0053_invoice
+    - 0054_invoice
+    - 0055_invoice
+    - 0056_invoice
+    - 0058_invoice
+    - 0059_invoice
+    - 0060_invoice
+    sample:
+    - 0001_invoice
+    - 0002_invoice
+    - 0003_invoice
+    - 0004_invoice
+    - 0005_invoice
+    - 0006_invoice
+    - 0007_invoice
+    - 0008_invoice
+    - 0009_invoice
+    - 0010_invoice
+  type: find
+- id: synth-find-policies-q4-2025
+  question: Find Marbledock policies that take effect in Q4 2025 (October, November,
+    or December 2025).
+  clause_category: cross-doc
+  gold_doc: (see answer_key.all)
+  answer_key:
+    count: 6
+    all:
+    - 0191_policy_doc
+    - 0201_policy_doc
+    - 0203_policy_doc
+    - 0204_policy_doc
+    - 0210_policy_doc
+    - 0215_policy_doc
+    sample:
+    - 0191_policy_doc
+    - 0201_policy_doc
+    - 0203_policy_doc
+    - 0204_policy_doc
+    - 0210_policy_doc
+    - 0215_policy_doc
+  type: find
+- id: synth-neg-invoice-99999
+  question: What is the total amount of invoice INV-99999?
+  clause_category: invoice
+  gold_doc: (none expected)
+  answer_key: null
+  type: negative
+- id: synth-find-neg-vendor-globex-aerospace
+  question: Find vendor contracts where the vendor is Globex Aerospace.
+  clause_category: cross-doc
+  gold_doc: (see answer_key.all)
+  answer_key:
+    count: 0
+    all: []
+    sample: []
+  type: find

--- a/scripts/test_corpora/pyproject.toml
+++ b/scripts/test_corpora/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12,<3.14"
 dependencies = [
     "httpx>=0.28",
     "anthropic>=0.43",
+    "openai>=1.50",
     "mcp>=1.9",
     "pyyaml>=6",
     "tenacity>=9",

--- a/scripts/test_corpora/runner/answer_eval.py
+++ b/scripts/test_corpora/runner/answer_eval.py
@@ -231,17 +231,19 @@ def run(
 def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) -> Callable[[GTItem], dict]:
     """Build the production capture function: a model+MCP run per item.
 
-    Reuses the phase-1 machinery — SyncMcpSession for the MCP tool calls,
-    BaselineGenerator for the agentic loop. The MCP session MUST be
+    Uses make_provider() to dispatch on model name (claude-* -> AnthropicProvider,
+    gpt-* / o1-* / o3-* -> OpenAIProvider). The MCP session MUST be
     authenticated with a corpus-scoped API key so HC's search is restricted to
     `corpus`: set HC_API_KEY to that scoped key. Falls back to a
     HC_USERNAME/HC_PASSWORD login, which yields an UNSCOPED (full-index)
     session — correct only when `corpus` is the lone corpus loaded.
-    """
-    import anthropic
 
-    from scripts.test_corpora.runner.claude_baseline import BaselineGenerator
+    The provider's underlying API client (anthropic.Anthropic() or
+    openai.OpenAI()) is lazily constructed inside the provider; both read
+    their API keys from env (ANTHROPIC_API_KEY / OPENAI_API_KEY).
+    """
     from scripts.test_corpora.runner.client import HarborClerkClient, SyncMcpSession
+    from scripts.test_corpora.runner.providers import make_provider
 
     token = os.environ.get("HC_API_KEY")
     if not token:
@@ -259,11 +261,10 @@ def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) 
 
     mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
     mcp = SyncMcpSession(url=mcp_url, headers={"Authorization": f"Bearer {token}"})
-    anthro = anthropic.Anthropic()
 
     def capture(item: GTItem) -> dict:
-        gen = BaselineGenerator(client=anthro, mcp_session=mcp, model=model)
-        res = gen.run_question(question=item.question, question_id=item.id, corpus=corpus)
+        provider = make_provider(model, mcp_session=mcp)
+        res = provider.run_question(question=item.question, question_id=item.id, corpus=corpus)
         return dataclasses.asdict(res)
 
     return capture

--- a/scripts/test_corpora/runner/answer_eval.py
+++ b/scripts/test_corpora/runner/answer_eval.py
@@ -262,8 +262,18 @@ def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) 
     mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
     mcp = SyncMcpSession(url=mcp_url, headers={"Authorization": f"Bearer {token}"})
 
+    # Build a single shared provider for the whole run — each call to
+    # make_provider() would otherwise construct a fresh openai.OpenAI() (and
+    # its httpx connection pool) per item; 29 leaked pools over a run.
+    # Cited-doc bookkeeping is per-question, so we wipe `_cited` between
+    # items to keep results comparable to the pre-refactor per-item model.
+    provider = make_provider(model, mcp_session=mcp)
+
     def capture(item: GTItem) -> dict:
-        provider = make_provider(model, mcp_session=mcp)
+        # Per-question reset: AnthropicProvider/OpenAIProvider both store
+        # cited docs in `_cited`. A fresh dict per item keeps each
+        # BaselineResult's cited_doc_ids scoped to that question's tool calls.
+        provider._cited = {}
         res = provider.run_question(question=item.question, question_id=item.id, corpus=corpus)
         return dataclasses.asdict(res)
 

--- a/scripts/test_corpora/runner/answer_judge.py
+++ b/scripts/test_corpora/runner/answer_judge.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 import re
 
 import anthropic
+
+log = logging.getLogger("answer_judge")
 
 JUDGE_MODEL = "claude-sonnet-4-6"
 
@@ -142,8 +145,25 @@ class AnswerJudge:
         )
         data = _extract_json(msg.content[0].text)
         return AnswerVerdict(
-            correctness=int(data["correctness"]),
-            groundedness=int(data["groundedness"]),
-            completeness=int(data["completeness"]),
+            correctness=_score(data, "correctness"),
+            groundedness=_score(data, "groundedness"),
+            completeness=_score(data, "completeness"),
             rationale=str(data.get("rationale", "")),
         )
+
+
+def _score(data: dict, key: str) -> int:
+    """Pull a 0–5 score from the judge's parsed JSON, defaulting to 0 with a
+    warning if the key is missing. Sonnet occasionally omits a score key when
+    the prompt says \"SET TO 0; do not guess it\" (as the find-type prompt does
+    for completeness) — interpreting \"don't guess\" as \"don't include.\"
+    Failing the whole run on one omission is too harsh; default + warn keeps
+    the eval progressing and surfaces the issue in logs."""
+    if key not in data:
+        log.warning("judge response missing %r — defaulting to 0", key)
+        return 0
+    try:
+        return int(data[key])
+    except (TypeError, ValueError):
+        log.warning("judge response %r=%r not coercible to int — defaulting to 0", key, data[key])
+        return 0

--- a/scripts/test_corpora/runner/claude_baseline.py
+++ b/scripts/test_corpora/runner/claude_baseline.py
@@ -1,195 +1,25 @@
-"""Phase 1 — Claude baseline generator.
+# scripts/test_corpora/runner/claude_baseline.py
+"""Back-compat shim — the real code lives in providers/anthropic_provider.py.
 
-Runs Sonnet 4.6 with Harbor Clerk's MCP server attached as a tool source.
-Captures the final answer plus the doc IDs surfaced via ``kb_search`` /
-``kb_read_passages`` / ``kb_get_document`` tool calls. Saves one JSON
-file per (corpus, question_id) under ``baselines/``.
+`BaselineGenerator` is exported as an alias for `AnthropicProvider` so that
+`sweep.py`'s 30+ import sites (and `tests/test_baseline.py`) continue to
+work unchanged. A follow-up PR can migrate `sweep.py` to use
+`make_provider()` directly; that's a larger blast radius — deferred.
 
-The tool-call loop mirrors what an MCP client does: send the user's
-question, get back tool_use blocks, execute them via the MCP session,
-feed results back, repeat until ``stop_reason == 'end_turn'``.
+See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md
+for the design rationale.
 """
 
 from __future__ import annotations
 
-import dataclasses
-import json
-import time
-from pathlib import Path
-from typing import Any
+from scripts.test_corpora.runner.providers.anthropic_provider import (
+    AnthropicProvider as BaselineGenerator,
+)
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT as SYSTEM_PROMPT,
+)
+from scripts.test_corpora.runner.providers.base import (
+    BaselineResult,
+)
 
-import anthropic
-
-SYSTEM_PROMPT = """You are answering a user's question about a specific document corpus.
-You have access to the corpus only through the provided MCP tools (kb_search,
-kb_read_passages, kb_get_document, kb_find_related, etc.). Use them as
-needed. Cite specific documents in your answer by doc_id.
-
-Be thorough — your answer is the gold-standard reference for evaluating
-local models. Spend tool calls liberally."""
-
-
-@dataclasses.dataclass
-class BaselineResult:
-    question_id: str
-    question: str
-    answer: str
-    cited_doc_ids: list[str]
-    # Stable, ingest-independent identifiers for the cited docs, parallel to
-    # cited_doc_ids (same order). doc_id is a random per-ingest UUID, so a
-    # baseline's cited_doc_ids never intersect a phase-4 response's doc_ids
-    # unless both ran against the exact same ingest. doc_title (the filename
-    # stem) is stable across re-ingests, so citation_overlap computed on
-    # titles stays correct even when baseline and response come from
-    # different ingests. Empty string for any cited doc whose tool result
-    # carried no title.
-    cited_doc_titles: list[str]
-    tool_call_count: int
-    # Per-call record [{tool, args, result_summary}] in call order — for
-    # groundedness scoring and tool-use auditing.
-    tool_transcript: list[dict]
-    elapsed_seconds: float
-    model: str
-    timestamp: str
-
-
-class BaselineGenerator:
-    """Runs Sonnet 4.6 + MCP for one question.
-
-    The constructor takes an opaque ``mcp_session`` — in production this is
-    an ``mcp.ClientSession`` connected to Harbor Clerk's MCP server. In tests,
-    it can be ``None`` if the mock anthropic client doesn't actually emit
-    tool_use blocks.
-    """
-
-    def __init__(
-        self,
-        client: anthropic.Anthropic,
-        mcp_session: Any,
-        model: str = "claude-sonnet-4-6",
-        doc_ids_seen: list[str] | None = None,
-    ):
-        self._client = client
-        self._mcp = mcp_session
-        self._model = model
-        # Ordered map doc_id -> doc_title, in first-seen order. dict preserves
-        # insertion order (3.7+), so cited_doc_ids and cited_doc_titles stay
-        # parallel. For tests: pre-seed via doc_ids_seen (titles default to "").
-        self._cited: dict[str, str] = {did: "" for did in doc_ids_seen} if doc_ids_seen else {}
-
-    def _list_tools(self) -> list[dict]:
-        """Discover MCP tools and convert to Anthropic's tool schema."""
-        if self._mcp is None:
-            return []
-        # mcp.types.Tool has .name, .description, .inputSchema
-        tools = self._mcp.list_tools()  # sync wrapper expected
-        return [{"name": t.name, "description": t.description or "", "input_schema": t.inputSchema} for t in tools]
-
-    def _exec_tool(self, name: str, args: dict) -> str:
-        """Execute one MCP tool call, capture any doc_ids in the result."""
-        result = self._mcp.call_tool(name, args)
-        # Collect text content; capture doc_ids if present in the JSON
-        text_chunks: list[str] = []
-        for block in result.content:
-            if hasattr(block, "text"):
-                text_chunks.append(block.text)
-                # Greedy extraction: if the tool returned JSON containing
-                # doc_id fields, harvest them. Robust to nested structures.
-                try:
-                    parsed = json.loads(block.text)
-                    self._collect_doc_ids(parsed)
-                except (json.JSONDecodeError, TypeError):
-                    pass
-        return "\n".join(text_chunks) or "(empty)"
-
-    def _collect_doc_ids(self, obj: Any) -> None:
-        if isinstance(obj, dict):
-            doc_id = obj.get("doc_id")
-            if isinstance(doc_id, str):
-                # Pair the doc_id with its title from the SAME dict. MCP tool
-                # results (kb_search etc.) emit doc_id + doc_title together;
-                # fall back to "title" then "". First-seen title wins — if a
-                # later result re-mentions the doc with a title where the
-                # first had none, upgrade the stored value.
-                title = obj.get("doc_title") or obj.get("title") or ""
-                if doc_id not in self._cited or (title and not self._cited[doc_id]):
-                    self._cited[doc_id] = title
-            for v in obj.values():
-                self._collect_doc_ids(v)
-        elif isinstance(obj, list):
-            for v in obj:
-                self._collect_doc_ids(v)
-
-    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
-        started = time.time()
-        tools = self._list_tools()
-        messages: list[dict] = [{"role": "user", "content": question}]
-        tool_call_count = 0
-        tool_transcript: list[dict] = []
-        resp = None
-
-        while True:
-            resp = self._client.messages.create(
-                model=self._model,
-                max_tokens=8000,
-                system=SYSTEM_PROMPT,
-                tools=tools,
-                messages=messages,
-            )
-            messages.append({"role": "assistant", "content": resp.content})
-
-            if resp.stop_reason == "end_turn":
-                break
-            if resp.stop_reason != "tool_use":
-                break  # safety
-
-            # Execute each tool_use block, send results back as user message
-            tool_results: list[dict] = []
-            for block in resp.content:
-                if getattr(block, "type", None) == "tool_use":
-                    tool_call_count += 1
-                    out = self._exec_tool(block.name, block.input)
-                    tool_transcript.append(
-                        {
-                            "tool": block.name,
-                            "args": dict(block.input),
-                            "result_summary": out[:600],
-                        }
-                    )
-                    tool_results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": block.id,
-                            "content": out,
-                        }
-                    )
-            messages.append({"role": "user", "content": tool_results})
-
-        # Final answer is the last text block in the assistant turn — scan from
-        # the end so a leading non-text block (e.g. tool_use) is skipped.
-        final = ""
-        if resp and resp.content:
-            for block in reversed(resp.content):
-                if hasattr(block, "text"):
-                    final = block.text
-                    break
-
-        return BaselineResult(
-            question_id=question_id,
-            question=question,
-            answer=final,
-            cited_doc_ids=list(self._cited.keys()),
-            cited_doc_titles=list(self._cited.values()),
-            tool_call_count=tool_call_count,
-            tool_transcript=tool_transcript,
-            elapsed_seconds=time.time() - started,
-            model=self._model,
-            timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        )
-
-    @staticmethod
-    def write(result: BaselineResult, results_dir: Path, corpus: str) -> Path:
-        out = results_dir / "baselines" / corpus / f"{result.question_id}.json"
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(dataclasses.asdict(result), indent=2))
-        return out
+__all__ = ["BaselineGenerator", "BaselineResult", "SYSTEM_PROMPT"]

--- a/scripts/test_corpora/runner/providers/__init__.py
+++ b/scripts/test_corpora/runner/providers/__init__.py
@@ -1,0 +1,7 @@
+# scripts/test_corpora/runner/providers/__init__.py
+"""Multi-provider abstraction for the answer-eval baseline.
+
+See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md for
+the design rationale (Provider protocol + factory dispatch by model-name
+prefix). Public exports are populated in Task 6.
+"""

--- a/scripts/test_corpora/runner/providers/__init__.py
+++ b/scripts/test_corpora/runner/providers/__init__.py
@@ -1,7 +1,31 @@
 # scripts/test_corpora/runner/providers/__init__.py
 """Multi-provider abstraction for the answer-eval baseline.
 
-See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md for
-the design rationale (Provider protocol + factory dispatch by model-name
-prefix). Public exports are populated in Task 6.
+Public API:
+  Provider              — typing.Protocol every provider satisfies
+  BaselineResult        — universal dataclass returned by every provider
+  DEFAULT_SYSTEM_PROMPT — shared system prompt across providers
+  AnthropicProvider     — Sonnet (or any claude-* model) + MCP
+  OpenAIProvider        — gpt-4o (or any gpt-*/o1-*/o3-* model) + MCP
+  make_provider         — factory: dispatch by model-name prefix
+
+See docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md.
 """
+
+from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
+    Provider,
+)
+from scripts.test_corpora.runner.providers.factory import make_provider
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+__all__ = [
+    "AnthropicProvider",
+    "BaselineResult",
+    "DEFAULT_SYSTEM_PROMPT",
+    "OpenAIProvider",
+    "Provider",
+    "make_provider",
+]

--- a/scripts/test_corpora/runner/providers/anthropic_provider.py
+++ b/scripts/test_corpora/runner/providers/anthropic_provider.py
@@ -40,13 +40,22 @@ class AnthropicProvider:
         client: anthropic.Anthropic | None = None,
         doc_ids_seen: list[str] | None = None,
     ):
-        self._client = client if client is not None else anthropic.Anthropic()
+        # Lazy client construction (symmetric with OpenAIProvider). Defer
+        # anthropic.Anthropic() until first API call so factory dispatch
+        # tests don't need ANTHROPIC_API_KEY set.
+        self._explicit_client = client
         self._mcp = mcp_session
         self._model = model
         # Ordered map doc_id -> doc_title, in first-seen order. dict preserves
         # insertion order (3.7+), so cited_doc_ids and cited_doc_titles stay
         # parallel. For tests: pre-seed via doc_ids_seen (titles default to "").
         self._cited: dict[str, str] = {did: "" for did in doc_ids_seen} if doc_ids_seen else {}
+
+    @property
+    def _client(self) -> anthropic.Anthropic:
+        if self._explicit_client is None:
+            self._explicit_client = anthropic.Anthropic()
+        return self._explicit_client
 
     def _list_tools(self) -> list[dict]:
         """Discover MCP tools and convert to Anthropic's tool schema."""

--- a/scripts/test_corpora/runner/providers/anthropic_provider.py
+++ b/scripts/test_corpora/runner/providers/anthropic_provider.py
@@ -1,0 +1,172 @@
+# scripts/test_corpora/runner/providers/anthropic_provider.py
+"""AnthropicProvider — Sonnet (or any claude-* model) + Harbor Clerk MCP.
+
+Body is the pre-refactor BaselineGenerator.run_question loop, lifted out of
+claude_baseline.py verbatim. claude_baseline.py becomes a thin re-export
+shim in Task 3 so sweep.py's existing import sites stay untouched.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import anthropic
+
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
+)
+
+
+class AnthropicProvider:
+    """Runs a Sonnet (or other claude-*) model + Harbor Clerk MCP for one question.
+
+    Constructor accepts `client=None` for back-compat with the pre-refactor
+    `BaselineGenerator(client=..., mcp_session=...)` call signature in
+    sweep.py — when not provided, the factory's convenience role lazily
+    constructs `anthropic.Anthropic()` (which reads ANTHROPIC_API_KEY from
+    env). Tests pass a mock client explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_session: Any,
+        model: str = "claude-sonnet-4-6",
+        client: anthropic.Anthropic | None = None,
+        doc_ids_seen: list[str] | None = None,
+    ):
+        self._client = client if client is not None else anthropic.Anthropic()
+        self._mcp = mcp_session
+        self._model = model
+        # Ordered map doc_id -> doc_title, in first-seen order. dict preserves
+        # insertion order (3.7+), so cited_doc_ids and cited_doc_titles stay
+        # parallel. For tests: pre-seed via doc_ids_seen (titles default to "").
+        self._cited: dict[str, str] = {did: "" for did in doc_ids_seen} if doc_ids_seen else {}
+
+    def _list_tools(self) -> list[dict]:
+        """Discover MCP tools and convert to Anthropic's tool schema."""
+        if self._mcp is None:
+            return []
+        # mcp.types.Tool has .name, .description, .inputSchema
+        tools = self._mcp.list_tools()  # sync wrapper expected
+        return [{"name": t.name, "description": t.description or "", "input_schema": t.inputSchema} for t in tools]
+
+    def _exec_tool(self, name: str, args: dict) -> str:
+        """Execute one MCP tool call, capture any doc_ids in the result."""
+        result = self._mcp.call_tool(name, args)
+        # Collect text content; capture doc_ids if present in the JSON
+        text_chunks: list[str] = []
+        for block in result.content:
+            if hasattr(block, "text"):
+                text_chunks.append(block.text)
+                # Greedy extraction: if the tool returned JSON containing
+                # doc_id fields, harvest them. Robust to nested structures.
+                try:
+                    parsed = json.loads(block.text)
+                    self._collect_doc_ids(parsed)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return "\n".join(text_chunks) or "(empty)"
+
+    def _collect_doc_ids(self, obj: Any) -> None:
+        if isinstance(obj, dict):
+            doc_id = obj.get("doc_id")
+            if isinstance(doc_id, str):
+                # Pair the doc_id with its title from the SAME dict. MCP tool
+                # results (kb_search etc.) emit doc_id + doc_title together;
+                # fall back to "title" then "". First-seen title wins — if a
+                # later result re-mentions the doc with a title where the
+                # first had none, upgrade the stored value.
+                title = obj.get("doc_title") or obj.get("title") or ""
+                if doc_id not in self._cited or (title and not self._cited[doc_id]):
+                    self._cited[doc_id] = title
+            for v in obj.values():
+                self._collect_doc_ids(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                self._collect_doc_ids(v)
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+        started = time.time()
+        tools = self._list_tools()
+        messages: list[dict] = [{"role": "user", "content": question}]
+        tool_call_count = 0
+        tool_transcript: list[dict] = []
+        resp = None
+
+        while True:
+            resp = self._client.messages.create(
+                model=self._model,
+                max_tokens=8000,
+                system=DEFAULT_SYSTEM_PROMPT,
+                tools=tools,
+                messages=messages,
+            )
+            messages.append({"role": "assistant", "content": resp.content})
+
+            if resp.stop_reason == "end_turn":
+                break
+            if resp.stop_reason != "tool_use":
+                break  # safety
+
+            # Execute each tool_use block, send results back as user message
+            tool_results: list[dict] = []
+            for block in resp.content:
+                if getattr(block, "type", None) == "tool_use":
+                    tool_call_count += 1
+                    out = self._exec_tool(block.name, block.input)
+                    tool_transcript.append(
+                        {
+                            "tool": block.name,
+                            "args": dict(block.input),
+                            "result_summary": out[:600],
+                        }
+                    )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": out,
+                        }
+                    )
+            messages.append({"role": "user", "content": tool_results})
+
+        # Final answer is the last text block in the assistant turn — scan from
+        # the end so a leading non-text block (e.g. tool_use) is skipped.
+        final = ""
+        if resp and resp.content:
+            for block in reversed(resp.content):
+                if hasattr(block, "text"):
+                    final = block.text
+                    break
+
+        return BaselineResult(
+            question_id=question_id,
+            question=question,
+            answer=final,
+            cited_doc_ids=list(self._cited.keys()),
+            cited_doc_titles=list(self._cited.values()),
+            tool_call_count=tool_call_count,
+            tool_transcript=tool_transcript,
+            elapsed_seconds=time.time() - started,
+            model=self._model,
+            timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        )
+
+    @staticmethod
+    def write(result: BaselineResult, results_dir: Path, corpus: str) -> Path:
+        """Write a BaselineResult JSON under results_dir/baselines/<corpus>/.
+
+        Kept as a @staticmethod (not a free function) for shim compatibility:
+        the sweep.py phase-1 baseline calls `BaselineGenerator.write(...)`,
+        which the shim re-exports as `AnthropicProvider.write`.
+        """
+        out = results_dir / "baselines" / corpus / f"{result.question_id}.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(dataclasses.asdict(result), indent=2))
+        return out

--- a/scripts/test_corpora/runner/providers/base.py
+++ b/scripts/test_corpora/runner/providers/base.py
@@ -1,0 +1,65 @@
+# scripts/test_corpora/runner/providers/base.py
+"""Provider Protocol + universal BaselineResult dataclass.
+
+Every concrete provider (AnthropicProvider, OpenAIProvider, ...) exposes the
+same `run_question(question, question_id, corpus) -> BaselineResult` method.
+BaselineResult is the canonical serialization shape under
+`workdir/answer-eval/captures/<corpus>/<model>/<question_id>.json` — same
+fields across providers so the judging loop in answer_eval.py is provider-blind.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol, runtime_checkable
+
+DEFAULT_SYSTEM_PROMPT = """You are answering a user's question about a specific document corpus.
+You have access to the corpus only through the provided MCP tools (kb_search,
+kb_read_passages, kb_get_document, kb_find_related, etc.). Use them as
+needed. Cite specific documents in your answer by doc_id.
+
+Be thorough — your answer is the gold-standard reference for evaluating
+local models. Spend tool calls liberally."""
+
+
+@dataclasses.dataclass
+class BaselineResult:
+    """Universal return shape from every Provider's `run_question`.
+
+    Fields mirror the pre-refactor `claude_baseline.BaselineResult` so the
+    file-on-disk format and downstream consumers (judge, metrics roll-up)
+    don't need to change.
+    """
+
+    question_id: str
+    question: str
+    answer: str
+    cited_doc_ids: list[str]
+    # Stable, ingest-independent identifiers for the cited docs, parallel to
+    # cited_doc_ids (same order). doc_id is a random per-ingest UUID, so a
+    # baseline's cited_doc_ids never intersect a phase-4 response's doc_ids
+    # unless both ran against the exact same ingest. doc_title (the filename
+    # stem) is stable across re-ingests, so citation_overlap computed on
+    # titles stays correct even when baseline and response come from
+    # different ingests. Empty string for any cited doc whose tool result
+    # carried no title.
+    cited_doc_titles: list[str]
+    tool_call_count: int
+    # Per-call record [{tool, args, result_summary}] in call order — for
+    # groundedness scoring and tool-use auditing.
+    tool_transcript: list[dict]
+    elapsed_seconds: float
+    model: str
+    timestamp: str
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """The narrow protocol every baseline provider satisfies.
+
+    Implementations: AnthropicProvider, OpenAIProvider. Use
+    `providers.factory.make_provider(model, *, mcp_session)` to construct
+    one by model name.
+    """
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult: ...

--- a/scripts/test_corpora/runner/providers/factory.py
+++ b/scripts/test_corpora/runner/providers/factory.py
@@ -1,0 +1,43 @@
+# scripts/test_corpora/runner/providers/factory.py
+"""make_provider — single dispatch point that maps model name → Provider.
+
+String matching by prefix:
+  claude-*           -> AnthropicProvider
+  gpt-* / o1-* / o3-* -> OpenAIProvider
+
+Unknown prefixes raise ValueError with the supported list. The factory
+lazily constructs the underlying client (anthropic.Anthropic() or
+openai.OpenAI()) inside the matched branch via the provider's own
+constructor — both read API keys from the standard env vars
+(ANTHROPIC_API_KEY, OPENAI_API_KEY).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+from scripts.test_corpora.runner.providers.base import Provider
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+_ANTHROPIC_PREFIXES = ("claude-",)
+_OPENAI_PREFIXES = ("gpt-", "o1-", "o3-")
+
+
+def make_provider(
+    model: str,
+    *,
+    mcp_session: Any,
+    doc_ids_seen: list[str] | None = None,
+) -> Provider:
+    """Construct a Provider for `model` wired to `mcp_session`.
+
+    `doc_ids_seen` pre-seeds the cited-doc map (used by tests + by callers
+    that want to anchor citations to a known starting set).
+    """
+    if model.startswith(_ANTHROPIC_PREFIXES):
+        return AnthropicProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
+    if model.startswith(_OPENAI_PREFIXES):
+        return OpenAIProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
+    supported = ", ".join(_ANTHROPIC_PREFIXES + _OPENAI_PREFIXES)
+    raise ValueError(f"unknown model {model!r}; supported prefixes: {supported}")

--- a/scripts/test_corpora/runner/providers/openai_provider.py
+++ b/scripts/test_corpora/runner/providers/openai_provider.py
@@ -31,6 +31,15 @@ from scripts.test_corpora.runner.providers.base import (
 log = logging.getLogger("openai_provider")
 
 
+# Retry budget for openai.RateLimitError (429) inside run_question. The SDK
+# does its own short retries (~5s) but a TPM-window reset takes up to 60s,
+# so the SDK gives up before the window clears on low-tier keys. We retry
+# with explicit exponential backoff (30s, 60s, 120s, 240s — capped) and
+# give up after the budget is exhausted, in which case the error propagates
+# and the eval runner can leave the unit PENDING for --rejudge later.
+_OPENAI_RATE_LIMIT_RETRY_DELAYS = (30.0, 60.0, 120.0, 240.0)
+
+
 class OpenAIProvider:
     """Runs a gpt-* (or o1-*/o3-*) model + Harbor Clerk MCP for one question."""
 
@@ -107,6 +116,33 @@ class OpenAIProvider:
             for v in obj:
                 self._collect_doc_ids(v)
 
+    def _create_with_rate_limit_retry(self, kwargs: dict):
+        """Retry openai.RateLimitError (429) with exponential backoff.
+
+        The OpenAI SDK's built-in retry obeys the API's Retry-After hint
+        (often "28ms" for TPM limits even though the window is actually 60s).
+        The SDK exhausts its short retry budget and propagates the 429
+        before the TPM window clears. We absorb that by retrying with a
+        30s/60s/120s/240s schedule on top of the SDK's own retries.
+
+        Looks up ``time.sleep`` at call time (not via default-arg binding)
+        so tests can patch ``time.sleep`` without monkey-patching the
+        provider's __init__ signature.
+        """
+        for attempt, delay in enumerate(_OPENAI_RATE_LIMIT_RETRY_DELAYS, start=1):
+            try:
+                return self._client.chat.completions.create(**kwargs)
+            except openai.RateLimitError:
+                log.warning(
+                    "openai 429 (rate limit) — backing off %.0fs before retry (attempt %d/%d)",
+                    delay,
+                    attempt,
+                    len(_OPENAI_RATE_LIMIT_RETRY_DELAYS),
+                )
+                time.sleep(delay)
+        # Final attempt — let any further error propagate
+        return self._client.chat.completions.create(**kwargs)
+
     def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
         started = time.time()
         tools = self._list_tools()
@@ -127,7 +163,7 @@ class OpenAIProvider:
             if tools:
                 kwargs["tools"] = tools
                 kwargs["tool_choice"] = "auto"
-            resp = self._client.chat.completions.create(**kwargs)
+            resp = self._create_with_rate_limit_retry(kwargs)
             choice = resp.choices[0]
             msg = choice.message
             finish = choice.finish_reason

--- a/scripts/test_corpora/runner/providers/openai_provider.py
+++ b/scripts/test_corpora/runner/providers/openai_provider.py
@@ -1,0 +1,192 @@
+# scripts/test_corpora/runner/providers/openai_provider.py
+"""OpenAIProvider — gpt-* (and o1-*/o3-*) + Harbor Clerk MCP.
+
+Structurally mirrors AnthropicProvider but speaks OpenAI's chat.completions
+tool_calls protocol:
+  1. Send user message + tools list.
+  2. Receive a response with `finish_reason`:
+     - "stop"        -> done, return final assistant text
+     - "tool_calls"  -> execute each tool, send results back, loop
+     - "length"      -> response truncated; treat as end-of-turn (logged warn)
+  3. Tool result messages have role="tool", tool_call_id=<call id>.
+
+Constructor accepts client=None for symmetry with AnthropicProvider; when
+None, openai.OpenAI() reads OPENAI_API_KEY from env.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import openai
+
+from scripts.test_corpora.runner.providers.base import (
+    DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
+)
+
+log = logging.getLogger("openai_provider")
+
+
+class OpenAIProvider:
+    """Runs a gpt-* (or o1-*/o3-*) model + Harbor Clerk MCP for one question."""
+
+    def __init__(
+        self,
+        *,
+        mcp_session: Any,
+        model: str = "gpt-4o",
+        client: openai.OpenAI | None = None,
+        doc_ids_seen: list[str] | None = None,
+    ):
+        # Lazy client construction — openai.OpenAI() validates OPENAI_API_KEY at
+        # __init__ time (anthropic.Anthropic() doesn't), so eager construction
+        # in the factory's no-API-call path (e.g. factory dispatch tests)
+        # would force every caller to have OPENAI_API_KEY set. Defer to first
+        # API call instead.
+        self._explicit_client = client
+        self._mcp = mcp_session
+        self._model = model
+        self._cited: dict[str, str] = {did: "" for did in doc_ids_seen} if doc_ids_seen else {}
+
+    @property
+    def _client(self) -> openai.OpenAI:
+        if self._explicit_client is None:
+            self._explicit_client = openai.OpenAI()
+        return self._explicit_client
+
+    def _list_tools(self) -> list[dict]:
+        """Discover MCP tools and convert to OpenAI's `tools` schema.
+
+        OpenAI shape: [{"type": "function", "function": {"name", "description",
+        "parameters"}}]. The MCP tool's `inputSchema` slots directly into
+        `function.parameters` (both are JSON Schema).
+        """
+        if self._mcp is None:
+            return []
+        tools = self._mcp.list_tools()
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description or "",
+                    "parameters": t.inputSchema,
+                },
+            }
+            for t in tools
+        ]
+
+    def _exec_tool(self, name: str, args: dict) -> str:
+        """Execute one MCP tool call, capture any doc_ids in the result."""
+        result = self._mcp.call_tool(name, args)
+        text_chunks: list[str] = []
+        for block in result.content:
+            if hasattr(block, "text"):
+                text_chunks.append(block.text)
+                try:
+                    parsed = json.loads(block.text)
+                    self._collect_doc_ids(parsed)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return "\n".join(text_chunks) or "(empty)"
+
+    def _collect_doc_ids(self, obj: Any) -> None:
+        if isinstance(obj, dict):
+            doc_id = obj.get("doc_id")
+            if isinstance(doc_id, str):
+                title = obj.get("doc_title") or obj.get("title") or ""
+                if doc_id not in self._cited or (title and not self._cited[doc_id]):
+                    self._cited[doc_id] = title
+            for v in obj.values():
+                self._collect_doc_ids(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                self._collect_doc_ids(v)
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+        started = time.time()
+        tools = self._list_tools()
+        messages: list[dict] = [
+            {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ]
+        tool_call_count = 0
+        tool_transcript: list[dict] = []
+        final_text = ""
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": 8000,
+                "messages": messages,
+            }
+            if tools:
+                kwargs["tools"] = tools
+                kwargs["tool_choice"] = "auto"
+            resp = self._client.chat.completions.create(**kwargs)
+            choice = resp.choices[0]
+            msg = choice.message
+            finish = choice.finish_reason
+
+            # Persist the assistant message before loop-deciding so subsequent
+            # tool results pair with it correctly. OpenAI requires the
+            # assistant message that contained the tool_calls to be in the
+            # history before the tool-result messages.
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": msg.content or ""}
+            if msg.tool_calls:
+                assistant_msg["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                    }
+                    for tc in msg.tool_calls
+                ]
+            messages.append(assistant_msg)
+
+            if finish == "tool_calls" and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_call_count += 1
+                    try:
+                        args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+                    except json.JSONDecodeError:
+                        args = {}
+                    out = self._exec_tool(tc.function.name, args)
+                    tool_transcript.append(
+                        {
+                            "tool": tc.function.name,
+                            "args": args,
+                            "result_summary": out[:600],
+                        }
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": out,
+                        }
+                    )
+                continue  # loop to next assistant turn
+
+            # finish in {"stop", "length", "content_filter", "function_call", ...}
+            if finish == "length":
+                log.warning("openai response truncated (finish_reason=length) — returning partial answer")
+            final_text = msg.content or ""
+            break
+
+        return BaselineResult(
+            question_id=question_id,
+            question=question,
+            answer=final_text,
+            cited_doc_ids=list(self._cited.keys()),
+            cited_doc_titles=list(self._cited.values()),
+            tool_call_count=tool_call_count,
+            tool_transcript=tool_transcript,
+            elapsed_seconds=time.time() - started,
+            model=self._model,
+            timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        )

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -96,35 +96,62 @@ ANTHROPIC_RETRY_MAX_DELAY_SECONDS = 600
 ANTHROPIC_RETRY_BUDGET_SECONDS = 3600
 
 
-def _with_anthropic_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = ANTHROPIC_RETRY_BUDGET_SECONDS):
-    """Call ``fn(*args)``, retrying on transient Anthropic API errors —
-    ``RateLimitError`` (HTTP 429) and ``OverloadedError`` (HTTP 529).
+def _retryable_exceptions(client_kind: str) -> tuple[type[BaseException], ...]:
+    """Return the exception classes treated as transient for `client_kind`.
 
-    A rate-limit window or Anthropic overload routinely lasts longer than the
-    SDK's built-in ~5s retry window. Rather than let an uncaught
-    ``RateLimitError`` / ``OverloadedError`` abort a multi-hour sweep, retry
-    with exponential backoff (60s, 120s, 240s, ... capped at 600s per attempt)
-    until ``fn`` succeeds or the cumulative backoff reaches
-    ``max_total_seconds`` (~1 hr). On budget exhaustion the original error is
-    re-raised so the caller can leave the unit PENDING for a later
-    ``--resume``.
+    Imported lazily for openai so the optional dep isn't required at module
+    import time even if no openai-targeted call ever runs.
+    """
+    if client_kind == "anthropic":
+        return (OverloadedError, RateLimitError)
+    if client_kind == "openai":
+        import openai
+
+        # openai.RateLimitError covers 429; openai.APIStatusError covers other
+        # transient statuses (502/503/504). We narrow inside the retry loop
+        # to "truly transient" based on .status_code so a 400 bad-request
+        # never gets retried.
+        return (openai.RateLimitError, openai.APIStatusError)
+    raise ValueError(f"unknown client_kind {client_kind!r}; supported: anthropic, openai")
+
+
+def _with_provider_retry(
+    fn,
+    *args,
+    client_kind: str = "anthropic",
+    sleep=time.sleep,
+    max_total_seconds: int = ANTHROPIC_RETRY_BUDGET_SECONDS,
+):
+    """Call ``fn(*args)``, retrying on transient API errors from `client_kind`.
+
+    `client_kind` ∈ {"anthropic", "openai"} — picks the exception classes to
+    catch. Backoff schedule is the same across providers: 60s, 120s, 240s,
+    capped at 600s/attempt, with a cumulative budget of `max_total_seconds`
+    (~1 hr default). On budget exhaustion the original exception is re-raised
+    so the caller can leave the unit PENDING for a later --resume.
 
     ``sleep`` is injectable so tests need not wait in real time.
     """
+    transient = _retryable_exceptions(client_kind)
     attempt = 0
     waited = 0.0
     while True:
         try:
             return fn(*args)
-        except (OverloadedError, RateLimitError) as exc:
+        except transient as exc:
+            # For openai.APIStatusError, narrow to truly transient statuses;
+            # a 400 bad-request shouldn't be retried.
+            status = getattr(exc, "status_code", None)
+            if client_kind == "openai" and status is not None and status not in (429, 500, 502, 503, 504):
+                raise
             if waited >= max_total_seconds:
                 raise
             delay = min(ANTHROPIC_RETRY_BASE_SECONDS * 2**attempt, ANTHROPIC_RETRY_MAX_DELAY_SECONDS)
             delay = min(delay, max_total_seconds - waited)
             log.warning(
-                "Anthropic API returned HTTP %s — backing off %.0fs before retry "
-                "(attempt %d, %.0fs of %ds budget used)",
-                exc.status_code,
+                "%s API returned HTTP %s — backing off %.0fs before retry (attempt %d, %.0fs of %ds budget used)",
+                client_kind,
+                status,
                 delay,
                 attempt + 1,
                 waited,
@@ -133,6 +160,20 @@ def _with_anthropic_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = 
             sleep(delay)
             waited += delay
             attempt += 1
+
+
+def _with_anthropic_retry(fn, *args, sleep=time.sleep, max_total_seconds: int = ANTHROPIC_RETRY_BUDGET_SECONDS):
+    """Back-compat alias for callers that haven't yet switched to
+    _with_provider_retry. Functionally identical to
+    _with_provider_retry(client_kind='anthropic', ...).
+    """
+    return _with_provider_retry(
+        fn,
+        *args,
+        client_kind="anthropic",
+        sleep=sleep,
+        max_total_seconds=max_total_seconds,
+    )
 
 
 def _wait_for_hc_reachable(hc: HarborClerkClient, max_wait_seconds: int = HC_RECOVERY_WAIT_SECONDS) -> bool:

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -107,11 +107,13 @@ def _retryable_exceptions(client_kind: str) -> tuple[type[BaseException], ...]:
     if client_kind == "openai":
         import openai
 
-        # openai.RateLimitError covers 429; openai.APIStatusError covers other
-        # transient statuses (502/503/504). We narrow inside the retry loop
-        # to "truly transient" based on .status_code so a 400 bad-request
-        # never gets retried.
-        return (openai.RateLimitError, openai.APIStatusError)
+        # openai.RateLimitError is a SUBCLASS of openai.APIStatusError, so
+        # catching APIStatusError alone covers both. We narrow inside the
+        # retry loop to "truly transient" based on .status_code so a 400
+        # bad-request never gets retried — RateLimitError (429) is always in
+        # the allowlist, but to make the intent explicit and survive future
+        # filter tightening, the retry loop checks isinstance() first.
+        return (openai.APIStatusError,)
     raise ValueError(f"unknown client_kind {client_kind!r}; supported: anthropic, openai")
 
 
@@ -140,10 +142,17 @@ def _with_provider_retry(
             return fn(*args)
         except transient as exc:
             # For openai.APIStatusError, narrow to truly transient statuses;
-            # a 400 bad-request shouldn't be retried.
+            # a 400 bad-request shouldn't be retried. RateLimitError is a
+            # subclass of APIStatusError — always retry it regardless of the
+            # status-code filter (defensive against the filter shifting).
             status = getattr(exc, "status_code", None)
-            if client_kind == "openai" and status is not None and status not in (429, 500, 502, 503, 504):
-                raise
+            if client_kind == "openai":
+                import openai as _openai_for_isinstance
+
+                if not isinstance(exc, _openai_for_isinstance.RateLimitError) and (
+                    status is not None and status not in (500, 502, 503, 504)
+                ):
+                    raise
             if waited >= max_total_seconds:
                 raise
             delay = min(ANTHROPIC_RETRY_BASE_SECONDS * 2**attempt, ANTHROPIC_RETRY_MAX_DELAY_SECONDS)

--- a/scripts/test_corpora/tests/test_answer_judge.py
+++ b/scripts/test_corpora/tests/test_answer_judge.py
@@ -72,6 +72,44 @@ def test_extract_json_ignores_trailing_prose():
     assert _extract_json(txt)["correctness"] == 5
 
 
+def test_judge_defaults_missing_score_keys_to_zero():
+    """If the judge omits a score key (Sonnet sometimes drops 'completeness'
+    for find items when told 'SET TO 0; do not guess'), default to 0 rather
+    than crash with a KeyError mid-eval."""
+    c = MagicMock()
+    c.messages.create.return_value = MagicMock(
+        content=[MagicMock(text='{"correctness": 5, "groundedness": 4, "rationale": "no completeness key"}')]
+    )
+    v = AnswerJudge(client=c).judge_answer(
+        question="q",
+        model_answer="a",
+        cited="",
+        answer_key="k",
+        qtype="lookup",
+    )
+    assert v.correctness == 5
+    assert v.groundedness == 4
+    assert v.completeness == 0  # defaulted
+
+
+def test_judge_defaults_non_int_score_to_zero():
+    """If the judge returns a non-integer score (e.g., 'N/A'), default to 0."""
+    c = MagicMock()
+    c.messages.create.return_value = MagicMock(
+        content=[MagicMock(text='{"correctness": "N/A", "groundedness": 4, "completeness": 5, "rationale": "x"}')]
+    )
+    v = AnswerJudge(client=c).judge_answer(
+        question="q",
+        model_answer="a",
+        cited="",
+        answer_key="k",
+        qtype="lookup",
+    )
+    assert v.correctness == 0  # defaulted
+    assert v.groundedness == 4
+    assert v.completeness == 5
+
+
 def test_answer_verdict_source_defaults_to_empty_dict():
     """AnswerVerdict has an optional `source` field defaulting to {}."""
     v = AnswerVerdict(correctness=5, groundedness=5, completeness=5, rationale="ok")

--- a/scripts/test_corpora/tests/test_openai_provider.py
+++ b/scripts/test_corpora/tests/test_openai_provider.py
@@ -108,6 +108,41 @@ def test_openai_provider_treats_length_finish_as_end_turn():
     assert res.tool_call_count == 0
 
 
+def test_openai_provider_retries_on_429_rate_limit(monkeypatch):
+    """openai.RateLimitError (429) inside run_question is absorbed with
+    exponential backoff — the SDK's own retry budget is too short for TPM
+    limit windows (60s) and would otherwise propagate up and kill the eval."""
+    import httpx
+    import openai
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    rate_limit_err = openai.RateLimitError("rate limited", response=response, body=None)
+
+    client = MagicMock()
+    # Throw 429 twice, then succeed
+    client.chat.completions.create.side_effect = [
+        rate_limit_err,
+        rate_limit_err,
+        _mk_resp(finish_reason="stop", text="finally got through"),
+    ]
+
+    # Patch the provider module's time.sleep so the test runs in ms not minutes
+    sleeps: list[float] = []
+    import scripts.test_corpora.runner.providers.openai_provider as openai_mod
+
+    monkeypatch.setattr(openai_mod.time, "sleep", sleeps.append)
+
+    p = OpenAIProvider(mcp_session=None, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q-rl", corpus="cuad")
+
+    assert res.answer == "finally got through"
+    assert client.chat.completions.create.call_count == 3
+    # First two attempts hit 429; backoff schedule is 30s, 60s, 120s, 240s,
+    # so we should see exactly [30.0, 60.0] sleeps.
+    assert sleeps == [30.0, 60.0]
+
+
 def test_openai_provider_handles_multiple_parallel_tool_calls_in_one_turn():
     """GPT-4o sometimes emits multiple tool_calls in a single assistant turn.
     Each call MUST get a matching role='tool' message keyed by tool_call_id —

--- a/scripts/test_corpora/tests/test_openai_provider.py
+++ b/scripts/test_corpora/tests/test_openai_provider.py
@@ -1,0 +1,133 @@
+# scripts/test_corpora/tests/test_openai_provider.py
+"""OpenAIProvider — gpt-4o + Harbor Clerk MCP via OpenAI's chat/completions
+tool_calls loop. Mirrors AnthropicProvider's shape but speaks OpenAI's API.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from scripts.test_corpora.runner.providers.base import BaselineResult
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+
+def _mk_resp(*, finish_reason: str, text: str = "", tool_calls=None):
+    """Build a minimal OpenAI-style ChatCompletion response object.
+
+    OpenAI SDK returns `resp.choices[0].finish_reason` and
+    `resp.choices[0].message.{content, tool_calls}`. tool_calls is a list of
+    objects with `.id`, `.type='function'`, `.function.name`, `.function.arguments`
+    (JSON string).
+    """
+    msg = SimpleNamespace(content=text, tool_calls=tool_calls)
+    choice = SimpleNamespace(finish_reason=finish_reason, message=msg)
+    return SimpleNamespace(choices=[choice])
+
+
+def _mk_tool_call(*, id: str, name: str, args: dict):
+    fn = SimpleNamespace(name=name, arguments=json.dumps(args))
+    return SimpleNamespace(id=id, type="function", function=fn)
+
+
+def test_openai_provider_parses_simple_end_turn_answer():
+    """A single response with finish_reason='stop' returns its content as the final answer."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _mk_resp(finish_reason="stop", text="The answer is 42.")
+    p = OpenAIProvider(mcp_session=None, model="gpt-4o", client=client)
+    res = p.run_question(question="What is the answer?", question_id="q1", corpus="cuad")
+    assert isinstance(res, BaselineResult)
+    assert res.answer == "The answer is 42."
+    assert res.tool_call_count == 0
+    assert res.cited_doc_ids == []
+    assert res.model == "gpt-4o"
+
+
+def test_openai_provider_tool_loop_captures_cited_docs():
+    """A tool_calls round followed by an end-turn round — cited_doc_ids
+    are harvested from the MCP result and the final answer is the second
+    response's content."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [
+        SimpleNamespace(name="kb_search", description="search", inputSchema={"type": "object"})
+    ]
+    # First MCP call returns one block with JSON containing a doc_id+doc_title pair
+    mcp.call_tool.return_value = SimpleNamespace(
+        content=[SimpleNamespace(text='{"doc_id": "doc-abc", "doc_title": "Acme Contract", "snippet": "..."}')]
+    )
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[_mk_tool_call(id="call-1", name="kb_search", args={"query": "acme"})],
+        ),
+        _mk_resp(finish_reason="stop", text="Per doc-abc, the answer is found."),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="Find acme.", question_id="q2", corpus="cuad")
+    assert res.tool_call_count == 1
+    assert res.cited_doc_ids == ["doc-abc"]
+    assert res.cited_doc_titles == ["Acme Contract"]
+    assert res.answer == "Per doc-abc, the answer is found."
+
+
+def test_openai_provider_transcript_records_each_call():
+    """tool_transcript has one entry per tool_call with tool, args, result_summary."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [SimpleNamespace(name="kb_search", description="", inputSchema={"type": "object"})]
+    mcp.call_tool.return_value = SimpleNamespace(content=[SimpleNamespace(text='{"doc_id": "x"}')])
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[_mk_tool_call(id="c1", name="kb_search", args={"query": "alpha"})],
+        ),
+        _mk_resp(finish_reason="stop", text="done"),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q3", corpus="cuad")
+    assert len(res.tool_transcript) == 1
+    entry = res.tool_transcript[0]
+    assert entry["tool"] == "kb_search"
+    assert entry["args"] == {"query": "alpha"}
+    assert entry["result_summary"].startswith('{"doc_id":')
+
+
+def test_openai_provider_treats_length_finish_as_end_turn():
+    """finish_reason='length' (response truncated) returns the partial answer
+    with a logged warning rather than crashing. PR-B's _score() in the judge
+    set this defensive precedent — Anthropic's API rarely hits this; OpenAI's
+    max_tokens semantics are subtly different and we may hit it."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _mk_resp(
+        finish_reason="length", text="The answer begins with the very long preamble"
+    )
+    p = OpenAIProvider(mcp_session=None, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q4", corpus="cuad")
+    assert res.answer.startswith("The answer begins")
+    assert res.tool_call_count == 0
+
+
+def test_openai_provider_falls_back_when_mcp_returns_empty_content():
+    """When a tool result has no text content, the loop sends '(empty)' so the
+    model doesn't choke on a literal empty string in the tool response."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [SimpleNamespace(name="kb_search", description="", inputSchema={"type": "object"})]
+    mcp.call_tool.return_value = SimpleNamespace(content=[])  # empty
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[_mk_tool_call(id="c1", name="kb_search", args={"q": "x"})],
+        ),
+        _mk_resp(finish_reason="stop", text="nothing found"),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="q5", corpus="cuad")
+    assert res.tool_transcript[0]["result_summary"] == "(empty)"
+    # Verify the tool result message sent back to the model contained "(empty)"
+    call_args_list = client.chat.completions.create.call_args_list
+    assert len(call_args_list) == 2
+    second_call_messages = call_args_list[1].kwargs["messages"]
+    tool_msg = next(m for m in second_call_messages if m.get("role") == "tool")
+    assert tool_msg["content"] == "(empty)"

--- a/scripts/test_corpora/tests/test_openai_provider.py
+++ b/scripts/test_corpora/tests/test_openai_provider.py
@@ -108,6 +108,51 @@ def test_openai_provider_treats_length_finish_as_end_turn():
     assert res.tool_call_count == 0
 
 
+def test_openai_provider_handles_multiple_parallel_tool_calls_in_one_turn():
+    """GPT-4o sometimes emits multiple tool_calls in a single assistant turn.
+    Each call MUST get a matching role='tool' message keyed by tool_call_id —
+    OpenAI rejects the next request with invalid_request_error otherwise.
+    Also: tool_call_count and tool_transcript should reflect ALL the calls."""
+    mcp = MagicMock()
+    mcp.list_tools.return_value = [SimpleNamespace(name="kb_search", description="", inputSchema={"type": "object"})]
+    # Each tool call returns a different doc
+    mcp.call_tool.side_effect = [
+        SimpleNamespace(content=[SimpleNamespace(text='{"doc_id": "doc-a", "doc_title": "Alpha"}')]),
+        SimpleNamespace(content=[SimpleNamespace(text='{"doc_id": "doc-b", "doc_title": "Beta"}')]),
+        SimpleNamespace(content=[SimpleNamespace(text='{"doc_id": "doc-c", "doc_title": "Gamma"}')]),
+    ]
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _mk_resp(
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mk_tool_call(id="call-1", name="kb_search", args={"query": "alpha"}),
+                _mk_tool_call(id="call-2", name="kb_search", args={"query": "beta"}),
+                _mk_tool_call(id="call-3", name="kb_search", args={"query": "gamma"}),
+            ],
+        ),
+        _mk_resp(finish_reason="stop", text="See doc-a, doc-b, doc-c."),
+    ]
+    p = OpenAIProvider(mcp_session=mcp, model="gpt-4o", client=client)
+    res = p.run_question(question="q", question_id="qpar", corpus="cuad")
+
+    # All three tools executed
+    assert res.tool_call_count == 3
+    assert len(res.tool_transcript) == 3
+    assert [e["tool"] for e in res.tool_transcript] == ["kb_search", "kb_search", "kb_search"]
+    assert [e["args"]["query"] for e in res.tool_transcript] == ["alpha", "beta", "gamma"]
+
+    # All three doc_ids harvested
+    assert set(res.cited_doc_ids) == {"doc-a", "doc-b", "doc-c"}
+
+    # Second request's messages MUST contain a `tool` message per tool_call_id;
+    # OpenAI's API enforces this — missing any tool_call_id raises
+    # invalid_request_error mid-eval.
+    second_call_messages = client.chat.completions.create.call_args_list[1].kwargs["messages"]
+    tool_msgs = [m for m in second_call_messages if m.get("role") == "tool"]
+    assert {m["tool_call_id"] for m in tool_msgs} == {"call-1", "call-2", "call-3"}
+
+
 def test_openai_provider_falls_back_when_mcp_returns_empty_content():
     """When a tool result has no text content, the loop sends '(empty)' so the
     model doesn't choke on a literal empty string in the tool response."""

--- a/scripts/test_corpora/tests/test_providers_base.py
+++ b/scripts/test_corpora/tests/test_providers_base.py
@@ -4,8 +4,8 @@
 import dataclasses
 
 from scripts.test_corpora.runner.providers.base import (
-    BaselineResult,
     DEFAULT_SYSTEM_PROMPT,
+    BaselineResult,
     Provider,
 )
 

--- a/scripts/test_corpora/tests/test_providers_base.py
+++ b/scripts/test_corpora/tests/test_providers_base.py
@@ -1,0 +1,57 @@
+# scripts/test_corpora/tests/test_providers_base.py
+"""Smoke tests for the Provider Protocol + BaselineResult dataclass."""
+
+import dataclasses
+
+from scripts.test_corpora.runner.providers.base import (
+    BaselineResult,
+    DEFAULT_SYSTEM_PROMPT,
+    Provider,
+)
+
+
+def test_baseline_result_is_a_dataclass_with_expected_fields():
+    """BaselineResult is the universal return shape from every Provider."""
+    assert dataclasses.is_dataclass(BaselineResult)
+    fields = {f.name for f in dataclasses.fields(BaselineResult)}
+    assert fields == {
+        "question_id",
+        "question",
+        "answer",
+        "cited_doc_ids",
+        "cited_doc_titles",
+        "tool_call_count",
+        "tool_transcript",
+        "elapsed_seconds",
+        "model",
+        "timestamp",
+    }
+
+
+def test_default_system_prompt_mentions_corpus_and_mcp_tools():
+    """DEFAULT_SYSTEM_PROMPT scopes the model to MCP-only retrieval."""
+    assert "MCP" in DEFAULT_SYSTEM_PROMPT or "mcp" in DEFAULT_SYSTEM_PROMPT
+    assert "corpus" in DEFAULT_SYSTEM_PROMPT.lower()
+
+
+def test_provider_is_a_protocol_with_run_question():
+    """Provider is a Protocol; any class with run_question matching the
+    signature satisfies it (duck-typed at runtime via @runtime_checkable)."""
+
+    class _FakeProvider:
+        def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+            return BaselineResult(
+                question_id=question_id,
+                question=question,
+                answer="",
+                cited_doc_ids=[],
+                cited_doc_titles=[],
+                tool_call_count=0,
+                tool_transcript=[],
+                elapsed_seconds=0.0,
+                model="fake",
+                timestamp="2026-05-23T00:00:00Z",
+            )
+
+    # @runtime_checkable Protocol allows isinstance() against duck-typed classes
+    assert isinstance(_FakeProvider(), Provider)

--- a/scripts/test_corpora/tests/test_providers_base.py
+++ b/scripts/test_corpora/tests/test_providers_base.py
@@ -70,3 +70,15 @@ def test_anthropic_provider_class_is_importable_from_new_path():
     assert hasattr(AnthropicProvider, "run_question")
     assert callable(AnthropicProvider.run_question)
     _ = Provider  # silence unused-import warning
+
+
+def test_providers_package_exports_canonical_api():
+    """The providers package re-exports the canonical API for callers."""
+    from scripts.test_corpora.runner import providers
+
+    assert providers.BaselineResult.__name__ == "BaselineResult"
+    assert providers.DEFAULT_SYSTEM_PROMPT  # non-empty string
+    assert callable(providers.make_provider)
+    assert providers.Provider.__name__ == "Provider"
+    assert providers.AnthropicProvider.__name__ == "AnthropicProvider"
+    assert providers.OpenAIProvider.__name__ == "OpenAIProvider"

--- a/scripts/test_corpora/tests/test_providers_base.py
+++ b/scripts/test_corpora/tests/test_providers_base.py
@@ -55,3 +55,18 @@ def test_provider_is_a_protocol_with_run_question():
 
     # @runtime_checkable Protocol allows isinstance() against duck-typed classes
     assert isinstance(_FakeProvider(), Provider)
+
+
+def test_anthropic_provider_class_is_importable_from_new_path():
+    """AnthropicProvider lives at providers.anthropic_provider — this is the
+    canonical path; claude_baseline.py becomes a shim in Task 3."""
+    from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+
+    assert AnthropicProvider.__name__ == "AnthropicProvider"
+    # AnthropicProvider needs a real client+mcp_session to instantiate, so we
+    # use a structural check via hasattr rather than isinstance against an
+    # instance. Provider is @runtime_checkable, but structural duck-typing
+    # against the class itself reads more clearly.
+    assert hasattr(AnthropicProvider, "run_question")
+    assert callable(AnthropicProvider.run_question)
+    _ = Provider  # silence unused-import warning

--- a/scripts/test_corpora/tests/test_providers_factory.py
+++ b/scripts/test_corpora/tests/test_providers_factory.py
@@ -1,0 +1,61 @@
+# scripts/test_corpora/tests/test_providers_factory.py
+"""make_provider() — string-prefix dispatch on model name."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
+from scripts.test_corpora.runner.providers.factory import make_provider
+from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
+
+
+def test_factory_dispatches_claude_to_anthropic():
+    """Any name starting with 'claude-' → AnthropicProvider."""
+    p = make_provider("claude-sonnet-4-6", mcp_session=MagicMock())
+    assert isinstance(p, AnthropicProvider)
+
+
+def test_factory_dispatches_claude_3_5_to_anthropic():
+    """Legacy claude- names still dispatch correctly."""
+    p = make_provider("claude-3-5-sonnet-20241022", mcp_session=MagicMock())
+    assert isinstance(p, AnthropicProvider)
+
+
+def test_factory_dispatches_gpt_to_openai():
+    """Any name starting with 'gpt-' → OpenAIProvider."""
+    p = make_provider("gpt-4o", mcp_session=MagicMock())
+    assert isinstance(p, OpenAIProvider)
+
+
+def test_factory_dispatches_o1_to_openai():
+    """Any name starting with 'o1-' → OpenAIProvider."""
+    p = make_provider("o1-preview", mcp_session=MagicMock())
+    assert isinstance(p, OpenAIProvider)
+
+
+def test_factory_dispatches_o3_to_openai():
+    """Any name starting with 'o3-' → OpenAIProvider."""
+    p = make_provider("o3-mini", mcp_session=MagicMock())
+    assert isinstance(p, OpenAIProvider)
+
+
+def test_factory_raises_value_error_on_unknown_model():
+    """An unknown prefix raises ValueError with the supported list in the message."""
+    with pytest.raises(ValueError, match=r"unknown model.*supported prefixes.*claude-.*gpt-"):
+        make_provider("llama-3.1-70b", mcp_session=MagicMock())
+
+
+def test_factory_forwards_doc_ids_seen_kwarg_to_anthropic():
+    """doc_ids_seen pre-seeds the provider's cited-doc map for test scenarios."""
+    p = make_provider("claude-sonnet-4-6", mcp_session=MagicMock(), doc_ids_seen=["doc-a", "doc-b"])
+    assert isinstance(p, AnthropicProvider)
+    # cited starts pre-seeded with the two doc ids (titles default to "")
+    assert list(p._cited.keys()) == ["doc-a", "doc-b"]
+
+
+def test_factory_forwards_doc_ids_seen_kwarg_to_openai():
+    """doc_ids_seen works the same way for the OpenAI provider."""
+    p = make_provider("gpt-4o", mcp_session=MagicMock(), doc_ids_seen=["doc-x"])
+    assert isinstance(p, OpenAIProvider)
+    assert list(p._cited.keys()) == ["doc-x"]

--- a/scripts/test_corpora/tests/test_sweep_overload_retry.py
+++ b/scripts/test_corpora/tests/test_sweep_overload_retry.py
@@ -108,6 +108,125 @@ def test_phase1_baseline_retry_recovers_from_anthropic_529(tmp_path):
     assert (tmp_path / "baselines" / "cuad" / "q1.json").exists()
 
 
+# ── provider-aware retry (PR-C) ─────────────────────────────────────────────
+
+
+def _make_openai_rate_limit_error():
+    """Build an openai.RateLimitError (HTTP 429)."""
+    import openai
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    return openai.RateLimitError("rate limited", response=response, body=None)
+
+
+def _make_openai_api_status_error_503():
+    """Build an openai.APIStatusError with status 503 (transient overload)."""
+    import openai
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(503, request=request)
+    return openai.APIStatusError("overloaded", response=response, body=None)
+
+
+def _make_openai_api_status_error_400():
+    """Build an openai.APIStatusError with status 400 (bad request) — should
+    NOT be retried."""
+    import openai
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    return openai.APIStatusError("bad request", response=response, body=None)
+
+
+def test_retry_handles_openai_rate_limit_error():
+    """OpenAI's RateLimitError triggers backoff via _with_provider_retry."""
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) < 2:
+            raise _make_openai_rate_limit_error()
+        return "ok"
+
+    result = _with_provider_retry(flaky, client_kind="openai", sleep=sleeps.append)
+    assert result == "ok"
+    assert len(calls) == 2
+    assert len(sleeps) == 1
+
+
+def test_retry_handles_openai_api_status_error_503():
+    """OpenAI's APIStatusError 503 (overloaded) triggers backoff."""
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) < 2:
+            raise _make_openai_api_status_error_503()
+        return "ok"
+
+    result = _with_provider_retry(flaky, client_kind="openai", sleep=sleeps.append)
+    assert result == "ok"
+    assert len(calls) == 2
+
+
+def test_retry_does_not_retry_openai_400_bad_request():
+    """A 400 from OpenAI is a permanent error — re-raise immediately, don't
+    burn the retry budget on it."""
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    sleeps: list[float] = []
+
+    def always_400():
+        raise _make_openai_api_status_error_400()
+
+    import openai
+
+    with pytest.raises(openai.APIStatusError):
+        _with_provider_retry(always_400, client_kind="openai", sleep=sleeps.append)
+    assert sleeps == []  # no retries
+
+
+def test_retry_with_anthropic_kind_still_works():
+    """Back-compat: _with_provider_retry(client_kind='anthropic') matches the
+    legacy _with_anthropic_retry behavior."""
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) < 2:
+            raise _make_rate_limit_error()
+        return "ok"
+
+    result = _with_provider_retry(flaky, client_kind="anthropic", sleep=sleeps.append)
+    assert result == "ok"
+    assert len(calls) == 2
+
+
+def test_with_anthropic_retry_legacy_alias_still_callable():
+    """The old _with_anthropic_retry name remains as a back-compat alias and
+    forwards to _with_provider_retry with client_kind='anthropic'."""
+    result = _with_anthropic_retry(lambda: "ok")
+    assert result == "ok"
+
+
+def test_retry_raises_on_unknown_client_kind():
+    """Unknown client_kind raises a clear ValueError."""
+    from scripts.test_corpora.runner.sweep import _with_provider_retry
+
+    with pytest.raises(ValueError, match="unknown client_kind"):
+        _with_provider_retry(lambda: "ok", client_kind="gemini")
+
+
 def test_with_anthropic_retry_retries_on_429_then_succeeds():
     """A transient 429 rate-limit burst is absorbed exactly like a 529:
     retried with exponential backoff, the eventual success returned. 429s


### PR DESCRIPTION
## Summary

**Phase 2c / PR-C** of the answer-eval work — adds a second baseline model (`gpt-4o`) to `--mode answer-eval` via a pluggable Provider protocol. Spec: `docs/superpowers/specs/2026-05-23-answer-eval-multi-model-design.md`. Plan: `docs/superpowers/plans/2026-05-23-answer-eval-multi-model.md`.

Zero changes to the judge's prompts, runner loop, ground-truth schemas, or `--label`/`--workdir` machinery — additive only. `sweep.py`'s 30+ `BaselineGenerator` import sites stay untouched (intentional shim).

## What's in it

- **`providers/` package** — `Provider` Protocol + `BaselineResult` dataclass + `DEFAULT_SYSTEM_PROMPT` in `base.py`; concrete `AnthropicProvider` and `OpenAIProvider`; `make_provider(model, *, mcp_session)` factory dispatching by model-name prefix (`claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` → OpenAI).
- **`claude_baseline.py` collapsed to a 19-line shim** re-exporting `AnthropicProvider as BaselineGenerator` — `sweep.py`'s 30+ import sites stay untouched.
- **`answer_eval._live_capture_fn` uses `make_provider`** — pass any supported model name via `--models`. Hoists provider construction outside the per-item loop (1 client per run, not 29) per fresh-eyes-review fix.
- **Provider-aware retry** — `_with_provider_retry(fn, *, client_kind=...)` generalizes `_with_anthropic_retry` to handle OpenAI's `RateLimitError` (429) + `APIStatusError` (502/503/504); 400 stays permanent (not retried). Legacy `_with_anthropic_retry` kept as an alias.
- **OpenAI-specific retry inside the provider** — `_create_with_rate_limit_retry` absorbs `openai.RateLimitError` with 30s/60s/120s/240s backoff (surfaced by the first live run — tier-1 TPM=30k clears in 60s; SDK gives up before then).
- **Judge hardening** (cherry-picked from PR-B `9508e69`) — defaults missing/non-int score keys to 0 with a logged warning. PR-B fix not yet on `main`, picked here so the live eval can run.
- **24 new tests** (5 base + 8 factory + 7 openai + 6 retry). Pre-existing tests still pass; 1 pre-existing `test_entity_overlap_english` failure unchanged (spaCy model missing in test venv).

## Test plan

- [x] `uv run --project scripts/test_corpora --extra test pytest scripts/test_corpora/tests/` — 329 pass / 1 pre-existing unrelated failure.
- [x] Root-level `ruff check` + `ruff format --check` clean on every changed file.
- [x] Built TDD with per-task spec + commits; final unconstrained `feature-dev:code-reviewer` pass — 3 findings addressed inline (RateLimitError subclass relationship, per-item provider construction leaking httpx pools, missing parallel-tool-call test).
- [x] **Live end-to-end run** — `gpt-4o` against synthetic (29 items, PR-B's frozen ground-truth set). Results below.

## First-run results (live)

| | n | correctness | groundedness | completeness |
|---|--:|--:|--:|--:|
| **Overall** | 29 | 2.83 / 5 | 3.79 / 5 | 2.83 / 5 |
| Lookup    | 25 | 2.92 | 4.00 | 3.16 |
| Find      |  3 | 3.00 | 3.33 | 1.00 |
| Negative  |  1 | 0.00 | 0.00 | 0.00 |

## Comparison with Sonnet (PR-B baseline, 30 items)

| | n | correctness | groundedness | completeness |
|---|--:|--:|--:|--:|
| Sonnet (PR-B)   | 30 | **3.33** | 3.57 | 2.73 |
| GPT-4o (this PR) | 29 | 2.83 | **3.79** | **2.83** |

**Headline:** Sonnet wins overall correctness (3.33 vs 2.83). GPT-4o edges Sonnet on groundedness (3.79 vs 3.57) and completeness (2.83 vs 2.73).

The most informative signals:

- **Negative-hedging confirmed cross-provider.** GPT-4o's lone negative item (`synth-neg-invoice-99999` — "what's the total of invoice INV-99999?", a number that doesn't exist) scored 0/0/0 — the model answered with a fabricated number instead of declining. Same product signal Sonnet exhibited on CUAD, Enron, and PR-B's synthetic run. The system prompt's failure mode is **provider-independent**, which strengthens the case for the prompt-tuning experiment queued after this PR.

- **Find items under-iterate `kb_search`.** Completeness=1.00 across all 3 finds (gpt-4o retrieved roughly one batch's worth of matches). Same pattern as Sonnet from PR-A and PR-B — also provider-independent.

- **Lookup items: gpt-4o behind Sonnet on correctness, ahead on groundedness.** Suggests gpt-4o sticks closer to what it cites but more often misidentifies the right doc. Likely the same "boundary doc retrieval" pattern noted in PR-A/B: HC's retrieval picks a neighbouring doc when the question identifier isn't unique, and gpt-4o (like Sonnet) trusts the retrieval rather than re-querying.

## Known limitations / follow-ups

- **The shim is intentional for this PR.** A follow-up can migrate `sweep.py`'s `BaselineGenerator(...)` call sites to `make_provider(model)` directly — but that's a larger blast radius and adds no behavioral benefit yet.
- **Cross-provider judge bias.** Sonnet judging gpt-4o introduces a same-family-vs-cross-family asymmetry. Future "swap the judge to gpt-4o" experiment for sensitivity analysis.
- **Lifting the Provider protocol into `harbor_clerk` proper** (for the "bring your own cloud LLM" use case in HC chat/research) is a separate effort with its own design review.
- **OpenAI TPM tier-1 (30k) is tight** — the live run spent ~5 minutes on 29 items mostly because of the 30s backoffs between rate-limit windows. Higher-tier keys would run ~2x faster.
- **Judge fix (`c7043e1`) is a cherry-pick** from PR-B (#386). When PR-B merges into `main`, this commit becomes a no-op and can be dropped on rebase.
- **`synthetic.yaml` (`f64a46c`) is also a cherry-pick** from PR-B. Same rebase-drop logic.
- **Prompt-tuning experiment** is next on the queue — addresses the cross-corpus negative-hedging finding (now confirmed on CUAD + Enron + synthetic across **both** providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
