### PR TITLE
feat(ingest): document metadata extractors + kb_search metadata_filter

### DIFF
--- a/alembic/versions/0004_documents_metadata.py
+++ b/alembic/versions/0004_documents_metadata.py
@@ -1,0 +1,49 @@
+"""documents.metadata JSONB column
+
+Adds a JSONB metadata column populated at ingest by the new extractor
+framework (Tika headers, YAML frontmatter, JSON sidecars). GIN index
+supports the @> containment operator used by kb_search's metadata_filter
+parameter.
+
+The SQLAlchemy attribute on Document is `doc_metadata` to avoid shadowing
+Base.metadata; the PostgreSQL column is `metadata`.
+
+Revision ID: 0004_documents_metadata
+Revises: 0003_wf_skip_tracking
+Create Date: 2026-05-24
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0004_documents_metadata"
+down_revision = "0003_wf_skip_tracking"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.create_index(
+        "ix_documents_metadata_gin",
+        "documents",
+        ["metadata"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_documents_metadata_gin", table_name="documents")
+    op.drop_column("documents", "metadata")

--- a/alembic/versions/0004_documents_metadata.py
+++ b/alembic/versions/0004_documents_metadata.py
@@ -13,17 +13,24 @@ Revises: 0003_wf_skip_tracking
 Create Date: 2026-05-24
 """
 
-from __future__ import annotations
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-revision = "0004_documents_metadata"
-down_revision = "0003_wf_skip_tracking"
-branch_labels = None
-depends_on = None
+revision: str = "0004_documents_metadata"
+down_revision: str | None = "0003_wf_skip_tracking"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# These four module-level names are read by alembic via attribute access
+# (``module.revision`` etc.) rather than ordinary imports, so static
+# analysis (CodeQL ``py/unused-global-variable``) doesn't see them as used.
+# Declaring them in ``__all__`` marks them as the module's intentional
+# public surface and silences the false positive.
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on", "upgrade", "downgrade"]
 
 
 def upgrade() -> None:

--- a/docs/superpowers/plans/2026-05-24-document-metadata-extractors.md
+++ b/docs/superpowers/plans/2026-05-24-document-metadata-extractors.md
@@ -1,0 +1,2206 @@
+# Document Metadata Extractors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture machine-readable metadata HC already has access to (Tika fields, YAML frontmatter, JSON sidecars) into a new `Document.doc_metadata` JSONB column, and expose it via a `metadata_filter` parameter on `kb_search` so models can disambiguate boundary-doc cases by fact rather than by similarity.
+
+**Architecture:** New `src/harbor_clerk/ingest/metadata_extractors/` package with pluggable per-source extractors. Extract stage runs them and merges results under namespaced keys (`{tika: ..., frontmatter: ..., sidecar: ..., _source_provenance: ...}`). Search layer translates `metadata_filter={path: value}` to JSONB `@>` containment + `?` existence queries against a new GIN index. Frontmatter is stripped from body text before chunking.
+
+**Tech Stack:** Python 3.12, SQLAlchemy 2.0 async (asyncpg), Alembic, FastAPI, PostgreSQL 18 + JSONB GIN, Tika 3.3.0 via httpx, `python-frontmatter` 1.x (new runtime dep), pytest.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md`
+
+---
+
+## File Structure
+
+**New files (this PR):**
+- `alembic/versions/0004_documents_metadata.py` — schema migration
+- `src/harbor_clerk/ingest/__init__.py` — package marker
+- `src/harbor_clerk/ingest/metadata_extractors/__init__.py` — registry + `run_all()` framework
+- `src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py` — Tika `/meta` extractor
+- `src/harbor_clerk/ingest/metadata_extractors/frontmatter.py` — YAML frontmatter parser for markdown
+- `src/harbor_clerk/ingest/metadata_extractors/sidecar.py` — `<stem>.json` loader
+- `tests/ingest/__init__.py`
+- `tests/ingest/test_metadata_extractor_framework.py` — `run_all()` orchestration
+- `tests/ingest/test_tika_metadata_extractor.py`
+- `tests/ingest/test_frontmatter_extractor.py`
+- `tests/ingest/test_sidecar_extractor.py`
+- `tests/ingest/test_search_metadata_filter.py` — end-to-end `metadata_filter` against a small in-memory corpus
+
+**Modified files (this PR):**
+- `src/harbor_clerk/models/document.py` — add `doc_metadata` column (SQLAlchemy attribute named `doc_metadata` to avoid shadowing `Base.metadata`)
+- `src/harbor_clerk/worker/stages/extract.py` — call `run_all()` after body extraction, persist to `Document.doc_metadata`
+- `src/harbor_clerk/worker/markdown_extract.py` — strip frontmatter from body text before chunking
+- `src/harbor_clerk/search.py` — add `metadata_filter` param + JSONB query translation in `hybrid_search`
+- `src/harbor_clerk/mcp_server.py` — add `metadata_filter` param to `kb_search` + add metadata field to `kb_get_document` response
+- `pyproject.toml` — add `python-frontmatter>=1.1` runtime dep
+
+**Untouched:** existing email-typed columns (`email_from_address`, etc.); existing kb_* tools other than `kb_search` and `kb_get_document` (those get description rewrites in PR-D).
+
+---
+
+## Task 1: Schema migration — add `doc_metadata` JSONB column
+
+**Files:**
+- Create: `alembic/versions/0004_documents_metadata.py`
+- Modify: `src/harbor_clerk/models/document.py`
+
+- [ ] **Step 1: Write the failing model test**
+
+Create `tests/models/test_document_metadata_column.py`:
+
+```python
+"""Tests for the doc_metadata JSONB column on Document."""
+
+from harbor_clerk.models import Document
+from harbor_clerk.models.enums import PipelineStatus
+
+
+async def test_document_doc_metadata_defaults_to_empty_dict(db_session):
+    """A freshly-created Document has doc_metadata = {}."""
+    doc = Document(
+        title="t",
+        status="active",
+        sha256=b"\x00" * 32,
+        pipeline_status=PipelineStatus.queued,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+    assert doc.doc_metadata == {}
+
+
+async def test_document_doc_metadata_persists_arbitrary_dict(db_session):
+    """The column stores and round-trips an arbitrary nested dict."""
+    payload = {
+        "tika": {"author": "Jane", "page_count": 3},
+        "frontmatter": {"tags": ["alpha", "beta"]},
+        "_source_provenance": {"tika": "2026-05-24T00:00:00+00:00"},
+    }
+    doc = Document(
+        title="t",
+        status="active",
+        sha256=b"\x01" * 32,
+        pipeline_status=PipelineStatus.queued,
+        doc_metadata=payload,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+    assert doc.doc_metadata == payload
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/models/test_document_metadata_column.py -v`
+Expected: `AttributeError: 'Document' object has no attribute 'doc_metadata'`.
+
+- [ ] **Step 3: Add the column to the Document model**
+
+Edit `src/harbor_clerk/models/document.py` — add after the existing email columns (around line 70, before the closing of the class). Add the `JSONB` import at the top of the imports:
+
+```python
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+```
+
+Add the column inside the `Document` class (preserve existing columns; insert near the end of the column declarations):
+
+```python
+    # Pluggable metadata extracted at ingest time. Namespaced by source:
+    # {"tika": {...}, "frontmatter": {...}, "sidecar": {...},
+    #  "_source_provenance": {"tika": "2026-...", ...}}
+    # The Python attribute is `doc_metadata` (not `metadata`) to avoid
+    # shadowing SQLAlchemy's `Base.metadata`. The PostgreSQL column is
+    # named `metadata` for natural querying.
+    doc_metadata: Mapped[dict] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=False,
+        server_default="{}",
+    )
+```
+
+(If `JSONB` is already imported, skip the import line.)
+
+- [ ] **Step 4: Create the alembic migration**
+
+Create `alembic/versions/0004_documents_metadata.py`:
+
+```python
+"""documents.metadata JSONB column
+
+Adds a JSONB metadata column populated at ingest by the new extractor
+framework (Tika headers, YAML frontmatter, JSON sidecars). GIN index
+supports the @> containment operator used by kb_search's metadata_filter
+parameter.
+
+The SQLAlchemy attribute on Document is `doc_metadata` to avoid shadowing
+Base.metadata; the PostgreSQL column is `metadata`.
+
+Revision ID: 0004_documents_metadata
+Revises: 0003_wf_skip_tracking
+Create Date: 2026-05-24
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0004_documents_metadata"
+down_revision = "0003_wf_skip_tracking"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.create_index(
+        "ix_documents_metadata_gin",
+        "documents",
+        ["metadata"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_documents_metadata_gin", table_name="documents")
+    op.drop_column("documents", "metadata")
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+The conftest applies alembic migrations against the test DB. Run:
+
+```bash
+uv run pytest tests/models/test_document_metadata_column.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/models/document.py alembic/versions/0004_documents_metadata.py tests/models/test_document_metadata_column.py
+uv run ruff format --check src/harbor_clerk/models/document.py alembic/versions/0004_documents_metadata.py tests/models/test_document_metadata_column.py
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add alembic/versions/0004_documents_metadata.py src/harbor_clerk/models/document.py tests/models/test_document_metadata_column.py
+git commit -m "feat(schema): documents.metadata JSONB column + GIN index" \
+  -m "First task in PR-F. Adds a namespaced metadata column populated at ingest by the new extractor framework (later tasks); GIN index supports the @> containment query used by kb_search's metadata_filter param. SQLAlchemy attribute is doc_metadata to avoid shadowing Base.metadata; PostgreSQL column is metadata for natural querying." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Extractor framework — Protocol + `run_all()` orchestrator
+
+**Files:**
+- Create: `src/harbor_clerk/ingest/__init__.py`
+- Create: `src/harbor_clerk/ingest/metadata_extractors/__init__.py`
+- Create: `tests/ingest/__init__.py`
+- Create: `tests/ingest/test_metadata_extractor_framework.py`
+
+- [ ] **Step 1: Write the failing framework test**
+
+Create `tests/ingest/__init__.py` (empty file).
+
+Create `tests/ingest/test_metadata_extractor_framework.py`:
+
+```python
+"""Tests for the metadata extractor framework: registration + run_all()."""
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from harbor_clerk.ingest.metadata_extractors import MetadataExtractor, _run_extractors
+
+
+@dataclass
+class _FakeDoc:
+    """Stand-in for Document; only needs doc_id + title for the framework tests."""
+
+    doc_id: uuid.UUID
+    title: str = "fake"
+
+
+class _AlphaExtractor:
+    name = "alpha"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        return {"foo": "bar"}
+
+
+class _BetaExtractor:
+    name = "beta"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        return {"baz": "qux"}
+
+
+class _SkippingExtractor:
+    name = "skipper"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        return None  # signals "doesn't apply to this doc"
+
+
+class _FailingExtractor:
+    name = "broken"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        raise RuntimeError("intentionally broken")
+
+
+def test_run_all_merges_namespaced_results():
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor(), _BetaExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    assert out["alpha"] == {"foo": "bar"}
+    assert out["beta"] == {"baz": "qux"}
+
+
+def test_run_all_records_provenance_per_extractor():
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    prov = out.get("_source_provenance", {})
+    assert "alpha" in prov
+    # ISO 8601 with offset
+    parsed = datetime.fromisoformat(prov["alpha"])
+    assert parsed.tzinfo is not None
+
+
+def test_run_all_skips_extractors_that_return_none():
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor(), _SkippingExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    assert "alpha" in out
+    assert "skipper" not in out
+    assert "skipper" not in out.get("_source_provenance", {})
+
+
+def test_run_all_isolates_extractor_failures(caplog):
+    """A failing extractor logs a warning but does not abort the others."""
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor(), _FailingExtractor(), _BetaExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    assert "alpha" in out
+    assert "beta" in out
+    assert "broken" not in out
+    # The warning landed
+    assert any("broken" in rec.message for rec in caplog.records if rec.levelname == "WARNING")
+
+
+def test_run_all_empty_when_no_extractors_match():
+    """All extractors skip → empty dict, no provenance key."""
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors([_SkippingExtractor()], doc=doc, raw_bytes=b"", source_path=None)
+    assert out == {}
+
+
+def test_metadata_extractor_protocol_is_satisfied_by_duck_type():
+    """MetadataExtractor is a @runtime_checkable Protocol — duck-typed mocks
+    satisfy isinstance()."""
+    assert isinstance(_AlphaExtractor(), MetadataExtractor)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/ingest/test_metadata_extractor_framework.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'harbor_clerk.ingest'`.
+
+- [ ] **Step 3: Create the ingest package**
+
+Create `src/harbor_clerk/ingest/__init__.py` (empty file).
+
+Create `src/harbor_clerk/ingest/metadata_extractors/__init__.py`:
+
+```python
+# src/harbor_clerk/ingest/metadata_extractors/__init__.py
+"""Pluggable metadata extractors for HC's ingest pipeline.
+
+Each extractor returns a dict of fields keyed under its `name` namespace
+on the document's metadata JSONB column. The framework runs them in
+EXTRACTORS order, merges results, and records per-source provenance
+timestamps. A failing extractor logs a warning but does not abort the
+others — ingestion stays resilient to one-off Tika hiccups or malformed
+frontmatter.
+
+Public surface:
+  MetadataExtractor — @runtime_checkable Protocol
+  EXTRACTORS        — production tuple, used by extract.py
+  run_all(...)      — production entry point (uses EXTRACTORS)
+  _run_extractors() — testable helper that takes an explicit extractor list
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class MetadataExtractor(Protocol):
+    """A single extractor; one per metadata source.
+
+    Implementations must declare `name` (the namespace key on the merged
+    metadata dict) and `extract(*, doc, raw_bytes, source_path) -> dict | None`.
+    Returning None signals "this extractor doesn't apply to this doc"
+    (e.g. frontmatter extractor on a PDF) — the namespace is omitted
+    entirely from the merged output.
+    """
+
+    name: str
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None: ...
+
+
+def _run_extractors(
+    extractors: list[MetadataExtractor],
+    *,
+    doc,
+    raw_bytes: bytes,
+    source_path: str | None,
+) -> dict[str, Any]:
+    """Run the given extractor list and merge results. See run_all() docstring."""
+    out: dict[str, Any] = {}
+    provenance: dict[str, str] = {}
+    for ext in extractors:
+        try:
+            result = ext.extract(doc=doc, raw_bytes=raw_bytes, source_path=source_path)
+        except Exception as exc:
+            log.warning(
+                "metadata extractor %s failed on doc %s: %s",
+                ext.name,
+                getattr(doc, "doc_id", "<unknown>"),
+                exc,
+            )
+            continue
+        if result:
+            out[ext.name] = result
+            provenance[ext.name] = datetime.now(UTC).isoformat()
+    if out:
+        out["_source_provenance"] = provenance
+    return out
+
+
+# Production extractor tuple — populated by individual extractors in
+# later tasks. Keep at the bottom of the module so the imports below
+# can reference symbols defined above.
+EXTRACTORS: list[MetadataExtractor] = []
+
+
+def run_all(*, doc, raw_bytes: bytes, source_path: str | None) -> dict[str, Any]:
+    """Entry point used by the extract stage. Runs EXTRACTORS in order,
+    merges results, returns a namespaced dict suitable for assigning to
+    Document.doc_metadata."""
+    return _run_extractors(EXTRACTORS, doc=doc, raw_bytes=raw_bytes, source_path=source_path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/ingest/test_metadata_extractor_framework.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/ingest/ tests/ingest/
+uv run ruff format --check src/harbor_clerk/ingest/ tests/ingest/
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/ingest/ tests/ingest/__init__.py tests/ingest/test_metadata_extractor_framework.py
+git commit -m "feat(ingest): metadata extractor framework — Protocol + run_all()" \
+  -m "Pluggable per-source extractors keyed by namespace. Failing extractor logs + continues so one-off Tika hiccups or malformed frontmatter don't abort ingestion. EXTRACTORS list is empty for now; populated by Tika/frontmatter/sidecar extractors in the next three tasks." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Tika metadata extractor
+
+**Files:**
+- Create: `src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py`
+- Modify: `src/harbor_clerk/ingest/metadata_extractors/__init__.py` (add to EXTRACTORS)
+- Create: `tests/ingest/test_tika_metadata_extractor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ingest/test_tika_metadata_extractor.py`:
+
+```python
+"""TikaMetadataExtractor — calls Tika's /meta endpoint, whitelists fields."""
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from harbor_clerk.ingest.metadata_extractors.tika_metadata import (
+    TIKA_FIELD_ALIASES,
+    TikaMetadataExtractor,
+)
+
+
+@dataclass
+class _FakeDoc:
+    doc_id: uuid.UUID
+    title: str
+    mime_type: str | None
+
+
+def test_tika_extractor_returns_aliased_whitelisted_fields(httpserver: HTTPServer, monkeypatch):
+    """Tika /meta returns a noisy dict; the extractor whitelists + aliases
+    to readable filter keys and drops everything else."""
+    tika_response = {
+        # Whitelisted aliases
+        "dc:creator": "Jane Doe",
+        "dc:title": "Q3 Report",
+        "dc:subject": "Quarterly Earnings",
+        "xmpTPg:NPages": 12,
+        "dcterms:created": "2024-09-15T10:30:00Z",
+        # Noise that should be dropped
+        "X-TIKA-Parsed-By": "org.apache.tika.parser.pdf.PDFParser",
+        "X-TIKA-Content-Length": "8432",
+        "pdf:PDFVersion": "1.7",
+        "Custom-Random-Field": "ignored",
+    }
+    httpserver.expect_request("/meta").respond_with_json(tika_response)
+
+    # Point Tika settings at the test server
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": httpserver.url_for("").rstrip("/")})(),
+    )
+
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="q3", mime_type="application/pdf"),
+        raw_bytes=b"%PDF-1.7\n...",
+        source_path=None,
+    )
+
+    assert out == {
+        "author": "Jane Doe",
+        "title": "Q3 Report",
+        "subject": "Quarterly Earnings",
+        "page_count": 12,
+        "created_at": "2024-09-15T10:30:00Z",
+    }
+
+
+def test_tika_extractor_returns_none_when_tika_url_unset(monkeypatch):
+    """If tika_url is empty, return None (no Tika to call)."""
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": ""})(),
+    )
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", mime_type="text/plain"),
+        raw_bytes=b"hello",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_tika_extractor_handles_empty_response(httpserver: HTTPServer, monkeypatch):
+    """Tika returning {} → return None (don't write an empty 'tika' namespace)."""
+    httpserver.expect_request("/meta").respond_with_json({})
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": httpserver.url_for("").rstrip("/")})(),
+    )
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", mime_type="application/pdf"),
+        raw_bytes=b"...",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_tika_extractor_collects_email_headers(httpserver: HTTPServer, monkeypatch):
+    """For .eml files, Tika emits Message-From/To/Cc/Subject headers."""
+    tika_response = {
+        "Message-From": "alice@example.com",
+        "Message-To": "bob@example.com,carol@example.com",
+        "Message-Cc": "dave@example.com",
+        "Message-Subject": "Re: Project Update",
+        "dcterms:created": "2024-09-15T10:30:00Z",
+    }
+    httpserver.expect_request("/meta").respond_with_json(tika_response)
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": httpserver.url_for("").rstrip("/")})(),
+    )
+
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="re-project-update", mime_type="message/rfc822"),
+        raw_bytes=b"From: alice@example.com\n...",
+        source_path=None,
+    )
+
+    assert out["email_from"] == "alice@example.com"
+    assert out["email_to"] == "bob@example.com,carol@example.com"
+    assert out["email_cc"] == "dave@example.com"
+    assert out["email_subject"] == "Re: Project Update"
+
+
+def test_tika_field_aliases_has_no_duplicate_target_keys():
+    """The alias map can map two Tika keys to the same target (e.g. both
+    xmpTPg:NPages and Page-Count → page_count); for each target key, the
+    LAST writer wins. Document the conflict set for future readers."""
+    targets = list(TIKA_FIELD_ALIASES.values())
+    # We allow duplicates (Tika emits aliases for the same concept), but the
+    # test pins the current count so a future refactor surfaces the change.
+    unique_targets = set(targets)
+    duplicates = [t for t in unique_targets if targets.count(t) > 1]
+    # Document expected duplicates explicitly:
+    assert sorted(duplicates) == sorted(["page_count"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/ingest/test_tika_metadata_extractor.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'harbor_clerk.ingest.metadata_extractors.tika_metadata'`.
+
+- [ ] **Step 3: Implement the Tika extractor**
+
+Create `src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py`:
+
+```python
+# src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
+"""TikaMetadataExtractor — captures Tika's metadata dict.
+
+Tika's /meta endpoint returns a JSON dict with potentially 50-200 fields,
+most of which are framework noise (X-TIKA-Parsed-By, X-TIKA-Content-Length,
+parser-specific keys). The whitelist + alias map normalizes the wildly
+varying Tika field names to readable filter keys; unknown fields are dropped.
+No raw passthrough — keeps the metadata blob bounded and the filter surface
+clean.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from harbor_clerk.config import get_settings
+
+log = logging.getLogger(__name__)
+
+# Tika field name → readable filter key. When two Tika fields map to the
+# same target, the LAST one wins (intentional — Tika sometimes emits the
+# same concept under multiple keys, and the most reliable one is listed
+# last). Test pins the duplicate set so a future refactor surfaces changes.
+TIKA_FIELD_ALIASES: dict[str, str] = {
+    # Dublin Core
+    "dc:creator": "author",
+    "dc:title": "title",
+    "dc:subject": "subject",
+    "dc:description": "description",
+    "dc:language": "language",
+    "dcterms:created": "created_at",
+    "dcterms:modified": "modified_at",
+    "meta:keyword": "keywords",
+    # Pagination / structure (last writer wins → Page-Count beats xmpTPg:NPages)
+    "xmpTPg:NPages": "page_count",
+    "Page-Count": "page_count",
+    # MIME / encoding
+    "Content-Type": "content_type",
+    "Content-Encoding": "encoding",
+    # Email headers (Tika's email parser; takes precedence over dcterms:created
+    # when both appear — order matters)
+    "Message-From": "email_from",
+    "Message-To": "email_to",
+    "Message-Cc": "email_cc",
+    "Message-Subject": "email_subject",
+}
+
+
+class TikaMetadataExtractor:
+    """Calls Tika's /meta endpoint, whitelists fields, drops noise."""
+
+    name = "tika"
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        settings = get_settings()
+        if not settings.tika_url:
+            return None
+        try:
+            with httpx.Client(timeout=30) as client:
+                resp = client.put(
+                    f"{settings.tika_url}/meta",
+                    content=raw_bytes,
+                    headers={"Accept": "application/json"},
+                )
+                if resp.status_code != 200:
+                    log.warning(
+                        "tika /meta returned HTTP %s for doc %s",
+                        resp.status_code,
+                        getattr(doc, "doc_id", "<unknown>"),
+                    )
+                    return None
+                raw: dict[str, Any] = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("tika /meta failed for doc %s: %s", getattr(doc, "doc_id", "<unknown>"), exc)
+            return None
+
+        # Whitelist + alias
+        out: dict[str, Any] = {}
+        for tika_key, target_key in TIKA_FIELD_ALIASES.items():
+            if tika_key in raw:
+                out[target_key] = raw[tika_key]
+
+        return out or None
+```
+
+- [ ] **Step 4: Register the extractor**
+
+Edit `src/harbor_clerk/ingest/metadata_extractors/__init__.py` — find the `EXTRACTORS` list (currently empty) and add the import + entry:
+
+```python
+# At the bottom of the file (after the existing class + function defs):
+from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
+
+EXTRACTORS: list[MetadataExtractor] = [TikaMetadataExtractor()]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/ingest/ -v
+```
+
+Expected: all 6 framework tests + 5 Tika tests pass (11 total).
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/ingest/ tests/ingest/
+uv run ruff format --check src/harbor_clerk/ingest/ tests/ingest/
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py src/harbor_clerk/ingest/metadata_extractors/__init__.py tests/ingest/test_tika_metadata_extractor.py
+git commit -m "feat(ingest): TikaMetadataExtractor — captures /meta, whitelists noise" \
+  -m "Calls Tika's /meta endpoint per file, whitelists ~15 useful fields (author, title, subject, dates, page_count, content_type, email headers for .eml), drops the 50-200 noise fields Tika emits (X-TIKA-Parsed-By, parser-specific keys, etc). Aliases Tika's wildly-varying field names (dc:creator, dcterms:created, etc) to readable filter keys." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Frontmatter extractor
+
+**Files:**
+- Modify: `pyproject.toml` (add `python-frontmatter>=1.1` runtime dep)
+- Create: `src/harbor_clerk/ingest/metadata_extractors/frontmatter.py`
+- Modify: `src/harbor_clerk/ingest/metadata_extractors/__init__.py` (register)
+- Create: `tests/ingest/test_frontmatter_extractor.py`
+
+- [ ] **Step 1: Add the runtime dependency**
+
+Edit `pyproject.toml`. Find the `dependencies = [...]` list and add `"python-frontmatter>=1.1",` alphabetically:
+
+```toml
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
+    # ... existing entries ...
+    "python-frontmatter>=1.1",
+    # ... continue with the rest ...
+]
+```
+
+Then sync:
+
+```bash
+uv sync --extra test
+```
+
+Expected: `python-frontmatter` installed successfully.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/ingest/test_frontmatter_extractor.py`:
+
+```python
+"""FrontmatterExtractor — parses YAML frontmatter from markdown."""
+
+import uuid
+from dataclasses import dataclass
+
+from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor
+
+
+@dataclass
+class _FakeDoc:
+    doc_id: uuid.UUID
+    title: str
+    canonical_filename: str | None
+
+
+def test_frontmatter_extractor_parses_yaml_block():
+    body = b"""---
+title: Meeting Notes
+date: 2024-09-15
+tags: [team, planning]
+status: draft
+---
+
+# Meeting Notes
+
+We discussed roadmap items.
+"""
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="meeting", canonical_filename="notes.md"),
+        raw_bytes=body,
+        source_path=None,
+    )
+    assert out == {
+        "title": "Meeting Notes",
+        "date": "2024-09-15",  # YAML date → ISO string at the boundary
+        "tags": ["team", "planning"],
+        "status": "draft",
+    }
+
+
+def test_frontmatter_extractor_returns_none_for_non_markdown():
+    """A .pdf or .docx file is never parsed for frontmatter."""
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="r", canonical_filename="report.pdf"),
+        raw_bytes=b"%PDF-1.7\n---\ntitle: nope\n---\n...",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_frontmatter_extractor_returns_none_for_markdown_without_frontmatter():
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="r", canonical_filename="note.md"),
+        raw_bytes=b"# Just a heading\n\nNo frontmatter here.\n",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_frontmatter_extractor_handles_malformed_yaml_without_raising():
+    """A markdown file with broken YAML in the frontmatter block → returns
+    None + logs a warning. Does NOT propagate the parser exception (the
+    framework would catch it anyway but the extractor itself is defensive)."""
+    body = b"""---
+title: Meeting
+date: 2024-09-15
+unclosed_list: [a, b
+---
+
+content
+"""
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="m", canonical_filename="m.md"),
+        raw_bytes=body,
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_frontmatter_extractor_recognises_markdown_extension_variants():
+    """Both .md and .markdown trigger parsing."""
+    body = b"---\nfoo: bar\n---\n\ncontent\n"
+    extractor = FrontmatterExtractor()
+    for ext in (".md", ".markdown"):
+        out = extractor.extract(
+            doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", canonical_filename=f"file{ext}"),
+            raw_bytes=body,
+            source_path=None,
+        )
+        assert out == {"foo": "bar"}, f"failed for extension {ext}"
+
+
+def test_frontmatter_extractor_falls_back_to_source_path_when_no_filename():
+    """If canonical_filename is None, use source_path to detect the extension."""
+    body = b"---\nfoo: bar\n---\n\ncontent\n"
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", canonical_filename=None),
+        raw_bytes=body,
+        source_path="/tmp/note.md",
+    )
+    assert out == {"foo": "bar"}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+uv run pytest tests/ingest/test_frontmatter_extractor.py -v
+```
+
+Expected: ImportError on `harbor_clerk.ingest.metadata_extractors.frontmatter`.
+
+- [ ] **Step 4: Implement the extractor**
+
+Create `src/harbor_clerk/ingest/metadata_extractors/frontmatter.py`:
+
+```python
+# src/harbor_clerk/ingest/metadata_extractors/frontmatter.py
+"""FrontmatterExtractor — parses YAML frontmatter from markdown files.
+
+Obsidian, MkDocs, Jekyll, Hugo all use the `---`-delimited YAML header
+pattern at the top of markdown files. The extractor parses that header
+and returns it as the metadata dict. For non-markdown files (PDFs, .eml,
+.docx, etc.) it returns None.
+
+Frontmatter values are normalized to JSON-serializable scalars: YAML
+dates → ISO strings at the boundary (the doc_metadata column is JSONB,
+which doesn't have a native date type — keeping dates as strings makes
+filter values comparable without further parsing).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import Any
+
+import frontmatter
+
+log = logging.getLogger(__name__)
+
+_MARKDOWN_EXTENSIONS = (".md", ".markdown")
+
+
+class FrontmatterExtractor:
+    """YAML frontmatter parser for markdown files."""
+
+    name = "frontmatter"
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        # Identify markdown via canonical_filename first, fall back to source_path
+        filename = getattr(doc, "canonical_filename", None) or source_path or ""
+        if not any(filename.lower().endswith(ext) for ext in _MARKDOWN_EXTENSIONS):
+            return None
+
+        try:
+            parsed = frontmatter.loads(raw_bytes.decode("utf-8", errors="replace"))
+        except Exception as exc:
+            log.warning(
+                "frontmatter parse failed for doc %s: %s",
+                getattr(doc, "doc_id", "<unknown>"),
+                exc,
+            )
+            return None
+
+        if not parsed.metadata:
+            return None
+
+        return _jsonify(parsed.metadata)
+
+
+def _jsonify(obj: Any) -> Any:
+    """Recursively convert YAML-parsed values to JSON-serializable equivalents.
+    Mainly: date/datetime → ISO string."""
+    if isinstance(obj, dict):
+        return {k: _jsonify(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_jsonify(v) for v in obj]
+    if isinstance(obj, _dt.datetime):
+        return obj.isoformat()
+    if isinstance(obj, _dt.date):
+        return obj.isoformat()
+    return obj
+```
+
+- [ ] **Step 5: Register the extractor**
+
+Edit `src/harbor_clerk/ingest/metadata_extractors/__init__.py` — extend the EXTRACTORS list:
+
+```python
+from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor  # noqa: E402
+from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
+
+EXTRACTORS: list[MetadataExtractor] = [
+    TikaMetadataExtractor(),
+    FrontmatterExtractor(),
+]
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+uv run pytest tests/ingest/ -v
+```
+
+Expected: all framework + Tika + frontmatter tests pass (17 total).
+
+- [ ] **Step 7: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/ingest/ tests/ingest/ pyproject.toml
+uv run ruff format --check src/harbor_clerk/ingest/ tests/ingest/
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/harbor_clerk/ingest/metadata_extractors/frontmatter.py src/harbor_clerk/ingest/metadata_extractors/__init__.py tests/ingest/test_frontmatter_extractor.py
+git commit -m "feat(ingest): FrontmatterExtractor — YAML frontmatter from markdown" \
+  -m "Parses --- delimited YAML header from .md/.markdown files via python-frontmatter (1.1+). Returns None for non-markdown or markdown without frontmatter. Malformed YAML logs a warning and returns None (defensive — framework would catch the exception anyway). YAML dates normalised to ISO strings since JSONB lacks a native date type and filter values need to be comparable as-is." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Sidecar extractor
+
+**Files:**
+- Create: `src/harbor_clerk/ingest/metadata_extractors/sidecar.py`
+- Modify: `src/harbor_clerk/ingest/metadata_extractors/__init__.py` (register)
+- Create: `tests/ingest/test_sidecar_extractor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ingest/test_sidecar_extractor.py`:
+
+```python
+"""SidecarExtractor — loads <stem>.json next to source_path."""
+
+import json
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from harbor_clerk.ingest.metadata_extractors.sidecar import SidecarExtractor
+
+
+@dataclass
+class _FakeDoc:
+    doc_id: uuid.UUID
+    title: str
+
+
+def test_sidecar_extractor_loads_json_next_to_source_path(tmp_path: Path):
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("invoice body text")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text(json.dumps({"vendor": "Acme", "total_usd": 1234.56}))
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"invoice body text",
+        source_path=str(doc_file),
+    )
+    assert out == {"vendor": "Acme", "total_usd": 1234.56}
+
+
+def test_sidecar_extractor_returns_none_when_no_sidecar_exists(tmp_path: Path):
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_returns_none_when_source_path_unset():
+    """Legacy uploaded docs without a watched-folder source_path → no sidecar."""
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_logs_and_returns_none_on_malformed_json(tmp_path: Path):
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text("{ not valid json")
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_returns_none_for_empty_sidecar(tmp_path: Path):
+    """An empty JSON object {} → return None so the namespace isn't written."""
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text("{}")
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_rejects_non_object_top_level(tmp_path: Path):
+    """A top-level list or string in the sidecar is not a valid metadata
+    dict — log warning, return None."""
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text('["not", "an", "object"]')
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/ingest/test_sidecar_extractor.py -v
+```
+
+Expected: ImportError on the sidecar module.
+
+- [ ] **Step 3: Implement**
+
+Create `src/harbor_clerk/ingest/metadata_extractors/sidecar.py`:
+
+```python
+# src/harbor_clerk/ingest/metadata_extractors/sidecar.py
+"""SidecarExtractor — loads <stem>.json next to source_path.
+
+For docs ingested via watched folders (synthetic test corpus, real-world
+power users with curated metadata files), look for a JSON file with the
+same stem as the source file and load it as the metadata dict.
+
+Example: a watched folder containing
+  invoices/2024-Q3/INV-001.pdf
+  invoices/2024-Q3/INV-001.json
+would surface the INV-001.json contents under the 'sidecar' namespace on
+the Document for INV-001.pdf.
+
+Returns None for docs without source_path (legacy uploads), without a
+matching sidecar file, with malformed JSON, with an empty object, or
+with a non-object top-level JSON value (list/string/etc).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class SidecarExtractor:
+    """Loads <stem>.json next to the source file."""
+
+    name = "sidecar"
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        if not source_path:
+            return None
+        src = Path(source_path)
+        sidecar = src.with_suffix(".json")
+        if not sidecar.is_file():
+            return None
+        try:
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning(
+                "sidecar load failed for doc %s (%s): %s",
+                getattr(doc, "doc_id", "<unknown>"),
+                sidecar,
+                exc,
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            log.warning(
+                "sidecar for doc %s is not a JSON object (got %s); ignoring",
+                getattr(doc, "doc_id", "<unknown>"),
+                type(payload).__name__,
+            )
+            return None
+
+        return payload or None
+```
+
+- [ ] **Step 4: Register**
+
+Edit `src/harbor_clerk/ingest/metadata_extractors/__init__.py`:
+
+```python
+from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor  # noqa: E402
+from harbor_clerk.ingest.metadata_extractors.sidecar import SidecarExtractor  # noqa: E402
+from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
+
+EXTRACTORS: list[MetadataExtractor] = [
+    TikaMetadataExtractor(),
+    FrontmatterExtractor(),
+    SidecarExtractor(),
+]
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/ingest/ -v
+```
+
+Expected: all framework + Tika + frontmatter + sidecar tests pass (23 total).
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/ingest/ tests/ingest/
+uv run ruff format --check src/harbor_clerk/ingest/ tests/ingest/
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/harbor_clerk/ingest/metadata_extractors/sidecar.py src/harbor_clerk/ingest/metadata_extractors/__init__.py tests/ingest/test_sidecar_extractor.py
+git commit -m "feat(ingest): SidecarExtractor — loads <stem>.json next to source_path" \
+  -m "For docs ingested via watched folders that happen to have a JSON sidecar with the same stem (synthetic test corpus + real-world power users with curated metadata files). Returns None for docs without source_path, without a matching sidecar, with malformed JSON, with an empty object, or with a non-object top-level JSON value." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Wire extractors into the extract stage
+
+**Files:**
+- Modify: `src/harbor_clerk/worker/stages/extract.py` — call `run_all()` and persist
+- Modify: `src/harbor_clerk/worker/markdown_extract.py` — strip frontmatter from body before chunking
+- Create: `tests/worker/test_extract_metadata_persistence.py`
+
+- [ ] **Step 1: Write the failing test for the extract stage**
+
+Create `tests/worker/test_extract_metadata_persistence.py`:
+
+```python
+"""End-to-end: the extract stage runs the extractor framework and persists
+results to Document.doc_metadata. Uses a tmp sidecar to avoid hitting Tika
+in the unit-test path."""
+
+import json
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import select
+
+from harbor_clerk.models import Document
+from harbor_clerk.models.enums import PipelineStatus
+
+
+async def test_extract_stage_writes_sidecar_metadata_to_doc(db_session, tmp_path: Path):
+    # Set up doc + source file + sidecar
+    source = tmp_path / "0001_invoice.txt"
+    source.write_text("Invoice body text")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text(json.dumps({"vendor": "Acme", "total_usd": 100}))
+
+    doc = Document(
+        title="0001_invoice",
+        canonical_filename="0001_invoice.txt",
+        status="active",
+        sha256=b"\x00" * 32,
+        pipeline_status=PipelineStatus.queued,
+        mime_type="text/plain",
+        source_path=str(source),
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    doc_id = doc.doc_id
+
+    # Run extract — mock Tika so we don't need a live Tika in tests
+    from harbor_clerk.worker.stages import extract
+
+    with patch.object(extract, "_extract_via_tika", return_value=[(1, "Invoice body text")]):
+        with patch(
+            "harbor_clerk.ingest.metadata_extractors.tika_metadata.httpx.Client"
+        ) as mock_tika_meta:
+            # Make Tika /meta return nothing — only sidecar will write metadata
+            mock_tika_meta.return_value.__enter__.return_value.put.return_value.status_code = 200
+            mock_tika_meta.return_value.__enter__.return_value.put.return_value.json.return_value = {}
+            extract.run_extract(doc_id)
+
+    # Verify doc.doc_metadata has the sidecar namespace
+    await db_session.expire_all()
+    doc = (await db_session.execute(select(Document).where(Document.doc_id == doc_id))).scalar_one()
+    assert "sidecar" in doc.doc_metadata
+    assert doc.doc_metadata["sidecar"] == {"vendor": "Acme", "total_usd": 100}
+    assert "_source_provenance" in doc.doc_metadata
+    assert "sidecar" in doc.doc_metadata["_source_provenance"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/worker/test_extract_metadata_persistence.py -v
+```
+
+Expected: assertion failure — doc.doc_metadata is still `{}` because the extract stage doesn't call run_all() yet.
+
+- [ ] **Step 3: Wire `run_all()` into the extract stage**
+
+Edit `src/harbor_clerk/worker/stages/extract.py`. Near the top, add the import:
+
+```python
+from harbor_clerk.ingest.metadata_extractors import run_all as run_metadata_extractors
+```
+
+Then find the `run_extract` function. After the body text + page extraction completes and BEFORE the session.commit() that persists Document changes, insert the metadata call. The exact location depends on the current file structure — locate the section that updates `doc.extracted_chars`, `doc.has_text_layer`, etc., and add the metadata block adjacent to those updates:
+
+```python
+# Extract metadata (Tika headers, frontmatter, sidecar). Runs after body
+# extraction so the Tika /meta call can be skipped cheaply if the body
+# extraction already failed (data is the raw_bytes available here).
+try:
+    metadata = run_metadata_extractors(doc=doc, raw_bytes=data, source_path=doc.source_path)
+    if metadata:
+        doc.doc_metadata = metadata
+except Exception as exc:
+    # Extractor framework swallows individual extractor failures already;
+    # this catch is for catastrophic framework-level failures (import
+    # errors, etc). Log and continue — metadata is additive.
+    logger.warning("metadata extraction framework failed for doc %s: %s", doc_id, exc)
+```
+
+(Use the existing `data` variable that holds the raw bytes loaded for body extraction. Naming may vary slightly — search for the variable used by `_extract_via_tika`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+uv run pytest tests/worker/test_extract_metadata_persistence.py -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 5: Write the failing test for frontmatter stripping**
+
+Create `tests/worker/test_markdown_frontmatter_stripping.py`:
+
+```python
+"""Markdown extract path strips YAML frontmatter from body text before
+chunking, so the chunks/embedding/FTS don't include raw YAML noise."""
+
+from harbor_clerk.worker.markdown_extract import strip_frontmatter
+
+
+def test_strip_frontmatter_removes_yaml_block():
+    body = """---
+title: Notes
+tags: [a, b]
+---
+
+# Heading
+
+Body content.
+"""
+    assert (
+        strip_frontmatter(body)
+        == """# Heading
+
+Body content.
+"""
+    )
+
+
+def test_strip_frontmatter_passes_through_unchanged_without_frontmatter():
+    body = "# Just a heading\n\nNo frontmatter.\n"
+    assert strip_frontmatter(body) == body
+
+
+def test_strip_frontmatter_passes_through_unchanged_when_yaml_is_malformed():
+    """Malformed YAML → don't risk losing body content; pass through unchanged.
+    Metadata extraction logs the parse failure separately."""
+    body = """---
+title: Meeting
+unclosed_list: [a, b
+---
+
+content
+"""
+    assert strip_frontmatter(body) == body
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+```bash
+uv run pytest tests/worker/test_markdown_frontmatter_stripping.py -v
+```
+
+Expected: ImportError on `strip_frontmatter`.
+
+- [ ] **Step 7: Implement `strip_frontmatter`**
+
+Edit `src/harbor_clerk/worker/markdown_extract.py`. Add at module scope:
+
+```python
+import frontmatter as _frontmatter
+
+
+def strip_frontmatter(text: str) -> str:
+    """Remove the leading YAML frontmatter block from markdown text.
+
+    If the text doesn't start with `---\\n` or the frontmatter is malformed,
+    return the text unchanged. Metadata extraction (FrontmatterExtractor in
+    src/harbor_clerk/ingest/metadata_extractors/frontmatter.py) logs the
+    parse failure separately, so this is a pure "drop the YAML if it parses
+    cleanly, else pass through" operation.
+    """
+    try:
+        parsed = _frontmatter.loads(text)
+    except Exception:
+        return text
+    if not parsed.metadata:
+        # No frontmatter detected → return as-is
+        return text
+    # frontmatter.loads.content strips the YAML header; restore a trailing
+    # newline if the original had one (defensive — most markdown files do)
+    content = parsed.content
+    if text.endswith("\n") and not content.endswith("\n"):
+        content += "\n"
+    return content
+```
+
+Then find where the markdown body text is chunked in the same file (search for "chunk" or the function that processes markdown after extraction) and call `strip_frontmatter()` on the body before chunking. The exact integration point depends on the file's structure; add the call where the body string is finalized for the chunker.
+
+- [ ] **Step 8: Run tests**
+
+```bash
+uv run pytest tests/worker/test_markdown_frontmatter_stripping.py tests/worker/test_extract_metadata_persistence.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 9: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/worker/stages/extract.py src/harbor_clerk/worker/markdown_extract.py tests/worker/
+uv run ruff format --check src/harbor_clerk/worker/stages/extract.py src/harbor_clerk/worker/markdown_extract.py tests/worker/
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/harbor_clerk/worker/stages/extract.py src/harbor_clerk/worker/markdown_extract.py tests/worker/test_extract_metadata_persistence.py tests/worker/test_markdown_frontmatter_stripping.py
+git commit -m "feat(worker): extract stage runs metadata extractors + strips frontmatter" \
+  -m "Extract stage now calls run_metadata_extractors() after body extraction; results land on Document.doc_metadata. Markdown body text gets its YAML frontmatter stripped before chunking so retrieval doesn't include raw 'tags: [foo, bar]' noise — the same fields are still accessible via the frontmatter metadata namespace and via metadata_filter." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `kb_search` `metadata_filter` parameter — query layer
+
+**Files:**
+- Modify: `src/harbor_clerk/search.py` — extend `hybrid_search` with `metadata_filter`
+- Create: `tests/test_search_metadata_filter.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_search_metadata_filter.py`:
+
+```python
+"""kb_search metadata_filter — JSONB @> containment + ? existence fallback."""
+
+import uuid
+
+from sqlalchemy import text
+
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.search import hybrid_search
+
+
+async def _seed_doc(db_session, *, title: str, metadata: dict) -> Document:
+    """Helper: insert a Document with one trivial Chunk so FTS can match."""
+    doc = Document(
+        title=title,
+        status="active",
+        sha256=uuid.uuid4().bytes,  # 16 bytes — pad to 32
+        pipeline_status=PipelineStatus.ready,
+        doc_metadata=metadata,
+    )
+    # sha256 must be exactly 32 bytes
+    doc.sha256 = (uuid.uuid4().bytes + uuid.uuid4().bytes)[:32]
+    db_session.add(doc)
+    await db_session.flush()
+    chunk = Chunk(
+        doc_id=doc.doc_id,
+        chunk_idx=0,
+        text="governing law jurisdiction terms",
+        language="english",
+    )
+    db_session.add(chunk)
+    # Manually populate fts_en since the generated column needs the row
+    # to exist; flushing covers this.
+    await db_session.flush()
+    return doc
+
+
+async def test_metadata_filter_pins_doc_by_scalar_field(db_session):
+    """A scalar filter on a scalar metadata value matches via @> containment."""
+    pinnacle = await _seed_doc(
+        db_session,
+        title="vendor-pinnacle-A",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24}},
+    )
+    other = await _seed_doc(
+        db_session,
+        title="vendor-other",
+        metadata={"sidecar": {"vendor": "Other Vendor, LLC", "term_months": 12}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="governing law",
+        k=10,
+        metadata_filter={"sidecar.vendor": "Pinnacle Tech Solutions, LLC"},
+    )
+    cited_doc_ids = {hit.doc_id for hit in result.hits}
+    assert pinnacle.doc_id in cited_doc_ids
+    assert other.doc_id not in cited_doc_ids
+
+
+async def test_metadata_filter_pins_doc_by_list_value_via_existence(db_session):
+    """A scalar filter on a list-valued metadata field matches if the list
+    contains the scalar (JSONB ? operator)."""
+    tagged = await _seed_doc(
+        db_session,
+        title="tagged-alpha",
+        metadata={"frontmatter": {"tags": ["alpha", "beta"]}},
+    )
+    untagged = await _seed_doc(
+        db_session,
+        title="untagged",
+        metadata={"frontmatter": {"tags": ["gamma"]}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="governing law",
+        k=10,
+        metadata_filter={"frontmatter.tags": "alpha"},
+    )
+    cited = {hit.doc_id for hit in result.hits}
+    assert tagged.doc_id in cited
+    assert untagged.doc_id not in cited
+
+
+async def test_metadata_filter_combines_multiple_keys_with_and(db_session):
+    """Two filter keys → AND. Both must match for a doc to be returned."""
+    a = await _seed_doc(
+        db_session,
+        title="vendor-pinnacle-24mo",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24}},
+    )
+    b = await _seed_doc(
+        db_session,
+        title="vendor-pinnacle-12mo",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 12}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="governing law",
+        k=10,
+        metadata_filter={
+            "sidecar.vendor": "Pinnacle Tech Solutions, LLC",
+            "sidecar.term_months": 24,
+        },
+    )
+    cited = {hit.doc_id for hit in result.hits}
+    assert a.doc_id in cited
+    assert b.doc_id not in cited
+
+
+async def test_metadata_filter_empty_match_returns_no_hits(db_session):
+    """A filter that matches no docs returns an empty result set (not an error)."""
+    await _seed_doc(
+        db_session,
+        title="vendor-pinnacle",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC"}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="governing law",
+        k=10,
+        metadata_filter={"sidecar.vendor": "Nonexistent Vendor Co"},
+    )
+    assert result.hits == []
+
+
+async def test_metadata_filter_absent_falls_back_to_existing_behavior(db_session):
+    """When metadata_filter is None, behavior is unchanged."""
+    doc = await _seed_doc(db_session, title="any", metadata={})
+    await db_session.commit()
+    result = await hybrid_search(db_session, query="governing law", k=10, metadata_filter=None)
+    assert any(hit.doc_id == doc.doc_id for hit in result.hits)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_search_metadata_filter.py -v
+```
+
+Expected: `TypeError: hybrid_search() got an unexpected keyword argument 'metadata_filter'`.
+
+- [ ] **Step 3: Extend `hybrid_search`**
+
+Edit `src/harbor_clerk/search.py`. Update the `hybrid_search` signature and the doc-filter assembly block. Find the existing signature and add `metadata_filter`:
+
+```python
+async def hybrid_search(
+    session: AsyncSession,
+    query: str,
+    k: int = 10,
+    doc_id: uuid.UUID | None = None,
+    offset: int = 0,
+    *,
+    doc_ids: list[uuid.UUID] | None = None,
+    after: datetime | None = None,
+    before: datetime | None = None,
+    language: str | None = None,
+    mime_type: str | None = None,
+    metadata_filter: dict[str, Any] | None = None,
+) -> SearchResult:
+```
+
+(Add `from typing import Any` at the top if not present.)
+
+In the body, after the existing `doc_conditions` block, add metadata filter translation:
+
+```python
+    # Metadata filter translation. Each "<namespace>.<key>": value pair
+    # becomes either:
+    #   - JSONB @> containment: doc_metadata @> '{"ns": {"key": value}}'
+    #   - JSONB ? existence (for list-valued targets): doc_metadata->'ns'->'key' ? 'value'
+    # We try containment first; if no docs match, retry with the existence
+    # operator since the metadata value might be list-valued. This handles
+    # both `{tags: "alpha"}` and `{tags: ["alpha", "beta"]}` filter shapes
+    # without the caller needing to know which the corpus uses.
+    if metadata_filter:
+        for path, value in metadata_filter.items():
+            ns, _, key = path.partition(".")
+            if not ns or not key:
+                raise ValueError(
+                    f"metadata_filter keys must be 'namespace.key', got {path!r}"
+                )
+            # Containment OR existence:
+            #   doc_metadata @> '{"ns": {"key": value}}' (scalar metadata)
+            #   OR doc_metadata->'ns'->'key' ? :value::text (list metadata; needs string key)
+            containment = Document.doc_metadata.op("@>")(
+                func.cast({ns: {key: value}}, JSONB)
+            )
+            if isinstance(value, str):
+                existence = Document.doc_metadata[ns][key].op("?")(value)
+                doc_conditions.append(or_(containment, existence))
+            else:
+                doc_conditions.append(containment)
+```
+
+Add the imports at the top of `search.py`:
+
+```python
+from sqlalchemy import or_, func
+from sqlalchemy.dialects.postgresql import JSONB
+```
+
+(Some may already be imported; just ensure all three are available.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_search_metadata_filter.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/search.py tests/test_search_metadata_filter.py
+uv run ruff format --check src/harbor_clerk/search.py tests/test_search_metadata_filter.py
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/search.py tests/test_search_metadata_filter.py
+git commit -m "feat(search): kb_search metadata_filter via JSONB @> + ? fallback" \
+  -m "hybrid_search gains metadata_filter dict[str, Any] | None. Each 'namespace.key': value pair translates to a JSONB containment (@>) OR existence (?) clause on Document.doc_metadata, AND-ed with other filter keys. The OR-with-existence handles list-valued metadata fields (e.g. tags: ['alpha', 'beta']) being filtered by a scalar value without the caller needing to know the metadata shape." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `kb_search` + `kb_get_document` MCP wiring
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py` — add `metadata_filter` to `kb_search`; add `metadata` field to `kb_get_document` response
+- Create: `tests/test_mcp_metadata_filter.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_mcp_metadata_filter.py`:
+
+```python
+"""MCP wiring for kb_search metadata_filter and kb_get_document metadata field."""
+
+import json
+import uuid
+
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+
+
+async def _seed(db_session, *, title: str, metadata: dict) -> Document:
+    doc = Document(
+        title=title,
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        doc_metadata=metadata,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(Chunk(doc_id=doc.doc_id, chunk_idx=0, text="hello world", language="english"))
+    await db_session.flush()
+    return doc
+
+
+async def test_kb_search_passes_metadata_filter_through(client, admin_user, admin_token, db_session):
+    """The MCP kb_search tool forwards metadata_filter to hybrid_search."""
+    target = await _seed(db_session, title="target", metadata={"sidecar": {"vendor": "Acme"}})
+    other = await _seed(db_session, title="other", metadata={"sidecar": {"vendor": "Beta"}})
+    await db_session.commit()
+
+    # The MCP server is invoked over its tool interface, but we can call
+    # the function directly with the test's principal context. The
+    # production path uses HTTP/MCP; for unit-test purposes we exercise
+    # the function with the admin's session context.
+    from harbor_clerk.mcp_server import kb_search
+
+    # ...In the test, the function pulls principal from contextvar; the
+    # admin fixture sets it up. Detailed setup follows the same pattern
+    # as the existing test_mcp_*.py files.
+    pass  # See implementation note below — this test requires the existing MCP-test fixtures
+```
+
+(Note: MCP tool tests in this codebase are nuanced because the principal is read from a contextvar. The implementation of this test should follow the existing pattern from any `tests/test_mcp_*.py` file. If no such file exists yet, the test can be simpler — directly call `hybrid_search` with the filter and verify the output, which is what Task 7's tests already do. In that case, this task's test focuses on Step 2: kb_get_document returning metadata.)
+
+Replace the `pass` body with a simpler test that focuses on what's new:
+
+```python
+async def test_kb_get_document_includes_doc_metadata(client, admin_user, admin_token, db_session):
+    """kb_get_document response includes the metadata dict so models can
+    inspect available filter keys."""
+    target = await _seed(
+        db_session,
+        title="invoice-acme",
+        metadata={"sidecar": {"vendor": "Acme", "total_usd": 100}},
+    )
+    await db_session.commit()
+
+    # Invoke the MCP tool function directly
+    from harbor_clerk.mcp_server import kb_get_document, set_principal_for_test
+
+    set_principal_for_test(admin_user)  # see implementation note
+    try:
+        raw = await kb_get_document(doc_id=str(target.doc_id))
+    finally:
+        set_principal_for_test(None)
+
+    parsed = json.loads(raw)
+    assert parsed.get("metadata") == {"sidecar": {"vendor": "Acme", "total_usd": 100}}
+```
+
+If `set_principal_for_test` doesn't exist, add a tiny test helper to `mcp_server.py` (just a thin wrapper around the contextvar set/reset), or use whatever fixture pattern existing MCP tests use. (Implementation discretion: if no MCP-tool tests exist, this test can be deferred to integration testing — note in the commit message.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_mcp_metadata_filter.py -v
+```
+
+Expected: failure (kb_get_document doesn't return metadata; kb_search doesn't accept metadata_filter).
+
+- [ ] **Step 3: Add `metadata_filter` to `kb_search`**
+
+Edit `src/harbor_clerk/mcp_server.py`. Find the `kb_search` function signature (around line 546). Add `metadata_filter` to the params:
+
+```python
+async def kb_search(
+    query: str,
+    k: int = 10,
+    offset: int = 0,
+    detail: str = "full",
+    brief_chars: int = 0,
+    doc_id: str | None = None,
+    doc_ids: list[str] | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    language: str | None = None,
+    mime_type: str | None = None,
+    metadata_filter: dict | None = None,
+    faceted: bool = False,
+) -> str:
+```
+
+Extend the docstring's "Filters" section:
+
+```python
+    Filters (all optional):
+      doc_id: restrict to a single document (mutually exclusive with doc_ids)
+      doc_ids: restrict to multiple documents (list of UUIDs, max 50)
+      after: only documents updated at or after this ISO datetime
+      before: only documents updated before this ISO datetime
+      language: chunk language filter ("english" or "french")
+      mime_type: document MIME type filter (e.g. "application/pdf")
+      metadata_filter: dict of {"namespace.key": value} pairs to match against
+        Document.metadata. Use to disambiguate when multiple candidates share
+        text but differ on a structured field. Example:
+        metadata_filter={"sidecar.vendor": "Acme", "sidecar.term_months": 24}.
+        Inspect a document's available metadata via kb_get_document.
+```
+
+Find the call to `hybrid_search` further down in the function body. Add `metadata_filter=metadata_filter` to its keyword arguments.
+
+- [ ] **Step 4: Add `metadata` to `kb_get_document` response**
+
+Find `kb_get_document` in `mcp_server.py` (search for `def kb_get_document` or `@mcp.tool` near "Full document"). In the response assembly, add the metadata field:
+
+```python
+    # In the dict that builds the response:
+    "metadata": doc.doc_metadata,
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_mcp_metadata_filter.py -v
+```
+
+Expected: 1 passed (or both if the kb_search MCP test was kept).
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+uv run ruff check src/harbor_clerk/mcp_server.py tests/test_mcp_metadata_filter.py
+uv run ruff format --check src/harbor_clerk/mcp_server.py tests/test_mcp_metadata_filter.py
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_server.py tests/test_mcp_metadata_filter.py
+git commit -m "feat(mcp): kb_search.metadata_filter + kb_get_document.metadata" \
+  -m "kb_search now accepts metadata_filter (forwarded to hybrid_search). kb_get_document response includes the document's metadata dict so models can inspect available filter keys before crafting a filter. Tool description for the new param is a placeholder; PR-D's full description rewrite pass will polish it." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Re-ingest script for existing dev/test corpora
+
+**Files:**
+- Create: `scripts/reextract_metadata.py`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/reextract_metadata.py`:
+
+```python
+#!/usr/bin/env python3
+"""One-shot script: re-extract metadata for all active documents in the
+current HC instance. Idempotent — running twice produces the same metadata.
+
+Use this after applying the documents.metadata migration to backfill
+metadata for documents that were ingested before the extractor framework
+existed.
+
+Doesn't change body text or chunks — only writes to Document.doc_metadata.
+For documents in source-path-backed watched folders, reads raw bytes from
+disk. For legacy uploads with stored objects, fetches from storage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from sqlalchemy import select
+
+from harbor_clerk.db import get_session_factory
+from harbor_clerk.ingest.metadata_extractors import run_all as run_metadata_extractors
+from harbor_clerk.models import Document
+from harbor_clerk.storage import get_storage
+
+log = logging.getLogger("reextract_metadata")
+
+
+async def reextract_all(*, dry_run: bool = False) -> tuple[int, int, int]:
+    """Returns (processed, updated, skipped)."""
+    session_factory = get_session_factory()
+    storage = get_storage()
+
+    processed = updated = skipped = 0
+    async with session_factory() as session:
+        result = await session.execute(select(Document).where(Document.status == "active"))
+        docs = result.scalars().all()
+
+        for doc in docs:
+            processed += 1
+            # Load raw bytes from source_path (watched folder) or storage (legacy upload)
+            raw_bytes: bytes | None = None
+            if doc.source_path and Path(doc.source_path).is_file():
+                raw_bytes = Path(doc.source_path).read_bytes()
+            elif doc.original_bucket and doc.original_object_key:
+                try:
+                    raw_bytes = storage.get_object(doc.original_bucket, doc.original_object_key)
+                except Exception as exc:
+                    log.warning("storage fetch failed for doc %s: %s", doc.doc_id, exc)
+                    skipped += 1
+                    continue
+            else:
+                log.info("doc %s has no source_path or storage object; skipping", doc.doc_id)
+                skipped += 1
+                continue
+
+            metadata = run_metadata_extractors(
+                doc=doc,
+                raw_bytes=raw_bytes,
+                source_path=doc.source_path,
+            )
+            if metadata == doc.doc_metadata:
+                continue  # idempotent no-op
+            if dry_run:
+                log.info("would update doc %s: %s", doc.doc_id, metadata)
+                updated += 1
+                continue
+            doc.doc_metadata = metadata
+            updated += 1
+
+        if not dry_run:
+            await session.commit()
+
+    return processed, updated, skipped
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="don't commit changes")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    processed, updated, skipped = asyncio.run(reextract_all(dry_run=args.dry_run))
+    log.info(
+        "reextract_metadata complete: processed=%d updated=%d skipped=%d (dry_run=%s)",
+        processed,
+        updated,
+        skipped,
+        args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Smoke-check it imports cleanly**
+
+```bash
+uv run python -c "from scripts.reextract_metadata import reextract_all; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Lint + format**
+
+```bash
+uv run ruff check scripts/reextract_metadata.py
+uv run ruff format --check scripts/reextract_metadata.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/reextract_metadata.py
+git commit -m "chore(scripts): reextract_metadata.py — one-shot metadata backfill" \
+  -m "For existing dev/test corpora (and any production user who wants to populate metadata on docs ingested before PR-F). Idempotent. Reads raw bytes from source_path (watched folders) or storage (legacy uploads). --dry-run flag for safe inspection." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Full-suite regression sanity check
+
+**No new files or code — verification only.**
+
+- [ ] **Step 1: Run the full pytest suite**
+
+```bash
+uv run pytest tests/ -q 2>&1 | tail -10
+```
+
+Expected: existing tests pass, no regressions from the model/search/extract changes. The pre-existing spaCy `test_entity_overlap_english` may still fail (unrelated; missing model in test venv). Roughly 30+ new tests for PR-F land on top of the existing suite.
+
+- [ ] **Step 2: Lint + format on every changed file**
+
+```bash
+uv run ruff check src/harbor_clerk/ tests/ scripts/
+uv run ruff format --check src/harbor_clerk/ tests/ scripts/
+```
+
+Expected: clean across the touched tree.
+
+- [ ] **Step 3: Frontend type-check** (no frontend changes in PR-F, but verifying nothing leaked):
+
+```bash
+cd frontend && npm run lint && npx tsc --noEmit
+```
+
+Expected: clean (or only pre-existing warnings).
+
+- [ ] **Step 4: No commit needed** — verification gate.
+
+If any check fails, return to the relevant earlier task and fix; don't proceed to Task 11 (live validation) on a yellow signal.
+
+---
+
+## Task 11: Live validation against the synthetic corpus
+
+**Prerequisites:**
+- HC must be running (`http://localhost:8100`).
+- PR-RSS's "Reprocess (no summaries)" button merged on main (lets us re-ingest fast without burning LLM spend on summaries that aren't changing).
+- Synthetic corpus already ingested in HC (per CLAUDE.md, lives under `~/Library/Application Support/Harbor Clerk/test-corpora/synthetic/ingest`).
+
+- [ ] **Step 1: Trigger the metadata extraction pass via Reprocess (no summaries)**
+
+Open System Maintenance in HC's UI, click "Reprocess (no summaries)", confirm. Wait for the pipeline to drain (watch Observatory queue widget go to 0).
+
+Alternative (CLI): hit the PR-RSS endpoint directly:
+
+```bash
+curl -X POST -H "Authorization: Bearer $HC_API_KEY" \
+  http://localhost:8100/api/system/reprocess-all-skip-summarize
+```
+
+- [ ] **Step 2: Spot-check the synthetic corpus's metadata**
+
+Pick a few synthetic docs (one each of invoice, vendor_contract, policy_doc, employee_handbook) and verify their metadata via `kb_get_document`. Expected:
+
+- **Invoice docs** (`0001_invoice.json` etc.) → `sidecar` namespace with `vendor`, `invoice_number`, `total_usd`, `date`.
+- **Vendor contract docs** → `sidecar` with `vendor`, `term_months`, `monthly_fee_usd`, `governing_law`.
+- **Policy docs** → `sidecar` with `policy_name`, `version`, `effective_date`, `owner`.
+
+```bash
+# Pull a doc's metadata via MCP
+hc_api_key=$HC_API_KEY  # Synthetic-scoped key
+curl -s -H "Authorization: Bearer $hc_api_key" \
+  "http://localhost:8100/api/docs?q=0131_vendor_contract" | jq '.[0].metadata'
+```
+
+Expected: `{"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24, ...}, "_source_provenance": {"sidecar": "2026-..."}}`.
+
+If the metadata is empty for synthetic docs, the sidecar extractor isn't finding the `.json` sidecars — debug the source_path being passed.
+
+- [ ] **Step 3: Spot-check non-synthetic metadata sources**
+
+If the user's HC has Obsidian-vault markdown files in a watched folder, pick one with frontmatter and verify the `frontmatter` namespace populates. If they have PDFs, verify `tika` namespace shows `author`, `title`, `page_count` where Tika supplies them. Document what's populated (and what isn't) for the PR description.
+
+- [ ] **Step 4: Validate `metadata_filter` end-to-end**
+
+Run a hand-crafted MCP search that exercises the disambiguation case:
+
+```bash
+curl -X POST http://localhost:8100/mcp/mcp \
+  -H "Authorization: Bearer $HC_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "kb_search",
+      "arguments": {
+        "query": "governing law",
+        "metadata_filter": {"sidecar.vendor": "Pinnacle Tech Solutions, LLC", "sidecar.term_months": 24},
+        "k": 3
+      }
+    }
+  }' | jq '.result.content[0].text' | jq '.hits[] | {doc_title, score}'
+```
+
+Expected: returns chunks from the specific Pinnacle 24-month contract (synthetic doc `0131_vendor_contract`), not from `0149` or other Pinnacle docs with different terms.
+
+- [ ] **Step 5: Record findings for PR description**
+
+Note in `/tmp/pr-f-validation-notes.md`:
+- Which extractors fired on which doc types
+- Field surface across mime types (Tika is uneven — DOCX rich, PDF sparse, .eml structured)
+- Any surprise/dropped fields
+- The exact `metadata_filter` query that pinned the Pinnacle 24-month contract
+
+These notes go into the PR body.
+
+---
+
+## Task 12: Self-review, fresh-eyes review, open PR
+
+- [ ] **Step 1: Diff summary against `main`**
+
+```bash
+git fetch origin main --quiet
+git log --oneline origin/main..HEAD
+git diff --stat origin/main..HEAD
+```
+
+Expected: ~10 commits, the file structure listed at the top of this plan.
+
+- [ ] **Step 2: Final lint + format pass**
+
+```bash
+uv run ruff check src/harbor_clerk/ tests/ scripts/
+uv run ruff format --check src/harbor_clerk/ tests/ scripts/
+```
+
+- [ ] **Step 3: Dispatch fresh-eyes code reviewer** (per MEMORY.md standing directive — minimal prompt, no carve-outs)
+
+Use the Agent tool with `subagent_type: feature-dev:code-reviewer` and a minimal prompt: "Review the diff `git diff origin/main..HEAD` on branch `feat/document-metadata-extractors`. Spec is at `docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md`. Identify bugs, security issues, design problems with ≥80 confidence."
+
+Address ≥80-confidence findings inline.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/document-metadata-extractors
+```
+
+- [ ] **Step 5: Open the PR with metrics + validation notes from Task 11**
+
+Use the validation notes from `/tmp/pr-f-validation-notes.md` to write the PR body. Use `gh pr create --base main --head feat/document-metadata-extractors --title "feat(ingest): document metadata extractors + kb_search metadata_filter" --body-file /tmp/pr-f-body.md`.
+
+PR body should cover:
+- What the extractors capture (Tika, frontmatter, sidecar)
+- `metadata_filter` shape + the smart `@>`/`?` fallback
+- Validation results from Task 11 (Pinnacle 24-month pinned, etc.)
+- Known limitations (only doc-types we tested for; future PRs will add folder-path metadata, LLM-extraction, frontend display, operators)
+- Pointers to upstream follow-ups: PR-D (tool description rewrites + kb_search response enhancements), PR-E (kb_verify_identifier + kb_documents_by_date), PR-G (harness audit + cross-judge sensitivity)
+
+---
+
+## Self-Review Notes (for the agentic worker)
+
+**1. Spec coverage:** Every section of `2026-05-24-document-metadata-extractors-design.md` has a corresponding task:
+- Schema (Document.metadata JSONB + GIN) → Task 1
+- Extractor framework (Protocol + run_all) → Task 2
+- TikaMetadataExtractor → Task 3
+- FrontmatterExtractor → Task 4
+- SidecarExtractor → Task 5
+- Extract stage wiring + frontmatter strip → Task 6
+- kb_search metadata_filter query layer → Task 7
+- kb_search + kb_get_document MCP wiring → Task 8
+- Re-ingest script → Task 9
+- Regression + ruff → Task 10
+- Live validation → Task 11
+- Fresh-eyes review + PR → Task 12
+
+The 4 locked-in decisions from spec review (frontmatter stripped, kb_get_document returns metadata, exact-match-only operators, smart @>/? fallback) all have implementing tasks.
+
+**2. Placeholder scan:** No `TBD` / "TODO" / "implement later" in any code step. Task 8's note about MCP-tool test fixtures explicitly says to follow existing patterns and fall back to direct-function testing if MCP fixtures don't exist — that's an honest "implementation discretion" point, not a placeholder.
+
+**3. Type consistency:**
+- `Document.doc_metadata` (Python attr) ↔ `metadata` (PostgreSQL column) — consistent across Task 1 (definition), Task 6 (extract stage assignment), Task 7 (query layer), Task 8 (MCP response), Task 9 (re-ingest script).
+- `MetadataExtractor` Protocol's `extract(*, doc, raw_bytes, source_path) -> dict | None` signature is consistent in Task 2 (definition) and Tasks 3–5 (all three implementations).
+- `metadata_filter` parameter shape `dict[str, Any] | None` (or `dict | None` in MCP-layer) is consistent across Task 7 (`hybrid_search` signature) and Task 8 (MCP `kb_search` signature).
+- Extractor `name` field values (`"tika"`, `"frontmatter"`, `"sidecar"`) are consistent across the extractor implementations and the test assertions on metadata namespaces.

--- a/docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md
+++ b/docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md
@@ -255,18 +255,19 @@ Naming note: `metadata` is a reserved column name in some ORMs (SQLAlchemy uses 
 - **Metadata can override per-doc reality.** If a user has a sidecar saying `vendor: "Acme"` but the actual contract is with Pinnacle, the filter answers questions about the sidecar's claim, not the doc's text. This is "garbage in, garbage out" and acceptable — users with sidecars are power users who know what they're declaring.
 - **JSONB column doesn't suit huge metadata blobs.** Tika can return very large metadata for some files (EXIF with thumbnails embedded as base64, etc.). The whitelist cap protects against this; worth noting in the field list documentation.
 
-## Open questions for spec review
+## Decisions (closed during spec review)
 
-- **Strip frontmatter from body text or leave it in?** Leaning strip — the metadata fields cover it and leaving them in adds noise to chunking + retrieval. But some users might write meaningful prose IN their frontmatter (e.g., a long `summary:` field). Decision: strip, document the behavior, revisit if users complain.
-- **`kb_get_document` should return the metadata** so models can inspect what filter keys are available. This is a small change in scope; include in PR-F or queue for PR-D? Leaning include here — keeps the surface coherent.
-- **`metadata_filter` value matching: exact only, or operators (>=, contains, in)?** Leaning exact-only for v1 — covers the boundary-doc disambiguation case. Operator support is a clean follow-up.
-- **List-valued field matching: `metadata_filter={"frontmatter.tags": "alpha"}` should match a frontmatter dict `{tags: ["alpha", "beta"]}`.** JSONB `?` operator handles this, but the query layer needs to know when to use `?` vs `@>`. Leaning: any scalar filter value matches via `@>` against either scalar metadata values OR list-valued metadata values that contain the scalar. Document the behavior.
+- **Frontmatter is stripped from body text.** The frontmatter block is removed before the body is chunked, embedded, and FTS-indexed. All frontmatter fields remain accessible via `Document.metadata.frontmatter` and via `metadata_filter`. Rationale: structured metadata belongs in the metadata column, not duplicated in chunks where YAML markup muddies semantic similarity. Matches Obsidian/MkDocs/Jekyll convention. Revisit if users report meaningful prose in their frontmatter (e.g., a long `summary:` field they expected to be searchable).
+- **`kb_get_document` returns the metadata dict alongside the body.** Lets models inspect available filter keys before crafting a `metadata_filter` query. Scope-creep is minimal (one extra field in an existing response); keeping the surface coherent is worth the small expansion.
+- **`metadata_filter` is exact-match only in v1.** A flat `{path: value}` dict translates to JSONB `@>` containment (with the list-valued fallback below). Covers the boundary-doc disambiguation case the eval surfaced. **Operator support (`>=`, `<`, `in`, `contains`, range queries) is noted as possible future work** — a clean follow-up PR once we see whether users + models actually reach for it.
+- **List-valued field matching uses a smart `@>`/`?` fallback.** A scalar filter value matches via `@>` against scalar metadata values OR via `?` (existence) against list-valued metadata values that contain the scalar. So `metadata_filter={"frontmatter.tags": "alpha"}` matches both `{tags: "alpha"}` and `{tags: ["alpha", "beta"]}`. The query layer detects the metadata shape at filter time. Document the behavior in the `kb_search` tool description.
 
 ## Out of scope / follow-ups
 
 - **PR-D (tool descriptions + kb_search response enhancements)** — sits on top of PR-F to surface the new filter capability in tool descriptions; ships immediately after.
 - **PR-E (kb_verify_identifier + kb_documents_by_date)** — `kb_verify_identifier` can now do exact metadata lookups; PR-E benefits architecturally from PR-F landing first.
 - **PR-G (harness audit + cross-judge sensitivity)** — pure harness work, can land in parallel with D/E if desired.
+- **`metadata_filter` operators** — `>=`, `<`, `in`, `contains`, range queries on date/numeric fields. v1 ships exact-match-only; revisit once we see whether users + models reach for richer operators.
 - **LLM-based metadata extraction** — separate PR with its own design. Tika + frontmatter + sidecar covers the no-LLM-cost layer.
 - **Folder-path-as-metadata** — separate PR; user-facing config story (regex template, opt-in) deserves its own design pass.
 - **Filename-pattern parsing** — separate PR; similar config story.

--- a/docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md
+++ b/docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md
@@ -1,0 +1,275 @@
+# PR-F — Document metadata extractors + structured-filter search
+
+**Status:** spec — awaiting user review before plan + implementation
+**Author:** Claude (with Alex)
+**Companion docs:** PR-A/B/C answer-eval specs (`2026-05-22`, `2026-05-23`); follow-on PR-D (tool descriptions), PR-E (verify_identifier + by_date), PR-G (harness audit) all queued behind this.
+
+## Goal
+
+Capture machine-readable metadata that HC already has access to but isn't storing today (Tika fields, YAML frontmatter, JSON sidecars), surface it on a new `Document.metadata` JSONB column, and expose it as a structured filter on `kb_search` so models can disambiguate boundary-doc cases by fact rather than by similarity. This is real production utility — every Tika-extracted file gets metadata for free; Obsidian/MkDocs vaults get their frontmatter; the synthetic test corpus and any power user with sidecar files gets full structured facts.
+
+## Why this PR exists (cross-corpus failure signal)
+
+The PR-A/B/C eval runs surfaced a reproducible failure mode on both Sonnet and gpt-4o: **boundary-doc retrieval ambiguity**. When the question's identifier isn't unique in the corpus (e.g., "the Pinnacle vendor contract," "the Senior Project Coordinator onboarding letter," "the Marbledock Elevate 2025 campaign"), HC's similarity ranker picks a neighbouring doc that shares the identifier text but reports the wrong fact. Both models trust the retrieval and answer from the wrong doc.
+
+The fix at the eval-prompt layer is partial — Sonnet correctly recognises the ambiguity (*"There are multiple Senior Project Coordinator onboarding letters in the corpus, each signed by a different manager"*) but has no way to resolve it without a structured filter. Adding `kb_search(metadata_filter={vendor: "Pinnacle Tech Solutions, LLC", term_months: 24})` lets the model pin doc 0131 vs doc 0149 by fact, not by string similarity. That's the leverage PR-F unlocks.
+
+## Non-goals
+
+- **No LLM-based metadata extraction.** Tika + frontmatter + sidecars cover the high-leverage real-world sources. Adding an LLM extraction step to the ingest pipeline (per-doc cost, prompt design, schema decisions) is its own future PR with its own design pass.
+- **No folder-path-as-metadata.** Watched-folder hierarchy is real organizational signal but the user-facing config story (regex template, opt-in, per-folder vs global) is its own design pass. Worth a fast follow-up, not this PR.
+- **No filename-pattern parsing.** Same reasoning — interesting heuristic source but needs its own design.
+- **No retroactive backfill UI.** A one-shot Python re-ingest script ships with this PR for existing dev/test corpora. A user-facing "re-extract metadata for all docs" admin button is out of scope.
+- **No metadata-driven UI in the React app.** This PR is plumbing + MCP exposure. Frontend display of metadata (e.g., a "Properties" panel on the document detail page) is a future polish PR.
+- **No change to the existing typed email columns.** `email_from_address`, `email_to_addresses`, `email_message_id`, etc. on the `documents` table stay as-is — they're already populated by the email-ingest path (PR #283) and have FKs/indexes that benefit from being typed columns. The new generic JSONB metadata column coexists; email-ingest also writes its fields into the JSONB column for filter consistency, but the typed columns remain the source of truth for email-specific queries.
+- **No multi-tenancy on metadata.** Single-tenant appliance — no tenant_id partitioning, same as the rest of the schema.
+
+## Background — what's in HC today
+
+**Document model** (`src/harbor_clerk/models/document.py`, 73 lines, flat post-0017): scalar columns for title, status, mime_type, summary, source_path, plus a block of typed email columns (`email_from_address`, `email_to_addresses`, `email_message_id`, `email_thread_id`, etc.) populated by the email-ingest path. **No generic metadata column exists.**
+
+**Extract stage** (`src/harbor_clerk/worker/stages/extract.py`, 474 lines): calls Tika's `/tika` endpoint for body text and `/rmeta/text` for exception detail. **Tika's metadata response is currently discarded.** Tika returns a dict per file with fields like `dc:creator`, `dc:title`, `dc:subject`, `Last-Modified`, `xmpTPg:NPages`, custom XMP properties, EXIF for images, RFC 822 headers for `.eml` files (`Message-From`, `Message-To`, `Message-Subject`, `dcterms:created`), Office document custom properties, etc.
+
+**MCP `kb_search`** (`src/harbor_clerk/mcp_server.py` + `src/harbor_clerk/llm/tools.py`): currently takes `query`, `k`, optional `doc_ids` filter. **No structured metadata filter exists.**
+
+**Markdown ingest** (`src/harbor_clerk/worker/markdown_extract.py`): currently passes markdown through as text, captures wikilinks (PR #384). **Frontmatter is currently part of the body text, not parsed out.** Reading `---` frontmatter out and storing as metadata would also have the nice side effect of removing frontmatter from chunked text (no more noise like `tags: [foo, bar]` in retrieval).
+
+## Architecture
+
+A small extractor framework: each extractor is a stateless function that takes the raw file bytes + the partial Document object and returns a dict of metadata fields. The extract stage runs them in a documented order and merges results into a single namespaced JSONB blob stored on `Document.metadata`. The merge keeps source provenance so a later debugger can tell whether `author: "X"` came from Tika, frontmatter, or a sidecar.
+
+```
+src/harbor_clerk/
+├── alembic/versions/00XX_add_documents_metadata.py   (new migration)
+├── models/document.py                                 (add metadata column)
+├── ingest/
+│   └── metadata_extractors/                           (NEW package)
+│       ├── __init__.py                                (extractor registry + run_all)
+│       ├── tika_metadata.py                           (calls /meta, whitelists fields)
+│       ├── frontmatter.py                             (parses YAML frontmatter from markdown)
+│       └── sidecar.py                                 (loads <stem>.json from source_path)
+├── worker/stages/extract.py                           (call run_all, persist to Document.metadata)
+├── worker/markdown_extract.py                         (strip frontmatter from body text)
+├── mcp_server.py + llm/tools.py                       (add metadata_filter param to kb_search)
+├── api/routes/search.py                               (thread filter through to query layer)
+└── search/engine.py (or wherever the query lives)     (translate filter to JSONB WHERE clause)
+```
+
+## Metadata schema (namespacing + precedence)
+
+Document.metadata is a JSONB column. Top-level structure:
+
+```jsonc
+{
+  "tika":        {"author": "...", "subject": "...", "page_count": 3, ...},
+  "frontmatter": {"tags": ["x", "y"], "status": "draft", "project": "alpha", ...},
+  "sidecar":     {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24, ...},
+  "_source_provenance": {"tika": "2026-05-24T...", "sidecar": "2026-05-24T..."}
+}
+```
+
+**Why namespaced instead of flat:**
+- Avoids collision when two sources have the same key (e.g., both Tika and frontmatter expose `author`)
+- Lets the filter API be precise: `metadata_filter={"sidecar.vendor": "Pinnacle"}` vs `metadata_filter={"tika.author": "Jane Doe"}`
+- Debugging: when a filter doesn't match, you can see immediately which source contributed (or didn't) which field
+- Makes Tika's noisy 50–200-field output containable — it lives under one key, doesn't pollute the top namespace
+
+**`_source_provenance`** records the timestamp each extractor wrote its slice — useful for "re-ingested vs first-pass" debugging and for a future "re-run only the X extractor" optimization.
+
+**Precedence on conflict:** Within a namespace, last-write-wins. Across namespaces, all coexist (no merging across namespaces — they're independent slices). For the rare case where two extractors of the same type are added (e.g., Tika + a Tika-equivalent), namespace them differently (`tika_v2`).
+
+## Extractor framework
+
+```python
+# src/harbor_clerk/ingest/metadata_extractors/__init__.py
+from typing import Protocol
+
+class MetadataExtractor(Protocol):
+    name: str  # namespace key — "tika", "frontmatter", "sidecar"
+
+    def extract(self, *, doc: Document, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        """Return a dict of metadata fields, or None if this extractor doesn't apply
+        (e.g., frontmatter extractor on a PDF). Returning None skips the namespace
+        entirely — namespaced output stays clean."""
+        ...
+
+EXTRACTORS: tuple[MetadataExtractor, ...] = (
+    TikaMetadataExtractor(),
+    FrontmatterExtractor(),
+    SidecarExtractor(),
+)
+
+def run_all(*, doc, raw_bytes, source_path) -> dict:
+    """Run all extractors in order; merge results into a namespaced blob."""
+    out: dict = {}
+    provenance: dict = {}
+    for ext in EXTRACTORS:
+        try:
+            result = ext.extract(doc=doc, raw_bytes=raw_bytes, source_path=source_path)
+            if result:
+                out[ext.name] = result
+                provenance[ext.name] = utc_now().isoformat()
+        except Exception as exc:
+            log.warning("metadata extractor %s failed on doc %s: %s", ext.name, doc.doc_id, exc)
+    if out:
+        out["_source_provenance"] = provenance
+    return out
+```
+
+Each extractor is a separate module, tested independently. The framework's job is just to run them and merge. **No extractor is required to succeed** — a failure logs a warning and the doc gets the other extractors' output. This keeps ingestion resilient to one-off Tika hiccups or malformed frontmatter.
+
+### TikaMetadataExtractor
+
+Calls Tika's `/meta` endpoint (vs the existing `/tika` for body text). Tika returns a JSON dict per file with potentially 50–200 fields, most of which are noise (X-TIKA-Parsed-By, X-TIKA-Content-Length, etc.). **Whitelist** to a curated set:
+
+```python
+TIKA_FIELD_ALIASES = {
+    # Generic Dublin Core
+    "dc:creator": "author",
+    "dc:title": "title",
+    "dc:subject": "subject",
+    "dc:description": "description",
+    "dc:language": "language",
+    "dcterms:created": "created_at",
+    "dcterms:modified": "modified_at",
+    "meta:keyword": "keywords",
+    # Pagination / structure
+    "xmpTPg:NPages": "page_count",
+    "Page-Count": "page_count",
+    # MIME / encoding
+    "Content-Type": "content_type",
+    "Content-Encoding": "encoding",
+    # Email-specific (RFC 822 headers from Tika's email parser)
+    "Message-From": "email_from",
+    "Message-To": "email_to",
+    "Message-Cc": "email_cc",
+    "Message-Subject": "email_subject",
+    "dcterms:created": "email_date",  # in email context, this is Send-Date
+}
+```
+
+Aliases normalize wildly-varying Tika field names to readable filter keys. Unknown Tika fields are dropped. **No raw passthrough** — keeps the metadata blob bounded and the filter surface clean.
+
+### FrontmatterExtractor
+
+For markdown files (`.md`, `.markdown`), parse YAML frontmatter delimited by `---`. Uses the `python-frontmatter` library (a ~10 kB wrapper around PyYAML; well-maintained, widely-used by Jekyll/Hugo/MkDocs tooling). Added to `pyproject.toml` as a runtime dep. Returns the parsed frontmatter dict as-is. Side effect: signal to `markdown_extract.py` that frontmatter has been parsed so it can be stripped from the body text before chunking.
+
+For non-markdown formats: returns `None`.
+
+### SidecarExtractor
+
+Looks for `<stem>.json` next to `source_path`. If found, loads the JSON as the namespace contents. For the synthetic corpus this is the existing pattern (sidecar generated alongside the doc). For real-world power users, this gives them an opt-in escape hatch for metadata HC doesn't otherwise capture.
+
+For docs without a `source_path` (legacy uploaded docs, the few rows left in `uploads`): returns `None`.
+
+## kb_search filter API
+
+New optional parameter on `kb_search`:
+
+```python
+kb_search(
+    query: str,
+    k: int = 10,
+    metadata_filter: dict[str, Any] | None = None,
+    # ... existing params ...
+) -> dict
+```
+
+`metadata_filter` is a flat dict of `"<namespace>.<key>": value` pairs. The query layer translates this to a JSONB containment WHERE clause:
+
+```sql
+WHERE metadata @> '{"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC"}}'::jsonb
+  AND metadata @> '{"sidecar": {"term_months": 24}}'::jsonb
+```
+
+Multiple filter keys combine with `AND`. The `@>` containment operator uses the GIN index efficiently. Models can stack filters:
+
+```python
+kb_search(
+    query="governing law",
+    metadata_filter={
+        "sidecar.vendor": "Pinnacle Tech Solutions, LLC",
+        "sidecar.term_months": 24,
+    },
+    k=3,
+)
+```
+
+This pins the right Pinnacle contract among many. When filters match nothing, the query degrades to an empty result set (model can re-query without filters). When filters are absent, behavior is unchanged from today.
+
+**Tool description for the new param** (lives in PR-D's full pass, but the param ships with PR-F): "Use `metadata_filter` to disambiguate when multiple candidate docs share text but differ on a structured field. Example: `metadata_filter={'sidecar.vendor': 'Acme', 'sidecar.term_months': 24}`. Inspect a document's available fields via `kb_get_document` first if you don't know what keys are available."
+
+## Re-ingest strategy
+
+Existing docs in dev/test corpora need a one-shot metadata-extraction pass. Two paths:
+
+1. **Per-corpus reprocess script** (`scripts/reextract_metadata.py`): iterates Documents in the test workdir, fetches raw bytes from storage (or rereads from `source_path` for watched-folder docs), runs the extractor framework, writes results. Idempotent — running twice produces the same metadata.
+
+2. **Just re-ingest** for small corpora: delete the synthetic ingest, re-run the corpus acquire, fresh extract stage picks up new metadata for free.
+
+For production HC users: existing docs get metadata on the next time they're re-extracted (rare event — only after delete+re-add or admin "Reprocess" button). Most existing docs stay metadata-free until then. **Acceptable** — the new tools degrade gracefully without metadata; new ingestions get the benefit immediately.
+
+## Migration
+
+Single alembic migration:
+
+```python
+def upgrade():
+    op.add_column("documents",
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="{}"))
+    op.create_index("ix_documents_metadata_gin", "documents", ["metadata"],
+                    postgresql_using="gin")
+
+def downgrade():
+    op.drop_index("ix_documents_metadata_gin", table_name="documents")
+    op.drop_column("documents", "metadata")
+```
+
+Default empty object (not NULL) so the `@>` containment query never has to special-case NULL. GIN index supports the containment operator efficiently.
+
+Naming note: `metadata` is a reserved column name in some ORMs (SQLAlchemy uses `__tablename__.metadata` as the MetaData object reference). The actual Python attribute on the Document model will need to be named `doc_metadata` or similar to avoid shadowing — call out during implementation. The PostgreSQL column name stays `metadata`.
+
+## Validation plan
+
+1. **All existing tests pass + new extractor tests** in `tests/ingest/metadata_extractors/`:
+   - Per-extractor unit tests (mock Tika response, sample markdown with frontmatter, sample JSON sidecar)
+   - Framework integration test (run_all with a mix of extractors that succeed/fail/skip)
+   - kb_search filter query test (against a small test DB with known metadata)
+2. **Ruff + frontend type-check clean**.
+3. **Live validation against the synthetic corpus**:
+   - Re-ingest synthetic so every doc gets sidecar metadata populated.
+   - Verify `kb_search(metadata_filter={"sidecar.vendor": "Pinnacle Tech Solutions, LLC"})` returns exactly the Pinnacle contracts.
+   - Re-run answer-eval on synthetic with both providers — expect to see boundary-doc lookup correctness improve once PR-D wires the filter into tool descriptions. (PR-F alone, without PR-D's description telling models to USE the filter, won't change scores. Validation here is "filter works mechanically"; the score-improvement validation is PR-D's.)
+4. **Tika field sanity check on a real-world doc set**:
+   - Re-ingest the existing watched-folder corpus on the user's mac
+   - Spot-check 10 docs of varying types (PDF, DOCX, .eml, .md): the extracted metadata should be sensible (author, dates, subject populated where Tika has them)
+   - Document expected/surprising fields in the PR description for future reference
+5. **Performance sanity** — Tika `/meta` call adds latency to the extract stage. Measure on a 100-doc batch; expect <10% overhead since extract is already Tika-bound. If it's worse, evaluate parallel calls or single-pass extraction (Tika supports returning body + meta together via `/rmeta/text`).
+
+## Risks
+
+- **Tika metadata is wildly inconsistent across formats.** PDF metadata is sparse; DOCX is rich; `.eml` has structured headers; images have EXIF (or nothing). The whitelist + alias map handles this, but expect the field surface to be uneven across a real corpus. Documented expectation, not a defect.
+- **Frontmatter parsing failures** on malformed YAML. The extractor catches + logs + returns None — but a doc with bad frontmatter gets no metadata namespace at all (not even the partial parse). Acceptable.
+- **Sidecar trust boundary.** Loading arbitrary user-supplied JSON next to a doc means user-controlled metadata. Filter values go into a SQL containment query, but SQLAlchemy's JSONB binding parameterizes properly — no SQL injection. Worth noting for review.
+- **Metadata can override per-doc reality.** If a user has a sidecar saying `vendor: "Acme"` but the actual contract is with Pinnacle, the filter answers questions about the sidecar's claim, not the doc's text. This is "garbage in, garbage out" and acceptable — users with sidecars are power users who know what they're declaring.
+- **JSONB column doesn't suit huge metadata blobs.** Tika can return very large metadata for some files (EXIF with thumbnails embedded as base64, etc.). The whitelist cap protects against this; worth noting in the field list documentation.
+
+## Open questions for spec review
+
+- **Strip frontmatter from body text or leave it in?** Leaning strip — the metadata fields cover it and leaving them in adds noise to chunking + retrieval. But some users might write meaningful prose IN their frontmatter (e.g., a long `summary:` field). Decision: strip, document the behavior, revisit if users complain.
+- **`kb_get_document` should return the metadata** so models can inspect what filter keys are available. This is a small change in scope; include in PR-F or queue for PR-D? Leaning include here — keeps the surface coherent.
+- **`metadata_filter` value matching: exact only, or operators (>=, contains, in)?** Leaning exact-only for v1 — covers the boundary-doc disambiguation case. Operator support is a clean follow-up.
+- **List-valued field matching: `metadata_filter={"frontmatter.tags": "alpha"}` should match a frontmatter dict `{tags: ["alpha", "beta"]}`.** JSONB `?` operator handles this, but the query layer needs to know when to use `?` vs `@>`. Leaning: any scalar filter value matches via `@>` against either scalar metadata values OR list-valued metadata values that contain the scalar. Document the behavior.
+
+## Out of scope / follow-ups
+
+- **PR-D (tool descriptions + kb_search response enhancements)** — sits on top of PR-F to surface the new filter capability in tool descriptions; ships immediately after.
+- **PR-E (kb_verify_identifier + kb_documents_by_date)** — `kb_verify_identifier` can now do exact metadata lookups; PR-E benefits architecturally from PR-F landing first.
+- **PR-G (harness audit + cross-judge sensitivity)** — pure harness work, can land in parallel with D/E if desired.
+- **LLM-based metadata extraction** — separate PR with its own design. Tika + frontmatter + sidecar covers the no-LLM-cost layer.
+- **Folder-path-as-metadata** — separate PR; user-facing config story (regex template, opt-in) deserves its own design pass.
+- **Filename-pattern parsing** — separate PR; similar config story.
+- **Frontend display of metadata** — a "Properties" panel on the document detail page. UI polish, separate PR.
+- **Admin "Reprocess Metadata" button** — bulk re-extraction trigger for production users who want to populate metadata on existing docs without delete+re-add. Future UX.
+- **Folder-level metadata config** — `.harbor-clerk.yaml` in a watched folder declaring "every doc here has type=invoice, client=Acme". Deferred to a future "folder metadata config" PR after we see real-world usage patterns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "langdetect>=1.0.9",
     "markdown-it-py>=3.0.0",
     "psycopg2-binary>=2.9.0",
+    "python-frontmatter>=1.1",
     "Pillow>=12.2.0",
     "mcp>=1.9.0",
     "huggingface_hub>=0.25.0",

--- a/scripts/reextract_metadata.py
+++ b/scripts/reextract_metadata.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""One-shot script: re-extract metadata for all active documents in the
+current HC instance. Idempotent — running twice produces the same metadata.
+
+Use this after applying the documents.metadata migration to backfill
+metadata for documents that were ingested before the extractor framework
+existed.
+
+Doesn't change body text or chunks — only writes to Document.doc_metadata.
+For documents in source-path-backed watched folders, reads raw bytes from
+disk. For legacy uploads with stored objects, fetches from storage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from sqlalchemy import select
+
+from harbor_clerk.db import async_session_factory
+from harbor_clerk.ingest.metadata_extractors import run_all as run_metadata_extractors
+from harbor_clerk.models.document import Document
+from harbor_clerk.storage import get_storage
+
+log = logging.getLogger("reextract_metadata")
+
+
+async def reextract_all(*, dry_run: bool = False) -> tuple[int, int, int]:
+    """Returns (processed, updated, skipped)."""
+    storage = get_storage()
+
+    processed = updated = skipped = 0
+    async with async_session_factory() as session:
+        result = await session.execute(select(Document).where(Document.status == "active"))
+        docs = result.scalars().all()
+
+        for doc in docs:
+            processed += 1
+            # Load raw bytes from source_path (watched folder) or storage (legacy upload)
+            raw_bytes: bytes | None = None
+            if doc.source_path and Path(doc.source_path).is_file():
+                raw_bytes = Path(doc.source_path).read_bytes()
+            elif doc.original_bucket and doc.original_object_key:
+                try:
+                    response = storage.get_object(doc.original_bucket, doc.original_object_key)
+                    raw_bytes = response.read()
+                except Exception as exc:
+                    log.warning("storage fetch failed for doc %s: %s", doc.doc_id, exc)
+                    skipped += 1
+                    continue
+            else:
+                log.info("doc %s has no source_path or storage object; skipping", doc.doc_id)
+                skipped += 1
+                continue
+
+            metadata = run_metadata_extractors(
+                doc=doc,
+                raw_bytes=raw_bytes,
+                source_path=doc.source_path,
+            )
+            if metadata == doc.doc_metadata:
+                continue  # idempotent no-op
+            if dry_run:
+                log.info("would update doc %s: %s", doc.doc_id, metadata)
+                updated += 1
+                continue
+            doc.doc_metadata = metadata
+            updated += 1
+
+        if not dry_run:
+            await session.commit()
+
+    return processed, updated, skipped
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="don't commit changes")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    processed, updated, skipped = asyncio.run(reextract_all(dry_run=args.dry_run))
+    log.info(
+        "reextract_metadata complete: processed=%d updated=%d skipped=%d (dry_run=%s)",
+        processed,
+        updated,
+        skipped,
+        args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/harbor_clerk/ingest/metadata_extractors/__init__.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/__init__.py
@@ -69,9 +69,8 @@ def _run_extractors(
     return out
 
 
-# Production extractor tuple — populated by individual extractors in
-# later tasks. Keep at the bottom of the module so the imports below
-# can reference symbols defined above.
+# Production extractors — registered here in declaration order. Kept at the
+# bottom of the module so the imports below can reference symbols defined above.
 from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
 
 EXTRACTORS: list[MetadataExtractor] = [TikaMetadataExtractor()]

--- a/src/harbor_clerk/ingest/metadata_extractors/__init__.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/__init__.py
@@ -1,0 +1,82 @@
+# src/harbor_clerk/ingest/metadata_extractors/__init__.py
+"""Pluggable metadata extractors for HC's ingest pipeline.
+
+Each extractor returns a dict of fields keyed under its `name` namespace
+on the document's metadata JSONB column. The framework runs them in
+EXTRACTORS order, merges results, and records per-source provenance
+timestamps. A failing extractor logs a warning but does not abort the
+others — ingestion stays resilient to one-off Tika hiccups or malformed
+frontmatter.
+
+Public surface:
+  MetadataExtractor — @runtime_checkable Protocol
+  EXTRACTORS        — production tuple, used by extract.py
+  run_all(...)      — production entry point (uses EXTRACTORS)
+  _run_extractors() — testable helper that takes an explicit extractor list
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class MetadataExtractor(Protocol):
+    """A single extractor; one per metadata source.
+
+    Implementations must declare `name` (the namespace key on the merged
+    metadata dict) and `extract(*, doc, raw_bytes, source_path) -> dict | None`.
+    Returning None signals "this extractor doesn't apply to this doc"
+    (e.g. frontmatter extractor on a PDF) — the namespace is omitted
+    entirely from the merged output.
+    """
+
+    name: str
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None: ...
+
+
+def _run_extractors(
+    extractors: list[MetadataExtractor],
+    *,
+    doc,
+    raw_bytes: bytes,
+    source_path: str | None,
+) -> dict[str, Any]:
+    """Run the given extractor list and merge results. See run_all() docstring."""
+    out: dict[str, Any] = {}
+    provenance: dict[str, str] = {}
+    for ext in extractors:
+        try:
+            result = ext.extract(doc=doc, raw_bytes=raw_bytes, source_path=source_path)
+        except Exception as exc:
+            log.warning(
+                "metadata extractor %s failed on doc %s: %s",
+                ext.name,
+                getattr(doc, "doc_id", "<unknown>"),
+                exc,
+            )
+            continue
+        if result:
+            out[ext.name] = result
+            provenance[ext.name] = datetime.now(UTC).isoformat()
+    if out:
+        out["_source_provenance"] = provenance
+    return out
+
+
+# Production extractor tuple — populated by individual extractors in
+# later tasks. Keep at the bottom of the module so the imports below
+# can reference symbols defined above.
+EXTRACTORS: list[MetadataExtractor] = []
+
+
+def run_all(*, doc, raw_bytes: bytes, source_path: str | None) -> dict[str, Any]:
+    """Entry point used by the extract stage. Runs EXTRACTORS in order,
+    merges results, returns a namespaced dict suitable for assigning to
+    Document.doc_metadata."""
+    return _run_extractors(EXTRACTORS, doc=doc, raw_bytes=raw_bytes, source_path=source_path)

--- a/src/harbor_clerk/ingest/metadata_extractors/__init__.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/__init__.py
@@ -71,9 +71,13 @@ def _run_extractors(
 
 # Production extractors — registered here in declaration order. Kept at the
 # bottom of the module so the imports below can reference symbols defined above.
+from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor  # noqa: E402
 from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
 
-EXTRACTORS: list[MetadataExtractor] = [TikaMetadataExtractor()]
+EXTRACTORS: list[MetadataExtractor] = [
+    TikaMetadataExtractor(),
+    FrontmatterExtractor(),
+]
 
 
 def run_all(*, doc, raw_bytes: bytes, source_path: str | None) -> dict[str, Any]:

--- a/src/harbor_clerk/ingest/metadata_extractors/__init__.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/__init__.py
@@ -10,7 +10,7 @@ frontmatter.
 
 Public surface:
   MetadataExtractor — @runtime_checkable Protocol
-  EXTRACTORS        — production tuple, used by extract.py
+  EXTRACTORS        — production list, used by extract.py
   run_all(...)      — production entry point (uses EXTRACTORS)
   _run_extractors() — testable helper that takes an explicit extractor list
 """

--- a/src/harbor_clerk/ingest/metadata_extractors/__init__.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/__init__.py
@@ -72,7 +72,9 @@ def _run_extractors(
 # Production extractor tuple — populated by individual extractors in
 # later tasks. Keep at the bottom of the module so the imports below
 # can reference symbols defined above.
-EXTRACTORS: list[MetadataExtractor] = []
+from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
+
+EXTRACTORS: list[MetadataExtractor] = [TikaMetadataExtractor()]
 
 
 def run_all(*, doc, raw_bytes: bytes, source_path: str | None) -> dict[str, Any]:

--- a/src/harbor_clerk/ingest/metadata_extractors/__init__.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/__init__.py
@@ -72,11 +72,13 @@ def _run_extractors(
 # Production extractors — registered here in declaration order. Kept at the
 # bottom of the module so the imports below can reference symbols defined above.
 from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor  # noqa: E402
+from harbor_clerk.ingest.metadata_extractors.sidecar import SidecarExtractor  # noqa: E402
 from harbor_clerk.ingest.metadata_extractors.tika_metadata import TikaMetadataExtractor  # noqa: E402
 
 EXTRACTORS: list[MetadataExtractor] = [
     TikaMetadataExtractor(),
     FrontmatterExtractor(),
+    SidecarExtractor(),
 ]
 
 

--- a/src/harbor_clerk/ingest/metadata_extractors/frontmatter.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/frontmatter.py
@@ -1,0 +1,66 @@
+# src/harbor_clerk/ingest/metadata_extractors/frontmatter.py
+"""FrontmatterExtractor — parses YAML frontmatter from markdown files.
+
+Obsidian, MkDocs, Jekyll, Hugo all use the `---`-delimited YAML header
+pattern at the top of markdown files. The extractor parses that header
+and returns it as the metadata dict. For non-markdown files (PDFs, .eml,
+.docx, etc.) it returns None.
+
+Frontmatter values are normalized to JSON-serializable scalars: YAML
+dates → ISO strings at the boundary (the doc_metadata column is JSONB,
+which doesn't have a native date type — keeping dates as strings makes
+filter values comparable without further parsing).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import Any
+
+import frontmatter
+
+log = logging.getLogger(__name__)
+
+_MARKDOWN_EXTENSIONS = (".md", ".markdown")
+
+
+class FrontmatterExtractor:
+    """YAML frontmatter parser for markdown files."""
+
+    name = "frontmatter"
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        # Identify markdown via canonical_filename first, fall back to source_path
+        filename = getattr(doc, "canonical_filename", None) or source_path or ""
+        if not any(filename.lower().endswith(ext) for ext in _MARKDOWN_EXTENSIONS):
+            return None
+
+        try:
+            parsed = frontmatter.loads(raw_bytes.decode("utf-8", errors="replace"))
+        except Exception as exc:
+            log.warning(
+                "frontmatter parse failed for doc %s: %s",
+                getattr(doc, "doc_id", "<unknown>"),
+                exc,
+            )
+            return None
+
+        if not parsed.metadata:
+            return None
+
+        return _jsonify(parsed.metadata)
+
+
+def _jsonify(obj: Any) -> Any:
+    """Recursively convert YAML-parsed values to JSON-serializable equivalents.
+    Mainly: date/datetime → ISO string."""
+    if isinstance(obj, dict):
+        return {k: _jsonify(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_jsonify(v) for v in obj]
+    if isinstance(obj, _dt.datetime):
+        return obj.isoformat()
+    if isinstance(obj, _dt.date):
+        return obj.isoformat()
+    return obj

--- a/src/harbor_clerk/ingest/metadata_extractors/frontmatter.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/frontmatter.py
@@ -37,7 +37,7 @@ class FrontmatterExtractor:
             return None
 
         try:
-            parsed = frontmatter.loads(raw_bytes.decode("utf-8", errors="replace"))
+            parsed = frontmatter.loads(raw_bytes.decode("utf-8-sig", errors="replace"))
         except Exception as exc:
             log.warning(
                 "frontmatter parse failed for doc %s: %s",
@@ -54,7 +54,9 @@ class FrontmatterExtractor:
 
 def _jsonify(obj: Any) -> Any:
     """Recursively convert YAML-parsed values to JSON-serializable equivalents.
-    Mainly: date/datetime → ISO string."""
+    Mainly: date/datetime → ISO string, bytes (YAML !!binary) → decoded string."""
+    if isinstance(obj, bytes):
+        return obj.decode("utf-8", errors="replace")
     if isinstance(obj, dict):
         return {k: _jsonify(v) for k, v in obj.items()}
     if isinstance(obj, list):

--- a/src/harbor_clerk/ingest/metadata_extractors/sidecar.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/sidecar.py
@@ -38,6 +38,23 @@ class SidecarExtractor:
         if not sidecar.is_file():
             return None
         try:
+            size = sidecar.stat().st_size
+        except OSError as exc:
+            log.warning(
+                "sidecar stat failed for doc %s (%s): %s",
+                getattr(doc, "doc_id", "<unknown>"),
+                sidecar,
+                exc,
+            )
+            return None
+        if size > 64_000:
+            log.warning(
+                "sidecar for doc %s is %d bytes (>64 KB cap); ignoring to avoid bloating doc_metadata",
+                getattr(doc, "doc_id", "<unknown>"),
+                size,
+            )
+            return None
+        try:
             payload = json.loads(sidecar.read_text(encoding="utf-8-sig"))
         except (OSError, json.JSONDecodeError) as exc:
             log.warning(

--- a/src/harbor_clerk/ingest/metadata_extractors/sidecar.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/sidecar.py
@@ -1,0 +1,59 @@
+# src/harbor_clerk/ingest/metadata_extractors/sidecar.py
+"""SidecarExtractor — loads <stem>.json next to source_path.
+
+For docs ingested via watched folders (synthetic test corpus, real-world
+power users with curated metadata files), look for a JSON file with the
+same stem as the source file and load it as the metadata dict.
+
+Example: a watched folder containing
+  invoices/2024-Q3/INV-001.pdf
+  invoices/2024-Q3/INV-001.json
+would surface the INV-001.json contents under the 'sidecar' namespace on
+the Document for INV-001.pdf.
+
+Returns None for docs without source_path (legacy uploads), without a
+matching sidecar file, with malformed JSON, with an empty object, or
+with a non-object top-level JSON value (list/string/etc).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class SidecarExtractor:
+    """Loads <stem>.json next to the source file."""
+
+    name = "sidecar"
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        if not source_path:
+            return None
+        src = Path(source_path)
+        sidecar = src.with_suffix(".json")
+        if not sidecar.is_file():
+            return None
+        try:
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning(
+                "sidecar load failed for doc %s (%s): %s",
+                getattr(doc, "doc_id", "<unknown>"),
+                sidecar,
+                exc,
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            log.warning(
+                "sidecar for doc %s is not a JSON object (got %s); ignoring",
+                getattr(doc, "doc_id", "<unknown>"),
+                type(payload).__name__,
+            )
+            return None
+
+        return payload or None

--- a/src/harbor_clerk/ingest/metadata_extractors/sidecar.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/sidecar.py
@@ -38,7 +38,7 @@ class SidecarExtractor:
         if not sidecar.is_file():
             return None
         try:
-            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+            payload = json.loads(sidecar.read_text(encoding="utf-8-sig"))
         except (OSError, json.JSONDecodeError) as exc:
             log.warning(
                 "sidecar load failed for doc %s (%s): %s",

--- a/src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
@@ -40,8 +40,7 @@ TIKA_FIELD_ALIASES: dict[str, str] = {
     # MIME / encoding
     "Content-Type": "content_type",
     "Content-Encoding": "encoding",
-    # Email headers (Tika's email parser; takes precedence over dcterms:created
-    # when both appear — order matters)
+    # Email headers (Tika's email parser populates these for .eml files)
     "Message-From": "email_from",
     "Message-To": "email_to",
     "Message-Cc": "email_cc",
@@ -60,10 +59,13 @@ class TikaMetadataExtractor:
             return None
         try:
             with httpx.Client(timeout=30) as client:
+                headers = {"Accept": "application/json"}
+                if getattr(doc, "mime_type", None):
+                    headers["Content-Type"] = doc.mime_type
                 resp = client.put(
                     f"{settings.tika_url}/meta",
                     content=raw_bytes,
-                    headers={"Accept": "application/json"},
+                    headers=headers,
                 )
                 if resp.status_code != 200:
                     log.warning(
@@ -73,6 +75,13 @@ class TikaMetadataExtractor:
                     )
                     return None
                 raw: dict[str, Any] = resp.json()
+                if not isinstance(raw, dict):
+                    log.warning(
+                        "tika /meta returned non-dict for doc %s: %s",
+                        getattr(doc, "doc_id", "<unknown>"),
+                        type(raw).__name__,
+                    )
+                    return None
         except (httpx.HTTPError, ValueError) as exc:
             log.warning("tika /meta failed for doc %s: %s", getattr(doc, "doc_id", "<unknown>"), exc)
             return None

--- a/src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
@@ -45,6 +45,10 @@ TIKA_FIELD_ALIASES: dict[str, str] = {
     "Message-To": "email_to",
     "Message-Cc": "email_cc",
     "Message-Subject": "email_subject",
+    # Tika's email parser also emits Message-Date as a dedicated header for
+    # .eml files, separate from dcterms:created. This gives callers an
+    # explicit email_date field distinct from the generic created_at alias.
+    "Message-Date": "email_date",
 }
 
 

--- a/src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
+++ b/src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
@@ -1,0 +1,86 @@
+# src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py
+"""TikaMetadataExtractor — captures Tika's metadata dict.
+
+Tika's /meta endpoint returns a JSON dict with potentially 50-200 fields,
+most of which are framework noise (X-TIKA-Parsed-By, X-TIKA-Content-Length,
+parser-specific keys). The whitelist + alias map normalizes the wildly
+varying Tika field names to readable filter keys; unknown fields are dropped.
+No raw passthrough — keeps the metadata blob bounded and the filter surface
+clean.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from harbor_clerk.config import get_settings
+
+log = logging.getLogger(__name__)
+
+# Tika field name → readable filter key. When two Tika fields map to the
+# same target, the LAST one wins (intentional — Tika sometimes emits the
+# same concept under multiple keys, and the most reliable one is listed
+# last). Test pins the duplicate set so a future refactor surfaces changes.
+TIKA_FIELD_ALIASES: dict[str, str] = {
+    # Dublin Core
+    "dc:creator": "author",
+    "dc:title": "title",
+    "dc:subject": "subject",
+    "dc:description": "description",
+    "dc:language": "language",
+    "dcterms:created": "created_at",
+    "dcterms:modified": "modified_at",
+    "meta:keyword": "keywords",
+    # Pagination / structure (last writer wins → Page-Count beats xmpTPg:NPages)
+    "xmpTPg:NPages": "page_count",
+    "Page-Count": "page_count",
+    # MIME / encoding
+    "Content-Type": "content_type",
+    "Content-Encoding": "encoding",
+    # Email headers (Tika's email parser; takes precedence over dcterms:created
+    # when both appear — order matters)
+    "Message-From": "email_from",
+    "Message-To": "email_to",
+    "Message-Cc": "email_cc",
+    "Message-Subject": "email_subject",
+}
+
+
+class TikaMetadataExtractor:
+    """Calls Tika's /meta endpoint, whitelists fields, drops noise."""
+
+    name = "tika"
+
+    def extract(self, *, doc, raw_bytes: bytes, source_path: str | None) -> dict | None:
+        settings = get_settings()
+        if not settings.tika_url:
+            return None
+        try:
+            with httpx.Client(timeout=30) as client:
+                resp = client.put(
+                    f"{settings.tika_url}/meta",
+                    content=raw_bytes,
+                    headers={"Accept": "application/json"},
+                )
+                if resp.status_code != 200:
+                    log.warning(
+                        "tika /meta returned HTTP %s for doc %s",
+                        resp.status_code,
+                        getattr(doc, "doc_id", "<unknown>"),
+                    )
+                    return None
+                raw: dict[str, Any] = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("tika /meta failed for doc %s: %s", getattr(doc, "doc_id", "<unknown>"), exc)
+            return None
+
+        # Whitelist + alias
+        out: dict[str, Any] = {}
+        for tika_key, target_key in TIKA_FIELD_ALIASES.items():
+            if tika_key in raw:
+                out[target_key] = raw[tika_key]
+
+        return out or None

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -555,6 +555,7 @@ async def kb_search(
     before: str | None = None,
     language: str | None = None,
     mime_type: str | None = None,
+    metadata_filter: dict | None = None,
     faceted: bool = False,
 ) -> str:
     """Search the knowledge base with hybrid FTS + vector search.
@@ -573,6 +574,11 @@ async def kb_search(
       before: only documents updated before this ISO datetime
       language: chunk language filter ("english" or "french")
       mime_type: document MIME type filter (e.g. "application/pdf")
+      metadata_filter: dict of {"namespace.key": value} pairs to match against
+        Document.metadata. Use to disambiguate when multiple candidate docs share
+        text but differ on a structured field. Example:
+        metadata_filter={"sidecar.vendor": "Acme", "sidecar.term_months": 24}.
+        Inspect a document's available metadata via kb_get_document.
 
     detail levels control how much text is returned per hit:
       "full" (default): complete chunk text — best for reading a small
@@ -669,6 +675,7 @@ async def kb_search(
             before=parsed_before,
             language=language,
             mime_type=mime_type,
+            metadata_filter=metadata_filter,
         )
         heading_map = await _resolve_headings(session, result.hits)
 
@@ -1073,6 +1080,7 @@ async def kb_get_document(doc_id: str) -> str:
             "extracted_chars": doc.extracted_chars,
             "source_path": doc.source_path,
             "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+            "metadata": doc.doc_metadata,
             "jobs": jobs,
         },
         indent=2,

--- a/src/harbor_clerk/models/document.py
+++ b/src/harbor_clerk/models/document.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import BigInteger, Boolean, DateTime, Enum, ForeignKey, Integer, LargeBinary, Text, text
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from harbor_clerk.models.base import Base, created_at, updated_at, uuid_pk
@@ -68,6 +68,19 @@ class Document(Base):
     email_cc_addresses: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
     email_date_sent: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     email_label_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Pluggable metadata extracted at ingest time. Namespaced by source:
+    # {"tika": {...}, "frontmatter": {...}, "sidecar": {...},
+    #  "_source_provenance": {"tika": "2026-...", ...}}
+    # The Python attribute is `doc_metadata` (not `metadata`) to avoid
+    # shadowing SQLAlchemy's `Base.metadata`. The PostgreSQL column is
+    # named `metadata` for natural querying.
+    doc_metadata: Mapped[dict] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=False,
+        server_default="{}",
+    )
 
     created_at: Mapped[created_at]
     updated_at: Mapped[updated_at]

--- a/src/harbor_clerk/search.py
+++ b/src/harbor_clerk/search.py
@@ -3,9 +3,11 @@
 import logging
 import uuid
 from datetime import datetime
+from typing import Any
 
 import httpx
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.config import get_settings
@@ -56,6 +58,7 @@ async def hybrid_search(
     before: datetime | None = None,
     language: str | None = None,
     mime_type: str | None = None,
+    metadata_filter: dict[str, Any] | None = None,
 ) -> SearchResult:
     """Run hybrid FTS + vector search, merge scores, return top K."""
 
@@ -79,6 +82,30 @@ async def hybrid_search(
         doc_conditions.append(Document.created_at < before)
     if mime_type is not None:
         doc_conditions.append(Document.mime_type == mime_type)
+    # Metadata filter translation. Each "<namespace>.<key>": value pair
+    # becomes either:
+    #   - JSONB @> containment: doc_metadata @> '{"ns": {"key": value}}'
+    #     (matches scalar metadata)
+    #   - OR JSONB ? existence: doc_metadata->'ns'->'key' ? 'value'
+    #     (matches list-valued metadata containing the scalar)
+    # The OR lets a caller use a scalar filter value to match either a
+    # scalar metadata field (sidecar.vendor: "Acme") OR a list-valued one
+    # (frontmatter.tags: ["alpha", "beta"]) without knowing the shape.
+    # Only string filter values get the OR — JSONB `?` operator requires
+    # string keys, so non-string scalars (numbers, bools) use containment
+    # only.
+    if metadata_filter:
+        for path, value in metadata_filter.items():
+            ns, _, key = path.partition(".")
+            if not ns or not key:
+                raise ValueError(f"metadata_filter keys must be 'namespace.key', got {path!r}")
+            containment = Document.doc_metadata.op("@>")(func.cast({ns: {key: value}}, JSONB))
+            if isinstance(value, str):
+                existence = Document.doc_metadata[ns][key].op("?")(value)
+                doc_conditions.append(or_(containment, existence))
+            else:
+                doc_conditions.append(containment)
+
     if doc_conditions:
         doc_subq = select(Document.doc_id).where(*doc_conditions)
         scope_filters.append(Chunk.doc_id.in_(doc_subq))

--- a/src/harbor_clerk/search.py
+++ b/src/harbor_clerk/search.py
@@ -96,9 +96,14 @@ async def hybrid_search(
     # only.
     if metadata_filter:
         for path, value in metadata_filter.items():
+            if path.count(".") != 1:
+                raise ValueError(
+                    f"metadata_filter keys must be exactly 'namespace.key' (one dot, two segments); "
+                    f"got {path!r}. Nested paths are not supported in v1."
+                )
             ns, _, key = path.partition(".")
             if not ns or not key:
-                raise ValueError(f"metadata_filter keys must be 'namespace.key', got {path!r}")
+                raise ValueError(f"metadata_filter keys must have a non-empty namespace and key, got {path!r}")
             containment = Document.doc_metadata.op("@>")(func.cast({ns: {key: value}}, JSONB))
             if isinstance(value, str):
                 existence = Document.doc_metadata[ns][key].op("?")(value)

--- a/src/harbor_clerk/worker/markdown_extract.py
+++ b/src/harbor_clerk/worker/markdown_extract.py
@@ -68,15 +68,13 @@ def strip_frontmatter(text: str) -> str:
     and the first body content is also stripped so callers get clean text.
     """
     fm, body = extract_frontmatter(text)
-    if not fm:
-        # No frontmatter detected (or malformed — extract_frontmatter returns
-        # ({}, original_text) on any parse failure).
+    # extract_frontmatter returns the literal `text` argument on no-match /
+    # malformed / not-a-dict paths, and a fresh stripped slice on the
+    # delimiter-stripped paths. Identity comparison distinguishes them: if
+    # `body is text`, nothing was stripped (pass through unchanged); else
+    # the helper already stripped the YAML block (lstrip leading newlines).
+    if body is text:
         return text
-    # extract_frontmatter captures the body starting from the character
-    # immediately after the closing ``---\n``, which typically leaves a
-    # leading newline when there's a blank line between the fence and the
-    # first heading. Strip leading newlines only (not all whitespace — that
-    # would eat indented code blocks at the very top of the body).
     return body.lstrip("\n")
 
 

--- a/src/harbor_clerk/worker/markdown_extract.py
+++ b/src/harbor_clerk/worker/markdown_extract.py
@@ -358,11 +358,8 @@ def extract_markdown(data: bytes) -> MarkdownExtractResult:
     """
     text = data.decode("utf-8", errors="replace")
 
-    frontmatter, body = extract_frontmatter(text)
-    # Strip the leading blank line that the regex leaves between the closing
-    # ``---`` fence and the first body content. This matches what
-    # strip_frontmatter() returns for external callers.
-    body = body.lstrip("\n")
+    frontmatter, _ = extract_frontmatter(text)
+    body = strip_frontmatter(text)
     title = frontmatter.get("title")
     if not isinstance(title, str) or not title.strip():
         title = None

--- a/src/harbor_clerk/worker/markdown_extract.py
+++ b/src/harbor_clerk/worker/markdown_extract.py
@@ -53,6 +53,33 @@ def extract_frontmatter(text: str) -> tuple[dict, str]:
     return parsed, body
 
 
+def strip_frontmatter(text: str) -> str:
+    """Remove the leading YAML frontmatter block from markdown text.
+
+    If the text doesn't start with ``---\\n`` or the frontmatter YAML is
+    malformed, return the text unchanged — don't risk losing content on a
+    parse error.  The FrontmatterExtractor in
+    ``src/harbor_clerk/ingest/metadata_extractors/frontmatter.py`` already
+    captures those fields into ``Document.doc_metadata.frontmatter``, so
+    stripping the block from the body text is pure noise reduction: raw
+    ``tags: [foo, bar]`` lines muddying FTS and semantic similarity.
+
+    The leading blank line that the regex leaves between the closing ``---``
+    and the first body content is also stripped so callers get clean text.
+    """
+    fm, body = extract_frontmatter(text)
+    if not fm:
+        # No frontmatter detected (or malformed — extract_frontmatter returns
+        # ({}, original_text) on any parse failure).
+        return text
+    # extract_frontmatter captures the body starting from the character
+    # immediately after the closing ``---\n``, which typically leaves a
+    # leading newline when there's a blank line between the fence and the
+    # first heading. Strip leading newlines only (not all whitespace — that
+    # would eat indented code blocks at the very top of the body).
+    return body.lstrip("\n")
+
+
 def _is_scalar(value) -> bool:
     return isinstance(value, (str, int, float, bool))
 
@@ -332,6 +359,10 @@ def extract_markdown(data: bytes) -> MarkdownExtractResult:
     text = data.decode("utf-8", errors="replace")
 
     frontmatter, body = extract_frontmatter(text)
+    # Strip the leading blank line that the regex leaves between the closing
+    # ``---`` fence and the first body content. This matches what
+    # strip_frontmatter() returns for external callers.
+    body = body.lstrip("\n")
     title = frontmatter.get("title")
     if not isinstance(title, str) or not title.strip():
         title = None

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -459,8 +459,7 @@ def run_extract(doc_id: uuid.UUID) -> None:
         # (mime_type, source_path) are fully resolved on the doc object.
         try:
             metadata = run_metadata_extractors(doc=doc, raw_bytes=data, source_path=doc.source_path)
-            if metadata:
-                doc.doc_metadata = metadata
+            doc.doc_metadata = metadata
         except Exception as exc:
             # Extractor framework swallows individual extractor failures already;
             # this catch is for catastrophic framework-level failures (import

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from harbor_clerk.config import get_settings
 from harbor_clerk.db_sync import get_sync_session
 from harbor_clerk.file_types import MARKDOWN_EXTENSIONS, PLAIN_TEXT_EXTENSIONS
+from harbor_clerk.ingest.metadata_extractors import run_all as run_metadata_extractors
 from harbor_clerk.models import Document, DocumentHeading, DocumentLink, DocumentPage
 from harbor_clerk.models.enums import JobStage
 from harbor_clerk.storage import get_storage
@@ -452,6 +453,19 @@ def run_extract(doc_id: uuid.UUID) -> None:
             doc.has_text_layer = total_chars > 0
 
         doc.extracted_chars = total_chars
+
+        # Extract metadata (Tika headers, frontmatter, sidecar). Runs after body
+        # extraction so raw_bytes are available and the document attributes
+        # (mime_type, source_path) are fully resolved on the doc object.
+        try:
+            metadata = run_metadata_extractors(doc=doc, raw_bytes=data, source_path=doc.source_path)
+            if metadata:
+                doc.doc_metadata = metadata
+        except Exception as exc:
+            # Extractor framework swallows individual extractor failures already;
+            # this catch is for catastrophic framework-level failures (import
+            # errors, etc). Log and continue — metadata is additive.
+            logger.warning("metadata extraction framework failed for doc %s: %s", doc_id, exc)
 
         session.commit()
         logger.info(

--- a/tests/ingest/test_frontmatter_extractor.py
+++ b/tests/ingest/test_frontmatter_extractor.py
@@ -1,0 +1,106 @@
+"""FrontmatterExtractor — parses YAML frontmatter from markdown."""
+
+import uuid
+from dataclasses import dataclass
+
+from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor
+
+
+@dataclass
+class _FakeDoc:
+    doc_id: uuid.UUID
+    title: str
+    canonical_filename: str | None
+
+
+def test_frontmatter_extractor_parses_yaml_block():
+    body = b"""---
+title: Meeting Notes
+date: 2024-09-15
+tags: [team, planning]
+status: draft
+---
+
+# Meeting Notes
+
+We discussed roadmap items.
+"""
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="meeting", canonical_filename="notes.md"),
+        raw_bytes=body,
+        source_path=None,
+    )
+    assert out == {
+        "title": "Meeting Notes",
+        "date": "2024-09-15",  # YAML date → ISO string at the boundary
+        "tags": ["team", "planning"],
+        "status": "draft",
+    }
+
+
+def test_frontmatter_extractor_returns_none_for_non_markdown():
+    """A .pdf or .docx file is never parsed for frontmatter."""
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="r", canonical_filename="report.pdf"),
+        raw_bytes=b"%PDF-1.7\n---\ntitle: nope\n---\n...",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_frontmatter_extractor_returns_none_for_markdown_without_frontmatter():
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="r", canonical_filename="note.md"),
+        raw_bytes=b"# Just a heading\n\nNo frontmatter here.\n",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_frontmatter_extractor_handles_malformed_yaml_without_raising():
+    """A markdown file with broken YAML in the frontmatter block → returns
+    None + logs a warning. Does NOT propagate the parser exception (the
+    framework would catch it anyway but the extractor itself is defensive)."""
+    body = b"""---
+title: Meeting
+date: 2024-09-15
+unclosed_list: [a, b
+---
+
+content
+"""
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="m", canonical_filename="m.md"),
+        raw_bytes=body,
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_frontmatter_extractor_recognises_markdown_extension_variants():
+    """Both .md and .markdown trigger parsing."""
+    body = b"---\nfoo: bar\n---\n\ncontent\n"
+    extractor = FrontmatterExtractor()
+    for ext in (".md", ".markdown"):
+        out = extractor.extract(
+            doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", canonical_filename=f"file{ext}"),
+            raw_bytes=body,
+            source_path=None,
+        )
+        assert out == {"foo": "bar"}, f"failed for extension {ext}"
+
+
+def test_frontmatter_extractor_falls_back_to_source_path_when_no_filename():
+    """If canonical_filename is None, use source_path to detect the extension."""
+    body = b"---\nfoo: bar\n---\n\ncontent\n"
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", canonical_filename=None),
+        raw_bytes=body,
+        source_path="/tmp/note.md",
+    )
+    assert out == {"foo": "bar"}

--- a/tests/ingest/test_frontmatter_extractor.py
+++ b/tests/ingest/test_frontmatter_extractor.py
@@ -3,7 +3,7 @@
 import uuid
 from dataclasses import dataclass
 
-from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor
+from harbor_clerk.ingest.metadata_extractors.frontmatter import FrontmatterExtractor, _jsonify
 
 
 @dataclass
@@ -104,3 +104,21 @@ def test_frontmatter_extractor_falls_back_to_source_path_when_no_filename():
         source_path="/tmp/note.md",
     )
     assert out == {"foo": "bar"}
+
+
+def test_frontmatter_extractor_strips_utf8_bom():
+    """UTF-8 BOM (U+FEFF) before --- delimiter shouldn't hide the frontmatter."""
+    body = b"\xef\xbb\xbf---\nfoo: bar\n---\n\ncontent\n"
+    extractor = FrontmatterExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", canonical_filename="note.md"),
+        raw_bytes=body,
+        source_path=None,
+    )
+    assert out == {"foo": "bar"}
+
+
+def test_jsonify_converts_yaml_binary_to_string():
+    """!!binary YAML tag produces bytes; _jsonify decodes to a JSON-serializable string."""
+    assert _jsonify({"data": b"hello"}) == {"data": "hello"}
+    assert _jsonify(b"raw") == "raw"

--- a/tests/ingest/test_metadata_extractor_framework.py
+++ b/tests/ingest/test_metadata_extractor_framework.py
@@ -1,0 +1,112 @@
+"""Tests for the metadata extractor framework: registration + run_all()."""
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from harbor_clerk.ingest.metadata_extractors import MetadataExtractor, _run_extractors
+
+
+@dataclass
+class _FakeDoc:
+    """Stand-in for Document; only needs doc_id + title for the framework tests."""
+
+    doc_id: uuid.UUID
+    title: str = "fake"
+
+
+class _AlphaExtractor:
+    name = "alpha"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        return {"foo": "bar"}
+
+
+class _BetaExtractor:
+    name = "beta"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        return {"baz": "qux"}
+
+
+class _SkippingExtractor:
+    name = "skipper"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        return None  # signals "doesn't apply to this doc"
+
+
+class _FailingExtractor:
+    name = "broken"
+
+    def extract(self, *, doc, raw_bytes, source_path):
+        raise RuntimeError("intentionally broken")
+
+
+def test_run_all_merges_namespaced_results():
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor(), _BetaExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    assert out["alpha"] == {"foo": "bar"}
+    assert out["beta"] == {"baz": "qux"}
+
+
+def test_run_all_records_provenance_per_extractor():
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    prov = out.get("_source_provenance", {})
+    assert "alpha" in prov
+    # ISO 8601 with offset
+    parsed = datetime.fromisoformat(prov["alpha"])
+    assert parsed.tzinfo is not None
+
+
+def test_run_all_skips_extractors_that_return_none():
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor(), _SkippingExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    assert "alpha" in out
+    assert "skipper" not in out
+    assert "skipper" not in out.get("_source_provenance", {})
+
+
+def test_run_all_isolates_extractor_failures(caplog):
+    """A failing extractor logs a warning but does not abort the others."""
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors(
+        [_AlphaExtractor(), _FailingExtractor(), _BetaExtractor()],
+        doc=doc,
+        raw_bytes=b"",
+        source_path=None,
+    )
+    assert "alpha" in out
+    assert "beta" in out
+    assert "broken" not in out
+    # The warning landed
+    assert any("broken" in rec.message for rec in caplog.records if rec.levelname == "WARNING")
+
+
+def test_run_all_empty_when_no_extractors_match():
+    """All extractors skip → empty dict, no provenance key."""
+    doc = _FakeDoc(doc_id=uuid.uuid4())
+    out = _run_extractors([_SkippingExtractor()], doc=doc, raw_bytes=b"", source_path=None)
+    assert out == {}
+
+
+def test_metadata_extractor_protocol_is_satisfied_by_duck_type():
+    """MetadataExtractor is a @runtime_checkable Protocol — duck-typed mocks
+    satisfy isinstance()."""
+    assert isinstance(_AlphaExtractor(), MetadataExtractor)

--- a/tests/ingest/test_sidecar_extractor.py
+++ b/tests/ingest/test_sidecar_extractor.py
@@ -99,3 +99,18 @@ def test_sidecar_extractor_rejects_non_object_top_level(tmp_path: Path):
         source_path=str(doc_file),
     )
     assert out is None
+
+
+def test_sidecar_extractor_handles_utf8_bom(tmp_path: Path):
+    """Windows/Excel-exported sidecars often have a UTF-8 BOM; accept them
+    cleanly rather than silently dropping the metadata."""
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_bytes(b'\xef\xbb\xbf{"vendor": "Acme"}')
+    (tmp_path / "0001_invoice.txt").write_text("body")
+
+    out = SidecarExtractor().extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(tmp_path / "0001_invoice.txt"),
+    )
+    assert out == {"vendor": "Acme"}

--- a/tests/ingest/test_sidecar_extractor.py
+++ b/tests/ingest/test_sidecar_extractor.py
@@ -101,6 +101,25 @@ def test_sidecar_extractor_rejects_non_object_top_level(tmp_path: Path):
     assert out is None
 
 
+def test_sidecar_extractor_rejects_oversize_sidecar(tmp_path: Path):
+    """Pathological large sidecars (>64 KB) get rejected with a warning,
+    not silently bloating the doc_metadata JSONB column."""
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    # 65 KB JSON payload — valid JSON, just too big
+    big_value = "x" * 65_000
+    sidecar.write_text(json.dumps({"too_big": big_value}))
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
 def test_sidecar_extractor_handles_utf8_bom(tmp_path: Path):
     """Windows/Excel-exported sidecars often have a UTF-8 BOM; accept them
     cleanly rather than silently dropping the metadata."""

--- a/tests/ingest/test_sidecar_extractor.py
+++ b/tests/ingest/test_sidecar_extractor.py
@@ -1,0 +1,101 @@
+"""SidecarExtractor — loads <stem>.json next to source_path."""
+
+import json
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from harbor_clerk.ingest.metadata_extractors.sidecar import SidecarExtractor
+
+
+@dataclass
+class _FakeDoc:
+    doc_id: uuid.UUID
+    title: str
+
+
+def test_sidecar_extractor_loads_json_next_to_source_path(tmp_path: Path):
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("invoice body text")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text(json.dumps({"vendor": "Acme", "total_usd": 1234.56}))
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"invoice body text",
+        source_path=str(doc_file),
+    )
+    assert out == {"vendor": "Acme", "total_usd": 1234.56}
+
+
+def test_sidecar_extractor_returns_none_when_no_sidecar_exists(tmp_path: Path):
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_returns_none_when_source_path_unset():
+    """Legacy uploaded docs without a watched-folder source_path → no sidecar."""
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_logs_and_returns_none_on_malformed_json(tmp_path: Path):
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text("{ not valid json")
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_returns_none_for_empty_sidecar(tmp_path: Path):
+    """An empty JSON object {} → return None so the namespace isn't written."""
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text("{}")
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None
+
+
+def test_sidecar_extractor_rejects_non_object_top_level(tmp_path: Path):
+    """A top-level list or string in the sidecar is not a valid metadata
+    dict — log warning, return None."""
+    doc_file = tmp_path / "0001_invoice.txt"
+    doc_file.write_text("body")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text('["not", "an", "object"]')
+
+    extractor = SidecarExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="i"),
+        raw_bytes=b"body",
+        source_path=str(doc_file),
+    )
+    assert out is None

--- a/tests/ingest/test_tika_metadata_extractor.py
+++ b/tests/ingest/test_tika_metadata_extractor.py
@@ -1,0 +1,130 @@
+"""TikaMetadataExtractor — calls Tika's /meta endpoint, whitelists fields."""
+
+import uuid
+from dataclasses import dataclass
+
+from pytest_httpserver import HTTPServer
+
+from harbor_clerk.ingest.metadata_extractors.tika_metadata import (
+    TIKA_FIELD_ALIASES,
+    TikaMetadataExtractor,
+)
+
+
+@dataclass
+class _FakeDoc:
+    doc_id: uuid.UUID
+    title: str
+    mime_type: str | None
+
+
+def test_tika_extractor_returns_aliased_whitelisted_fields(httpserver: HTTPServer, monkeypatch):
+    """Tika /meta returns a noisy dict; the extractor whitelists + aliases
+    to readable filter keys and drops everything else."""
+    tika_response = {
+        # Whitelisted aliases
+        "dc:creator": "Jane Doe",
+        "dc:title": "Q3 Report",
+        "dc:subject": "Quarterly Earnings",
+        "xmpTPg:NPages": 12,
+        "dcterms:created": "2024-09-15T10:30:00Z",
+        # Noise that should be dropped
+        "X-TIKA-Parsed-By": "org.apache.tika.parser.pdf.PDFParser",
+        "X-TIKA-Content-Length": "8432",
+        "pdf:PDFVersion": "1.7",
+        "Custom-Random-Field": "ignored",
+    }
+    httpserver.expect_request("/meta").respond_with_json(tika_response)
+
+    # Point Tika settings at the test server
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": httpserver.url_for("").rstrip("/")})(),
+    )
+
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="q3", mime_type="application/pdf"),
+        raw_bytes=b"%PDF-1.7\n...",
+        source_path=None,
+    )
+
+    assert out == {
+        "author": "Jane Doe",
+        "title": "Q3 Report",
+        "subject": "Quarterly Earnings",
+        "page_count": 12,
+        "created_at": "2024-09-15T10:30:00Z",
+    }
+
+
+def test_tika_extractor_returns_none_when_tika_url_unset(monkeypatch):
+    """If tika_url is empty, return None (no Tika to call)."""
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": ""})(),
+    )
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", mime_type="text/plain"),
+        raw_bytes=b"hello",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_tika_extractor_handles_empty_response(httpserver: HTTPServer, monkeypatch):
+    """Tika returning {} → return None (don't write an empty 'tika' namespace)."""
+    httpserver.expect_request("/meta").respond_with_json({})
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": httpserver.url_for("").rstrip("/")})(),
+    )
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="t", mime_type="application/pdf"),
+        raw_bytes=b"...",
+        source_path=None,
+    )
+    assert out is None
+
+
+def test_tika_extractor_collects_email_headers(httpserver: HTTPServer, monkeypatch):
+    """For .eml files, Tika emits Message-From/To/Cc/Subject headers."""
+    tika_response = {
+        "Message-From": "alice@example.com",
+        "Message-To": "bob@example.com,carol@example.com",
+        "Message-Cc": "dave@example.com",
+        "Message-Subject": "Re: Project Update",
+        "dcterms:created": "2024-09-15T10:30:00Z",
+    }
+    httpserver.expect_request("/meta").respond_with_json(tika_response)
+    monkeypatch.setattr(
+        "harbor_clerk.ingest.metadata_extractors.tika_metadata.get_settings",
+        lambda: type("S", (), {"tika_url": httpserver.url_for("").rstrip("/")})(),
+    )
+
+    extractor = TikaMetadataExtractor()
+    out = extractor.extract(
+        doc=_FakeDoc(doc_id=uuid.uuid4(), title="re-project-update", mime_type="message/rfc822"),
+        raw_bytes=b"From: alice@example.com\n...",
+        source_path=None,
+    )
+
+    assert out["email_from"] == "alice@example.com"
+    assert out["email_to"] == "bob@example.com,carol@example.com"
+    assert out["email_cc"] == "dave@example.com"
+    assert out["email_subject"] == "Re: Project Update"
+
+
+def test_tika_field_aliases_has_no_duplicate_target_keys():
+    """The alias map can map two Tika keys to the same target (e.g. both
+    xmpTPg:NPages and Page-Count → page_count); for each target key, the
+    LAST writer wins. Document the conflict set for future readers."""
+    targets = list(TIKA_FIELD_ALIASES.values())
+    # We allow duplicates (Tika emits aliases for the same concept), but the
+    # test pins the current count so a future refactor surfaces the change.
+    unique_targets = set(targets)
+    duplicates = [t for t in unique_targets if targets.count(t) > 1]
+    # Document expected duplicates explicitly:
+    assert sorted(duplicates) == sorted(["page_count"])

--- a/tests/models/test_document_metadata_column.py
+++ b/tests/models/test_document_metadata_column.py
@@ -1,0 +1,38 @@
+"""Tests for the doc_metadata JSONB column on Document."""
+
+from harbor_clerk.models import Document
+from harbor_clerk.models.enums import PipelineStatus
+
+
+async def test_document_doc_metadata_defaults_to_empty_dict(db_session):
+    """A freshly-created Document has doc_metadata = {}."""
+    doc = Document(
+        title="t",
+        status="active",
+        sha256=b"\x00" * 32,
+        pipeline_status=PipelineStatus.queued,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+    assert doc.doc_metadata == {}
+
+
+async def test_document_doc_metadata_persists_arbitrary_dict(db_session):
+    """The column stores and round-trips an arbitrary nested dict."""
+    payload = {
+        "tika": {"author": "Jane", "page_count": 3},
+        "frontmatter": {"tags": ["alpha", "beta"]},
+        "_source_provenance": {"tika": "2026-05-24T00:00:00+00:00"},
+    }
+    doc = Document(
+        title="t",
+        status="active",
+        sha256=b"\x01" * 32,
+        pipeline_status=PipelineStatus.queued,
+        doc_metadata=payload,
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+    assert doc.doc_metadata == payload

--- a/tests/test_mcp_metadata_filter.py
+++ b/tests/test_mcp_metadata_filter.py
@@ -1,0 +1,104 @@
+"""MCP wiring for kb_get_document metadata field.
+
+The kb_search metadata_filter param's behavior is covered by the
+tests/test_search_metadata_filter.py suite (Task 7); this file pins the
+MCP-layer additions: kb_get_document returns the doc's metadata dict so
+models can inspect available filter keys."""
+
+import json
+import uuid
+from contextlib import asynccontextmanager, contextmanager
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.mcp_server import _mcp_principal, kb_get_document
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _principal_in_context(user):
+    """Set the MCP principal contextvar for the duration of the test."""
+    token = _mcp_principal.set(Principal(type="user", id=user.user_id, role="admin"))
+    try:
+        yield
+    finally:
+        _mcp_principal.reset(token)
+
+
+@pytest.fixture
+async def mock_session_factory(db_session: AsyncSession, _engine, monkeypatch):
+    """Patch async_session_factory to create proper AsyncSessions sharing the
+    test connection, so lazy loading (greenlet-based) works correctly."""
+    conn = await db_session.connection()
+
+    @asynccontextmanager
+    async def _factory():
+        session = AsyncSession(bind=conn, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.async_session_factory", _factory)
+
+
+async def _seed_doc(db_session, *, title: str, metadata: dict) -> Document:
+    doc = Document(
+        title=title,
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        doc_metadata=metadata,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="some body text", language="english"))
+    await db_session.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_kb_get_document_includes_doc_metadata(client, admin_user, db_session, mock_session_factory):
+    """kb_get_document response includes the metadata dict so models can
+    inspect available filter keys."""
+    target = await _seed_doc(
+        db_session,
+        title="invoice-acme",
+        metadata={"sidecar": {"vendor": "Acme", "total_usd": 100}},
+    )
+    # flush only — commit would invalidate the connection shared with mock_session_factory
+    await db_session.flush()
+
+    with _principal_in_context(admin_user):
+        raw = await kb_get_document(doc_id=str(target.doc_id))
+
+    parsed = json.loads(raw)
+    assert "metadata" in parsed
+    assert parsed["metadata"] == {"sidecar": {"vendor": "Acme", "total_usd": 100}}
+
+
+async def test_kb_get_document_metadata_field_is_empty_dict_when_unset(
+    client, admin_user, db_session, mock_session_factory
+):
+    """Docs with no metadata extracted yet should report metadata = {} (the
+    server default), not None or missing."""
+    target = await _seed_doc(db_session, title="no-meta", metadata={})
+    # flush only — commit would invalidate the connection shared with mock_session_factory
+    await db_session.flush()
+
+    with _principal_in_context(admin_user):
+        raw = await kb_get_document(doc_id=str(target.doc_id))
+
+    parsed = json.loads(raw)
+    assert parsed.get("metadata") == {}

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -540,6 +540,7 @@ def mock_hybrid_search(monkeypatch):
         before=None,
         language=None,
         mime_type=None,
+        metadata_filter=None,
     ):
         captured.update(
             query=query,
@@ -551,6 +552,7 @@ def mock_hybrid_search(monkeypatch):
             before=before,
             language=language,
             mime_type=mime_type,
+            metadata_filter=metadata_filter,
         )
         return result_override
 

--- a/tests/test_search_metadata_filter.py
+++ b/tests/test_search_metadata_filter.py
@@ -1,0 +1,134 @@
+"""kb_search metadata_filter — JSONB @> containment + ? existence fallback."""
+
+import uuid
+
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.search import hybrid_search
+
+
+async def _seed_doc(db_session, *, title: str, metadata: dict) -> Document:
+    """Helper: insert a Document with one trivial Chunk so FTS can match."""
+    doc = Document(
+        title=title,
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        doc_metadata=metadata,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    chunk = Chunk(
+        doc_id=doc.doc_id,
+        chunk_num=0,
+        chunk_text="jurisdiction indemnification arbitration clause",
+        language="english",
+    )
+    db_session.add(chunk)
+    await db_session.flush()
+    return doc
+
+
+async def test_metadata_filter_pins_doc_by_scalar_field(db_session):
+    """A scalar filter on a scalar metadata value matches via @> containment."""
+    pinnacle = await _seed_doc(
+        db_session,
+        title="vendor-pinnacle-A",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24}},
+    )
+    other = await _seed_doc(
+        db_session,
+        title="vendor-other",
+        metadata={"sidecar": {"vendor": "Other Vendor, LLC", "term_months": 12}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="jurisdiction arbitration",
+        k=10,
+        metadata_filter={"sidecar.vendor": "Pinnacle Tech Solutions, LLC"},
+    )
+    cited_doc_ids = {hit.doc_id for hit in result.hits}
+    assert str(pinnacle.doc_id) in cited_doc_ids
+    assert str(other.doc_id) not in cited_doc_ids
+
+
+async def test_metadata_filter_pins_doc_by_list_value_via_existence(db_session):
+    """A scalar filter on a list-valued metadata field matches if the list
+    contains the scalar (JSONB ? operator)."""
+    tagged = await _seed_doc(
+        db_session,
+        title="tagged-alpha",
+        metadata={"frontmatter": {"tags": ["alpha", "beta"]}},
+    )
+    untagged = await _seed_doc(
+        db_session,
+        title="untagged",
+        metadata={"frontmatter": {"tags": ["gamma"]}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="jurisdiction arbitration",
+        k=10,
+        metadata_filter={"frontmatter.tags": "alpha"},
+    )
+    cited = {hit.doc_id for hit in result.hits}
+    assert str(tagged.doc_id) in cited
+    assert str(untagged.doc_id) not in cited
+
+
+async def test_metadata_filter_combines_multiple_keys_with_and(db_session):
+    """Two filter keys → AND. Both must match for a doc to be returned."""
+    a = await _seed_doc(
+        db_session,
+        title="vendor-pinnacle-24mo",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 24}},
+    )
+    b = await _seed_doc(
+        db_session,
+        title="vendor-pinnacle-12mo",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC", "term_months": 12}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="jurisdiction arbitration",
+        k=10,
+        metadata_filter={
+            "sidecar.vendor": "Pinnacle Tech Solutions, LLC",
+            "sidecar.term_months": 24,
+        },
+    )
+    cited = {hit.doc_id for hit in result.hits}
+    assert str(a.doc_id) in cited
+    assert str(b.doc_id) not in cited
+
+
+async def test_metadata_filter_empty_match_returns_no_hits(db_session):
+    """A filter that matches no docs returns an empty result set (not an error)."""
+    await _seed_doc(
+        db_session,
+        title="vendor-pinnacle",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions, LLC"}},
+    )
+    await db_session.commit()
+
+    result = await hybrid_search(
+        db_session,
+        query="jurisdiction arbitration",
+        k=10,
+        metadata_filter={"sidecar.vendor": "Nonexistent Vendor Co"},
+    )
+    assert result.hits == []
+
+
+async def test_metadata_filter_absent_falls_back_to_existing_behavior(db_session):
+    """When metadata_filter is None, behavior is unchanged."""
+    doc = await _seed_doc(db_session, title="any", metadata={})
+    await db_session.commit()
+    result = await hybrid_search(db_session, query="jurisdiction arbitration", k=10, metadata_filter=None)
+    assert any(hit.doc_id == str(doc.doc_id) for hit in result.hits)

--- a/tests/test_search_metadata_filter.py
+++ b/tests/test_search_metadata_filter.py
@@ -132,3 +132,39 @@ async def test_metadata_filter_absent_falls_back_to_existing_behavior(db_session
     await db_session.commit()
     result = await hybrid_search(db_session, query="jurisdiction arbitration", k=10, metadata_filter=None)
     assert any(hit.doc_id == str(doc.doc_id) for hit in result.hits)
+
+
+async def test_metadata_filter_rejects_multi_dot_paths(db_session):
+    """A multi-dot path like 'sidecar.contract.term' silently produces 'no
+    match' under naive partition logic — fail loudly instead. Spec v1 is
+    namespace.key only."""
+    import pytest
+
+    with pytest.raises(ValueError, match="exactly 'namespace.key'"):
+        await hybrid_search(
+            db_session,
+            query="jurisdiction",
+            k=10,
+            metadata_filter={"sidecar.contract.term": 24},
+        )
+
+
+async def test_metadata_filter_rejects_empty_namespace_or_key(db_session):
+    """Edge cases the dot-count check lets through but the partition check
+    catches: leading dot (empty ns), trailing dot (empty key)."""
+    import pytest
+
+    with pytest.raises(ValueError, match="non-empty"):
+        await hybrid_search(
+            db_session,
+            query="jurisdiction",
+            k=10,
+            metadata_filter={".key": "x"},
+        )
+    with pytest.raises(ValueError, match="non-empty"):
+        await hybrid_search(
+            db_session,
+            query="jurisdiction",
+            k=10,
+            metadata_filter={"ns.": "x"},
+        )

--- a/tests/worker/test_extract_metadata_persistence.py
+++ b/tests/worker/test_extract_metadata_persistence.py
@@ -1,0 +1,58 @@
+"""End-to-end: the extract stage runs the extractor framework and persists
+results to Document.doc_metadata. Uses a sidecar JSON file next to the source
+file — no Tika call needed for plain-text files so the test stays hermetic."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from harbor_clerk.db_sync import get_sync_session
+from harbor_clerk.models import Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
+
+
+@pytest.mark.asyncio
+async def test_extract_stage_writes_sidecar_metadata_to_doc(db_session, tmp_path: Path):
+    """run_extract on a .txt file with a companion sidecar .json populates
+    doc.doc_metadata['sidecar'] and doc.doc_metadata['_source_provenance']."""
+    # Set up source file + sidecar
+    source = tmp_path / "0001_invoice.txt"
+    source.write_text("Invoice body text")
+    sidecar = tmp_path / "0001_invoice.json"
+    sidecar.write_text(json.dumps({"vendor": "Acme", "total_usd": 100}))
+
+    doc = Document(
+        title="0001_invoice",
+        canonical_filename="0001_invoice.txt",
+        status="active",
+        sha256=hashlib.sha256(source.read_bytes()).digest(),
+        pipeline_status=PipelineStatus.queued,
+        mime_type="text/plain",
+        source_path=str(source),
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.queued))
+    await db_session.commit()
+    doc_id = doc.doc_id
+
+    # run_extract is sync — call directly (same pattern as test_pipeline.py).
+    from harbor_clerk.worker.stages.extract import run_extract
+
+    run_extract(doc_id)
+
+    # Re-fetch via a fresh sync session (run_extract commits its own session).
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one()
+        metadata = refreshed.doc_metadata
+    finally:
+        sync_session.close()
+
+    assert "sidecar" in metadata, f"expected 'sidecar' key in doc_metadata, got: {metadata}"
+    assert metadata["sidecar"] == {"vendor": "Acme", "total_usd": 100}
+    assert "_source_provenance" in metadata
+    assert "sidecar" in metadata["_source_provenance"]

--- a/tests/worker/test_extract_metadata_persistence.py
+++ b/tests/worker/test_extract_metadata_persistence.py
@@ -56,3 +56,57 @@ async def test_extract_stage_writes_sidecar_metadata_to_doc(db_session, tmp_path
     assert metadata["sidecar"] == {"vendor": "Acme", "total_usd": 100}
     assert "_source_provenance" in metadata
     assert "sidecar" in metadata["_source_provenance"]
+
+
+@pytest.mark.asyncio
+async def test_extract_stage_clears_stale_metadata_when_extractors_return_empty(db_session, tmp_path: Path):
+    """Re-ingesting a doc whose sidecar was deleted should drop the stale
+    sidecar metadata, not keep it sticky. Same applies if Tika is unavailable
+    and no other extractor produces results — doc_metadata should be {},
+    not the pre-extract value."""
+    from unittest.mock import patch
+
+    from harbor_clerk.worker.stages import extract
+
+    source = tmp_path / "0001_invoice.txt"
+    source.write_text("Body without any sidecar.")
+    # NOTE: deliberately NO sidecar file created.
+
+    doc = Document(
+        title="0001_invoice",
+        canonical_filename="0001_invoice.txt",
+        status="active",
+        sha256=hashlib.sha256(source.read_bytes()).digest(),
+        pipeline_status=PipelineStatus.queued,
+        mime_type="text/plain",
+        source_path=str(source),
+        # Pre-existing stale metadata that should be cleared
+        doc_metadata={
+            "sidecar": {"vendor": "OldVendor"},
+            "_source_provenance": {"sidecar": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.queued))
+    await db_session.commit()
+    doc_id = doc.doc_id
+
+    with patch.object(extract, "_extract_via_tika", return_value=[(1, "Body without any sidecar.")]):
+        from harbor_clerk.worker.stages.extract import run_extract
+
+        run_extract(doc_id)
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one()
+        metadata = refreshed.doc_metadata
+    finally:
+        sync_session.close()
+
+    # Stale "OldVendor" should be gone, since the sidecar file doesn't exist
+    # and Tika has no body-format-specific metadata for plain text.
+    assert "sidecar" not in metadata, f"stale sidecar key should be cleared, got: {metadata}"
+    # The whole metadata dict should be empty (or at most contain whatever
+    # Tika /meta returned, which for text/plain in this hermetic env is None).
+    assert metadata == {}

--- a/tests/worker/test_markdown_frontmatter_stripping.py
+++ b/tests/worker/test_markdown_frontmatter_stripping.py
@@ -1,0 +1,35 @@
+"""Markdown extract path strips YAML frontmatter from body text before
+chunking, so the chunks/embedding/FTS don't include raw YAML noise."""
+
+from harbor_clerk.worker.markdown_extract import strip_frontmatter
+
+
+def test_strip_frontmatter_removes_yaml_block():
+    body = """---
+title: Notes
+tags: [a, b]
+---
+
+# Heading
+
+Body content.
+"""
+    assert strip_frontmatter(body) == "# Heading\n\nBody content.\n"
+
+
+def test_strip_frontmatter_passes_through_unchanged_without_frontmatter():
+    body = "# Just a heading\n\nNo frontmatter.\n"
+    assert strip_frontmatter(body) == body
+
+
+def test_strip_frontmatter_passes_through_unchanged_when_yaml_is_malformed():
+    """Malformed YAML → don't risk losing body content; pass through unchanged.
+    Metadata extraction logs the parse failure separately."""
+    body = """---
+title: Meeting
+unclosed_list: [a, b
+---
+
+content
+"""
+    assert strip_frontmatter(body) == body

--- a/tests/worker/test_markdown_frontmatter_stripping.py
+++ b/tests/worker/test_markdown_frontmatter_stripping.py
@@ -33,3 +33,12 @@ unclosed_list: [a, b
 content
 """
     assert strip_frontmatter(body) == body
+
+
+def test_strip_frontmatter_removes_empty_yaml_block():
+    """Empty frontmatter block (---\\n---\\n) should still have its
+    delimiters stripped from the body. extract_frontmatter handles this
+    case (the dedicated test_extract_frontmatter_empty_block test proves
+    it), and strip_frontmatter must preserve that behavior."""
+    body = "---\n---\nBody content.\n"
+    assert strip_frontmatter(body) == "Body content.\n"

--- a/uv.lock
+++ b/uv.lock
@@ -752,6 +752,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pypdfium2" },
     { name = "pytesseract" },
+    { name = "python-frontmatter" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "spacy" },
@@ -801,6 +802,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
     { name = "pytest-httpserver", marker = "extra == 'test'", specifier = ">=1.1" },
     { name = "pytest-httpx", marker = "extra == 'test'", specifier = ">=0.32" },
+    { name = "python-frontmatter", specifier = ">=1.1" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11" },
@@ -2176,6 +2178,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements **document metadata extractors + structured-filter search** — the first of four PRs in the cloud-models tools-improvement track. Motivated by the boundary-doc retrieval failure mode confirmed cross-provider in PR-A/B/C: both Sonnet and gpt-4o trust HC's top-1 retrieval and answer from the wrong doc when the question's identifier isn't unique (Pinnacle contract X vs Y, "Senior Project Coordinator" onboarding letter, "Marbledock Elevate 2025" campaign brief).

Spec: [`docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md`](docs/superpowers/specs/2026-05-24-document-metadata-extractors-design.md). Plan: [`docs/superpowers/plans/2026-05-24-document-metadata-extractors.md`](docs/superpowers/plans/2026-05-24-document-metadata-extractors.md).

## What's in it

**Schema (Task 1):**
- New `Document.doc_metadata` JSONB column (Python attr `doc_metadata` to avoid shadowing `Base.metadata`; PostgreSQL column `metadata`) + GIN index for `@>` containment queries. Migration `0004_documents_metadata`.

**Extractor framework (Task 2):**
- `MetadataExtractor` `@runtime_checkable` Protocol + `run_all()` orchestrator in `src/harbor_clerk/ingest/metadata_extractors/`. Per-extractor failure isolation (log + continue), namespaced output (`{tika: ..., frontmatter: ..., sidecar: ..., _source_provenance: ...}`).

**Three concrete extractors (Tasks 3-5):**
- **`TikaMetadataExtractor`** — calls Tika `/meta` per file, whitelists ~16 useful fields via alias map (Dublin Core + pagination + MIME + email headers including the new `Message-Date → email_date`). Drops the 50-200 noise fields Tika emits. Handles non-dict responses + Content-Type passthrough.
- **`FrontmatterExtractor`** — parses YAML frontmatter from `.md`/`.markdown` files via `python-frontmatter` (new runtime dep). UTF-8 BOM stripping; YAML date/datetime → ISO strings; bytes (`!!binary`) → decoded strings; defensive exception handling.
- **`SidecarExtractor`** — loads `<stem>.json` next to `source_path`. UTF-8 BOM stripping; 64 KB size cap; rejects non-object top-level JSON.

**Production wiring (Task 6):**
- Extract stage calls `run_metadata_extractors()` after body extraction; results land on `doc.doc_metadata`. Empty-dict assignment is unconditional (drops stale metadata on re-ingest after sidecar removal).
- Markdown extract path strips YAML frontmatter from body text via `strip_frontmatter()` before chunking — no more YAML noise in embeddings/FTS. Handles the empty-block (`---\n---\n`) case correctly via identity check.

**Search layer (Task 7):**
- `hybrid_search` gains `metadata_filter: dict[str, Any] | None`. Each `"namespace.key": value` entry becomes a JSONB containment (`@>`) clause; string values get OR'd with an existence (`?`) clause so list-valued metadata (e.g. `tags: ["alpha", "beta"]`) matches scalar filters without the caller knowing the shape. Multi-dot paths and empty segments raise `ValueError` (loud failure, not silent no-match).

**MCP wiring (Task 8):**
- `kb_search` accepts and forwards `metadata_filter`. Tool description includes an example + points to `kb_get_document` for filter-key discovery.
- `kb_get_document` response includes the `metadata` dict so models can inspect available filter keys before crafting a query.

**Backfill script (Task 9):**
- `scripts/reextract_metadata.py` — one-shot async script to backfill metadata on existing dev/test corpora. Idempotent; `--dry-run` for safe inspection.

**Test coverage:** ~50 new tests across the ingest framework, search layer, MCP, and worker stages. 931 total tests pass on this branch.

## Live validation

**Deferred to user-side QA post-merge.** Live validation requires rebuilding the macOS app from this branch + restarting HC with the new build to apply migration 0004 and re-ingest the corpus. Recommended steps:

1. `make -C macos apps && cp -R ...` (or whatever your install flow is)
2. Restart HC menubar — alembic 0004 applies on startup
3. Hit **Reprocess (no summaries)** in System Maintenance (the new button from #388) to re-ingest the synthetic corpus with extractors active
4. Spot-check `kb_get_document` on a synthetic doc — should show `metadata.sidecar.vendor`, etc.
5. Try `kb_search(query="governing law", metadata_filter={"sidecar.vendor": "Pinnacle Tech Solutions, LLC", "sidecar.term_months": 24})` — should pin the right Pinnacle contract among many
6. (Optional) Re-run PR-C's gpt-4o synthetic eval — expect lookup-correctness ↑ for the boundary-doc items once tool descriptions in PR-D nudge models toward the new filter

The unit tests cover the extractor framework comprehensively (27 ingest tests, 7 search-layer tests, 2 MCP tests, 4 worker-stage tests); the live step is empirical confidence on a real corpus.

## Test plan

- [x] `uv run pytest tests/` — 931 pass, 17 skipped, 0 fail
- [x] `uv run ruff check` + `uv run ruff format --check` clean across `src/harbor_clerk/`, `tests/`, `scripts/`
- [x] Frontend lint + type-check (no frontend changes in PR-F, verified nothing leaked)
- [x] TDD throughout — every task gates implementation on a failing test, then passing test, then commit
- [x] Per-task spec compliance + code quality reviews by isolated subagents (`feature-dev:code-reviewer`)
- [x] Final unconstrained fresh-eyes review against the full 21-commit diff
- [ ] **Live validation against synthetic corpus** — deferred to user-side QA (see above)

## Pre-existing bugs surfaced by the final review

The fresh-eyes review surfaced two bugs that turn out to **pre-exist on `main`** (verified via `git show origin/main`). Not PR-F regressions; flagging for follow-up rather than scope-creeping this PR:

1. **`worker/stages/extract.py:305`** — early `return` on `check_pipeline_seq` mismatch skips `mark_stage_done`. Job row stays `running` until the reaper times it out at 2× the 600s timeout (20 min). New pipeline's extract is blocked during that window.
2. **`mcp_server.py:1074`** — `kb_get_document` response includes the absolute `source_path` of the document. For watched-folder docs this leaks the host filesystem tree to any MCP client (including cloud LLMs). Should be omitted or replaced with `basename(source_path)`.

Both will land in `pr_followups.md` for tracking.

## Known limitations / queued follow-ups

- **PR-D (tool description rewrites + kb_search response enhancements)** — sits on top of PR-F to surface the new filter capability in tool descriptions; immediately next in the cloud-models track.
- **PR-E (kb_verify_identifier + kb_documents_by_date)** — `kb_verify_identifier` can now do exact metadata lookups; benefits from PR-F's structured filter.
- **PR-G (harness audit + cross-judge sensitivity)** — pure harness work; can land in parallel.
- **LLM-based metadata extraction** — separate future PR.
- **Folder-path-as-metadata + filename-pattern parsing** — separate future PRs with their own user-config story.
- **Frontend display of metadata** — UI polish PR.
- **Admin "Reprocess Metadata" button** — bulk re-extraction UX.
- **`metadata_filter` operators (`>=`, `<`, `in`, `contains`)** — v1 ships exact-match-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
