### PR TITLE
fix(build): ensurepip in build-venv.sh — recover from PR #383's strip-on-success

### DIFF
--- a/macos/scripts/build-venv.sh
+++ b/macos/scripts/build-venv.sh
@@ -50,6 +50,16 @@ fi
 # Use the venv's python directly (not pip script, since shebangs get patched later)
 VENV_PYTHON="$VENV_DIR/bin/python3"
 
+# ── Ensure pip is installed ──
+# Fresh venvs from `python -m venv` ship with pip. But this script strips pip
+# at the end (see "Removing pip from runtime venv" below — the bundled appliance
+# is frozen and doesn't need pip at runtime). Reusing a cached venv from a
+# prior successful build means pip is gone, so the upgrade step below would
+# fail with "No module named pip". `ensurepip --default-pip` is a stdlib no-op
+# when pip is already present and reinstalls from the bundled wheel otherwise.
+echo "==> Ensuring pip is installed"
+"$VENV_PYTHON" -m ensurepip --default-pip
+
 # ── Upgrade pip ──
 # python-build-standalone ships an older pip; upgrade so subsequent installs
 # don't print the "new release available" notice on every invocation.


### PR DESCRIPTION
## Summary

PR #383 added a `pip uninstall` step at the end of `macos/scripts/build-venv.sh` to strip pip from the runtime venv (the frozen appliance doesn't need it at runtime). But the script reuses cached venvs via the `if [ ! -x "$VENV_DIR/bin/python3" ]` guard near the top — so a venv that was successfully built once (and had pip stripped) fails on the next `make` with:

```
==> Setting up Python 3.12 + venv
==> Upgrading pip
/Users/alex/mcp-gateway/macos/build/venv/bin/python3: No module named pip
make: *** [venv] Error 1
```

Fresh builds (no `macos/build`) work fine because `python -m venv` includes pip by default. The bug only surfaces on rebuilds against a cached venv.

## Fix

Run `python -m ensurepip --default-pip` before the upgrade step. Stdlib no-op when pip is already present; reinstalls from the bundled wheel when it isn't. Works for both fresh and post-strip venvs without forcing a full venv recreation.

## Verification

Reproduced the failure on a local broken venv, applied the fix, ran `python -m ensurepip --default-pip` directly — pip recovered from `/var/folders/.../pip-25.0.1-py3-none-any.whl` (the bundled wheel that python-build-standalone ships). Confirmed `pip --version` returns `pip 25.0.1` after.

## Why this needs to land

Blocks `make` for anyone with a cached build tree from a prior successful PR #383 era (basically everyone since #383 merged). Smoke-testing PR-F (#389) + PR-D (#390) after merging required this fix to even start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
