### PR TITLE
feat: 'Reprocess (no summaries)' button + endpoint

### DIFF
--- a/frontend/src/pages/SystemMaintenancePage.tsx
+++ b/frontend/src/pages/SystemMaintenancePage.tsx
@@ -7,6 +7,7 @@ export default function SystemMaintenancePage() {
   const [error, setError] = useState('')
   const [actionResult, setActionResult] = useState('')
   const [confirmingReprocess, setConfirmingReprocess] = useState(false)
+  const [confirmingReprocessSkipSummary, setConfirmingReprocessSkipSummary] = useState(false)
   const [confirmingResummarize, setConfirmingResummarize] = useState(false)
   const [topicsRunning, setTopicsRunning] = useState(false)
   const [deleteStep, setDeleteStep] = useState<0 | 1 | 2>(0)
@@ -48,6 +49,26 @@ export default function SystemMaintenancePage() {
       setActionResult(`Reprocess all complete: ${data.reprocessed} documents queued`)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Reprocess all failed')
+    }
+  }
+
+  async function handleReprocessAllSkipSummary() {
+    if (!confirmingReprocessSkipSummary) {
+      setConfirmingReprocessSkipSummary(true)
+      return
+    }
+    setConfirmingReprocessSkipSummary(false)
+    setError('')
+    setActionResult('')
+    try {
+      const data = await post<{ reprocessed: number; skipped_stages: string[] }>(
+        '/api/system/reprocess-all-skip-summarize',
+      )
+      setActionResult(
+        `Reprocess (no summaries) complete: ${data.reprocessed} documents queued. Run "Resummarize All" later to fill in summaries.`,
+      )
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Reprocess (no summaries) failed')
     }
   }
 
@@ -170,6 +191,34 @@ export default function SystemMaintenancePage() {
             {confirmingReprocess && (
               <button
                 onClick={() => setConfirmingReprocess(false)}
+                className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="px-5 py-4">
+          <p className="mb-1.5 text-sm text-gray-600 dark:text-gray-400">
+            Same as Reprocess All, but skip the summarize stage (the only LLM-bound step). Cuts a full reprocess from
+            minutes-per-doc to seconds-per-doc when iterating on non-summary pipeline changes. Existing summaries are
+            preserved unchanged; run Resummarize All afterwards to regenerate them when ready.
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleReprocessAllSkipSummary}
+              className={`rounded-lg px-4 py-2 text-sm font-medium ${
+                confirmingReprocessSkipSummary
+                  ? 'bg-amber-600 text-white hover:bg-amber-700'
+                  : 'bg-(--color-bg-tertiary) text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+              }`}
+            >
+              {confirmingReprocessSkipSummary ? 'Click again to confirm' : 'Reprocess (no summaries)'}
+            </button>
+            {confirmingReprocessSkipSummary && (
+              <button
+                onClick={() => setConfirmingReprocessSkipSummary(false)}
                 className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
               >
                 Cancel

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -429,6 +429,77 @@ async def reprocess_all(
     return {"reprocessed": count}
 
 
+@router.post("/system/reprocess-all-skip-summarize")
+async def reprocess_all_skip_summarize(
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    """Re-run the ingestion pipeline on every active document, skipping summarize.
+
+    `summarize` is the only LLM-bound stage; for pipelines hitting only
+    in-process work (extract/ocr/chunk/entities/embed/finalize) it dominates
+    wall-clock by 2-3 orders of magnitude. This endpoint exists so iterative
+    work on the non-summarize stages (e.g. metadata extractor changes, chunker
+    tweaks) can re-ingest the full corpus in seconds-per-doc instead of
+    minutes-per-doc. Use `/system/resummarize-all` afterwards to populate
+    summaries once the iteration is done.
+
+    Mechanism: pre-inserts a "done with skipped=True" IngestionJob row for
+    summarize on each doc immediately after reset_jobs. The cascade in
+    `advance_pipeline` then sees an existing summarize row and won't enqueue
+    a new one.
+    """
+    from harbor_clerk.db_sync import get_sync_session
+    from harbor_clerk.worker.pipeline import enqueue_stage, reset_jobs
+
+    result = await session.execute(select(Document).where(Document.status == "active"))
+    docs = result.scalars().all()
+
+    count = 0
+    doc_ids: list[uuid.UUID] = []
+    for doc in docs:
+        doc.pipeline_status = PipelineStatus.queued
+        doc.pipeline_seq = (doc.pipeline_seq or 0) + 1
+        doc.error = None
+        doc_ids.append(doc.doc_id)
+        count += 1
+
+    await log_audit(
+        session,
+        user_id=admin.id,
+        action="reprocess_all_skip_summarize",
+        detail={"reprocessed_count": count, "skipped_stages": ["summarize"]},
+    )
+    await session.commit()
+
+    # Reset jobs, then pre-insert the summarize "skip marker" row, then
+    # enqueue extract. Order matters: reset_jobs deletes prior job rows
+    # (including any summarize), so the skip marker must come after it.
+    for doc_id in doc_ids:
+        reset_jobs(doc_id)
+        sync_session = get_sync_session()
+        try:
+            now = datetime.now(UTC)
+            sync_session.add(
+                IngestionJob(
+                    doc_id=doc_id,
+                    stage=JobStage.summarize,
+                    status=JobStatus.done,
+                    started_at=now,
+                    finished_at=now,
+                    metrics={"skipped": True, "reason": "reprocess_all_skip_summarize"},
+                    priority=0,
+                )
+            )
+            sync_session.commit()
+        finally:
+            sync_session.close()
+        enqueue_stage(doc_id, JobStage.extract)
+
+    logger.info("Reprocess-all-skip-summarize: %d documents queued", count)
+    return {"reprocessed": count, "skipped_stages": ["summarize"]}
+
+
 @router.post("/system/resummarize-all")
 async def resummarize_all(
     admin: Principal = Depends(require_admin),

--- a/tests/api/test_reprocess_skip_summarize.py
+++ b/tests/api/test_reprocess_skip_summarize.py
@@ -1,0 +1,131 @@
+"""Tests for POST /api/system/reprocess-all-skip-summarize.
+
+The endpoint re-enqueues the ingestion pipeline for every active document but
+pre-inserts a "done-with-skipped" IngestionJob row for the summarize stage so
+the worker cascade in `advance_pipeline` doesn't auto-enqueue it. Used for
+fast iteration on non-summarize pipeline changes (metadata extractors,
+chunker tweaks, embedder swaps).
+"""
+
+from sqlalchemy import select
+
+from harbor_clerk.models import Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
+from tests.conftest import auth_header
+
+
+async def test_reprocess_all_skip_summarize_marks_summarize_as_done_with_skip_metric(
+    client, admin_user, admin_token, db_session
+):
+    """The endpoint creates a 'done' IngestionJob row for summarize on every
+    active doc, with metrics that record the skip + reason. The worker's
+    cascade in advance_pipeline checks `if stage in existing_stages: continue`
+    and won't enqueue summarize when a row already exists."""
+    doc = Document(
+        title="test-doc",
+        status="active",
+        sha256=b"\x00" * 32,
+        pipeline_status=PipelineStatus.ready,
+        pipeline_seq=1,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    doc_id = doc.doc_id
+
+    resp = await client.post(
+        "/api/system/reprocess-all-skip-summarize",
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["reprocessed"] == 1
+    assert body["skipped_stages"] == ["summarize"]
+
+    # Doc was reset (pipeline_seq incremented; error cleared). pipeline_status
+    # is `extracting` rather than `queued` because enqueue_stage(extract) flips
+    # it to the stage's running_status immediately — same as production
+    # reprocess_all behavior; the prior `ready` state is gone, which is what
+    # matters for the reset semantics.
+    await db_session.refresh(doc)
+    assert doc.pipeline_seq == 2
+    assert doc.error is None
+    assert doc.pipeline_status != PipelineStatus.ready
+
+    # Summarize job row exists, marked done with the skip metric
+    jobs = (await db_session.execute(select(IngestionJob).where(IngestionJob.doc_id == doc_id))).scalars().all()
+    by_stage = {j.stage: j for j in jobs}
+
+    assert JobStage.summarize in by_stage, "summarize skip-marker row should be inserted"
+    summarize_job = by_stage[JobStage.summarize]
+    assert summarize_job.status == JobStatus.done
+    assert summarize_job.metrics.get("skipped") is True
+    assert summarize_job.metrics.get("reason") == "reprocess_all_skip_summarize"
+
+    # Extract job enqueued by the cascade-kickoff
+    assert JobStage.extract in by_stage, "extract should be queued to start the cascade"
+    assert by_stage[JobStage.extract].status == JobStatus.queued
+
+
+async def test_reprocess_all_skip_summarize_handles_multiple_docs(client, admin_user, admin_token, db_session):
+    """All active docs get the skip marker; status='inactive' docs are ignored."""
+    active_a = Document(
+        title="active-a",
+        status="active",
+        sha256=b"\x01" * 32,
+        pipeline_status=PipelineStatus.ready,
+        pipeline_seq=1,
+    )
+    active_b = Document(
+        title="active-b",
+        status="active",
+        sha256=b"\x02" * 32,
+        pipeline_status=PipelineStatus.ready,
+        pipeline_seq=1,
+    )
+    inactive = Document(
+        title="inactive",
+        status="inactive",
+        sha256=b"\x03" * 32,
+        pipeline_status=PipelineStatus.ready,
+        pipeline_seq=1,
+    )
+    db_session.add_all([active_a, active_b, inactive])
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/system/reprocess-all-skip-summarize",
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["reprocessed"] == 2
+
+    # Both active docs have the summarize skip-marker; inactive doc has no jobs
+    for doc in (active_a, active_b):
+        jobs = (await db_session.execute(select(IngestionJob).where(IngestionJob.doc_id == doc.doc_id))).scalars().all()
+        stages = {j.stage for j in jobs}
+        assert JobStage.summarize in stages
+        assert JobStage.extract in stages
+
+    inactive_jobs = (
+        (await db_session.execute(select(IngestionJob).where(IngestionJob.doc_id == inactive.doc_id))).scalars().all()
+    )
+    assert inactive_jobs == []
+
+
+async def test_reprocess_all_skip_summarize_requires_admin(client, regular_user, user_token, db_session):
+    """Non-admin callers get 403."""
+    resp = await client.post(
+        "/api/system/reprocess-all-skip-summarize",
+        headers=auth_header(user_token),
+    )
+    assert resp.status_code == 403
+
+
+async def test_reprocess_all_skip_summarize_zero_docs(client, admin_user, admin_token, db_session):
+    """No active docs → reprocessed=0, no error."""
+    resp = await client.post(
+        "/api/system/reprocess-all-skip-summarize",
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"reprocessed": 0, "skipped_stages": ["summarize"]}


### PR DESCRIPTION
## Summary

A small dev-affordance PR that unblocks fast iteration on PR-F (document metadata extractors) and any future pipeline work that doesn't touch summarize.

Adds **`POST /api/system/reprocess-all-skip-summarize`** + a matching **"Reprocess (no summaries)" button** on the System Maintenance page. Runs the full ingest pipeline (extract → ocr → chunk → entities → embed → finalize) on every active document but skips the `summarize` stage entirely.

## Why

`summarize` is the only LLM-bound stage in HC's pipeline and dominates wall-clock by 2–3 orders of magnitude (seconds-per-doc for everything else; minutes-per-doc for summarize on cloud LLMs, sometimes much more on local ones). When iterating on non-summarize changes — the upcoming metadata extractor work in PR-F, but also chunker tweaks, embedder swaps, extract-stage changes — running a full Reprocess All wastes a huge wall-clock budget on summaries that aren't changing.

Summaries can be backfilled afterwards with the existing **Resummarize All** button.

## Mechanism

The pipeline's `advance_pipeline` cascade already gates summarize on `if stage in existing_stages: continue` (the existing comment in `worker/pipeline.py` explains why: it prevents an errored summarize from looping). So the endpoint pre-inserts a `done`-status `IngestionJob` row for summarize with `metrics={skipped: True, reason: "reprocess_all_skip_summarize"}` immediately after `reset_jobs` clears prior job rows. The cascade then sees the row exists and won't auto-enqueue summarize after chunk completes.

No changes to `worker/pipeline.py`; the new endpoint piggybacks on existing primitives (`reset_jobs`, `IngestionJob`, `enqueue_stage`).

## What's in it

- **`POST /api/system/reprocess-all-skip-summarize`** — admin-only, returns `{reprocessed: N, skipped_stages: ["summarize"]}`.
- **4 backend tests** (`tests/api/test_reprocess_skip_summarize.py`): skip-marker shape + extract enqueued, multi-doc with `status='inactive'` filtering, admin gate (regular user → 403), zero-doc edge case. All pass.
- **Frontend button** on `SystemMaintenancePage` next to "Reprocess All" and "Resummarize All". Same two-click confirmation pattern; amber rather than red since the action is recoverable (re-run Resummarize All). Description copy explains the trade-off.

## Test plan

- [x] `uv run pytest tests/api/test_reprocess_skip_summarize.py -v` — 4/4 pass
- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [x] `npm run lint` + `npx tsc --noEmit` + `npx prettier --check` clean for the changed frontend file
- [ ] Manual smoke: click the button on the running app, verify summary chips don't regenerate on the affected docs

## Out of scope

- No change to existing reprocess/resummarize endpoints or their behavior.
- No change to `worker/pipeline.py` — the cascade gating logic that makes this work was already in place.
- No CLI / MCP exposure of the new endpoint; admin UI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
