### PR TITLE
feat(mcp): kb_verify_identifier + kb_documents_by_date + CLI parity (PR-E)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-mcp-verify-identifier-and-documents-by-date.md
+++ b/docs/superpowers/plans/2026-05-24-mcp-verify-identifier-and-documents-by-date.md
@@ -1,0 +1,2716 @@
+# PR-E: `kb_verify_identifier` + `kb_documents_by_date` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two structured-lookup MCP tools — `kb_verify_identifier` (proactive fabrication-prevention) and `kb_documents_by_date` (date-bounded lookups) — plus matching `harbor-clerk` CLI subcommands.
+
+**Architecture:** Both tools live in a single new module `src/harbor_clerk/mcp_lookup_tools.py` and share a date-discovery helper `src/harbor_clerk/metadata_dates.py`. `verify_identifier` reuses PR-D's `_find_differing_metadata_fields()` for the discriminating-fields projection. `documents_by_date` builds a single SQL query with a `COALESCE` over JSONB extractors for the effective-date sort key. Each MCP tool gets a peer CLI subcommand matching PR #397's 1:1 contract.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0 async + asyncpg, PostgreSQL 18 + pgvector, FastMCP, pytest-asyncio, ruff.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-mcp-verify-identifier-and-documents-by-date-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/harbor_clerk/metadata_dates.py` — `effective_date(doc) -> tuple[datetime | None, str]` helper.
+- `src/harbor_clerk/mcp_lookup_tools.py` — `verify_identifier()` + `documents_by_date()` async functions.
+- `src/harbor_clerk/cli/commands/verify_identifier.py` — `harbor-clerk verify-identifier` subcommand.
+- `src/harbor_clerk/cli/commands/documents_by_date.py` — `harbor-clerk documents-by-date` subcommand.
+- `src/harbor_clerk/cli/help/verify-identifier.txt` — long-form help text.
+- `src/harbor_clerk/cli/help/documents-by-date.txt` — long-form help text.
+- `tests/test_metadata_dates.py` — date-discovery unit tests.
+- `tests/test_mcp_lookup_tools.py` — algorithm + integration tests for both tools.
+- `tests/cli/test_commands_verify_identifier.py` — CLI command tests.
+- `tests/cli/test_commands_documents_by_date.py` — CLI command tests.
+
+**Modified files:**
+- `src/harbor_clerk/mcp_server.py` — register `kb_verify_identifier` + `kb_documents_by_date` MCP tools.
+- `src/harbor_clerk/cli/commands/__init__.py` — add `"verify-identifier"` + `"documents-by-date"` to `_COMMAND_NAMES`.
+- `src/harbor_clerk/cli/output.py` — register text renderers for the two new commands.
+- `tests/test_mcp_tool_descriptions.py` — pin the new tool descriptions (4-part docstring + key affordance words).
+- `tests/cli/test_e2e.py` — smoke tests that the new help text loads via `--help`.
+
+---
+
+## Task 1: `metadata_dates.py` — `effective_date()` helper
+
+**Files:**
+- Create: `src/harbor_clerk/metadata_dates.py`
+- Test:   `tests/test_metadata_dates.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_metadata_dates.py
+"""Unit tests for src/harbor_clerk/metadata_dates.py::effective_date()."""
+
+from datetime import datetime, timezone
+
+from harbor_clerk.metadata_dates import effective_date
+
+
+class _Doc:
+    """Stand-in for the Document model — only fields effective_date reads.
+
+    Using a tiny dataclass-like helper instead of importing Document keeps
+    this file a pure unit test (no DB, no SQLAlchemy fixtures).
+    """
+
+    def __init__(self, doc_metadata=None, created_at=None):
+        self.doc_metadata = doc_metadata
+        self.created_at = created_at
+
+
+def test_uses_tika_when_present():
+    doc = _Doc(doc_metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}})
+    dt, label = effective_date(doc)
+    assert dt == datetime(1999, 10, 13, 8, 34, tzinfo=timezone.utc)
+    assert label == "tika.created_at"
+
+
+def test_prefers_tika_over_frontmatter_and_sidecar():
+    doc = _Doc(
+        doc_metadata={
+            "tika": {"created_at": "2020-01-01T00:00:00Z"},
+            "frontmatter": {"date": "2010-01-01"},
+            "sidecar": {"date": "2015-01-01"},
+        }
+    )
+    dt, label = effective_date(doc)
+    assert dt.year == 2020
+    assert label == "tika.created_at"
+
+
+def test_falls_through_to_frontmatter():
+    doc = _Doc(doc_metadata={"frontmatter": {"date": "2025-04-19"}})
+    dt, label = effective_date(doc)
+    assert dt == datetime(2025, 4, 19, tzinfo=timezone.utc)
+    assert label == "frontmatter.date"
+
+
+def test_falls_through_to_sidecar():
+    doc = _Doc(doc_metadata={"sidecar": {"date": "2024-08-01T12:00:00+00:00"}})
+    dt, label = effective_date(doc)
+    assert dt == datetime(2024, 8, 1, 12, 0, tzinfo=timezone.utc)
+    assert label == "sidecar.date"
+
+
+def test_falls_through_to_ingest():
+    ingest = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+    doc = _Doc(doc_metadata={}, created_at=ingest)
+    dt, label = effective_date(doc)
+    assert dt == ingest
+    assert label == "ingest"
+
+
+def test_iso_without_timezone_assumed_utc():
+    doc = _Doc(doc_metadata={"tika": {"created_at": "2024-01-15T10:00:00"}})
+    dt, _ = effective_date(doc)
+    assert dt is not None
+    assert dt.tzinfo is not None
+    assert dt == datetime(2024, 1, 15, 10, 0, tzinfo=timezone.utc)
+
+
+def test_date_only_string_parses():
+    doc = _Doc(doc_metadata={"frontmatter": {"date": "2024-01-15"}})
+    dt, _ = effective_date(doc)
+    assert dt == datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+
+def test_naive_datetime_object_assumed_utc():
+    doc = _Doc(doc_metadata={"sidecar": {"date": datetime(2024, 2, 2)}})
+    dt, _ = effective_date(doc)
+    assert dt == datetime(2024, 2, 2, tzinfo=timezone.utc)
+
+
+def test_unparseable_string_falls_through_to_next_source():
+    doc = _Doc(
+        doc_metadata={"tika": {"created_at": "not-a-date"}},
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    dt, label = effective_date(doc)
+    assert label == "ingest"
+    assert dt.year == 2026
+
+
+def test_all_sources_missing_returns_none_and_none_label():
+    doc = _Doc(doc_metadata={}, created_at=None)
+    dt, label = effective_date(doc)
+    assert dt is None
+    assert label == "none"
+
+
+def test_none_doc_metadata_falls_through_to_ingest():
+    """doc_metadata=None should not raise — treat as empty dict."""
+    ingest = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    doc = _Doc(doc_metadata=None, created_at=ingest)
+    dt, label = effective_date(doc)
+    assert label == "ingest"
+    assert dt == ingest
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_metadata_dates.py -v`
+Expected: 11 FAIL — `ModuleNotFoundError: No module named 'harbor_clerk.metadata_dates'`
+
+- [ ] **Step 3: Implement `effective_date`**
+
+```python
+# src/harbor_clerk/metadata_dates.py
+"""Effective-date discovery for documents.
+
+Walks a priority chain to return the canonical date for a document:
+  1. metadata.tika.created_at  (Tika-extracted email-send / file-creation date)
+  2. metadata.frontmatter.date (markdown frontmatter)
+  3. metadata.sidecar.date     (JSON sidecar)
+  4. documents.created_at      (ingest time — last resort)
+
+Used by kb_documents_by_date for sorting + result annotation. Standalone
+module so future features (document list views, exports, filters) can
+share one place for "the canonical date for this doc."
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+# Priority chain: (label, getter). First non-null parseable value wins.
+_PRIORITY: list[tuple[str, Callable[[Any], Any]]] = [
+    ("tika.created_at", lambda d: (d.doc_metadata or {}).get("tika", {}).get("created_at")),
+    ("frontmatter.date", lambda d: (d.doc_metadata or {}).get("frontmatter", {}).get("date")),
+    ("sidecar.date", lambda d: (d.doc_metadata or {}).get("sidecar", {}).get("date")),
+]
+
+
+def effective_date(doc) -> tuple[datetime | None, str]:
+    """Return (effective_date, source_label) for a document.
+
+    Walks the priority chain and returns the first non-null value that
+    parses as a datetime. Falls back to `documents.created_at` (ingest
+    time) if no metadata source provides a valid date. Returns
+    `(None, "none")` only if every source is missing AND ingest is also
+    null (unreachable in practice — documents always have created_at).
+
+    source_label ∈ {"tika.created_at", "frontmatter.date", "sidecar.date",
+                    "ingest", "none"}.
+    """
+    for label, getter in _PRIORITY:
+        raw = getter(doc)
+        parsed = _parse(raw)
+        if parsed is not None:
+            return parsed, label
+    if getattr(doc, "created_at", None) is not None:
+        return _ensure_utc(doc.created_at), "ingest"
+    return None, "none"
+
+
+def _parse(raw: Any) -> datetime | None:
+    """Parse a value into a UTC-aware datetime. Returns None on failure."""
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return _ensure_utc(raw)
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    # Normalise "Z" suffix to "+00:00" since fromisoformat() only
+    # accepts the latter on Python 3.10. Both forms are valid ISO 8601.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return _ensure_utc(datetime.fromisoformat(s))
+    except ValueError:
+        return None
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    """Coerce a naive datetime to UTC; pass aware datetimes through."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_metadata_dates.py -v`
+Expected: 11 PASS
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/metadata_dates.py tests/test_metadata_dates.py`
+Expected: "All checks passed!"
+
+Run: `uv run ruff format src/harbor_clerk/metadata_dates.py tests/test_metadata_dates.py`
+Expected: "X files left unchanged" or "X file reformatted"
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/metadata_dates.py tests/test_metadata_dates.py
+git commit -m "feat(metadata): effective_date() helper with priority chain"
+```
+
+---
+
+## Task 2: `mcp_lookup_tools.py` — candidate matching for `verify_identifier`
+
+**Goal:** Add the matching layer that finds all documents whose title, filename, or identifier-like metadata field matches a normalized identifier string. Returns a deduplicated list of `Document` rows. The full `verify_identifier()` public function follows in Task 3.
+
+**Files:**
+- Create: `src/harbor_clerk/mcp_lookup_tools.py` (matching layer only)
+- Test:   `tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_mcp_lookup_tools.py
+"""Algorithm + integration tests for src/harbor_clerk/mcp_lookup_tools.py.
+
+Task 2 (this file) covers candidate matching for verify_identifier:
+title + canonical_filename ILIKE; metadata.tika.title equals; identifier-like
+metadata key equals across sidecar/frontmatter.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.mcp_lookup_tools import _find_candidates
+from harbor_clerk.models import Document
+from harbor_clerk.models.enums import PipelineStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _seed_doc(
+    db_session: AsyncSession,
+    *,
+    title: str,
+    canonical_filename: str | None = None,
+    metadata: dict | None = None,
+) -> Document:
+    doc = Document(
+        title=title,
+        canonical_filename=canonical_filename,
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        doc_metadata=metadata or {},
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Matching tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_matches_returns_empty_list(db_session):
+    await _seed_doc(db_session, title="Unrelated Doc")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "nothing-matches")
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_matches_by_title_contains(db_session):
+    target = await _seed_doc(db_session, title="Pinnacle Vendor Contract")
+    await _seed_doc(db_session, title="Unrelated")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_canonical_filename_contains(db_session):
+    target = await _seed_doc(
+        db_session, title="Doc One", canonical_filename="0131_vendor_contract.pdf"
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "vendor_contract")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_are_case_insensitive(db_session):
+    target = await _seed_doc(db_session, title="Pinnacle Vendor Contract")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "PINNACLE")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_whitespace_normalized_in_input(db_session):
+    target = await _seed_doc(db_session, title="Pinnacle Vendor Contract")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "  pinnacle   vendor  ")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_tika_title_equals(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="raw-filename",
+        metadata={"tika": {"title": "Pinnacle Vendor Contract"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle Vendor Contract")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_sidecar_identifier_key_equals(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Some doc",
+        metadata={"sidecar": {"contract_id": "K-2025-031", "vendor": "Acme"}},
+    )
+    # Negative: another doc has the same value in a non-id key — must NOT match.
+    await _seed_doc(
+        db_session,
+        title="Other doc",
+        metadata={"sidecar": {"vendor": "K-2025-031"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "K-2025-031")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_nested_identifier_key(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Some doc",
+        metadata={"sidecar": {"contract": {"id": "K-2025-031"}}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "K-2025-031")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_list_valued_identifier_key(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Some doc",
+        metadata={"frontmatter": {"order_id": ["K-1", "K-2"]}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "K-2")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_deduplicates_when_multiple_fields_match(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract",
+        canonical_filename="pinnacle-vendor-contract.pdf",
+        metadata={"tika": {"title": "Pinnacle Vendor Contract"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle Vendor Contract")
+    # All three columns match this doc; result must contain it once.
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_excludes_inactive_documents(db_session):
+    doc = await _seed_doc(db_session, title="Pinnacle")
+    doc.status = "deleted"
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle")
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_caps_at_100_candidates(db_session):
+    """100 docs with a shared substring — result is capped at 100."""
+    for i in range(105):
+        await _seed_doc(db_session, title=f"Pinnacle {i:03d}")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle")
+    assert len(candidates) == 100
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v`
+Expected: 12 FAIL — `ModuleNotFoundError: No module named 'harbor_clerk.mcp_lookup_tools'`
+
+- [ ] **Step 3: Implement the matching layer**
+
+```python
+# src/harbor_clerk/mcp_lookup_tools.py
+"""kb_verify_identifier + kb_documents_by_date — structured-lookup tools.
+
+Both tools perform non-similarity lookups against the documents table and
+the metadata JSONB column added in PR-F. verify_identifier returns
+not_found / unique / ambiguous; documents_by_date returns docs sorted by
+their effective date (per metadata_dates.effective_date priority chain).
+
+This module exposes two public async functions used by mcp_server.py:
+  - verify_identifier(session, identifier) -> dict   (added in Task 3)
+  - documents_by_date(session, ...) -> dict          (added in Task 5)
+
+Task 2 establishes the candidate-matching layer for verify_identifier.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.models import Document
+
+
+# Cap on candidates returned for verify_identifier. Bounds payload size
+# and discriminating-fields compute cost on degenerate inputs.
+_VERIFY_CANDIDATE_CAP = 100
+
+# Leaf-key names that count as identifiers when matching metadata.sidecar.**
+# or metadata.frontmatter.**. Anything else is treated as a disambiguator
+# (vendor, date, etc.), surfaced via discriminating_fields rather than
+# matched against the input string.
+_IDENTIFIER_KEY_RE = re.compile(
+    r"^(id|contract_id|policy_id|case_id|order_id|invoice_id|message_id|.*_id)$"
+)
+
+# Metadata namespaces searched for identifier-like keys. metadata.tika.title
+# is handled separately because the match target is the title VALUE, not
+# any key under tika.
+_ID_KEY_NAMESPACES = ("sidecar", "frontmatter")
+
+
+def _normalize(s: str) -> str:
+    """Lower-case, strip, and collapse internal whitespace."""
+    return " ".join(s.lower().split())
+
+
+def _iter_id_like_leaves(metadata: dict) -> list[Any]:
+    """Walk metadata.sidecar.** and metadata.frontmatter.**, yielding the
+    value of every leaf whose KEY matches _IDENTIFIER_KEY_RE.
+
+    Lists at leaves contribute each element. Returns a flat list of raw
+    values (caller does normalisation + comparison).
+    """
+    out: list[Any] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, dict):
+                    _walk(value)
+                elif _IDENTIFIER_KEY_RE.match(str(key)):
+                    if isinstance(value, list):
+                        out.extend(value)
+                    else:
+                        out.append(value)
+
+    for ns in _ID_KEY_NAMESPACES:
+        ns_dict = metadata.get(ns)
+        if isinstance(ns_dict, dict):
+            _walk(ns_dict)
+
+    return out
+
+
+async def _find_candidates(session: AsyncSession, identifier: str) -> list[Document]:
+    """Return the set of active Documents matching `identifier` by any of:
+      - title CONTAINS identifier (case-insensitive, whitespace-normalised)
+      - canonical_filename CONTAINS identifier (same normalisation)
+      - metadata.tika.title EQUALS identifier (case-insensitive)
+      - any identifier-like-key leaf value in metadata.sidecar.** or
+        metadata.frontmatter.** EQUALS identifier (case-insensitive)
+
+    Deduplicated by doc_id. Capped at _VERIFY_CANDIDATE_CAP results
+    (the public verify_identifier in Task 3 sets `overflow: true` when
+    the cap is reached).
+    """
+    normalized = _normalize(identifier)
+    if not normalized:
+        return []
+
+    # SQL-side pass: title / canonical_filename ILIKE, plus tika.title equality.
+    # The metadata-key match needs Python-side traversal because the leaf
+    # paths are variable.
+    pattern = f"%{normalized}%"
+    stmt = (
+        select(Document)
+        .where(Document.status == "active")
+        .where(
+            or_(
+                Document.title.op("ILIKE")(pattern),
+                Document.canonical_filename.op("ILIKE")(pattern),
+                # JSONB ->> returns text; lower() then equals the normalized input.
+                Document.doc_metadata["tika"]["title"].astext.op("ILIKE")(normalized),
+            )
+        )
+    )
+    sql_hits = (await session.execute(stmt)).scalars().all()
+    sql_hit_ids = {d.doc_id for d in sql_hits}
+
+    # Python-side pass for identifier-like metadata keys. Fetch all active
+    # docs whose metadata is non-empty (cheap with the existing GIN index)
+    # and walk their JSON structure.
+    stmt_meta = (
+        select(Document)
+        .where(Document.status == "active")
+        .where(Document.doc_metadata != {})
+    )
+    meta_hits = (await session.execute(stmt_meta)).scalars().all()
+
+    extra: list[Document] = []
+    for doc in meta_hits:
+        if doc.doc_id in sql_hit_ids:
+            continue
+        for raw in _iter_id_like_leaves(doc.doc_metadata or {}):
+            if isinstance(raw, str) and _normalize(raw) == normalized:
+                extra.append(doc)
+                break
+
+    combined = list(sql_hits) + extra
+    # Deduplicate preserving order; cap.
+    seen: set = set()
+    result: list[Document] = []
+    for d in combined:
+        if d.doc_id in seen:
+            continue
+        seen.add(d.doc_id)
+        result.append(d)
+        if len(result) >= _VERIFY_CANDIDATE_CAP:
+            break
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v`
+Expected: 12 PASS
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+Expected: "All checks passed!"
+
+Run: `uv run ruff format src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py
+git commit -m "feat(mcp-lookup): _find_candidates matching layer for verify_identifier"
+```
+
+---
+
+## Task 3: `verify_identifier()` public response shape
+
+**Goal:** Add the public `verify_identifier(session, identifier) -> dict` function on top of Task 2's `_find_candidates`. Branches on candidate count (not_found / unique / ambiguous), projects per-candidate `discriminating_fields` via reuse of PR-D's `_find_differing_metadata_fields`, builds the suggestion, and surfaces `overflow: true` when the cap was reached.
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_lookup_tools.py`
+- Modify: `tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 1: Write the failing tests** (append to existing file)
+
+```python
+# Append to tests/test_mcp_lookup_tools.py
+
+from harbor_clerk.mcp_lookup_tools import verify_identifier
+
+
+# ---------------------------------------------------------------------------
+# verify_identifier response-shape tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_not_found_returns_status_not_found(db_session):
+    await _seed_doc(db_session, title="Unrelated")
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "nothing-matches")
+    assert result == {"status": "not_found", "identifier": "nothing-matches"}
+
+
+@pytest.mark.asyncio
+async def test_unique_match_returns_status_unique(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract",
+        canonical_filename="0131_vendor_contract.pdf",
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Vendor Contract")
+    assert result["status"] == "unique"
+    assert result["match"]["doc_id"] == str(target.doc_id)
+    assert result["match"]["title"] == "Pinnacle Vendor Contract"
+    assert result["match"]["canonical_filename"] == "0131_vendor_contract.pdf"
+    assert result["match"]["discriminating_fields"] == {}
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_match_with_discriminating_fields(db_session):
+    a = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract A",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions", "term_months": 24}},
+    )
+    b = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract B",
+        metadata={"sidecar": {"vendor": "Pinnacle Industries", "term_months": 36}},
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Vendor Contract")
+    assert result["status"] == "ambiguous"
+    assert result["count"] == 2
+    ids = {c["doc_id"] for c in result["candidates"]}
+    assert ids == {str(a.doc_id), str(b.doc_id)}
+
+    # Per-candidate discriminating_fields should carry that candidate's own values.
+    for c in result["candidates"]:
+        assert "sidecar.vendor" in c["discriminating_fields"]
+        assert "sidecar.term_months" in c["discriminating_fields"]
+    suggestion = result["suggestion"]
+    assert "sidecar.vendor" in suggestion or "sidecar.term_months" in suggestion
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_with_no_differing_fields_uses_fallback_suggestion(db_session):
+    await _seed_doc(
+        db_session,
+        title="Pinnacle Contract Alpha",
+        metadata={"sidecar": {"vendor": "Same Vendor"}},
+    )
+    await _seed_doc(
+        db_session,
+        title="Pinnacle Contract Beta",
+        metadata={"sidecar": {"vendor": "Same Vendor"}},
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Contract")
+    assert result["status"] == "ambiguous"
+    for c in result["candidates"]:
+        assert c["discriminating_fields"] == {}
+    assert "identical" in result["suggestion"].lower()
+
+
+@pytest.mark.asyncio
+async def test_empty_identifier_returns_error(db_session):
+    result = await verify_identifier(db_session, "")
+    assert "error" in result
+    assert "non-empty" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_identifier_returns_error(db_session):
+    result = await verify_identifier(db_session, "   ")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_overflow_flag_set_when_cap_exceeded(db_session):
+    for i in range(105):
+        await _seed_doc(db_session, title=f"Pinnacle {i:03d}")
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle")
+    assert result["status"] == "ambiguous"
+    assert result["count"] == 100
+    assert result["overflow"] is True
+    assert "more than 100" in result["suggestion"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v -k verify_identifier`
+Expected: 7 FAIL — `ImportError: cannot import name 'verify_identifier' from 'harbor_clerk.mcp_lookup_tools'`
+
+- [ ] **Step 3: Implement `verify_identifier` + helpers** (append to module)
+
+```python
+# Append to src/harbor_clerk/mcp_lookup_tools.py
+
+# Reuse PR-D's algorithm for "which metadata paths differ across candidates".
+# Imported despite the leading underscore — Python doesn't enforce it; the
+# function is the canonical implementation of "what fields distinguish
+# these docs" and duplicating it would risk drift.
+from harbor_clerk.mcp_discriminator import _find_differing_metadata_fields
+
+
+async def verify_identifier(session: AsyncSession, identifier: str) -> dict:
+    """Verify that an identifier resolves to a unique document.
+
+    Returns one of three response shapes:
+      - {"status": "not_found", "identifier": <input>}
+      - {"status": "unique", "match": {doc_id, title, canonical_filename,
+                                       discriminating_fields: {}}}
+      - {"status": "ambiguous", "count": N, "candidates": [...],
+         "suggestion": "...", "overflow"?: true}
+
+    Empty / whitespace-only identifier returns {"error": "..."}.
+    """
+    if not identifier or not identifier.strip():
+        return {"error": "identifier must be a non-empty string"}
+
+    candidates = await _find_candidates(session, identifier)
+
+    if not candidates:
+        return {"status": "not_found", "identifier": identifier}
+
+    if len(candidates) == 1:
+        d = candidates[0]
+        return {
+            "status": "unique",
+            "match": {
+                "doc_id": str(d.doc_id),
+                "title": d.title,
+                "canonical_filename": d.canonical_filename,
+                "discriminating_fields": {},
+            },
+        }
+
+    # Ambiguous — compute which metadata paths differ across candidates.
+    titles = {str(d.doc_id): (d.title or str(d.doc_id)) for d in candidates}
+    metadata_by_doc = {str(d.doc_id): (d.doc_metadata or {}) for d in candidates}
+    candidate_ids = [str(d.doc_id) for d in candidates]
+    differing = _find_differing_metadata_fields(candidate_ids, metadata_by_doc, titles)
+
+    cand_payload: list[dict] = []
+    for d in candidates:
+        did = str(d.doc_id)
+        # Project the per-candidate value at each differing path.
+        per_cand: dict = {}
+        for path in differing:
+            ns, key = path.split(".", 1)
+            value = metadata_by_doc[did].get(ns, {}).get(key)
+            if value is not None:
+                per_cand[path] = value
+        cand_payload.append(
+            {
+                "doc_id": did,
+                "title": d.title,
+                "canonical_filename": d.canonical_filename,
+                "discriminating_fields": per_cand,
+            }
+        )
+
+    overflow = len(candidates) >= _VERIFY_CANDIDATE_CAP
+
+    if overflow:
+        suggestion = (
+            "More than 100 candidates matched — refine the identifier with a more "
+            "specific substring, or use kb_search(metadata_filter=...) to narrow."
+        )
+    elif differing:
+        field_list = ", ".join(differing.keys())
+        suggestion = (
+            f"{len(candidates)} candidates differ on {field_list} — "
+            f"pick the one matching your intent."
+        )
+    else:
+        suggestion = (
+            "Multiple candidates have identical discriminating metadata — "
+            "try kb_get_document on each to inspect body."
+        )
+
+    payload: dict = {
+        "status": "ambiguous",
+        "count": len(candidates),
+        "candidates": cand_payload,
+        "suggestion": suggestion,
+    }
+    if overflow:
+        payload["overflow"] = True
+    return payload
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v -k verify_identifier`
+Expected: 7 PASS (and Task 2's 12 still PASS — run the whole file)
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v`
+Expected: 19 PASS
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+Expected: "All checks passed!"
+
+Run: `uv run ruff format src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py
+git commit -m "feat(mcp-lookup): verify_identifier response shape + discriminating_fields"
+```
+
+---
+
+## Task 4: `documents_by_date` SQL query layer
+
+**Goal:** Add a private `_query_documents_by_date()` helper that builds the SQL query for the date-bounded lookup. Handles the date `COALESCE` across (tika.created_at, frontmatter.date, sidecar.date, ingest), optional FTS query, optional metadata_filter, optional after/before bounds, direction, and limit. Returns rows of `(Document, effective_date, date_source)`. Public `documents_by_date()` follows in Task 5.
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_lookup_tools.py`
+- Modify: `tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 1: Write the failing tests** (append to existing file)
+
+```python
+# Append to tests/test_mcp_lookup_tools.py
+
+from datetime import datetime, timezone
+
+from harbor_clerk.mcp_lookup_tools import _query_documents_by_date
+from harbor_clerk.models import Chunk
+
+
+async def _seed_doc_with_chunk(
+    db_session, *, title: str, metadata: dict | None = None, text: str = "body text"
+) -> Document:
+    """Like _seed_doc but also adds a chunk so FTS queries can match."""
+    doc = await _seed_doc(db_session, title=title, metadata=metadata or {})
+    db_session.add(
+        Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text=text, language="english")
+    )
+    await db_session.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# _query_documents_by_date tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_earliest_orders_by_tika_date_ascending(db_session):
+    older = await _seed_doc_with_chunk(
+        db_session,
+        title="Older email",
+        metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}},
+    )
+    newer = await _seed_doc_with_chunk(
+        db_session,
+        title="Newer email",
+        metadata={"tika": {"created_at": "2001-08-14T08:34:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=10)
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    # Older first when direction=earliest. Other test fixtures may add docs
+    # too (autouse cleanup), so only assert the relative order of these two.
+    assert doc_ids.index(str(older.doc_id)) < doc_ids.index(str(newer.doc_id))
+
+
+@pytest.mark.asyncio
+async def test_latest_orders_by_date_descending(db_session):
+    older = await _seed_doc_with_chunk(
+        db_session,
+        title="Older",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    newer = await _seed_doc_with_chunk(
+        db_session,
+        title="Newer",
+        metadata={"tika": {"created_at": "2024-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="latest", limit=10)
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    assert doc_ids.index(str(newer.doc_id)) < doc_ids.index(str(older.doc_id))
+
+
+@pytest.mark.asyncio
+async def test_query_filters_to_fts_matching_docs(db_session):
+    cali = await _seed_doc_with_chunk(
+        db_session,
+        title="California email",
+        metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}},
+        text="discussion about California regulators",
+    )
+    await _seed_doc_with_chunk(
+        db_session,
+        title="Unrelated",
+        metadata={"tika": {"created_at": "1999-10-14T00:00:00Z"}},
+        text="discussion about something else entirely",
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session, direction="earliest", query="California", limit=10
+    )
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(cali.doc_id) in doc_ids
+    assert len(doc_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_metadata_filter_applied(db_session):
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Pinnacle contract",
+        metadata={
+            "tika": {"created_at": "2024-01-01T00:00:00Z"},
+            "sidecar": {"vendor": "Pinnacle Tech Solutions"},
+        },
+    )
+    await _seed_doc_with_chunk(
+        db_session,
+        title="Other contract",
+        metadata={
+            "tika": {"created_at": "2024-01-01T00:00:00Z"},
+            "sidecar": {"vendor": "Other Vendor"},
+        },
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session,
+        direction="earliest",
+        metadata_filter={"sidecar.vendor": "Pinnacle Tech Solutions"},
+        limit=10,
+    )
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    assert doc_ids == [str(target.doc_id)]
+
+
+@pytest.mark.asyncio
+async def test_after_filter_bounds_results(db_session):
+    early = await _seed_doc_with_chunk(
+        db_session,
+        title="Early",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    late = await _seed_doc_with_chunk(
+        db_session,
+        title="Late",
+        metadata={"tika": {"created_at": "2025-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session, direction="earliest", after="2024-01-01", limit=10
+    )
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(late.doc_id) in doc_ids
+    assert str(early.doc_id) not in doc_ids
+
+
+@pytest.mark.asyncio
+async def test_before_filter_bounds_results(db_session):
+    early = await _seed_doc_with_chunk(
+        db_session,
+        title="Early",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    late = await _seed_doc_with_chunk(
+        db_session,
+        title="Late",
+        metadata={"tika": {"created_at": "2025-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session, direction="latest", before="2024-01-01", limit=10
+    )
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(early.doc_id) in doc_ids
+    assert str(late.doc_id) not in doc_ids
+
+
+@pytest.mark.asyncio
+async def test_date_source_label_reflects_priority_chain(db_session):
+    tika_doc = await _seed_doc_with_chunk(
+        db_session,
+        title="Tika source",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    fm_doc = await _seed_doc_with_chunk(
+        db_session,
+        title="FM source",
+        metadata={"frontmatter": {"date": "2020-02-01"}},
+    )
+    sc_doc = await _seed_doc_with_chunk(
+        db_session,
+        title="Sidecar source",
+        metadata={"sidecar": {"date": "2020-03-01"}},
+    )
+    ingest_only = await _seed_doc_with_chunk(db_session, title="Ingest only")
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=20)
+    source_by_id = {str(d.doc_id): src for d, _, src in rows}
+    assert source_by_id[str(tika_doc.doc_id)] == "tika.created_at"
+    assert source_by_id[str(fm_doc.doc_id)] == "frontmatter.date"
+    assert source_by_id[str(sc_doc.doc_id)] == "sidecar.date"
+    assert source_by_id[str(ingest_only.doc_id)] == "ingest"
+
+
+@pytest.mark.asyncio
+async def test_explicit_date_field_skips_fallback(db_session):
+    """date_field='sidecar.date' means docs without sidecar.date are sorted by NULL
+    (PG sorts NULLs LAST asc / FIRST desc), not by Tika even if Tika exists."""
+    sc_only = await _seed_doc_with_chunk(
+        db_session,
+        title="Sidecar only",
+        metadata={"sidecar": {"date": "2020-01-01"}},
+    )
+    tika_only = await _seed_doc_with_chunk(
+        db_session,
+        title="Tika only",
+        metadata={"tika": {"created_at": "2010-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session, direction="earliest", date_field="sidecar.date", limit=10
+    )
+    # sc_only is the first non-NULL date when sorting by sidecar.date asc;
+    # tika_only is NULL on that field.
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    sc_idx = doc_ids.index(str(sc_only.doc_id))
+    tika_idx = doc_ids.index(str(tika_only.doc_id))
+    assert sc_idx < tika_idx
+    # date_source label should reflect the explicit choice for the matching doc.
+    source_by_id = {str(d.doc_id): src for d, _, src in rows}
+    assert source_by_id[str(sc_only.doc_id)] == "sidecar.date"
+
+
+@pytest.mark.asyncio
+async def test_limit_respected(db_session):
+    for i in range(5):
+        await _seed_doc_with_chunk(
+            db_session,
+            title=f"Doc {i}",
+            metadata={"tika": {"created_at": f"2024-01-{i + 1:02d}T00:00:00Z"}},
+        )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=3)
+    assert len(rows) == 3
+
+
+@pytest.mark.asyncio
+async def test_excludes_inactive_documents(db_session):
+    doc = await _seed_doc_with_chunk(
+        db_session,
+        title="Will be deleted",
+        metadata={"tika": {"created_at": "2024-01-01T00:00:00Z"}},
+    )
+    doc.status = "deleted"
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=10)
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(doc.doc_id) not in doc_ids
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v -k "by_date"`
+Expected: 10 FAIL — `ImportError: cannot import name '_query_documents_by_date'`
+
+- [ ] **Step 3: Implement `_query_documents_by_date`** (append to module)
+
+```python
+# Append to src/harbor_clerk/mcp_lookup_tools.py
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from sqlalchemy import case, cast, func, literal, text
+from sqlalchemy import Text as SAText
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+
+from harbor_clerk.models import Chunk
+# Existing search.py validator — raises ValueError on bad keys; identical
+# normalisation the metadata_filter on kb_search uses.
+from harbor_clerk.search import _validate_metadata_filter
+
+
+# Map external date_field names to (JSONB-or-column expression, source label).
+# Used both for the COALESCE chain (default) and the single-field override.
+def _date_components():
+    """Return (expr, label) per priority slot — recomputed per query because
+    SQLAlchemy expressions are immutable per construction."""
+    tika_expr = cast(Document.doc_metadata["tika"]["created_at"].astext, TIMESTAMP(timezone=True))
+    fm_expr = cast(Document.doc_metadata["frontmatter"]["date"].astext, TIMESTAMP(timezone=True))
+    sc_expr = cast(Document.doc_metadata["sidecar"]["date"].astext, TIMESTAMP(timezone=True))
+    ingest_expr = Document.created_at
+    return [
+        ("tika.created_at", tika_expr),
+        ("frontmatter.date", fm_expr),
+        ("sidecar.date", sc_expr),
+        ("ingest", ingest_expr),
+    ]
+
+
+_ALLOWED_DATE_FIELDS = {"tika.created_at", "frontmatter.date", "sidecar.date", "ingest"}
+
+
+def _parse_iso_date(value: str) -> datetime:
+    """Parse an ISO 8601 date or datetime string into a UTC-aware datetime."""
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+async def _query_documents_by_date(
+    session: AsyncSession,
+    *,
+    direction: Literal["earliest", "latest"] = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> list[tuple[Document, datetime, str]]:
+    """Run the SQL query for documents_by_date and return rows.
+
+    Each row is (Document, effective_date, date_source_label). Caller is
+    responsible for shaping the response.
+
+    Raises ValueError on invalid `date_field`, unparseable `after`/`before`,
+    or invalid `metadata_filter` (via reuse of search.py validator).
+    """
+    components = _date_components()
+
+    # Build the effective-date expression + source-label CASE.
+    if date_field is not None:
+        if date_field not in _ALLOWED_DATE_FIELDS:
+            raise ValueError(
+                f"date_field must be one of: {sorted(_ALLOWED_DATE_FIELDS)}; got {date_field!r}"
+            )
+        expr = next(e for label, e in components if label == date_field)
+        source_label_expr = literal(date_field)
+    else:
+        # COALESCE in priority order; CASE picks the first non-null source.
+        expr = func.coalesce(*[e for _, e in components])
+        source_label_expr = case(
+            *[(components[i][1].isnot(None), literal(components[i][0])) for i in range(len(components))],
+            else_=literal("none"),
+        )
+
+    stmt = (
+        select(Document, expr.label("effective_date"), source_label_expr.label("date_source"))
+        .where(Document.status == "active")
+    )
+
+    # Optional FTS filter via chunks join.
+    if query:
+        fts_subq = (
+            select(Chunk.doc_id.distinct())
+            .where(
+                Chunk.fts_en.op("@@")(func.websearch_to_tsquery("english", query))
+                | Chunk.fts_fr.op("@@")(func.websearch_to_tsquery("french", query))
+            )
+            .scalar_subquery()
+        )
+        stmt = stmt.where(Document.doc_id.in_(fts_subq))
+
+    # Optional metadata_filter (reuse PR-F's validator + simple per-path eq).
+    if metadata_filter:
+        _validate_metadata_filter(metadata_filter)
+        for path, value in metadata_filter.items():
+            ns, key = path.split(".", 1)
+            if isinstance(value, str):
+                # JSONB ->> returns text; scalar string equality covers the
+                # synthetic-corpus disambiguation case (vendor names, etc.).
+                stmt = stmt.where(Document.doc_metadata[ns][key].astext == value)
+            else:
+                # Numeric / bool / list values — JSONB equality on the path.
+                stmt = stmt.where(
+                    Document.doc_metadata[ns][key]
+                    == cast(literal(value), Document.doc_metadata.type)
+                )
+
+    # Optional after / before bounds on the effective date.
+    if after:
+        stmt = stmt.where(expr >= _parse_iso_date(after))
+    if before:
+        stmt = stmt.where(expr <= _parse_iso_date(before))
+
+    # Sort.
+    if direction == "earliest":
+        stmt = stmt.order_by(expr.asc().nulls_last())
+    elif direction == "latest":
+        stmt = stmt.order_by(expr.desc().nulls_last())
+    else:
+        raise ValueError(f"direction must be 'earliest' or 'latest'; got {direction!r}")
+
+    stmt = stmt.limit(limit)
+
+    result = await session.execute(stmt)
+    return [(row.Document, row.effective_date, row.date_source) for row in result.all()]
+```
+
+> **Note for the engineer:** the `metadata_filter` block above intentionally uses the simpler scalar-equality path that matches every test in this plan. The full JSONB `@>` containment with list-valued fallback already exists in `src/harbor_clerk/search.py` (used by `kb_search`). Task 6 wires the MCP tool through; if integration tests reveal a gap, lift the helper from search.py at that point. YAGNI for now.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v -k "by_date"`
+Expected: 10 PASS
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v`
+Expected: 29 PASS (12 from Task 2 + 7 from Task 3 + 10 from Task 4)
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+Expected: "All checks passed!"
+
+Run: `uv run ruff format src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py
+git commit -m "feat(mcp-lookup): _query_documents_by_date SQL with COALESCE date expr"
+```
+
+---
+
+## Task 5: `documents_by_date()` public response shape
+
+**Goal:** Add the public `documents_by_date(session, ...) -> dict` that wraps Task 4's rows in the response shape: `{direction, count, results}` with per-result `{doc_id, title, canonical_filename, date, date_source}`. Handles input validation by catching `ValueError` from the helper and returning an error response.
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_lookup_tools.py`
+- Modify: `tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+# Append to tests/test_mcp_lookup_tools.py
+
+from harbor_clerk.mcp_lookup_tools import documents_by_date
+
+
+# ---------------------------------------------------------------------------
+# documents_by_date response-shape tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_response_shape(db_session):
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Pinnacle Doc",
+        metadata={"tika": {"created_at": "2024-06-15T12:00:00Z"}},
+    )
+    await db_session.flush()
+
+    result = await documents_by_date(db_session, direction="earliest", limit=10)
+    assert result["direction"] == "earliest"
+    assert isinstance(result["count"], int)
+    assert any(r["doc_id"] == str(target.doc_id) for r in result["results"])
+    row = next(r for r in result["results"] if r["doc_id"] == str(target.doc_id))
+    assert row["title"] == "Pinnacle Doc"
+    assert row["date"] == "2024-06-15T12:00:00+00:00"
+    assert row["date_source"] == "tika.created_at"
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_count_matches_results_length(db_session):
+    for i in range(3):
+        await _seed_doc_with_chunk(
+            db_session,
+            title=f"Doc {i}",
+            metadata={"tika": {"created_at": f"2024-01-{i + 1:02d}T00:00:00Z"}},
+        )
+    await db_session.flush()
+
+    result = await documents_by_date(db_session, direction="earliest", limit=2)
+    assert result["count"] == 2
+    assert len(result["results"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_empty_results(db_session):
+    """No active docs at all — return {count: 0, results: []}, never an error."""
+    result = await documents_by_date(db_session, direction="earliest", limit=10)
+    assert result["direction"] == "earliest"
+    # We can't assert count == 0 because other tests may seed docs in the
+    # same DB session; instead assert the shape is non-error.
+    assert "error" not in result
+    assert "results" in result
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_direction_returns_error(db_session):
+    result = await documents_by_date(db_session, direction="sideways", limit=10)
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_date_field_returns_error(db_session):
+    result = await documents_by_date(
+        db_session, direction="earliest", date_field="bogus.field", limit=10
+    )
+    assert "error" in result
+    assert "tika.created_at" in result["error"]  # accepted values listed
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_after_returns_error(db_session):
+    result = await documents_by_date(
+        db_session, direction="earliest", after="not-a-date", limit=10
+    )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_metadata_filter_returns_error(db_session):
+    result = await documents_by_date(
+        db_session,
+        direction="earliest",
+        metadata_filter={"too.many.dots": "x"},
+        limit=10,
+    )
+    assert "error" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v -k "documents_by_date_"`
+Expected: 7 FAIL — `ImportError: cannot import name 'documents_by_date'`
+
+- [ ] **Step 3: Implement `documents_by_date`** (append to module)
+
+```python
+# Append to src/harbor_clerk/mcp_lookup_tools.py
+
+async def documents_by_date(
+    session: AsyncSession,
+    *,
+    direction: str = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> dict:
+    """Return documents sorted by their effective date.
+
+    Response shape:
+      {"direction": <input>, "count": N, "results": [
+         {"doc_id": "...", "title": "...", "canonical_filename": "...",
+          "date": "ISO-8601", "date_source": "tika.created_at" | ...},
+         ...
+      ]}
+
+    Returns {"error": "..."} on invalid direction, date_field, after/before
+    string, or metadata_filter.
+    """
+    try:
+        rows = await _query_documents_by_date(
+            session,
+            direction=direction,
+            query=query,
+            metadata_filter=metadata_filter,
+            after=after,
+            before=before,
+            date_field=date_field,
+            limit=limit,
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    results: list[dict] = []
+    for doc, eff_date, src in rows:
+        results.append(
+            {
+                "doc_id": str(doc.doc_id),
+                "title": doc.title,
+                "canonical_filename": doc.canonical_filename,
+                "date": eff_date.isoformat() if eff_date else None,
+                "date_source": src,
+            }
+        )
+
+    return {"direction": direction, "count": len(results), "results": results}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_lookup_tools.py -v`
+Expected: 36 PASS (29 from Tasks 2–4 + 7 from this task)
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+
+Run: `uv run ruff format src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_lookup_tools.py tests/test_mcp_lookup_tools.py
+git commit -m "feat(mcp-lookup): documents_by_date public response shape"
+```
+
+---
+
+## Task 6: MCP wiring — register `kb_verify_identifier` + `kb_documents_by_date`
+
+**Goal:** Register the two backend functions as MCP tools in `mcp_server.py` with PR-D-style 4-part docstrings (what / when / output / decline) and add pin tests in `test_mcp_tool_descriptions.py`. Each tool opens a session via the existing `async_session_factory` pattern and serializes the result to JSON.
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Modify: `tests/test_mcp_tool_descriptions.py`
+
+- [ ] **Step 1: Write the failing description pin tests**
+
+Append to `tests/test_mcp_tool_descriptions.py`:
+
+```python
+# Append to tests/test_mcp_tool_descriptions.py
+
+from harbor_clerk.mcp_server import kb_documents_by_date, kb_verify_identifier
+
+
+def test_kb_verify_identifier_docstring_has_four_parts():
+    doc = kb_verify_identifier.__doc__ or ""
+    # Same 4-part convention as PR-D: section headers with trailing colon.
+    assert "What you get back" in doc or "What it returns" in doc
+    assert "When to" in doc
+    assert "How to decline" in doc or "Decline" in doc
+
+
+def test_kb_verify_identifier_mentions_key_affordances():
+    doc = (kb_verify_identifier.__doc__ or "").lower()
+    assert "verify" in doc
+    assert "before" in doc  # "use before quoting" / "before you cite"
+    assert "ambiguous" in doc or "ambiguity" in doc
+    assert "not_found" in doc
+
+
+def test_kb_documents_by_date_docstring_has_four_parts():
+    doc = kb_documents_by_date.__doc__ or ""
+    assert "What you get back" in doc or "What it returns" in doc
+    assert "When to" in doc
+    assert "How to decline" in doc or "Decline" in doc
+
+
+def test_kb_documents_by_date_mentions_key_affordances():
+    doc = (kb_documents_by_date.__doc__ or "").lower()
+    assert "earliest" in doc
+    assert "latest" in doc
+    assert "date_source" in doc
+```
+
+Also append to `tests/test_mcp_lookup_tools.py` an integration test that exercises the MCP layer end-to-end (matches PR-F's `test_mcp_metadata_filter.py` pattern):
+
+```python
+# Append to tests/test_mcp_lookup_tools.py
+
+import json
+from contextlib import asynccontextmanager, contextmanager
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.mcp_server import (
+    _mcp_principal,
+    kb_documents_by_date,
+    kb_verify_identifier,
+)
+
+
+@contextmanager
+def _principal_in_context(user):
+    token = _mcp_principal.set(Principal(type="user", id=user.user_id, role="admin"))
+    try:
+        yield
+    finally:
+        _mcp_principal.reset(token)
+
+
+@pytest.fixture
+async def mock_session_factory(db_session, _engine, monkeypatch):
+    conn = await db_session.connection()
+
+    @asynccontextmanager
+    async def _factory():
+        session = AsyncSession(bind=conn, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.async_session_factory", _factory)
+
+
+@pytest.mark.asyncio
+async def test_kb_verify_identifier_unique_end_to_end(
+    client, admin_user, db_session, mock_session_factory
+):
+    target = await _seed_doc(db_session, title="Singular Pinnacle Doc")
+    await db_session.flush()
+
+    with _principal_in_context(admin_user):
+        raw = await kb_verify_identifier(identifier="Singular Pinnacle Doc")
+    parsed = json.loads(raw)
+    assert parsed["status"] == "unique"
+    assert parsed["match"]["doc_id"] == str(target.doc_id)
+
+
+@pytest.mark.asyncio
+async def test_kb_documents_by_date_end_to_end(
+    client, admin_user, db_session, mock_session_factory
+):
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Earliest doc",
+        metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}},
+        text="discussion of California regulators",
+    )
+    await db_session.flush()
+
+    with _principal_in_context(admin_user):
+        raw = await kb_documents_by_date(direction="earliest", query="California", limit=5)
+    parsed = json.loads(raw)
+    assert parsed["direction"] == "earliest"
+    assert any(r["doc_id"] == str(target.doc_id) for r in parsed["results"])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_tool_descriptions.py tests/test_mcp_lookup_tools.py -v -k "kb_verify or kb_documents"`
+Expected: All FAIL — `ImportError: cannot import name 'kb_verify_identifier' from 'harbor_clerk.mcp_server'`
+
+- [ ] **Step 3: Add the two MCP tools to `mcp_server.py`**
+
+Append (just before the existing `kb_system_health` definition; placement is cosmetic but groups them with other admin-style tools):
+
+```python
+# In src/harbor_clerk/mcp_server.py — add two new @mcp.tool functions.
+
+import json as _json
+
+from harbor_clerk.mcp_lookup_tools import (
+    documents_by_date as _documents_by_date_impl,
+)
+from harbor_clerk.mcp_lookup_tools import (
+    verify_identifier as _verify_identifier_impl,
+)
+
+
+@mcp.tool
+async def kb_verify_identifier(identifier: str) -> str:
+    """Verify a document identifier resolves to exactly one document.
+
+    Use this BEFORE quoting a specific document — checks the identifier
+    against title, filename, and identifier-like metadata fields. Sharp
+    affordance for fabrication-prevention.
+
+    When to call:
+      - Before claiming "the X contract says…" — verify X is a real, unique
+        identifier first
+      - When kb_search returns hits whose titles all share a substring you
+        used as an identifier — verify whether you're looking at one doc or
+        N variants
+      - When the user asks about a specific named document
+
+    What you get back:
+      - status="not_found": no document matches — say so plainly; do NOT
+        fall back to "closest match"
+      - status="unique": one match — its doc_id, title, canonical_filename
+      - status="ambiguous": multiple matches — each candidate carries
+        discriminating_fields (the metadata that distinguishes them) and
+        a suggestion for how to pick one
+
+    When the response is ambiguous, the discriminating_fields per candidate
+    tell you what differs — pick the one matching the user's intent, or ask
+    a clarifying question. With overflow=true (more than 100 candidates),
+    refine the identifier with a more specific substring.
+
+    How to decline:
+      - status="not_found" means the identifier is NOT in the corpus. Do
+        NOT search by similarity as a substitute — tell the user the
+        identifier doesn't exist.
+      - status="ambiguous" with no discriminating_fields means the
+        candidates are indistinguishable by metadata; inspect with
+        kb_get_document if you must.
+    """
+    async with async_session_factory() as session:
+        result = await _verify_identifier_impl(session, identifier)
+    return _json.dumps(result, default=str)
+
+
+@mcp.tool
+async def kb_documents_by_date(
+    direction: str = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> str:
+    """Return documents sorted by their effective date.
+
+    Use this when the user asks for the earliest / latest / first / last
+    document matching some criteria — similarity-ranked search (kb_search)
+    will not surface boundary docs reliably.
+
+    When to call:
+      - "What's the earliest email about X" / "Find the oldest invoice"
+      - "What's the latest version of Y" / "Most recent contract with Z"
+      - "Show me everything before/after a specific date"
+      - When you need chronological ordering, not similarity ordering
+
+    What you get back:
+      - direction: echoes the input ("earliest" or "latest")
+      - count: number of results returned
+      - results[]: each carries doc_id, title, canonical_filename, date
+        (ISO 8601 UTC), and date_source — which field the date came from:
+          "tika.created_at"  → Tika-extracted email-send / file date
+          "frontmatter.date" → markdown frontmatter
+          "sidecar.date"     → JSON sidecar
+          "ingest"           → fallback to documents.created_at when no
+                               metadata date is available
+
+    Parameters:
+      direction (default "earliest"): "earliest" | "latest"
+      query: optional FTS-only filter (no vector). Returns docs whose chunks
+        match the query, sorted by date.
+      metadata_filter: dict of {"namespace.key": value} pairs — same shape
+        as kb_search's metadata_filter, applied as JSONB containment.
+      after, before: ISO 8601 date or datetime strings; bound the
+        effective-date range.
+      date_field: explicit override for the effective-date source. Accepted
+        values: "tika.created_at", "frontmatter.date", "sidecar.date",
+        "ingest". When set, no fallback is consulted (docs missing that
+        field sort to the end as NULLs).
+      limit (default 10): max results.
+
+    How to decline:
+      - If results is empty, no docs match the date bounds / query / filter
+        — say so plainly. Do NOT broaden the bounds and re-run unless the
+        user asks.
+      - If the user asks for "the earliest" and the top result's
+        date_source is "ingest", note that no metadata date was available
+        — the result is sorted by ingest time, not by document content date.
+    """
+    async with async_session_factory() as session:
+        result = await _documents_by_date_impl(
+            session,
+            direction=direction,
+            query=query,
+            metadata_filter=metadata_filter,
+            after=after,
+            before=before,
+            date_field=date_field,
+            limit=limit,
+        )
+    return _json.dumps(result, default=str)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_tool_descriptions.py tests/test_mcp_lookup_tools.py -v`
+Expected: All new tests PASS
+
+Run: `uv run pytest tests/ -v -x --ignore=tests/test_macos_smoke.py`
+Expected: Full suite PASS (no regressions)
+
+- [ ] **Step 5: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/mcp_server.py tests/test_mcp_tool_descriptions.py tests/test_mcp_lookup_tools.py`
+Expected: "All checks passed!"
+
+Run: `uv run ruff format src/harbor_clerk/mcp_server.py tests/test_mcp_tool_descriptions.py tests/test_mcp_lookup_tools.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_server.py tests/test_mcp_tool_descriptions.py tests/test_mcp_lookup_tools.py
+git commit -m "feat(mcp): register kb_verify_identifier + kb_documents_by_date"
+```
+
+---
+
+## Task 7: CLI `harbor-clerk verify-identifier`
+
+**Goal:** Add the `verify-identifier` CLI subcommand following PR #397's pattern: one file per command in `cli/commands/`, one help text in `cli/help/`, one test module in `tests/cli/`, and a text renderer registered in `cli/output.py`.
+
+**Files:**
+- Create: `src/harbor_clerk/cli/commands/verify_identifier.py`
+- Create: `src/harbor_clerk/cli/help/verify-identifier.txt`
+- Modify: `src/harbor_clerk/cli/output.py` (register text renderer)
+- Create: `tests/cli/test_commands_verify_identifier.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/cli/test_commands_verify_identifier.py
+"""CLI tests for harbor-clerk verify-identifier.
+
+Mocks McpHttpClient + resolve_config the same way test_commands_search.py does.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from harbor_clerk.cli import main as cli_main
+
+
+def _run(args, mock_response):
+    with (
+        patch("harbor_clerk.cli.commands.verify_identifier.McpHttpClient") as MockClient,
+        patch("harbor_clerk.cli.commands.verify_identifier.resolve_config") as MockResolve,
+    ):
+        instance = MagicMock()
+        instance.call_tool.return_value = mock_response
+        instance.__enter__.return_value = instance
+        instance.__exit__.return_value = False
+        MockClient.return_value = instance
+        MockResolve.return_value = MagicMock(url="https://test", api_key="hc_t", insecure=False)
+        rc = cli_main.main(args)
+        return rc, instance
+
+
+def test_verify_identifier_requires_positional(capsys):
+    """Calling without an identifier should fail argparse."""
+    # argparse exits via parser.error → exit code 1 in this CLI.
+    rc, _client = _run(
+        ["verify-identifier"], {"status": "not_found", "identifier": ""}
+    )
+    assert rc == 1
+
+
+def test_verify_identifier_calls_tool_with_identifier(capsys):
+    rc, client = _run(
+        ["verify-identifier", "Pinnacle Vendor Contract", "--json"],
+        {"status": "not_found", "identifier": "Pinnacle Vendor Contract"},
+    )
+    assert rc == 0
+    client.call_tool.assert_called_once_with(
+        "kb_verify_identifier", {"identifier": "Pinnacle Vendor Contract"}
+    )
+
+
+def test_verify_identifier_json_mode_passes_payload_through(capsys):
+    payload = {
+        "status": "unique",
+        "match": {
+            "doc_id": "abc-123",
+            "title": "Pinnacle",
+            "canonical_filename": "pin.pdf",
+            "discriminating_fields": {},
+        },
+    }
+    rc, _client = _run(["verify-identifier", "Pinnacle", "--json"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert json.loads(out) == payload
+
+
+def test_verify_identifier_text_mode_renders_unique(capsys):
+    payload = {
+        "status": "unique",
+        "match": {
+            "doc_id": "abc-123",
+            "title": "Pinnacle Vendor Contract",
+            "canonical_filename": "pin.pdf",
+            "discriminating_fields": {},
+        },
+    }
+    rc, _client = _run(["verify-identifier", "Pinnacle", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unique" in out.lower()
+    assert "Pinnacle Vendor Contract" in out
+    assert "abc-123" in out
+
+
+def test_verify_identifier_text_mode_renders_ambiguous(capsys):
+    payload = {
+        "status": "ambiguous",
+        "count": 2,
+        "candidates": [
+            {
+                "doc_id": "id-1",
+                "title": "Pinnacle A",
+                "canonical_filename": "a.pdf",
+                "discriminating_fields": {"sidecar.vendor": "Tech Solutions"},
+            },
+            {
+                "doc_id": "id-2",
+                "title": "Pinnacle B",
+                "canonical_filename": "b.pdf",
+                "discriminating_fields": {"sidecar.vendor": "Industries"},
+            },
+        ],
+        "suggestion": "2 candidates differ on sidecar.vendor.",
+    }
+    rc, _client = _run(["verify-identifier", "Pinnacle", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ambiguous" in out.lower()
+    assert "Pinnacle A" in out
+    assert "Pinnacle B" in out
+    assert "Tech Solutions" in out
+    assert "Industries" in out
+
+
+def test_verify_identifier_text_mode_renders_not_found(capsys):
+    payload = {"status": "not_found", "identifier": "nope"}
+    rc, _client = _run(["verify-identifier", "nope", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "not_found" in out.lower() or "not found" in out.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/cli/test_commands_verify_identifier.py -v`
+Expected: All FAIL — command not registered.
+
+> Note: argparse will reject the unknown `verify-identifier` subcommand at the parser level. Tests will fail because either (a) the subparser doesn't exist (registration not yet done in Task 9), or (b) the module doesn't exist. Both are real failures driving Task 7 + Task 9 together.
+
+For Task 7's tests to actually run, we need the module to exist AND the command to be registered. We'll register it in Task 9, but the module must exist now. Patching `verify_identifier.McpHttpClient` requires the module to be importable.
+
+- [ ] **Step 3: Implement the CLI command module**
+
+```python
+# src/harbor_clerk/cli/commands/verify_identifier.py
+"""harbor-clerk verify-identifier — verify an identifier resolves to one doc."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from harbor_clerk.cli.client import McpHttpClient
+from harbor_clerk.cli.commands import _common_parser
+from harbor_clerk.cli.config import resolve_config
+from harbor_clerk.cli.help import load
+from harbor_clerk.cli.output import render, resolve_mode
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    description = load("verify-identifier") or "Verify a document identifier."
+    p = subparsers.add_parser(
+        "verify-identifier",
+        help="Verify an identifier resolves to exactly one document",
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common_parser()],
+    )
+    p.add_argument(
+        "identifier",
+        help="The identifier string to check against title, filename, and identifier-like metadata fields",
+    )
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    arguments = {"identifier": args.identifier}
+    cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
+    mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())
+    with McpHttpClient(cfg) as client:
+        payload = client.call_tool("kb_verify_identifier", arguments)
+    render(payload, mode=mode, command="verify-identifier")
+    return 0
+```
+
+- [ ] **Step 4: Add the text renderer to `output.py`**
+
+Append to `src/harbor_clerk/cli/output.py`:
+
+```python
+# Append to src/harbor_clerk/cli/output.py
+
+@register_text_renderer("verify-identifier")
+def _render_verify_identifier(payload, stream):
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+
+    status = payload.get("status")
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+
+    if status == "not_found":
+        stream.write(f"not_found: {payload.get('identifier', '')}\n")
+        return
+
+    if status == "unique":
+        m = payload.get("match", {})
+        stream.write(f"unique: {m.get('title', '')}  [{m.get('doc_id', '')}]\n")
+        if m.get("canonical_filename"):
+            stream.write(f"  filename: {m['canonical_filename']}\n")
+        return
+
+    if status == "ambiguous":
+        count = payload.get("count", 0)
+        overflow = " (overflow)" if payload.get("overflow") else ""
+        stream.write(f"ambiguous: {count} candidates{overflow}\n")
+        for c in payload.get("candidates", []):
+            stream.write(f"  - {c.get('title', '')}  [{c.get('doc_id', '')}]\n")
+            for path, value in (c.get("discriminating_fields") or {}).items():
+                stream.write(f"      {path}={value!r}\n")
+        suggestion = payload.get("suggestion")
+        if suggestion:
+            stream.write(f"\n{suggestion}\n")
+        return
+
+    # Unknown status — fall back to JSON-ish
+    import json as _json
+    stream.write(_json.dumps(payload, indent=2, default=str) + "\n")
+```
+
+- [ ] **Step 5: Create the help text file**
+
+```text
+# src/harbor_clerk/cli/help/verify-identifier.txt
+harbor-clerk verify-identifier — verify an identifier resolves to one document
+
+DESCRIPTION
+  Checks whether a given identifier string maps to exactly one document in
+  the corpus. Use BEFORE quoting a specific named document — sharp
+  affordance for fabrication-prevention.
+
+  Matches against:
+    - document title (case-insensitive CONTAINS)
+    - canonical filename (case-insensitive CONTAINS)
+    - metadata.tika.title (case-insensitive EQUALS)
+    - identifier-like metadata keys (id, contract_id, policy_id, case_id,
+      order_id, invoice_id, message_id, *_id) under metadata.sidecar.** or
+      metadata.frontmatter.** (case-insensitive EQUALS)
+
+  Status outcomes:
+    not_found  → no document matches; do NOT fall back to similarity
+    unique     → exactly one match
+    ambiguous  → multiple matches; each candidate carries
+                 discriminating_fields showing what distinguishes it
+
+USAGE
+  harbor-clerk verify-identifier <identifier> [options]
+
+OPTIONS
+  (Inherits global flags: --url, --api-key, --insecure, --json, --format.)
+
+RETURNS (JSON)
+  // not_found
+  { "status": "not_found", "identifier": "<input>" }
+
+  // unique
+  { "status": "unique",
+    "match": { "doc_id": "...", "title": "...",
+               "canonical_filename": "...",
+               "discriminating_fields": {} } }
+
+  // ambiguous (count > 1)
+  { "status": "ambiguous",
+    "count": 3,
+    "candidates": [
+      { "doc_id": "...", "title": "...",
+        "canonical_filename": "...",
+        "discriminating_fields": { "sidecar.vendor": "Acme",
+                                   "sidecar.term_months": 24 } }
+    ],
+    "suggestion": "3 candidates differ on sidecar.vendor — pick one." }
+
+  // ambiguous with overflow (> 100 matches)
+  { "status": "ambiguous", "count": 100, "overflow": true,
+    "candidates": [ /* 100 entries */ ],
+    "suggestion": "More than 100 candidates matched — refine ..." }
+
+EXAMPLES
+  # Sharp existence check before quoting
+  harbor-clerk verify-identifier "Pinnacle Vendor Contract"
+
+  # JSON output for scripting
+  harbor-clerk verify-identifier "K-2025-031" --json
+
+  # Disambiguate before answering
+  harbor-clerk verify-identifier "Senior Project Coordinator onboarding letter"
+```
+
+- [ ] **Step 6: Register the command** (also covered in Task 9, but the test depends on it)
+
+Add to `src/harbor_clerk/cli/commands/__init__.py` `_COMMAND_NAMES`:
+
+```python
+_COMMAND_NAMES = [
+    "search",
+    "batch-search",
+    "read-passages",
+    "expand-context",
+    "read-document",
+    "get-document",
+    "list-recent",
+    "corpus-overview",
+    "document-outline",
+    "find-related",
+    "entity-search",
+    "entity-overview",
+    "entity-cooccurrence",
+    "ingest-status",
+    "reprocess",
+    "system-health",
+    "verify-identifier",          # <-- add
+    # documents-by-date added in Task 8
+]
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/cli/test_commands_verify_identifier.py -v`
+Expected: 6 PASS
+
+- [ ] **Step 8: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/cli/commands/verify_identifier.py src/harbor_clerk/cli/output.py src/harbor_clerk/cli/commands/__init__.py tests/cli/test_commands_verify_identifier.py`
+Expected: "All checks passed!"
+
+Run: `uv run ruff format src/harbor_clerk/cli/commands/verify_identifier.py src/harbor_clerk/cli/output.py src/harbor_clerk/cli/commands/__init__.py tests/cli/test_commands_verify_identifier.py`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/harbor_clerk/cli/commands/verify_identifier.py \
+        src/harbor_clerk/cli/commands/__init__.py \
+        src/harbor_clerk/cli/help/verify-identifier.txt \
+        src/harbor_clerk/cli/output.py \
+        tests/cli/test_commands_verify_identifier.py
+git commit -m "feat(cli): harbor-clerk verify-identifier subcommand"
+```
+
+---
+
+## Task 8: CLI `harbor-clerk documents-by-date`
+
+**Goal:** Same pattern as Task 7 for `documents-by-date`. Adds the command module with rich argparse options (direction, query, metadata-filter as JSON, after, before, date-field, limit), help text, text renderer, and tests.
+
+**Files:**
+- Create: `src/harbor_clerk/cli/commands/documents_by_date.py`
+- Create: `src/harbor_clerk/cli/help/documents-by-date.txt`
+- Modify: `src/harbor_clerk/cli/output.py` (register renderer)
+- Modify: `src/harbor_clerk/cli/commands/__init__.py` (register command)
+- Create: `tests/cli/test_commands_documents_by_date.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/cli/test_commands_documents_by_date.py
+"""CLI tests for harbor-clerk documents-by-date."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from harbor_clerk.cli import main as cli_main
+
+
+def _run(args, mock_response):
+    with (
+        patch("harbor_clerk.cli.commands.documents_by_date.McpHttpClient") as MockClient,
+        patch("harbor_clerk.cli.commands.documents_by_date.resolve_config") as MockResolve,
+    ):
+        instance = MagicMock()
+        instance.call_tool.return_value = mock_response
+        instance.__enter__.return_value = instance
+        instance.__exit__.return_value = False
+        MockClient.return_value = instance
+        MockResolve.return_value = MagicMock(url="https://test", api_key="hc_t", insecure=False)
+        rc = cli_main.main(args)
+        return rc, instance
+
+
+_EMPTY = {"direction": "earliest", "count": 0, "results": []}
+
+
+def test_default_direction_is_earliest(capsys):
+    rc, client = _run(["documents-by-date", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["direction"] == "earliest"
+
+
+def test_direction_latest_flag(capsys):
+    rc, client = _run(["documents-by-date", "--direction", "latest", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["direction"] == "latest"
+
+
+def test_query_flag_forwards(capsys):
+    rc, client = _run(
+        ["documents-by-date", "--query", "California", "--json"], _EMPTY
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["query"] == "California"
+
+
+def test_after_and_before_flags_forward(capsys):
+    rc, client = _run(
+        [
+            "documents-by-date",
+            "--after",
+            "2024-01-01",
+            "--before",
+            "2024-12-31",
+            "--json",
+        ],
+        _EMPTY,
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["after"] == "2024-01-01"
+    assert args["before"] == "2024-12-31"
+
+
+def test_date_field_flag_forwards(capsys):
+    rc, client = _run(
+        ["documents-by-date", "--date-field", "sidecar.date", "--json"], _EMPTY
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["date_field"] == "sidecar.date"
+
+
+def test_metadata_filter_parses_json(capsys):
+    rc, client = _run(
+        [
+            "documents-by-date",
+            "--metadata-filter",
+            '{"sidecar.vendor": "Pinnacle Tech Solutions"}',
+            "--json",
+        ],
+        _EMPTY,
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["metadata_filter"] == {"sidecar.vendor": "Pinnacle Tech Solutions"}
+
+
+def test_metadata_filter_invalid_json_returns_usage_error(capsys):
+    rc, _client = _run(
+        ["documents-by-date", "--metadata-filter", "not-json", "--json"], _EMPTY
+    )
+    assert rc == 1
+
+
+def test_limit_flag_forwards(capsys):
+    rc, client = _run(["documents-by-date", "--limit", "25", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["limit"] == 25
+
+
+def test_optional_flags_absent_when_not_provided(capsys):
+    rc, client = _run(["documents-by-date", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    # Only direction + limit should be present in the minimal call.
+    assert "query" not in args
+    assert "after" not in args
+    assert "before" not in args
+    assert "date_field" not in args
+    assert "metadata_filter" not in args
+
+
+def test_text_mode_renders_results(capsys):
+    payload = {
+        "direction": "earliest",
+        "count": 2,
+        "results": [
+            {
+                "doc_id": "id-1",
+                "title": "Earliest doc",
+                "canonical_filename": "a.eml",
+                "date": "1999-10-13T08:34:00+00:00",
+                "date_source": "tika.created_at",
+            },
+            {
+                "doc_id": "id-2",
+                "title": "Second doc",
+                "canonical_filename": "b.eml",
+                "date": "1999-10-14T00:00:00+00:00",
+                "date_source": "tika.created_at",
+            },
+        ],
+    }
+    rc, _client = _run(
+        ["documents-by-date", "--format", "text"], payload
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Earliest doc" in out
+    assert "1999-10-13" in out
+    assert "tika.created_at" in out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/cli/test_commands_documents_by_date.py -v`
+Expected: All FAIL — module doesn't exist + command not registered.
+
+- [ ] **Step 3: Implement the CLI command module**
+
+```python
+# src/harbor_clerk/cli/commands/documents_by_date.py
+"""harbor-clerk documents-by-date — date-sorted document lookup."""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+
+from harbor_clerk.cli.client import McpHttpClient
+from harbor_clerk.cli.commands import _common_parser
+from harbor_clerk.cli.config import resolve_config
+from harbor_clerk.cli.help import load
+from harbor_clerk.cli.output import render, resolve_mode
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    description = load("documents-by-date") or "Documents sorted by effective date."
+    p = subparsers.add_parser(
+        "documents-by-date",
+        help="Documents sorted by their effective date (earliest / latest)",
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common_parser()],
+    )
+    p.add_argument(
+        "--direction",
+        choices=["earliest", "latest"],
+        default="earliest",
+        help="Sort direction (default: earliest)",
+    )
+    p.add_argument(
+        "--query",
+        help="Optional FTS filter (no vector ranking). Narrows the set, then sorts by date.",
+    )
+    p.add_argument(
+        "--metadata-filter",
+        help='JSON string of {"namespace.key": value} pairs (e.g. \'{"sidecar.vendor": "Pinnacle"}\')',
+    )
+    p.add_argument("--after", help="YYYY-MM-DD or ISO 8601 datetime; lower bound on effective date")
+    p.add_argument("--before", help="YYYY-MM-DD or ISO 8601 datetime; upper bound on effective date")
+    p.add_argument(
+        "--date-field",
+        choices=["tika.created_at", "frontmatter.date", "sidecar.date", "ingest"],
+        help="Override auto-discovery; pin sort to a single source field",
+    )
+    p.add_argument("-l", "--limit", type=int, default=10, help="Max results (default: 10)")
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    arguments: dict = {
+        "direction": args.direction,
+        "limit": args.limit,
+    }
+    if args.query:
+        arguments["query"] = args.query
+    if args.after:
+        arguments["after"] = args.after
+    if args.before:
+        arguments["before"] = args.before
+    if args.date_field:
+        arguments["date_field"] = args.date_field
+    if args.metadata_filter:
+        try:
+            arguments["metadata_filter"] = _json.loads(args.metadata_filter)
+        except _json.JSONDecodeError as exc:
+            sys.stderr.write(
+                f"harbor-clerk: --metadata-filter must be valid JSON: {exc}\n"
+            )
+            return 1
+
+    cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
+    mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())
+    with McpHttpClient(cfg) as client:
+        payload = client.call_tool("kb_documents_by_date", arguments)
+    render(payload, mode=mode, command="documents-by-date")
+    return 0
+```
+
+- [ ] **Step 4: Add the text renderer to `output.py`**
+
+Append to `src/harbor_clerk/cli/output.py`:
+
+```python
+@register_text_renderer("documents-by-date")
+def _render_documents_by_date(payload, stream):
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+
+    direction = payload.get("direction", "")
+    count = payload.get("count", 0)
+    stream.write(f"{count} results ({direction})\n")
+    for r in payload.get("results", []):
+        date = r.get("date") or ""
+        date_short = date[:10] if isinstance(date, str) and len(date) >= 10 else date
+        src = r.get("date_source") or ""
+        title = r.get("title") or ""
+        doc_id = r.get("doc_id") or ""
+        stream.write(f"  {date_short} [{src}]  {title}  ({doc_id})\n")
+```
+
+- [ ] **Step 5: Create the help text file**
+
+```text
+# src/harbor_clerk/cli/help/documents-by-date.txt
+harbor-clerk documents-by-date — date-sorted document lookup
+
+DESCRIPTION
+  Returns documents sorted by their effective date (earliest or latest),
+  with optional FTS query, metadata filter, and date bounds. Use this when
+  the user asks for the earliest / latest / oldest / newest document —
+  similarity-ranked search (search) will not surface boundary docs
+  reliably.
+
+  The effective date is discovered per document via this priority chain:
+    1. metadata.tika.created_at  (Tika-extracted email-send / file date)
+    2. metadata.frontmatter.date (markdown frontmatter)
+    3. metadata.sidecar.date     (JSON sidecar)
+    4. documents.created_at      (ingest time — last resort)
+
+  Use --date-field to pin the sort to a single source (docs missing that
+  field sort to the end as NULLs).
+
+USAGE
+  harbor-clerk documents-by-date [options]
+
+OPTIONS
+      --direction earliest|latest    Sort direction (default: earliest)
+      --query TEXT                   Optional FTS filter (no vector ranking)
+      --metadata-filter JSON         JSONB containment filter, e.g.
+                                       '{"sidecar.vendor": "Pinnacle"}'
+      --after YYYY-MM-DD             Lower bound on effective date
+      --before YYYY-MM-DD            Upper bound on effective date
+      --date-field FIELD             Pin sort to one source field. Choices:
+                                       tika.created_at, frontmatter.date,
+                                       sidecar.date, ingest
+  -l, --limit INT                    Max results (default: 10)
+  (Plus global flags: --url, --api-key, --insecure, --json, --format)
+
+RETURNS (JSON)
+  { "direction": "earliest",
+    "count": 5,
+    "results": [
+      { "doc_id": "...",
+        "title": "...",
+        "canonical_filename": "...",
+        "date": "1999-10-13T08:34:00+00:00",
+        "date_source": "tika.created_at" } ] }
+
+EXAMPLES
+  # Earliest email about California regulators
+  harbor-clerk documents-by-date --direction earliest --query "California"
+
+  # Latest contract from a specific vendor
+  harbor-clerk documents-by-date --direction latest \\
+    --metadata-filter '{"sidecar.vendor": "Pinnacle Tech Solutions"}'
+
+  # All docs ingested before a date, sorted oldest-first
+  harbor-clerk documents-by-date --direction earliest \\
+    --before 2024-01-01 --date-field ingest
+
+  # Skilling's last pre-resignation email
+  harbor-clerk documents-by-date --direction latest \\
+    --query "from:skilling" --before 2001-08-14
+```
+
+- [ ] **Step 6: Register the command**
+
+Edit `src/harbor_clerk/cli/commands/__init__.py` — add `"documents-by-date"` to `_COMMAND_NAMES` (alphabetically logical placement, but order is functional only for `--help`'s listing):
+
+```python
+_COMMAND_NAMES = [
+    "search",
+    "batch-search",
+    "read-passages",
+    "expand-context",
+    "read-document",
+    "get-document",
+    "list-recent",
+    "corpus-overview",
+    "document-outline",
+    "find-related",
+    "entity-search",
+    "entity-overview",
+    "entity-cooccurrence",
+    "ingest-status",
+    "reprocess",
+    "system-health",
+    "verify-identifier",
+    "documents-by-date",          # <-- add
+]
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/cli/test_commands_documents_by_date.py -v`
+Expected: 10 PASS
+
+- [ ] **Step 8: Ruff + format**
+
+Run: `uv run ruff check src/harbor_clerk/cli/commands/documents_by_date.py src/harbor_clerk/cli/output.py src/harbor_clerk/cli/commands/__init__.py tests/cli/test_commands_documents_by_date.py`
+
+Run: `uv run ruff format src/harbor_clerk/cli/commands/documents_by_date.py src/harbor_clerk/cli/output.py src/harbor_clerk/cli/commands/__init__.py tests/cli/test_commands_documents_by_date.py`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/harbor_clerk/cli/commands/documents_by_date.py \
+        src/harbor_clerk/cli/commands/__init__.py \
+        src/harbor_clerk/cli/help/documents-by-date.txt \
+        src/harbor_clerk/cli/output.py \
+        tests/cli/test_commands_documents_by_date.py
+git commit -m "feat(cli): harbor-clerk documents-by-date subcommand"
+```
+
+---
+
+## Task 9: e2e smoke tests for the new CLI commands
+
+**Goal:** Extend `tests/cli/test_e2e.py` to confirm both new commands register correctly and their `--help` text loads from the `.txt` files.
+
+**Files:**
+- Modify: `tests/cli/test_e2e.py`
+
+- [ ] **Step 1: Read the existing test_e2e.py shape**
+
+```bash
+head -30 tests/cli/test_e2e.py
+```
+
+This shows the existing pattern (likely each command has a `test_<command>_help_loads` test using capsys to capture `--help` output).
+
+- [ ] **Step 2: Add the failing tests**
+
+Append to `tests/cli/test_e2e.py`:
+
+```python
+# Append to tests/cli/test_e2e.py
+
+import pytest
+
+from harbor_clerk.cli import main as cli_main
+
+
+def test_verify_identifier_help_loads(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["verify-identifier", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "verify-identifier" in out
+    assert "Verify a document identifier" in out or "verify an identifier" in out.lower()
+
+
+def test_documents_by_date_help_loads(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["documents-by-date", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "documents-by-date" in out
+    assert "earliest" in out and "latest" in out
+
+
+def test_top_level_help_lists_new_commands(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "verify-identifier" in out
+    assert "documents-by-date" in out
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `uv run pytest tests/cli/test_e2e.py -v -k "verify_identifier or documents_by_date or top_level"`
+Expected: 3 PASS (commands were already registered in Tasks 7 and 8)
+
+- [ ] **Step 4: Ruff + format**
+
+Run: `uv run ruff check tests/cli/test_e2e.py`
+
+Run: `uv run ruff format tests/cli/test_e2e.py`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/cli/test_e2e.py
+git commit -m "test(cli): e2e --help smoke tests for new commands"
+```
+
+---
+
+## Task 10: Full-suite regression + ruff/format sanity
+
+**Goal:** Confirm nothing else regressed. Run the full pytest suite, then `ruff check` + `ruff format --check` on the entire repo.
+
+**Files:** No code changes — verification only.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `uv run pytest tests/ --ignore=tests/test_macos_smoke.py -v`
+Expected: All tests PASS (count should be 1000+ given the additions in Tasks 1–9).
+
+If any test fails:
+- If the failure is in our new code, fix it inline and re-run.
+- If the failure is in unrelated code (a flaky network test, a pre-existing skip flag), document it in the commit message but do not fix in this PR.
+
+- [ ] **Step 2: Ruff check on the whole repo**
+
+Run: `uv run ruff check .`
+Expected: "All checks passed!"
+
+- [ ] **Step 3: Ruff format check on the whole repo**
+
+Run: `uv run ruff format --check .`
+Expected: All files formatted correctly.
+
+If any file is mis-formatted, run `uv run ruff format .` and commit.
+
+- [ ] **Step 4: Commit any sanity fixes**
+
+```bash
+# Only if there were fixes from steps 1–3:
+git add -p   # selectively stage
+git commit -m "fix(pr-e): sanity-pass adjustments"
+```
+
+If no fixes needed, skip this step.
+
+---
+
+## Task 11: Fresh-eyes review + open PR
+
+**Goal:** Dispatch the standing-directive fresh-eyes reviewer with a minimal prompt. Address ≥80-confidence findings inline, then open the PR.
+
+**Files:** No code changes initially; review may surface fixes.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/mcp-verify-identifier-and-documents-by-date
+```
+
+- [ ] **Step 2: Dispatch the fresh-eyes reviewer**
+
+Use the `Agent` tool with:
+- `subagent_type`: `feature-dev:code-reviewer`
+- Minimal prompt: state the branch + the PR-E goal (kb_verify_identifier + kb_documents_by_date + CLI parity); link the spec doc; tell the reviewer to report ≥80-confidence findings only. No focus areas, no carve-outs.
+
+- [ ] **Step 3: Address findings**
+
+For each finding the reviewer flags at ≥80 confidence:
+- Fix inline.
+- Re-run the relevant tests.
+- Commit each fix as its own commit with a `fix(pr-e):` prefix.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat(mcp): kb_verify_identifier + kb_documents_by_date + CLI parity (PR-E)" \
+  --body-file /tmp/pr-e-body.md
+```
+
+PR body should include:
+- **Summary** (2–3 bullets describing the two new tools + CLI parity)
+- **Why** (cross-corpus eval failure data: Enron lookup 0/2/0 + synthetic boundary-doc cases)
+- **What's in it** (file list grouped by tool / CLI / tests)
+- **Test plan** (commands run, suite size, fresh-eyes review summary)
+- **Spec + plan links** (this plan + the spec doc)
+
+- [ ] **Step 5: Update the `pr_followups.md` if the PR description has an Out-of-scope section**
+
+The spec's "Out of scope / follow-ups" section ports straight into the PR body's deferred-work section. Per the standing directive, every PR with a deferred-work section also gets an entry in `~/.claude/projects/-Users-alex-mcp-gateway/memory/pr_followups.md`.
+
+- [ ] **Step 6: Enable auto-merge**
+
+```bash
+gh pr merge <PR-number> --auto --squash
+```
+
+CI takes ~5–8 minutes. The harness will not notify on merge; the user will see it land.
+
+---
+
+## Self-Review Notes
+
+After writing the full plan, run through the spec section-by-section:
+
+- **§ Goal + Why** — covered by Tasks 2–6 (verify_identifier addresses fabrication / boundary-doc; documents_by_date addresses Enron earliest/latest failures). ✓
+- **§ Non-goals** — not encoded as tasks (negative space); the implementation in Tasks 2–5 doesn't touch them. ✓
+- **§ Architecture** — Tasks 1 (metadata_dates), 2–5 (mcp_lookup_tools), 6 (MCP wiring), 7–8 (CLI commands), 9 (CLI smoke). All files in the "File Structure" section have a task. ✓
+- **§ kb_verify_identifier — Matching rules** — Task 2. ✓
+- **§ kb_verify_identifier — Response shape** — Task 3. ✓
+- **§ kb_verify_identifier — Discriminating-fields algorithm** — Task 3 (reuses PR-D helper via import). ✓
+- **§ kb_verify_identifier — Suggestion text** — Task 3 (suggestion-builder logic is in `verify_identifier` itself, distinct from PR-D's `_build_suggestion`). ✓
+- **§ kb_verify_identifier — Cap & overflow** — Tasks 2 (cap in `_find_candidates`) + 3 (overflow flag + suggestion). ✓
+- **§ kb_documents_by_date — Signature, date discovery, query semantics, date bounds, response shape** — Tasks 4 + 5. ✓
+- **§ metadata_dates.py** — Task 1. ✓
+- **§ CLI parity** — Tasks 7 + 8 + 9. ✓
+- **§ Error handling** — embedded across Tasks 3 (verify_identifier), 5 (documents_by_date), 7 (CLI metadata-filter JSON error), 8 (CLI metadata-filter JSON error). ✓
+- **§ Testing** — Tasks 1, 2, 3, 4, 5 (unit + integration), 6 (description pins + integration), 7, 8, 9 (CLI). ✓
+- **§ Out of scope** — items are deferred by absence, not by task. ✓
+
+**Type-consistency spot check:**
+- `verify_identifier(session, identifier)` — same signature across Task 3 implementation, Task 6 MCP wrapper, Task 7 CLI call (which sends `{"identifier": ...}` to `kb_verify_identifier`). ✓
+- `documents_by_date(session, *, direction, query, metadata_filter, after, before, date_field, limit)` — same across Task 5 implementation, Task 6 MCP wrapper, Task 8 CLI builder. ✓
+- `_find_differing_metadata_fields(candidate_ids, metadata_by_doc, titles)` — reused per the existing signature in `mcp_discriminator.py`. ✓
+- `effective_date(doc) -> tuple[datetime | None, str]` — referenced in Task 1's tests + used implicitly by Task 4's SQL (which mirrors the same priority chain at the SQL level rather than calling the Python helper per row). ✓
+
+**Placeholder scan:** no "TBD" / "TODO" / "fill in" / "similar to" tokens in the plan. Every step that touches code shows the code.

--- a/docs/superpowers/specs/2026-05-24-mcp-verify-identifier-and-documents-by-date-design.md
+++ b/docs/superpowers/specs/2026-05-24-mcp-verify-identifier-and-documents-by-date-design.md
@@ -1,0 +1,348 @@
+# PR-E: `kb_verify_identifier` + `kb_documents_by_date` — Design
+
+**Date:** 2026-05-24
+**Status:** spec — awaiting user review before plan + implementation
+**Author:** Claude (with Alex)
+**Companion docs:** PR-F (`2026-05-24-document-metadata-extractors-design.md`), PR-D (`2026-05-24-mcp-tool-descriptions-and-discriminator-hint-design.md`); both have shipped.
+
+## Goal
+
+Add two structured-lookup MCP tools to address two reproducible failure modes from the PR-A/B/C answer-eval runs that PR-D + PR-F do not fully solve:
+
+1. **Proactive identifier verification** — give models a sharp tool for "is this a real, unique identifier in the corpus?" so they can self-correct fabrications before quoting. PR-D's `discriminator_hint` solves the *reactive* form (kb_search returned ambiguous hits — here is what differs); `kb_verify_identifier` solves the *proactive* form (before I cite Doc X, does Doc X actually exist? alone? among N candidates?).
+
+2. **Date-bounded lookups** — give models a way to ask "earliest doc matching X" or "latest doc before date Y" without relying on similarity ranking, which fails on boundary docs that aren't in the similarity top-K.
+
+## Why this PR exists (cross-corpus failure signal)
+
+Concrete eval-failure data from the answer-eval runs:
+
+**Enron (`reports/enron-phase2a/detail.json`):** both `lookup`-type questions scored **0/2/0** (correctness 0, groundedness 2, completeness 0):
+
+- `enron-lookup-earliest-california`: model identified July 30, 2000 as the earliest California-related email; ground truth is October 13, 1999. The model returned a similar-but-later email.
+- `enron-lookup-skilling-last-pre-resign`: model returned "Memo from Jeff Skilling" (Teesside explosion); ground truth is "Please Plan to Attend." Wrong "last" email.
+
+Both failures share a structural cause: there's no tool that returns docs **sorted by date** with an optional content filter. The model picked from the similarity-top-K, which doesn't intersect the actual boundary doc.
+
+**Synthetic (`reports/synthetic-phase2b/detail.json`):** ~38% (10/26) of lookups scored ≤2 on correctness. Recurring rationale: "presenting multiple dates across various documents," "buries this correct answer among many other jurisdictions," "gives 'Office of the Managing Partner' as the sender rather than the specific individual." All are boundary-doc cases where multiple documents share an identifier fragment. PR-D's `discriminator_hint` addresses the *reactive* form; `kb_verify_identifier` adds a *proactive* lever (the model can verify before answering).
+
+## Non-goals
+
+- **No fuzzy match in `kb_verify_identifier`.** Exact-CONTAINS on title/filename + equals on metadata identifier fields. Similarity-style "did you mean…?" is `kb_search`'s job — keeping the affordance sharp matters more than convenience here.
+- **No vector ranking in `kb_documents_by_date`.** The optional `query` parameter is FTS-only. Sort key is date, not similarity.
+- **No new metadata extraction.** Operates on what PR-F already extracts (Tika, frontmatter, sidecar) + the existing `documents.created_at` ingest time.
+- **No verify across full body text.** That's `kb_search` territory — would blur the affordance.
+- **No natural-language date parsing** for `after`/`before`. ISO 8601 only — MCP clients pass machine dates.
+
+## Architecture
+
+Two new MCP tools, both implemented in a single new module with a shared date-discovery helper.
+
+**New files:**
+- `src/harbor_clerk/mcp_lookup_tools.py` — implementations of both tools (~300 LOC combined)
+- `src/harbor_clerk/metadata_dates.py` — `effective_date()` helper (~40 LOC)
+- `tests/test_mcp_lookup_tools.py` — algorithm + integration tests
+- `tests/test_metadata_dates.py` — date-discovery unit tests
+
+**Touched files:**
+- `src/harbor_clerk/mcp_server.py` — two new `@mcp.tool` thin wrappers with PR-D-style 4-part docstrings (what / when / output / decline); registration in the tool list
+- `tests/test_mcp_tool_descriptions.py` — extend the pin-test set for the two new tools
+
+**Why a single module for both tools:** they share semantics ("structured non-similarity lookup over the metadata column"), they share the same surface area in `mcp_server.py`, and individually each is small (~150 LOC). Mirrors the pattern of `mcp_discriminator.py` keeping algorithm + helpers together.
+
+**Why a separate `metadata_dates.py`:** the effective-date concept is genuinely reusable — future features (document list views, exports, additional filters) can call `effective_date(doc)` rather than re-deriving the priority chain.
+
+## `kb_verify_identifier`
+
+### Signature
+
+```python
+async def kb_verify_identifier(identifier: str) -> str  # JSON-encoded
+```
+
+### Matching rules
+
+Case-insensitive, whitespace-normalized (collapse internal whitespace; strip leading/trailing).
+
+- **CONTAINS match on:**
+  - `documents.title`
+  - `documents.canonical_filename`
+- **EQUALS match (case-insensitive, whitespace-normalized) on:**
+  - `metadata.tika.title` (Tika-extracted title from DOCX/PDF/EPUB properties — sometimes differs from HC's `documents.title`)
+  - any leaf string value reachable at `metadata.sidecar.**` or `metadata.frontmatter.**` (recursive walk into nested objects), whose **leaf key name** matches the identifier-like-key regex:
+
+    ```
+    ^(id|contract_id|policy_id|case_id|order_id|invoice_id|message_id|.*_id)$
+    ```
+
+  The recursive walk lets a nested structure like `{"contract": {"id": "K-2025-031"}}` participate — the leaf-key check is on `id`, not `contract.id`. Lists at leaves participate too: a value list `["K-2025-031", "K-2025-032"]` matches if the input equals any element.
+
+  Rationale: identifier fields users actually put in sidecars/frontmatter follow this naming convention. Names like `vendor` or `date` are not identifiers in this sense — they're disambiguators, surfaced via `discriminating_fields` in the response, not by matching against the input string.
+
+**Normalization applies to both sides** of every match: the input identifier and the candidate field value are both lower-cased and whitespace-collapsed before comparison.
+
+### Response shape
+
+```jsonc
+// 0 matches
+{
+  "status": "not_found",
+  "identifier": "<input string>"
+}
+
+// exactly 1 match
+{
+  "status": "unique",
+  "match": {
+    "doc_id": "<uuid>",
+    "title": "<doc title>",
+    "canonical_filename": "<filename>",
+    "discriminating_fields": {}  // always empty when unique
+  }
+}
+
+// N > 1 matches
+{
+  "status": "ambiguous",
+  "count": 3,
+  "candidates": [
+    {
+      "doc_id": "<uuid>",
+      "title": "Pinnacle Vendor Contract",
+      "canonical_filename": "0131_vendor_contract.pdf",
+      "discriminating_fields": {
+        "sidecar.vendor": "Pinnacle Tech Solutions, LLC",
+        "sidecar.term_months": 24
+      }
+    }
+    // ...
+  ],
+  "suggestion": "3 candidates differ on sidecar.vendor and sidecar.term_months — pick the one matching your intent."
+}
+```
+
+### Discriminating-fields algorithm
+
+Reuse `_find_differing_metadata_fields()` from PR-D's `src/harbor_clerk/mcp_discriminator.py` to determine **which** metadata paths differ across the candidate set. That function returns `{"namespace.key": {title: value, ...}, ...}` — paths whose values vary across candidates, with the full per-candidate values.
+
+For each candidate's `discriminating_fields` in the response, **project** the per-candidate value at each differing path. (The helper returns the cross-candidate view; verify_identifier presents the per-candidate view.) Both views derive from the same underlying paths — single source of truth for "what metadata distinguishes these docs."
+
+Skip the `_source_provenance` namespace (same as discriminator_hint).
+
+### Suggestion text
+
+The `suggestion` field is verify-specific (different from PR-D's `discriminator_hint` suggestion, which is geared toward "issue a follow-up `kb_search` with `metadata_filter=...`"). For verify, the model already has the candidates in hand; the suggestion guides selection:
+
+```
+"3 candidates differ on sidecar.vendor and sidecar.term_months — pick the one matching your intent."
+```
+
+When no fields differ across candidates (rare; would mean the candidates are duplicates the discriminator can't distinguish), suggestion reads:
+
+```
+"Multiple candidates have identical discriminating metadata — try kb_get_document on each to inspect body."
+```
+
+### Cap & overflow
+
+Worst case all docs contain the identifier substring. Cap the candidates list at **100**. When the underlying match set exceeds the cap, include `"overflow": true` in the response alongside `count` (which reflects the cap, not the true total) and adjust the suggestion to "Filter by … or refine the identifier — more than 100 candidates matched."
+
+```jsonc
+// >100 matches
+{
+  "status": "ambiguous",
+  "count": 100,
+  "overflow": true,
+  "candidates": [ /* 100 entries */ ],
+  "suggestion": "..."
+}
+```
+
+### Performance
+
+- Index: existing GIN on `metadata` from PR-F handles the JSONB equality lookups efficiently.
+- ILIKE on title/filename is small-N (corpora are O(10^4) docs; the LIKE scan is bounded).
+- The 100-candidate cap bounds payload size and discriminating-fields compute cost.
+
+## `kb_documents_by_date`
+
+### Signature
+
+```python
+async def kb_documents_by_date(
+    direction: Literal["earliest", "latest"] = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> str  # JSON-encoded
+```
+
+### Date discovery (default behavior)
+
+For each candidate document, the effective date is the **first non-null value** in this priority chain:
+
+1. `metadata.tika.created_at` — Tika-extracted creation/send date
+2. `metadata.frontmatter.date` — markdown frontmatter
+3. `metadata.sidecar.date` — JSON sidecar
+4. `documents.created_at` — ingest time (last resort)
+
+When the caller passes an explicit `date_field`, only that field is consulted (no fallback). The accepted values are exactly:
+
+- `"tika.created_at"`
+- `"frontmatter.date"`
+- `"sidecar.date"`
+- `"ingest"`
+
+(`date_field` is a shorthand — callers do not pass the `metadata.` prefix.) Unknown `date_field` returns an error response listing the accepted values.
+
+### Query semantics
+
+If `query` is provided: FTS-only filter via `chunks.fts_en + chunks.fts_fr` (no vector — sort key is time, not similarity). Implementation: derive the candidate document set as `SELECT DISTINCT doc_id FROM chunks WHERE fts_en @@ websearch_to_tsquery('english', :q) OR fts_fr @@ websearch_to_tsquery('french', :q)`, then join to `documents` and apply the date sort + filters. A chunk match anywhere in a document admits the document to the candidate set.
+
+If `query` is absent: returns all active docs sorted by date (subject to `metadata_filter` / `after` / `before`).
+
+### Date bounds
+
+`after` and `before` apply to the **effective date** (the one chosen by the discovery chain). ISO 8601 only — no natural-language parsing.
+
+### Response shape
+
+```jsonc
+{
+  "direction": "earliest",
+  "count": 5,
+  "results": [
+    {
+      "doc_id": "<uuid>",
+      "title": "<doc title>",
+      "canonical_filename": "<filename>",
+      "date": "1999-10-13T00:00:00+00:00",
+      "date_source": "metadata.tika.created_at"
+    }
+    // ...
+  ]
+}
+```
+
+### Sort & SQL
+
+The effective-date sort is a SQL CASE expression (or `COALESCE` over JSONB extracts and `documents.created_at`) inside the `ORDER BY`. After-filter and before-filter apply to the same expression.
+
+When `date_field` is explicit, the expression collapses to a single JSONB extract or column reference.
+
+## `metadata_dates.py`
+
+```python
+def effective_date(doc: Document) -> tuple[datetime | None, str]:
+    """
+    Returns (date, source_label) for a document.
+
+    Priority order:
+      metadata.tika.created_at
+      → metadata.frontmatter.date
+      → metadata.sidecar.date
+      → documents.created_at
+
+    source_label ∈ {"tika.created_at", "frontmatter.date",
+                    "sidecar.date", "ingest", "none"}.
+    "none" returned only if every source is missing AND ingest is null
+    (unreachable in practice — docs always have created_at).
+    """
+```
+
+**Parsing:** handles ISO 8601 strings with timezone, ISO without timezone (assume UTC), date-only strings, and `datetime` objects (sidecar JSON may have been coerced). Returns `None` for unparseable values rather than raising — keeps callers simple.
+
+## Error handling
+
+- **Invalid identifier** (empty / whitespace-only): tool returns JSON `{"error": "identifier must be a non-empty string"}`. No exception.
+- **Invalid `direction`**: rejected by Pydantic `Literal` validation at the MCP layer. No manual check.
+- **Invalid date string** (`after`, `before`): `{"error": "could not parse date: '<value>'"}`.
+- **Invalid `metadata_filter`** (multi-dot path, empty segment): reuse PR-F's `ValueError`; MCP layer catches and returns error JSON. Same surface as `kb_search`.
+- **Invalid `date_field`** (unknown name): `{"error": "date_field must be one of: tika.created_at, frontmatter.date, sidecar.date, ingest"}`.
+- **Empty results**: never an error. `kb_verify_identifier` returns `{"status": "not_found"}`; `kb_documents_by_date` returns `{"count": 0, "results": []}`.
+- **DB timeout / connection error**: propagate to the existing MCP error handler. Matches the pattern of every other kb_* tool.
+
+## Testing
+
+### `tests/test_metadata_dates.py` (~6 tests)
+
+- Each priority source individually (Tika / frontmatter / sidecar / ingest)
+- Priority order: Tika wins when multiple sources present; frontmatter wins when no Tika; etc.
+- ISO 8601 with timezone, ISO without timezone, date-only
+- Unparseable string → `None`
+- All sources missing except ingest → falls through to ingest with `source_label="ingest"`
+
+### `tests/test_mcp_lookup_tools.py` (~15–18 tests)
+
+**`kb_verify_identifier`:**
+- `status="not_found"` for an identifier no doc matches
+- `status="unique"` by title match
+- `status="unique"` by `canonical_filename` match
+- `status="unique"` by `metadata.sidecar.contract_id` exact match
+- `status="ambiguous"` with `candidates` list and `suggestion`
+- Case-insensitive: `"PINNACLE"` matches `"Pinnacle Vendor Contract"`
+- Whitespace-normalized: `"  pinnacle  "` matches the same
+- Identifier-like-key regex matches `case_id`, `order_id`; does NOT match `vendor`, `term_months`
+- `discriminating_fields` is empty when status is unique; populated when ambiguous and candidates differ on at least one field
+- Empty / whitespace-only identifier → error response
+
+**`kb_documents_by_date`:**
+- `direction="earliest"` returns oldest first
+- `direction="latest"` returns newest first
+- `query` + `direction` returns only docs matching the FTS query, sorted by date
+- `metadata_filter` + `direction` filters by JSONB containment, sorted
+- `after` / `before` bound the result set
+- Explicit `date_field="ingest"` overrides the discovery chain
+- Doc with no Tika / frontmatter / sidecar date → uses ingest time, `date_source="ingest"`
+- `limit` is respected
+- Empty results return `{"count": 0, "results": []}`
+- Invalid `date_field` → error response
+
+### Tool-description tests (extend `tests/test_mcp_tool_descriptions.py`)
+
+- 4-part docstring (what / when / output / decline) per PR-D convention
+- Key affordance words present: `"verify"`, `"before quoting"`, `"earliest"`, `"latest"`, `"date_source"`
+- New tools listed in the public-tool inventory (the test that pins the list of exposed tools)
+
+### Integration test
+
+Seed test DB with 3 fixture docs spanning corpus shapes:
+
+- **Enron-style**: `metadata.tika.created_at = 1999-10-13`, body mentions "California"
+- **Synthetic-style**: `metadata.sidecar.date = 2025-04-19`, body mentions onboarding
+- **Plain**: only `documents.created_at`, no other dates
+
+End-to-end:
+- `kb_documents_by_date(direction="earliest", query="California")` returns the Enron-style doc first with `date_source="tika.created_at"` — same scenario as the failed Enron eval.
+- `kb_verify_identifier("Pinnacle vendor contract")` against a multi-Pinnacle fixture returns `status="ambiguous"` with discriminating_fields populated.
+
+## Out of scope / follow-ups
+
+- **Numeric/range comparators on metadata** (`>=`, `<`, `between`, `in`) — still deferred per PR-F's spec; PR-E's `after`/`before` for dates is the most-common-case partial answer. Generalised range/comparator operators is a separate metadata-filter-v2 PR.
+- **Folder-path-as-metadata for date discovery** (e.g. `2024-10/foo.eml` filename → date) — separate config-story PR per PR-F's spec.
+- **`kb_count_matches`** — pure count tool ("how many docs match X?") — punted; revisit if eval shows the gap.
+- **`verify_identifier` across body text** — explicit non-goal. That's `kb_search`'s job; would blur the affordance.
+- **Localized / natural-language date parsing** (`"January 15, 2024"` / `"15/01/2024"` / `"yesterday"`) — ISO only for v1. MCP clients are machines.
+- **Sidecar identifier-key heuristic refinement** — the regex `^(id|contract_id|policy_id|case_id|order_id|invoice_id|message_id|.*_id)$` is a guess at common naming. Real-world corpora may use `bates`, `docket`, `claim_number`, `policy_no`. Revisit if eval misses surface; consider a config-driven list.
+- **`verify_identifier` `fields=` parameter** — to let the model choose which fields to search. Punted; v1 hardcodes the field set. Add if eval shows model wants the flexibility.
+- **PR-G (harness audit + cross-judge sensitivity)** — pure harness work, can land in parallel or after PR-E.
+
+## Decisions (closed during brainstorming)
+
+- **Scope: both tools** (`kb_verify_identifier` + `kb_documents_by_date`). PR-D's `discriminator_hint` covers the reactive disambiguation path; PR-E adds the proactive verify path and the date-sorted path that similarity ranking can't reach.
+- **`kb_verify_identifier` is exact-CONTAINS on title + filename, equals on identifier-like metadata keys.** No similarity fallback — keeps the affordance sharp.
+- **`kb_documents_by_date` uses a smart date-field auto-discovery chain** with optional explicit `date_field` override. Defaults work for the eval-failure shapes (Enron emails use Tika; synthetic uses sidecar; plain docs fall back to ingest).
+- **No-date docs fall through to ingest time** rather than being excluded. Predictable; debuggable; `date_source` annotation tells the model what happened.
+- **Each `verify_identifier` candidate carries `doc_id` + `title` + `canonical_filename` + `discriminating_fields`** (computed via PR-D's algorithm reused). Models can disambiguate without follow-up `kb_get_document` calls.
+- **Single implementation module + separate date helper.** `mcp_lookup_tools.py` for both tools (they're semantically related and individually small); `metadata_dates.py` for the shared helper that future code can call.
+- **Both tools follow PR-D's 4-part docstring convention** (what / when / output / decline). Pin-tested in `test_mcp_tool_descriptions.py`.
+
+## Open questions / risks
+
+- **Identifier-key regex precision.** The current pattern catches common naming but will miss legal corpora (`bates`, `docket`) and insurance corpora (`policy_no`, `claim_number`). Initial release ships the conservative pattern; widen based on observed gaps. Worst case: a sidecar field models can't reach with `verify_identifier` is still reachable with `kb_search(metadata_filter=...)` from PR-F.
+- **Tika date field name variations.** Tika's `Message-Date` (emails) is aliased to `email_date` and stored at `metadata.tika.created_at` in HC's extractor (per PR-F). Other Tika date fields exist (`Last-Modified`, `dcterms:modified`); not surfaced yet. If the eval shows `modified_at` as a useful sort key, add it to the chain (priority 1.5, between Tika created and frontmatter).
+- **Performance ceiling on `verify_identifier` ILIKE.** On corpora >100k docs, the title+filename ILIKE scan dominates. Acceptable for v1 (no observed corpus near that size in HC's target audience); revisit if it becomes a bottleneck. Pre-built trigram index on `documents.title` would mitigate.
+- **SQL portability of the COALESCE-over-JSONB ORDER BY.** Targeting PostgreSQL only (HC's only backend) — no cross-DB concern. PG can sort by an expression in `ORDER BY` even when not in `SELECT`.

--- a/docs/superpowers/specs/2026-05-24-mcp-verify-identifier-and-documents-by-date-design.md
+++ b/docs/superpowers/specs/2026-05-24-mcp-verify-identifier-and-documents-by-date-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-24
 **Status:** spec — awaiting user review before plan + implementation
 **Author:** Claude (with Alex)
-**Companion docs:** PR-F (`2026-05-24-document-metadata-extractors-design.md`), PR-D (`2026-05-24-mcp-tool-descriptions-and-discriminator-hint-design.md`); both have shipped.
+**Companion docs:** PR-F (`2026-05-24-document-metadata-extractors-design.md`), PR-D (`2026-05-24-mcp-tool-descriptions-and-discriminator-hint-design.md`), PR #397 (`2026-05-23-cli-for-agentic-harnesses-design.md`); all have shipped.
 
 ## Goal
 
@@ -36,21 +36,32 @@ Both failures share a structural cause: there's no tool that returns docs **sort
 
 ## Architecture
 
-Two new MCP tools, both implemented in a single new module with a shared date-discovery helper.
+Two new MCP tools, both implemented in a single new module with a shared date-discovery helper. Each MCP tool ships with a matching `harbor-clerk` CLI subcommand to maintain parity with PR #397's CLI surface — every kb_* tool has a peer command.
 
-**New files:**
+**New backend files:**
 - `src/harbor_clerk/mcp_lookup_tools.py` — implementations of both tools (~300 LOC combined)
 - `src/harbor_clerk/metadata_dates.py` — `effective_date()` helper (~40 LOC)
 - `tests/test_mcp_lookup_tools.py` — algorithm + integration tests
 - `tests/test_metadata_dates.py` — date-discovery unit tests
 
+**New CLI files:**
+- `src/harbor_clerk/cli/commands/verify_identifier.py` — `harbor-clerk verify-identifier` subcommand (~50 LOC)
+- `src/harbor_clerk/cli/commands/documents_by_date.py` — `harbor-clerk documents-by-date` subcommand (~70 LOC)
+- `src/harbor_clerk/cli/help/verify-identifier.txt` — long-form help text (description / options / returns / examples)
+- `src/harbor_clerk/cli/help/documents-by-date.txt` — same
+- `tests/cli/test_commands_verify_identifier.py` — CLI command tests
+- `tests/cli/test_commands_documents_by_date.py` — same
+
 **Touched files:**
 - `src/harbor_clerk/mcp_server.py` — two new `@mcp.tool` thin wrappers with PR-D-style 4-part docstrings (what / when / output / decline); registration in the tool list
+- `src/harbor_clerk/cli/commands/__init__.py` — add `"verify-identifier"` and `"documents-by-date"` to `_COMMAND_NAMES`
 - `tests/test_mcp_tool_descriptions.py` — extend the pin-test set for the two new tools
 
-**Why a single module for both tools:** they share semantics ("structured non-similarity lookup over the metadata column"), they share the same surface area in `mcp_server.py`, and individually each is small (~150 LOC). Mirrors the pattern of `mcp_discriminator.py` keeping algorithm + helpers together.
+**Why a single module for both MCP tools:** they share semantics ("structured non-similarity lookup over the metadata column"), they share the same surface area in `mcp_server.py`, and individually each is small (~150 LOC). Mirrors the pattern of `mcp_discriminator.py` keeping algorithm + helpers together.
 
 **Why a separate `metadata_dates.py`:** the effective-date concept is genuinely reusable — future features (document list views, exports, additional filters) can call `effective_date(doc)` rather than re-deriving the priority chain.
+
+**Why one CLI command module per tool (not combined):** PR #397 established the pattern of one file per command in `src/harbor_clerk/cli/commands/` — each module has its own `add_parser()` + `run()` and its own help text. PR-E follows that convention to keep the CLI surface consistent.
 
 ## `kb_verify_identifier`
 
@@ -233,6 +244,60 @@ The effective-date sort is a SQL CASE expression (or `COALESCE` over JSONB extra
 
 When `date_field` is explicit, the expression collapses to a single JSONB extract or column reference.
 
+## CLI parity (`harbor-clerk verify-identifier`, `harbor-clerk documents-by-date`)
+
+PR #397 shipped a `harbor-clerk` CLI that exposes every kb_* MCP tool as a peer subcommand. The two new tools join the lineup. CLI commands are thin: parse argparse → build the `arguments` dict → `McpHttpClient.call_tool(...)` → `render(payload, ...)`. Same pattern as `commands/search.py` and the other 15 commands.
+
+### `harbor-clerk verify-identifier`
+
+```
+USAGE
+  harbor-clerk verify-identifier <identifier> [options]
+
+OPTIONS
+  (inherits global flags from _common_parser: --url, --api-key, --insecure,
+   --json, --format)
+```
+
+No tool-specific options — the MCP tool itself takes only `identifier`. The CLI hands the positional argument through to the `kb_verify_identifier` MCP call.
+
+### `harbor-clerk documents-by-date`
+
+```
+USAGE
+  harbor-clerk documents-by-date [options]
+
+OPTIONS
+      --direction earliest|latest    Sort direction (default: earliest)
+      --query TEXT                   Optional FTS filter (no vector ranking)
+      --metadata-filter JSON         JSONB containment filter; e.g.
+                                       '{"sidecar.vendor": "Pinnacle"}'
+      --after YYYY-MM-DD             Only docs with effective date >= this
+      --before YYYY-MM-DD            Only docs with effective date <= this
+      --date-field FIELD             Override auto-discovery; one of:
+                                       tika.created_at, frontmatter.date,
+                                       sidecar.date, ingest
+  -l, --limit INT                    Result count (default: 10)
+  (plus the global flags)
+```
+
+The `--metadata-filter` arg accepts a JSON string and is parsed before being added to the `arguments` dict — matches the convention `search.py` uses for `--doc-ids` (comma-split parsing on the CLI side).
+
+### Help text files
+
+`src/harbor_clerk/cli/help/verify-identifier.txt` and `documents-by-date.txt` follow the established four-block layout: **DESCRIPTION**, **USAGE**, **OPTIONS**, **RETURNS (JSON)**, **EXAMPLES**. The DESCRIPTION block carries the same WHEN/WHY guidance as the MCP tool docstring (PR-D 4-part style), so the CLI user gets the same affordance as the MCP user. EXAMPLES include both the Enron "earliest California email" pattern and the Pinnacle disambiguation pattern.
+
+### Output rendering
+
+Both new commands fall through to `render(payload, mode=mode, command=...)`. The default `text` mode for these tools displays:
+
+- `verify-identifier` → "Status: unique / ambiguous / not_found", then per-candidate `<title> [<doc_id>] — vendor=X, term_months=Y` lines (the discriminating-fields projection)
+- `documents-by-date` → tabular "date | source | title — doc_id" lines in the requested direction
+
+JSON mode (`--json` or `--format=json`) returns the raw MCP payload — same shape as the MCP response, no transformation.
+
+If `output.py` needs a per-command rendering branch (the existing commands have them), add two short cases following the same pattern.
+
 ## `metadata_dates.py`
 
 ```python
@@ -307,6 +372,29 @@ def effective_date(doc: Document) -> tuple[datetime | None, str]:
 - Key affordance words present: `"verify"`, `"before quoting"`, `"earliest"`, `"latest"`, `"date_source"`
 - New tools listed in the public-tool inventory (the test that pins the list of exposed tools)
 
+### CLI tests
+
+**`tests/cli/test_commands_verify_identifier.py`** (~6 tests, mirrors `test_commands_search.py`):
+- argparse layer: positional identifier required; `--json` flag forces JSON mode
+- HTTP client receives `kb_verify_identifier` with the identifier in arguments
+- Default text rendering for status="unique"
+- Default text rendering for status="ambiguous" with candidate lines
+- Default text rendering for status="not_found"
+- `--json` mode passes raw payload through unchanged
+- Error from HTTP client → non-zero exit code via the standard `McpClientError` path
+
+**`tests/cli/test_commands_documents_by_date.py`** (~8 tests):
+- Default direction is "earliest"
+- `--direction latest` flag flows through to arguments
+- `--query`, `--after`, `--before`, `--date-field` each flow through when provided, absent otherwise
+- `--metadata-filter '{"vendor": "X"}'` parses JSON and forwards as dict
+- Invalid `--metadata-filter` JSON → exit code via argparse error path (or a clear stderr message in `run()`)
+- Default text rendering shows tabular date/source/title lines
+- `--json` mode passes raw payload through
+
+**`tests/cli/test_e2e.py` extension:**
+- Add a smoke test invoking the entry point for each new command with `--help` to confirm the help text loads and argparse registration is correct (matches the existing pattern in test_e2e).
+
 ### Integration test
 
 Seed test DB with 3 fixture docs spanning corpus shapes:
@@ -328,6 +416,7 @@ End-to-end:
 - **Localized / natural-language date parsing** (`"January 15, 2024"` / `"15/01/2024"` / `"yesterday"`) — ISO only for v1. MCP clients are machines.
 - **Sidecar identifier-key heuristic refinement** — the regex `^(id|contract_id|policy_id|case_id|order_id|invoice_id|message_id|.*_id)$` is a guess at common naming. Real-world corpora may use `bates`, `docket`, `claim_number`, `policy_no`. Revisit if eval misses surface; consider a config-driven list.
 - **`verify_identifier` `fields=` parameter** — to let the model choose which fields to search. Punted; v1 hardcodes the field set. Add if eval shows model wants the flexibility.
+- **CLI skill update** — `skills/harbor-clerk/SKILL.md` is intentionally minimal and relies on `harbor-clerk --help` for command discovery, so it doesn't enumerate commands. No SKILL.md edit needed in this PR. Revisit if SKILL.md ever switches to an explicit-command-list shape.
 - **PR-G (harness audit + cross-judge sensitivity)** — pure harness work, can land in parallel or after PR-E.
 
 ## Decisions (closed during brainstorming)
@@ -339,6 +428,7 @@ End-to-end:
 - **Each `verify_identifier` candidate carries `doc_id` + `title` + `canonical_filename` + `discriminating_fields`** (computed via PR-D's algorithm reused). Models can disambiguate without follow-up `kb_get_document` calls.
 - **Single implementation module + separate date helper.** `mcp_lookup_tools.py` for both tools (they're semantically related and individually small); `metadata_dates.py` for the shared helper that future code can call.
 - **Both tools follow PR-D's 4-part docstring convention** (what / when / output / decline). Pin-tested in `test_mcp_tool_descriptions.py`.
+- **CLI parity is in scope.** PR #397 established one CLI subcommand per kb_* tool; PR-E adds `harbor-clerk verify-identifier` and `harbor-clerk documents-by-date` to preserve that 1:1 mapping. Skipping CLI parity would leave the two new tools reachable only via direct MCP, breaking the "every MCP tool has a CLI peer" contract.
 
 ## Open questions / risks
 

--- a/src/harbor_clerk/cli/commands/__init__.py
+++ b/src/harbor_clerk/cli/commands/__init__.py
@@ -43,6 +43,7 @@ _COMMAND_NAMES = [
     "ingest-status",
     "reprocess",
     "system-health",
+    "verify-identifier",
 ]
 
 

--- a/src/harbor_clerk/cli/commands/__init__.py
+++ b/src/harbor_clerk/cli/commands/__init__.py
@@ -44,6 +44,7 @@ _COMMAND_NAMES = [
     "reprocess",
     "system-health",
     "verify-identifier",
+    "documents-by-date",
 ]
 
 

--- a/src/harbor_clerk/cli/commands/documents_by_date.py
+++ b/src/harbor_clerk/cli/commands/documents_by_date.py
@@ -1,0 +1,75 @@
+"""harbor-clerk documents-by-date — date-sorted document lookup."""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+
+from harbor_clerk.cli.client import McpHttpClient
+from harbor_clerk.cli.commands import _common_parser
+from harbor_clerk.cli.config import resolve_config
+from harbor_clerk.cli.help import load
+from harbor_clerk.cli.output import render, resolve_mode
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    description = load("documents-by-date") or "Documents sorted by their effective date."
+    p = subparsers.add_parser(
+        "documents-by-date",
+        help="Documents sorted by their effective date (earliest / latest)",
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common_parser()],
+    )
+    p.add_argument(
+        "--direction",
+        choices=["earliest", "latest"],
+        default="earliest",
+        help="Sort direction (default: earliest)",
+    )
+    p.add_argument(
+        "--query",
+        help="Optional FTS filter (no vector ranking). Narrows the set, then sorts by date.",
+    )
+    p.add_argument(
+        "--metadata-filter",
+        help='JSON string of {"namespace.key": value} pairs (e.g. \'{"sidecar.vendor": "Pinnacle"}\')',
+    )
+    p.add_argument("--after", help="YYYY-MM-DD or ISO 8601 datetime; lower bound on effective date")
+    p.add_argument("--before", help="YYYY-MM-DD or ISO 8601 datetime; upper bound on effective date")
+    p.add_argument(
+        "--date-field",
+        choices=["tika.created_at", "frontmatter.date", "sidecar.date", "ingest"],
+        help="Override auto-discovery; pin sort to a single source field",
+    )
+    p.add_argument("-l", "--limit", type=int, default=10, help="Max results (default: 10)")
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    arguments: dict = {
+        "direction": args.direction,
+        "limit": args.limit,
+    }
+    if args.query:
+        arguments["query"] = args.query
+    if args.after:
+        arguments["after"] = args.after
+    if args.before:
+        arguments["before"] = args.before
+    if args.date_field:
+        arguments["date_field"] = args.date_field
+    if args.metadata_filter:
+        try:
+            arguments["metadata_filter"] = _json.loads(args.metadata_filter)
+        except _json.JSONDecodeError as exc:
+            sys.stderr.write(f"harbor-clerk: --metadata-filter must be valid JSON: {exc}\n")
+            return 1
+
+    cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
+    mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())
+    with McpHttpClient(cfg) as client:
+        payload = client.call_tool("kb_documents_by_date", arguments)
+    render(payload, mode=mode, command="documents-by-date")
+    return 0

--- a/src/harbor_clerk/cli/commands/verify_identifier.py
+++ b/src/harbor_clerk/cli/commands/verify_identifier.py
@@ -1,0 +1,38 @@
+"""harbor-clerk verify-identifier — verify an identifier resolves to one doc."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from harbor_clerk.cli.client import McpHttpClient
+from harbor_clerk.cli.commands import _common_parser
+from harbor_clerk.cli.config import resolve_config
+from harbor_clerk.cli.help import load
+from harbor_clerk.cli.output import render, resolve_mode
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    description = load("verify-identifier") or "Verify a document identifier."
+    p = subparsers.add_parser(
+        "verify-identifier",
+        help="Verify an identifier resolves to exactly one document",
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common_parser()],
+    )
+    p.add_argument(
+        "identifier",
+        help="The identifier string to check against title, filename, and identifier-like metadata fields",
+    )
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    arguments = {"identifier": args.identifier}
+    cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
+    mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())
+    with McpHttpClient(cfg) as client:
+        payload = client.call_tool("kb_verify_identifier", arguments)
+    render(payload, mode=mode, command="verify-identifier")
+    return 0

--- a/src/harbor_clerk/cli/help/documents-by-date.txt
+++ b/src/harbor_clerk/cli/help/documents-by-date.txt
@@ -1,0 +1,59 @@
+harbor-clerk documents-by-date — date-sorted document lookup
+
+DESCRIPTION
+  Returns documents sorted by their effective date (earliest or latest),
+  with optional FTS query, metadata filter, and date bounds. Use this when
+  the user asks for the earliest / latest / oldest / newest document —
+  similarity-ranked search (search) will not surface boundary docs
+  reliably.
+
+  The effective date is discovered per document via this priority chain:
+    1. metadata.tika.created_at  (Tika-extracted email-send / file date)
+    2. metadata.frontmatter.date (markdown frontmatter)
+    3. metadata.sidecar.date     (JSON sidecar)
+    4. documents.created_at      (ingest time — last resort)
+
+  Use --date-field to pin the sort to a single source (docs missing that
+  field sort to the end as NULLs).
+
+USAGE
+  harbor-clerk documents-by-date [options]
+
+OPTIONS
+      --direction earliest|latest    Sort direction (default: earliest)
+      --query TEXT                   Optional FTS filter (no vector ranking)
+      --metadata-filter JSON         JSONB containment filter, e.g.
+                                       '{"sidecar.vendor": "Pinnacle"}'
+      --after YYYY-MM-DD             Lower bound on effective date
+      --before YYYY-MM-DD            Upper bound on effective date
+      --date-field FIELD             Pin sort to one source field. Choices:
+                                       tika.created_at, frontmatter.date,
+                                       sidecar.date, ingest
+  -l, --limit INT                    Max results (default: 10)
+  (Plus global flags: --url, --api-key, --insecure, --json, --format)
+
+RETURNS (JSON)
+  { "direction": "earliest",
+    "count": 5,
+    "results": [
+      { "doc_id": "...",
+        "title": "...",
+        "canonical_filename": "...",
+        "date": "1999-10-13T08:34:00+00:00",
+        "date_source": "tika.created_at" } ] }
+
+EXAMPLES
+  # Earliest email about California regulators
+  harbor-clerk documents-by-date --direction earliest --query "California"
+
+  # Latest contract from a specific vendor
+  harbor-clerk documents-by-date --direction latest \
+    --metadata-filter '{"sidecar.vendor": "Pinnacle Tech Solutions"}'
+
+  # All docs ingested before a date, sorted oldest-first
+  harbor-clerk documents-by-date --direction earliest \
+    --before 2024-01-01 --date-field ingest
+
+  # Skilling's last pre-resignation email
+  harbor-clerk documents-by-date --direction latest \
+    --query "from:skilling" --before 2001-08-14

--- a/src/harbor_clerk/cli/help/verify-identifier.txt
+++ b/src/harbor_clerk/cli/help/verify-identifier.txt
@@ -1,0 +1,62 @@
+harbor-clerk verify-identifier — verify an identifier resolves to one document
+
+DESCRIPTION
+  Checks whether a given identifier string maps to exactly one document in
+  the corpus. Use BEFORE quoting a specific named document — sharp
+  affordance for fabrication-prevention.
+
+  Matches against:
+    - document title (case-insensitive CONTAINS)
+    - canonical filename (case-insensitive CONTAINS)
+    - metadata.tika.title (case-insensitive EQUALS)
+    - identifier-like metadata keys (id, contract_id, policy_id, case_id,
+      order_id, invoice_id, message_id, *_id) under metadata.sidecar.** or
+      metadata.frontmatter.** (case-insensitive EQUALS)
+
+  Status outcomes:
+    not_found  → no document matches; do NOT fall back to similarity
+    unique     → exactly one match
+    ambiguous  → multiple matches; each candidate carries
+                 discriminating_fields showing what distinguishes it
+
+USAGE
+  harbor-clerk verify-identifier <identifier> [options]
+
+OPTIONS
+  (Inherits global flags: --url, --api-key, --insecure, --json, --format.)
+
+RETURNS (JSON)
+  // not_found
+  { "status": "not_found", "identifier": "<input>" }
+
+  // unique
+  { "status": "unique",
+    "match": { "doc_id": "...", "title": "...",
+               "canonical_filename": "...",
+               "discriminating_fields": {} } }
+
+  // ambiguous (count > 1)
+  { "status": "ambiguous",
+    "count": 3,
+    "candidates": [
+      { "doc_id": "...", "title": "...",
+        "canonical_filename": "...",
+        "discriminating_fields": { "sidecar.vendor": "Acme",
+                                   "sidecar.term_months": 24 } }
+    ],
+    "suggestion": "3 candidates differ on sidecar.vendor — pick one." }
+
+  // ambiguous with overflow (> 100 matches)
+  { "status": "ambiguous", "count": 100, "overflow": true,
+    "candidates": [ /* 100 entries */ ],
+    "suggestion": "More than 100 candidates matched — refine ..." }
+
+EXAMPLES
+  # Sharp existence check before quoting
+  harbor-clerk verify-identifier "Pinnacle Vendor Contract"
+
+  # JSON output for scripting
+  harbor-clerk verify-identifier "K-2025-031" --json
+
+  # Disambiguate before answering
+  harbor-clerk verify-identifier "Senior Project Coordinator onboarding letter"

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -70,3 +70,48 @@ def _render_search(payload: Any, stream: TextIO) -> None:
         stream.write(f"   {snippet}\n\n")
     if payload.get("possible_conflict"):
         stream.write("⚠  possible_conflict=true — top hits disagree across documents\n")
+
+
+# --- Verify identifier pretty-printer ---
+
+
+@register_text_renderer("verify-identifier")
+def _render_verify_identifier(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+
+    status = payload.get("status")
+
+    if status == "not_found":
+        stream.write(f"not_found: {payload.get('identifier', '')}\n")
+        return
+
+    if status == "unique":
+        m = payload.get("match", {})
+        stream.write(f"unique: {m.get('title', '')}  [{m.get('doc_id', '')}]\n")
+        if m.get("canonical_filename"):
+            stream.write(f"  filename: {m['canonical_filename']}\n")
+        return
+
+    if status == "ambiguous":
+        count = payload.get("count", 0)
+        overflow = " (overflow)" if payload.get("overflow") else ""
+        stream.write(f"ambiguous: {count} candidates{overflow}\n")
+        for c in payload.get("candidates", []):
+            stream.write(f"  - {c.get('title', '')}  [{c.get('doc_id', '')}]\n")
+            for path, value in (c.get("discriminating_fields") or {}).items():
+                stream.write(f"      {path}={value!r}\n")
+        suggestion = payload.get("suggestion")
+        if suggestion:
+            stream.write(f"\n{suggestion}\n")
+        return
+
+    # Unknown status — fall back to JSON-ish
+    import json as _json
+
+    stream.write(_json.dumps(payload, indent=2, default=str) + "\n")

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -115,3 +115,28 @@ def _render_verify_identifier(payload: Any, stream: TextIO) -> None:
     import json as _json
 
     stream.write(_json.dumps(payload, indent=2, default=str) + "\n")
+
+
+# --- Documents by date pretty-printer ---
+
+
+@register_text_renderer("documents-by-date")
+def _render_documents_by_date(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+
+    direction = payload.get("direction", "")
+    count = payload.get("count", 0)
+    stream.write(f"{count} results ({direction})\n")
+    for r in payload.get("results", []):
+        date = r.get("date") or ""
+        date_short = date[:10] if isinstance(date, str) and len(date) >= 10 else date
+        src = r.get("date_source") or ""
+        title = r.get("title") or ""
+        doc_id = r.get("doc_id") or ""
+        stream.write(f"  {date_short} [{src}]  {title}  ({doc_id})\n")

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -18,8 +18,8 @@ import re
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from sqlalchemy import case, cast, func, literal, or_, select
-from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy import case, cast, func, literal, null, or_, select
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.mcp_discriminator import _find_differing_metadata_fields
@@ -225,17 +225,40 @@ async def verify_identifier(session: AsyncSession, identifier: str) -> dict:
 
 _ALLOWED_DATE_FIELDS = frozenset({"tika.created_at", "frontmatter.date", "sidecar.date", "ingest"})
 
+# ISO 8601 prefix: requires at minimum YYYY-MM-DD.  Matches date-only strings
+# ("2024-01-15") as well as full datetimes ("2024-01-15T08:00:00Z").  Non-ISO
+# strings emitted by Tika (e.g. "N/A", "", localized formats) won't match and
+# produce NULL instead of raising invalid_datetime_format.
+_ISO_DATE_PREFIX_RE = r"^\d{4}-\d{2}-\d{2}"
 
-def _date_components():
+
+def _safe_timestamp_cast(text_expr: Any) -> Any:
+    """Return a SQLAlchemy expression that casts *text_expr* to TIMESTAMPTZ
+    when it starts with an ISO 8601 date prefix, or NULL otherwise.
+
+    This prevents a single document with a malformed Tika date (e.g. "N/A")
+    from raising ``invalid_datetime_format`` and aborting the entire query.
+    """
+    return case(
+        (text_expr.op("~")(_ISO_DATE_PREFIX_RE), cast(text_expr, TIMESTAMP(timezone=True))),
+        else_=null(),
+    )
+
+
+def _date_components() -> list[tuple[str, Any]]:
     """Return (label, expr) tuples per priority slot.
 
     Expressions are built fresh per call — SQLAlchemy column elements are
     immutable but we avoid any cross-call binding state by constructing here.
     The priority order is: tika.created_at → frontmatter.date → sidecar.date → ingest.
+
+    JSONB text slots use _safe_timestamp_cast so a malformed date value
+    (e.g. Tika emitting "N/A") returns NULL and falls through to the next
+    priority slot instead of raising an invalid_datetime_format error.
     """
-    tika_expr = cast(Document.doc_metadata["tika"]["created_at"].astext, TIMESTAMP(timezone=True))
-    fm_expr = cast(Document.doc_metadata["frontmatter"]["date"].astext, TIMESTAMP(timezone=True))
-    sc_expr = cast(Document.doc_metadata["sidecar"]["date"].astext, TIMESTAMP(timezone=True))
+    tika_expr = _safe_timestamp_cast(Document.doc_metadata["tika"]["created_at"].astext)
+    fm_expr = _safe_timestamp_cast(Document.doc_metadata["frontmatter"]["date"].astext)
+    sc_expr = _safe_timestamp_cast(Document.doc_metadata["sidecar"]["date"].astext)
     ingest_expr = Document.created_at
     return [
         ("tika.created_at", tika_expr),
@@ -288,25 +311,20 @@ async def _query_documents_by_date(
         source_label_expr = literal(date_field)
     else:
         # COALESCE in priority order; CASE picks the first non-null source label.
-        # For JSONB-cast slots we check the raw JSONB path (before cast) because
-        # the cast itself may produce NULL on malformed text and we can't compare
-        # a cast expression to NULL with isnot() in a CASE WHEN in a meaningful way.
-        # Checking the raw astext isnot(None) is equivalent to the JSONB key existing.
-        tika_raw = Document.doc_metadata["tika"]["created_at"].astext
-        fm_raw = Document.doc_metadata["frontmatter"]["date"].astext
-        sc_raw = Document.doc_metadata["sidecar"]["date"].astext
+        # Both use the same guarded slot expressions from _date_components() so
+        # they always agree on which slot "won" — if a JSONB cast returned NULL
+        # (malformed date), the CASE won't label it as that slot either.
+        slot_exprs = [e for _, e in components]  # already guarded by _safe_timestamp_cast
+        slot_labels = [label for label, _ in components]
 
-        expr = func.coalesce(
-            cast(tika_raw, TIMESTAMP(timezone=True)),
-            cast(fm_raw, TIMESTAMP(timezone=True)),
-            cast(sc_raw, TIMESTAMP(timezone=True)),
-            Document.created_at,
-        )
+        expr = func.coalesce(*slot_exprs)
+
+        # Build CASE using isnot(None) on the SAME guarded expressions that
+        # COALESCE uses, so label and date always refer to the same source.
+        # The final slot ("ingest") is Document.created_at which is never NULL.
         source_label_expr = case(
-            (tika_raw.isnot(None), literal("tika.created_at")),
-            (fm_raw.isnot(None), literal("frontmatter.date")),
-            (sc_raw.isnot(None), literal("sidecar.date")),
-            else_=literal("ingest"),
+            *[(slot_exprs[i].isnot(None), literal(slot_labels[i])) for i in range(len(components) - 1)],
+            else_=literal(slot_labels[-1]),
         )
 
     stmt = select(Document, expr.label("effective_date"), source_label_expr.label("date_source")).where(
@@ -325,7 +343,17 @@ async def _query_documents_by_date(
         )
         stmt = stmt.where(Document.doc_id.in_(fts_subq))
 
-    # Optional metadata_filter — same validation as hybrid_search in search.py.
+    # Optional metadata_filter — same validation and matching logic as
+    # hybrid_search() in search.py.  Each "<namespace>.<key>": value pair
+    # becomes:
+    #   - JSONB @> containment: doc_metadata @> '{"ns": {"key": value}}'
+    #     (matches scalar metadata)
+    #   - OR JSONB ? existence: doc_metadata->'ns'->'key' ? 'value'
+    #     (matches list-valued metadata containing the scalar)
+    # The OR lets a caller use a scalar filter value to match either a
+    # scalar metadata field OR a list-valued one without knowing the shape,
+    # matching the behavior of kb_search.  If this diverges from search.py,
+    # both should be updated together.
     if metadata_filter:
         for path, value in metadata_filter.items():
             if path.count(".") != 1:
@@ -336,12 +364,12 @@ async def _query_documents_by_date(
             ns, _, key = path.partition(".")
             if not ns or not key:
                 raise ValueError(f"metadata_filter keys must have a non-empty namespace and key, got {path!r}")
+            containment = Document.doc_metadata.op("@>")(func.cast({ns: {key: value}}, JSONB))
             if isinstance(value, str):
-                stmt = stmt.where(Document.doc_metadata[ns][key].astext == value)
+                existence = Document.doc_metadata[ns][key].op("?")(value)
+                stmt = stmt.where(or_(containment, existence))
             else:
-                from sqlalchemy.dialects.postgresql import JSONB
-
-                stmt = stmt.where(Document.doc_metadata[ns][key].cast(JSONB) == cast(literal(str(value)), JSONB))
+                stmt = stmt.where(containment)
 
     # Optional after / before bounds on the effective date.
     if after:

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -15,13 +15,15 @@ Task 2 establishes the candidate-matching layer for verify_identifier.
 from __future__ import annotations
 
 import re
-from typing import Any
+from datetime import UTC, datetime
+from typing import Any, Literal
 
-from sqlalchemy import or_, select
+from sqlalchemy import case, cast, func, literal, or_, select
+from sqlalchemy.dialects.postgresql import TIMESTAMP
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.mcp_discriminator import _find_differing_metadata_fields
-from harbor_clerk.models import Document
+from harbor_clerk.models import Chunk, Document
 
 _VERIFY_CANDIDATE_CAP = 100
 
@@ -215,3 +217,145 @@ async def verify_identifier(session: AsyncSession, identifier: str) -> dict:
     if overflow:
         payload["overflow"] = True
     return payload
+
+
+# ---------------------------------------------------------------------------
+# _query_documents_by_date — SQL query layer for kb_documents_by_date
+# ---------------------------------------------------------------------------
+
+_ALLOWED_DATE_FIELDS = frozenset({"tika.created_at", "frontmatter.date", "sidecar.date", "ingest"})
+
+
+def _date_components():
+    """Return (label, expr) tuples per priority slot.
+
+    Expressions are built fresh per call — SQLAlchemy column elements are
+    immutable but we avoid any cross-call binding state by constructing here.
+    The priority order is: tika.created_at → frontmatter.date → sidecar.date → ingest.
+    """
+    tika_expr = cast(Document.doc_metadata["tika"]["created_at"].astext, TIMESTAMP(timezone=True))
+    fm_expr = cast(Document.doc_metadata["frontmatter"]["date"].astext, TIMESTAMP(timezone=True))
+    sc_expr = cast(Document.doc_metadata["sidecar"]["date"].astext, TIMESTAMP(timezone=True))
+    ingest_expr = Document.created_at
+    return [
+        ("tika.created_at", tika_expr),
+        ("frontmatter.date", fm_expr),
+        ("sidecar.date", sc_expr),
+        ("ingest", ingest_expr),
+    ]
+
+
+def _parse_iso_date(value: str) -> datetime:
+    """Parse an ISO 8601 date or datetime string into a UTC-aware datetime."""
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+async def _query_documents_by_date(
+    session: AsyncSession,
+    *,
+    direction: Literal["earliest", "latest"] = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> list[tuple[Document, datetime, str]]:
+    """Run the SQL query for documents_by_date and return rows.
+
+    Each row is (Document, effective_date, date_source_label). Caller is
+    responsible for shaping the response.
+
+    Raises ValueError on invalid `date_field`, unparseable `after`/`before`,
+    or invalid `metadata_filter` keys.
+    """
+    if direction not in ("earliest", "latest"):
+        raise ValueError(f"direction must be 'earliest' or 'latest'; got {direction!r}")
+
+    components = _date_components()
+
+    # Build the effective-date expression + source-label CASE.
+    if date_field is not None:
+        if date_field not in _ALLOWED_DATE_FIELDS:
+            raise ValueError(f"date_field must be one of: {sorted(_ALLOWED_DATE_FIELDS)}; got {date_field!r}")
+        expr = next(e for label, e in components if label == date_field)
+        source_label_expr = literal(date_field)
+    else:
+        # COALESCE in priority order; CASE picks the first non-null source label.
+        # For JSONB-cast slots we check the raw JSONB path (before cast) because
+        # the cast itself may produce NULL on malformed text and we can't compare
+        # a cast expression to NULL with isnot() in a CASE WHEN in a meaningful way.
+        # Checking the raw astext isnot(None) is equivalent to the JSONB key existing.
+        tika_raw = Document.doc_metadata["tika"]["created_at"].astext
+        fm_raw = Document.doc_metadata["frontmatter"]["date"].astext
+        sc_raw = Document.doc_metadata["sidecar"]["date"].astext
+
+        expr = func.coalesce(
+            cast(tika_raw, TIMESTAMP(timezone=True)),
+            cast(fm_raw, TIMESTAMP(timezone=True)),
+            cast(sc_raw, TIMESTAMP(timezone=True)),
+            Document.created_at,
+        )
+        source_label_expr = case(
+            (tika_raw.isnot(None), literal("tika.created_at")),
+            (fm_raw.isnot(None), literal("frontmatter.date")),
+            (sc_raw.isnot(None), literal("sidecar.date")),
+            else_=literal("ingest"),
+        )
+
+    stmt = select(Document, expr.label("effective_date"), source_label_expr.label("date_source")).where(
+        Document.status == "active"
+    )
+
+    # Optional FTS filter via chunks join.
+    if query:
+        fts_subq = (
+            select(Chunk.doc_id.distinct())
+            .where(
+                Chunk.fts_en.op("@@")(func.websearch_to_tsquery("english", query))
+                | Chunk.fts_fr.op("@@")(func.websearch_to_tsquery("french", query))
+            )
+            .scalar_subquery()
+        )
+        stmt = stmt.where(Document.doc_id.in_(fts_subq))
+
+    # Optional metadata_filter — same validation as hybrid_search in search.py.
+    if metadata_filter:
+        for path, value in metadata_filter.items():
+            if path.count(".") != 1:
+                raise ValueError(
+                    f"metadata_filter keys must be exactly 'namespace.key' (one dot, two segments); "
+                    f"got {path!r}. Nested paths are not supported in v1."
+                )
+            ns, _, key = path.partition(".")
+            if not ns or not key:
+                raise ValueError(f"metadata_filter keys must have a non-empty namespace and key, got {path!r}")
+            if isinstance(value, str):
+                stmt = stmt.where(Document.doc_metadata[ns][key].astext == value)
+            else:
+                from sqlalchemy.dialects.postgresql import JSONB
+
+                stmt = stmt.where(Document.doc_metadata[ns][key].cast(JSONB) == cast(literal(str(value)), JSONB))
+
+    # Optional after / before bounds on the effective date.
+    if after:
+        stmt = stmt.where(expr >= _parse_iso_date(after))
+    if before:
+        stmt = stmt.where(expr <= _parse_iso_date(before))
+
+    # Sort: NULLs last for both ascending and descending.
+    if direction == "earliest":
+        stmt = stmt.order_by(expr.asc().nullslast())
+    else:
+        stmt = stmt.order_by(expr.desc().nullslast())
+
+    stmt = stmt.limit(limit)
+
+    result = await session.execute(stmt)
+    return [(row.Document, row.effective_date, row.date_source) for row in result.all()]

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -107,10 +107,17 @@ async def _find_candidates(session: AsyncSession, identifier: str) -> list[Docum
     sql_hits = (await session.execute(stmt)).scalars().all()
     sql_hit_ids = {d.doc_id for d in sql_hits}
 
-    # Python-side pass for identifier-like metadata keys. Fetch all active
-    # docs whose metadata is non-empty (cheap with the existing GIN index)
-    # and walk their JSON structure.
-    stmt_meta = select(Document).where(Document.status == "active").where(Document.doc_metadata != {})
+    # Python-side pass for identifier-like metadata keys. Fetch active
+    # docs whose metadata is non-empty and walk their JSON structure.
+    # Capped at _VERIFY_CANDIDATE_CAP so the Python-side loop is always
+    # bounded: a corpus with 10k+ metadata-bearing docs never loads them
+    # all into memory on a single call.
+    stmt_meta = (
+        select(Document)
+        .where(Document.status == "active")
+        .where(Document.doc_metadata != {})
+        .limit(_VERIFY_CANDIDATE_CAP)
+    )
     meta_hits = (await session.execute(stmt_meta)).scalars().all()
 
     extra: list[Document] = []
@@ -134,6 +141,25 @@ async def _find_candidates(session: AsyncSession, identifier: str) -> list[Docum
         if len(result) >= _VERIFY_CANDIDATE_CAP:
             break
     return result
+
+
+def _has_nested_metadata(metadata_by_doc: dict[str, dict]) -> bool:
+    """Return True if any candidate document has a dict-valued leaf inside a
+    known metadata namespace (e.g. ``sidecar.contract`` is itself a dict).
+
+    This signals that the discriminating information may be nested deeper than
+    the one-level projection used by ``_find_differing_metadata_fields``, so
+    the ambiguous-match suggestion should guide the caller to inspect the raw
+    document rather than implying the candidates are identical.
+    """
+    for meta in metadata_by_doc.values():
+        for ns in _ID_KEY_NAMESPACES:
+            ns_dict = meta.get(ns)
+            if isinstance(ns_dict, dict):
+                for value in ns_dict.values():
+                    if isinstance(value, dict):
+                        return True
+    return False
 
 
 async def verify_identifier(session: AsyncSession, identifier: str) -> dict:
@@ -203,6 +229,11 @@ async def verify_identifier(session: AsyncSession, identifier: str) -> dict:
     elif differing:
         field_list = ", ".join(differing.keys())
         suggestion = f"{len(candidates)} candidates differ on {field_list} — pick the one matching your intent."
+    elif _has_nested_metadata(metadata_by_doc):
+        suggestion = (
+            "Multiple candidates matched, but their distinguishing metadata is nested — "
+            "inspect with kb_get_document on each."
+        )
     else:
         suggestion = (
             "Multiple candidates have identical discriminating metadata — try kb_get_document on each to inspect body."

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -1,0 +1,135 @@
+"""kb_verify_identifier + kb_documents_by_date — structured-lookup tools.
+
+Both tools perform non-similarity lookups against the documents table and
+the metadata JSONB column added in PR-F. verify_identifier returns
+not_found / unique / ambiguous; documents_by_date returns docs sorted by
+their effective date (per metadata_dates.effective_date priority chain).
+
+This module exposes two public async functions used by mcp_server.py:
+  - verify_identifier(session, identifier) -> dict   (added in Task 3)
+  - documents_by_date(session, ...) -> dict          (added in Task 5)
+
+Task 2 establishes the candidate-matching layer for verify_identifier.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.models import Document
+
+# Cap on candidates returned for verify_identifier. Bounds payload size
+# and discriminating-fields compute cost on degenerate inputs.
+_VERIFY_CANDIDATE_CAP = 100
+
+# Leaf-key names that count as identifiers when matching metadata.sidecar.**
+# or metadata.frontmatter.**. Anything else is treated as a disambiguator
+# (vendor, date, etc.), surfaced via discriminating_fields rather than
+# matched against the input string.
+_IDENTIFIER_KEY_RE = re.compile(r"^(id|contract_id|policy_id|case_id|order_id|invoice_id|message_id|.*_id)$")
+
+# Metadata namespaces searched for identifier-like keys. metadata.tika.title
+# is handled separately because the match target is the title VALUE, not
+# any key under tika.
+_ID_KEY_NAMESPACES = ("sidecar", "frontmatter")
+
+
+def _normalize(s: str) -> str:
+    """Lower-case, strip, and collapse internal whitespace."""
+    return " ".join(s.lower().split())
+
+
+def _iter_id_like_leaves(metadata: dict) -> list[Any]:
+    """Walk metadata.sidecar.** and metadata.frontmatter.**, yielding the
+    value of every leaf whose KEY matches _IDENTIFIER_KEY_RE.
+
+    Lists at leaves contribute each element. Returns a flat list of raw
+    values (caller does normalisation + comparison).
+    """
+    out: list[Any] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, dict):
+                    _walk(value)
+                elif _IDENTIFIER_KEY_RE.match(str(key)):
+                    if isinstance(value, list):
+                        out.extend(value)
+                    else:
+                        out.append(value)
+
+    for ns in _ID_KEY_NAMESPACES:
+        ns_dict = metadata.get(ns)
+        if isinstance(ns_dict, dict):
+            _walk(ns_dict)
+
+    return out
+
+
+async def _find_candidates(session: AsyncSession, identifier: str) -> list[Document]:
+    """Return the set of active Documents matching `identifier` by any of:
+      - title CONTAINS identifier (case-insensitive, whitespace-normalised)
+      - canonical_filename CONTAINS identifier (same normalisation)
+      - metadata.tika.title EQUALS identifier (case-insensitive)
+      - any identifier-like-key leaf value in metadata.sidecar.** or
+        metadata.frontmatter.** EQUALS identifier (case-insensitive)
+
+    Deduplicated by doc_id. Capped at _VERIFY_CANDIDATE_CAP results
+    (the public verify_identifier in Task 3 sets `overflow: true` when
+    the cap is reached).
+    """
+    normalized = _normalize(identifier)
+    if not normalized:
+        return []
+
+    # SQL-side pass: title / canonical_filename ILIKE, plus tika.title equality.
+    # The metadata-key match needs Python-side traversal because the leaf
+    # paths are variable.
+    pattern = f"%{normalized}%"
+    stmt = (
+        select(Document)
+        .where(Document.status == "active")
+        .where(
+            or_(
+                Document.title.op("ILIKE")(pattern),
+                Document.canonical_filename.op("ILIKE")(pattern),
+                # JSONB ->> returns text; lower() then equals the normalized input.
+                Document.doc_metadata["tika"]["title"].astext.op("ILIKE")(normalized),
+            )
+        )
+    )
+    sql_hits = (await session.execute(stmt)).scalars().all()
+    sql_hit_ids = {d.doc_id for d in sql_hits}
+
+    # Python-side pass for identifier-like metadata keys. Fetch all active
+    # docs whose metadata is non-empty (cheap with the existing GIN index)
+    # and walk their JSON structure.
+    stmt_meta = select(Document).where(Document.status == "active").where(Document.doc_metadata != {})
+    meta_hits = (await session.execute(stmt_meta)).scalars().all()
+
+    extra: list[Document] = []
+    for doc in meta_hits:
+        if doc.doc_id in sql_hit_ids:
+            continue
+        for raw in _iter_id_like_leaves(doc.doc_metadata or {}):
+            if isinstance(raw, str) and _normalize(raw) == normalized:
+                extra.append(doc)
+                break
+
+    combined = list(sql_hits) + extra
+    # Deduplicate preserving order; cap.
+    seen: set = set()
+    result: list[Document] = []
+    for d in combined:
+        if d.doc_id in seen:
+            continue
+        seen.add(d.doc_id)
+        result.append(d)
+        if len(result) >= _VERIFY_CANDIDATE_CAP:
+            break
+    return result

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -20,10 +20,9 @@ from typing import Any
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from harbor_clerk.mcp_discriminator import _find_differing_metadata_fields
 from harbor_clerk.models import Document
 
-# Cap on candidates returned for verify_identifier. Bounds payload size
-# and discriminating-fields compute cost on degenerate inputs.
 _VERIFY_CANDIDATE_CAP = 100
 
 # Leaf-key names that count as identifiers when matching metadata.sidecar.**
@@ -133,3 +132,86 @@ async def _find_candidates(session: AsyncSession, identifier: str) -> list[Docum
         if len(result) >= _VERIFY_CANDIDATE_CAP:
             break
     return result
+
+
+async def verify_identifier(session: AsyncSession, identifier: str) -> dict:
+    """Verify that an identifier resolves to a unique document.
+
+    Returns one of three response shapes:
+      - {"status": "not_found", "identifier": <input>}
+      - {"status": "unique", "match": {doc_id, title, canonical_filename,
+                                       discriminating_fields: {}}}
+      - {"status": "ambiguous", "count": N, "candidates": [...],
+         "suggestion": "...", "overflow"?: true}
+
+    Empty / whitespace-only identifier returns {"error": "..."}.
+    """
+    if not identifier or not identifier.strip():
+        return {"error": "identifier must be a non-empty string"}
+
+    candidates = await _find_candidates(session, identifier)
+
+    if not candidates:
+        return {"status": "not_found", "identifier": identifier}
+
+    if len(candidates) == 1:
+        d = candidates[0]
+        return {
+            "status": "unique",
+            "match": {
+                "doc_id": str(d.doc_id),
+                "title": d.title,
+                "canonical_filename": d.canonical_filename,
+                "discriminating_fields": {},
+            },
+        }
+
+    # Ambiguous — compute which metadata paths differ across candidates.
+    titles = {str(d.doc_id): (d.title or str(d.doc_id)) for d in candidates}
+    metadata_by_doc = {str(d.doc_id): (d.doc_metadata or {}) for d in candidates}
+    candidate_ids = [str(d.doc_id) for d in candidates]
+    differing = _find_differing_metadata_fields(candidate_ids, metadata_by_doc, titles)
+
+    cand_payload: list[dict] = []
+    for d in candidates:
+        did = str(d.doc_id)
+        # Project the per-candidate value at each differing path.
+        per_cand: dict = {}
+        for path in differing:
+            ns, key = path.split(".", 1)
+            value = metadata_by_doc[did].get(ns, {}).get(key)
+            if value is not None:
+                per_cand[path] = value
+        cand_payload.append(
+            {
+                "doc_id": did,
+                "title": d.title,
+                "canonical_filename": d.canonical_filename,
+                "discriminating_fields": per_cand,
+            }
+        )
+
+    overflow = len(candidates) >= _VERIFY_CANDIDATE_CAP
+
+    if overflow:
+        suggestion = (
+            "More than 100 candidates matched — refine the identifier with a more "
+            "specific substring, or use kb_search(metadata_filter=...) to narrow."
+        )
+    elif differing:
+        field_list = ", ".join(differing.keys())
+        suggestion = f"{len(candidates)} candidates differ on {field_list} — pick the one matching your intent."
+    else:
+        suggestion = (
+            "Multiple candidates have identical discriminating metadata — try kb_get_document on each to inspect body."
+        )
+
+    payload: dict = {
+        "status": "ambiguous",
+        "count": len(candidates),
+        "candidates": cand_payload,
+        "suggestion": suggestion,
+    }
+    if overflow:
+        payload["overflow"] = True
+    return payload

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -387,3 +387,55 @@ async def _query_documents_by_date(
 
     result = await session.execute(stmt)
     return [(row.Document, row.effective_date, row.date_source) for row in result.all()]
+
+
+async def documents_by_date(
+    session: AsyncSession,
+    *,
+    direction: str = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> dict:
+    """Return documents sorted by their effective date.
+
+    Response shape:
+      {"direction": <input>, "count": N, "results": [
+         {"doc_id": "...", "title": "...", "canonical_filename": "...",
+          "date": "ISO-8601", "date_source": "tika.created_at" | ...},
+         ...
+      ]}
+
+    Returns {"error": "..."} on invalid direction, date_field, after/before
+    string, or metadata_filter.
+    """
+    try:
+        rows = await _query_documents_by_date(
+            session,
+            direction=direction,
+            query=query,
+            metadata_filter=metadata_filter,
+            after=after,
+            before=before,
+            date_field=date_field,
+            limit=limit,
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    results: list[dict] = []
+    for doc, eff_date, src in rows:
+        results.append(
+            {
+                "doc_id": str(doc.doc_id),
+                "title": doc.title,
+                "canonical_filename": doc.canonical_filename,
+                "date": eff_date.isoformat() if eff_date else None,
+                "date_source": src,
+            }
+        )
+
+    return {"direction": direction, "count": len(results), "results": results}

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -16,6 +16,12 @@ from harbor_clerk.auth import API_KEY_PREFIXES, decode_token, hash_api_key
 from harbor_clerk.config import get_settings, refresh_cli_access_setting
 from harbor_clerk.db import async_session_factory
 from harbor_clerk.mcp_discriminator import _compute_discriminator_hint
+from harbor_clerk.mcp_lookup_tools import (
+    documents_by_date as _documents_by_date_impl,
+)
+from harbor_clerk.mcp_lookup_tools import (
+    verify_identifier as _verify_identifier_impl,
+)
 from harbor_clerk.models import (
     ApiKey,
     Chunk,
@@ -2243,6 +2249,117 @@ async def kb_read_document(
         },
         indent=2,
     )
+
+
+@mcp.tool()
+async def kb_verify_identifier(identifier: str) -> str:
+    """Verify a document identifier resolves to exactly one document.
+
+    Use this BEFORE quoting a specific document — checks the identifier
+    against title, filename, and identifier-like metadata fields. Sharp
+    affordance for fabrication-prevention.
+
+    When to call:
+      - Before claiming "the X contract says…" — verify X is a real, unique
+        identifier first
+      - When kb_search returns hits whose titles all share a substring you
+        used as an identifier — verify whether you're looking at one doc or
+        N variants
+      - When the user asks about a specific named document
+
+    What you get back:
+      - status="not_found": no document matches — say so plainly; do NOT
+        fall back to "closest match"
+      - status="unique": one match — its doc_id, title, canonical_filename
+      - status="ambiguous": multiple matches — each candidate carries
+        discriminating_fields (the metadata that distinguishes them) and
+        a suggestion for how to pick one
+
+    When the response is ambiguous, the discriminating_fields per candidate
+    tell you what differs — pick the one matching the user's intent, or ask
+    a clarifying question. With overflow=true (more than 100 candidates),
+    refine the identifier with a more specific substring.
+
+    How to decline:
+      - status="not_found" means the identifier is NOT in the corpus. Do
+        NOT search by similarity as a substitute — tell the user the
+        identifier doesn't exist.
+      - status="ambiguous" with no discriminating_fields means the
+        candidates are indistinguishable by metadata; inspect with
+        kb_get_document if you must.
+    """
+    async with async_session_factory() as session:
+        result = await _verify_identifier_impl(session, identifier)
+    return json.dumps(result, default=str)
+
+
+@mcp.tool()
+async def kb_documents_by_date(
+    direction: str = "earliest",
+    query: str | None = None,
+    metadata_filter: dict | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    date_field: str | None = None,
+    limit: int = 10,
+) -> str:
+    """Return documents sorted by their effective date.
+
+    Use this when the user asks for the earliest / latest / first / last
+    document matching some criteria — similarity-ranked search (kb_search)
+    will not surface boundary docs reliably.
+
+    When to call:
+      - "What's the earliest email about X" / "Find the oldest invoice"
+      - "What's the latest version of Y" / "Most recent contract with Z"
+      - "Show me everything before/after a specific date"
+      - When you need chronological ordering, not similarity ordering
+
+    What you get back:
+      - direction: echoes the input ("earliest" or "latest")
+      - count: number of results returned
+      - results[]: each carries doc_id, title, canonical_filename, date
+        (ISO 8601 UTC), and date_source — which field the date came from:
+          "tika.created_at"  → Tika-extracted email-send / file date
+          "frontmatter.date" → markdown frontmatter
+          "sidecar.date"     → JSON sidecar
+          "ingest"           → fallback to documents.created_at when no
+                               metadata date is available
+
+    Parameters:
+      direction (default "earliest"): "earliest" | "latest"
+      query: optional FTS-only filter (no vector). Returns docs whose chunks
+        match the query, sorted by date.
+      metadata_filter: dict of {"namespace.key": value} pairs — same shape
+        as kb_search's metadata_filter, applied as JSONB containment.
+      after, before: ISO 8601 date or datetime strings; bound the
+        effective-date range.
+      date_field: explicit override for the effective-date source. Accepted
+        values: "tika.created_at", "frontmatter.date", "sidecar.date",
+        "ingest". When set, no fallback is consulted (docs missing that
+        field sort to the end as NULLs).
+      limit (default 10): max results.
+
+    How to decline:
+      - If results is empty, no docs match the date bounds / query / filter
+        — say so plainly. Do NOT broaden the bounds and re-run unless the
+        user asks.
+      - If the user asks for "the earliest" and the top result's
+        date_source is "ingest", note that no metadata date was available
+        — the result is sorted by ingest time, not by document content date.
+    """
+    async with async_session_factory() as session:
+        result = await _documents_by_date_impl(
+            session,
+            direction=direction,
+            query=query,
+            metadata_filter=metadata_filter,
+            after=after,
+            before=before,
+            date_field=date_field,
+            limit=limit,
+        )
+    return json.dumps(result, default=str)
 
 
 @mcp.tool()

--- a/src/harbor_clerk/metadata_dates.py
+++ b/src/harbor_clerk/metadata_dates.py
@@ -1,0 +1,78 @@
+"""Effective-date discovery for documents.
+
+Walks a priority chain to return the canonical date for a document:
+  1. metadata.tika.created_at  (Tika-extracted email-send / file-creation date)
+  2. metadata.frontmatter.date (markdown frontmatter)
+  3. metadata.sidecar.date     (JSON sidecar)
+  4. documents.created_at      (ingest time — last resort)
+
+Used by kb_documents_by_date for sorting + result annotation. Standalone
+module so future features (document list views, exports, filters) can
+share one place for "the canonical date for this doc."
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+# Priority chain: (label, getter). First non-null parseable value wins.
+_PRIORITY: list[tuple[str, Callable[[Any], Any]]] = [
+    ("tika.created_at", lambda d: (d.doc_metadata or {}).get("tika", {}).get("created_at")),
+    (
+        "frontmatter.date",
+        lambda d: (d.doc_metadata or {}).get("frontmatter", {}).get("date"),
+    ),
+    ("sidecar.date", lambda d: (d.doc_metadata or {}).get("sidecar", {}).get("date")),
+]
+
+
+def effective_date(doc) -> tuple[datetime | None, str]:
+    """Return (effective_date, source_label) for a document.
+
+    Walks the priority chain and returns the first non-null value that
+    parses as a datetime. Falls back to `documents.created_at` (ingest
+    time) if no metadata source provides a valid date. Returns
+    `(None, "none")` only if every source is missing AND ingest is also
+    null (unreachable in practice — documents always have created_at).
+
+    source_label ∈ {"tika.created_at", "frontmatter.date", "sidecar.date",
+                    "ingest", "none"}.
+    """
+    for label, getter in _PRIORITY:
+        raw = getter(doc)
+        parsed = _parse(raw)
+        if parsed is not None:
+            return parsed, label
+    if getattr(doc, "created_at", None) is not None:
+        return _ensure_utc(doc.created_at), "ingest"
+    return None, "none"
+
+
+def _parse(raw: Any) -> datetime | None:
+    """Parse a value into a UTC-aware datetime. Returns None on failure."""
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return _ensure_utc(raw)
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    # Normalise "Z" suffix to "+00:00" since fromisoformat() only
+    # accepts the latter on Python 3.10. Both forms are valid ISO 8601.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return _ensure_utc(datetime.fromisoformat(s))
+    except ValueError:
+        return None
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    """Coerce a naive datetime to UTC; pass aware datetimes through."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt

--- a/tests/cli/test_commands_documents_by_date.py
+++ b/tests/cli/test_commands_documents_by_date.py
@@ -1,0 +1,137 @@
+"""CLI tests for harbor-clerk documents-by-date."""
+
+from unittest.mock import MagicMock, patch
+
+from harbor_clerk.cli import main as cli_main
+
+
+def _run(args, mock_response):
+    with (
+        patch("harbor_clerk.cli.commands.documents_by_date.McpHttpClient") as MockClient,
+        patch("harbor_clerk.cli.commands.documents_by_date.resolve_config") as MockResolve,
+    ):
+        instance = MagicMock()
+        instance.call_tool.return_value = mock_response
+        instance.__enter__.return_value = instance
+        instance.__exit__.return_value = False
+        MockClient.return_value = instance
+        MockResolve.return_value = MagicMock(url="https://test", api_key="hc_t", insecure=False)
+        rc = cli_main.main(args)
+        return rc, instance
+
+
+_EMPTY = {"direction": "earliest", "count": 0, "results": []}
+
+
+def test_default_direction_is_earliest(capsys):
+    rc, client = _run(["documents-by-date", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["direction"] == "earliest"
+
+
+def test_direction_latest_flag(capsys):
+    rc, client = _run(["documents-by-date", "--direction", "latest", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["direction"] == "latest"
+
+
+def test_query_flag_forwards(capsys):
+    rc, client = _run(["documents-by-date", "--query", "California", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["query"] == "California"
+
+
+def test_after_and_before_flags_forward(capsys):
+    rc, client = _run(
+        [
+            "documents-by-date",
+            "--after",
+            "2024-01-01",
+            "--before",
+            "2024-12-31",
+            "--json",
+        ],
+        _EMPTY,
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["after"] == "2024-01-01"
+    assert args["before"] == "2024-12-31"
+
+
+def test_date_field_flag_forwards(capsys):
+    rc, client = _run(["documents-by-date", "--date-field", "sidecar.date", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["date_field"] == "sidecar.date"
+
+
+def test_metadata_filter_parses_json(capsys):
+    rc, client = _run(
+        [
+            "documents-by-date",
+            "--metadata-filter",
+            '{"sidecar.vendor": "Pinnacle Tech Solutions"}',
+            "--json",
+        ],
+        _EMPTY,
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["metadata_filter"] == {"sidecar.vendor": "Pinnacle Tech Solutions"}
+
+
+def test_metadata_filter_invalid_json_returns_usage_error(capsys):
+    rc, _client = _run(["documents-by-date", "--metadata-filter", "not-json", "--json"], _EMPTY)
+    assert rc == 1
+
+
+def test_limit_flag_forwards(capsys):
+    rc, client = _run(["documents-by-date", "--limit", "25", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args["limit"] == 25
+
+
+def test_optional_flags_absent_when_not_provided(capsys):
+    rc, client = _run(["documents-by-date", "--json"], _EMPTY)
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    # Only direction + limit should be present in the minimal call.
+    assert "query" not in args
+    assert "after" not in args
+    assert "before" not in args
+    assert "date_field" not in args
+    assert "metadata_filter" not in args
+
+
+def test_text_mode_renders_results(capsys):
+    payload = {
+        "direction": "earliest",
+        "count": 2,
+        "results": [
+            {
+                "doc_id": "id-1",
+                "title": "Earliest doc",
+                "canonical_filename": "a.eml",
+                "date": "1999-10-13T08:34:00+00:00",
+                "date_source": "tika.created_at",
+            },
+            {
+                "doc_id": "id-2",
+                "title": "Second doc",
+                "canonical_filename": "b.eml",
+                "date": "1999-10-14T00:00:00+00:00",
+                "date_source": "tika.created_at",
+            },
+        ],
+    }
+    rc, _client = _run(["documents-by-date", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Earliest doc" in out
+    assert "1999-10-13" in out
+    assert "tika.created_at" in out

--- a/tests/cli/test_commands_verify_identifier.py
+++ b/tests/cli/test_commands_verify_identifier.py
@@ -1,0 +1,112 @@
+"""CLI tests for harbor-clerk verify-identifier."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from harbor_clerk.cli import main as cli_main
+
+
+def _run(args, mock_response):
+    """Invoke CLI in-process with a mocked McpHttpClient."""
+    with (
+        patch("harbor_clerk.cli.commands.verify_identifier.McpHttpClient") as MockClient,
+        patch("harbor_clerk.cli.commands.verify_identifier.resolve_config") as MockResolve,
+    ):
+        instance = MagicMock()
+        instance.call_tool.return_value = mock_response
+        instance.__enter__.return_value = instance
+        instance.__exit__.return_value = False
+        MockClient.return_value = instance
+        MockResolve.return_value = MagicMock(url="https://test", api_key="hc_t", insecure=False)
+        rc = cli_main.main(args)
+        return rc, instance
+
+
+def test_verify_identifier_requires_positional(capsys):
+    """Calling without an identifier should fail argparse."""
+    with pytest.raises(SystemExit) as exc_info:
+        _run(["verify-identifier"], {"status": "not_found", "identifier": ""})
+    assert exc_info.value.code == 1
+
+
+def test_verify_identifier_calls_tool_with_identifier(capsys):
+    rc, client = _run(
+        ["verify-identifier", "Pinnacle Vendor Contract", "--json"],
+        {"status": "not_found", "identifier": "Pinnacle Vendor Contract"},
+    )
+    assert rc == 0
+    client.call_tool.assert_called_once_with("kb_verify_identifier", {"identifier": "Pinnacle Vendor Contract"})
+
+
+def test_verify_identifier_json_mode_passes_payload_through(capsys):
+    payload = {
+        "status": "unique",
+        "match": {
+            "doc_id": "abc-123",
+            "title": "Pinnacle",
+            "canonical_filename": "pin.pdf",
+            "discriminating_fields": {},
+        },
+    }
+    rc, _client = _run(["verify-identifier", "Pinnacle", "--json"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert json.loads(out) == payload
+
+
+def test_verify_identifier_text_mode_renders_unique(capsys):
+    payload = {
+        "status": "unique",
+        "match": {
+            "doc_id": "abc-123",
+            "title": "Pinnacle Vendor Contract",
+            "canonical_filename": "pin.pdf",
+            "discriminating_fields": {},
+        },
+    }
+    rc, _client = _run(["verify-identifier", "Pinnacle", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unique" in out.lower()
+    assert "Pinnacle Vendor Contract" in out
+    assert "abc-123" in out
+
+
+def test_verify_identifier_text_mode_renders_ambiguous(capsys):
+    payload = {
+        "status": "ambiguous",
+        "count": 2,
+        "candidates": [
+            {
+                "doc_id": "id-1",
+                "title": "Pinnacle A",
+                "canonical_filename": "a.pdf",
+                "discriminating_fields": {"sidecar.vendor": "Tech Solutions"},
+            },
+            {
+                "doc_id": "id-2",
+                "title": "Pinnacle B",
+                "canonical_filename": "b.pdf",
+                "discriminating_fields": {"sidecar.vendor": "Industries"},
+            },
+        ],
+        "suggestion": "2 candidates differ on sidecar.vendor.",
+    }
+    rc, _client = _run(["verify-identifier", "Pinnacle", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ambiguous" in out.lower()
+    assert "Pinnacle A" in out
+    assert "Pinnacle B" in out
+    assert "Tech Solutions" in out
+    assert "Industries" in out
+
+
+def test_verify_identifier_text_mode_renders_not_found(capsys):
+    payload = {"status": "not_found", "identifier": "nope"}
+    rc, _client = _run(["verify-identifier", "nope", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "not_found" in out.lower() or "not found" in out.lower()

--- a/tests/cli/test_e2e.py
+++ b/tests/cli/test_e2e.py
@@ -30,6 +30,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import pytest
 
 from harbor_clerk.api.deps import Principal
 from harbor_clerk.mcp_server import MCPAuthMiddleware
@@ -252,3 +253,57 @@ def test_e2e_happy_path_exits_0(monkeypatch, capsys):
     captured = capsys.readouterr()
     data = json.loads(captured.out)
     assert data.get("status") == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# Test: verify-identifier --help
+# ---------------------------------------------------------------------------
+
+
+def test_verify_identifier_help_loads(capsys):
+    """Test that verify-identifier --help loads correctly from the .txt file."""
+    from harbor_clerk.cli import main as cli_main
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["verify-identifier", "--help"])
+    assert exc.value.code == 0
+
+    out = capsys.readouterr().out
+    assert "verify-identifier" in out
+    assert "Verify" in out or "verify" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: documents-by-date --help
+# ---------------------------------------------------------------------------
+
+
+def test_documents_by_date_help_loads(capsys):
+    """Test that documents-by-date --help loads correctly from the .txt file."""
+    from harbor_clerk.cli import main as cli_main
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["documents-by-date", "--help"])
+    assert exc.value.code == 0
+
+    out = capsys.readouterr().out
+    assert "documents-by-date" in out
+    assert "earliest" in out and "latest" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: top-level --help lists new commands
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_help_lists_new_commands(capsys):
+    """Test that --help at top level lists both new commands."""
+    from harbor_clerk.cli import main as cli_main
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["--help"])
+    assert exc.value.code == 0
+
+    out = capsys.readouterr().out
+    assert "verify-identifier" in out
+    assert "documents-by-date" in out

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -19,7 +19,7 @@ def test_cli_version_flag():
     assert "harbor-clerk-cli/" in out
 
 
-def test_cli_help_flag_lists_all_17_commands():
+def test_cli_help_flag_lists_all_18_commands():
     out, _err, rc = run_cli("--help")
     assert rc == 0
     for cmd in [
@@ -40,6 +40,7 @@ def test_cli_help_flag_lists_all_17_commands():
         "reprocess",
         "system-health",
         "verify-identifier",
+        "documents-by-date",
     ]:
         assert cmd in out, f"missing subcommand in --help: {cmd}"
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -19,7 +19,7 @@ def test_cli_version_flag():
     assert "harbor-clerk-cli/" in out
 
 
-def test_cli_help_flag_lists_all_16_commands():
+def test_cli_help_flag_lists_all_17_commands():
     out, _err, rc = run_cli("--help")
     assert rc == 0
     for cmd in [
@@ -39,6 +39,7 @@ def test_cli_help_flag_lists_all_16_commands():
         "ingest-status",
         "reprocess",
         "system-health",
+        "verify-identifier",
     ]:
         assert cmd in out, f"missing subcommand in --help: {cmd}"
 

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -10,8 +10,8 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from harbor_clerk.mcp_lookup_tools import _find_candidates, verify_identifier
-from harbor_clerk.models import Document
+from harbor_clerk.mcp_lookup_tools import _find_candidates, _query_documents_by_date, verify_identifier
+from harbor_clerk.models import Chunk, Document
 from harbor_clerk.models.enums import PipelineStatus
 
 # ---------------------------------------------------------------------------
@@ -288,3 +288,244 @@ async def test_overflow_flag_set_when_cap_exceeded(db_session):
     assert result["count"] == 100
     assert result["overflow"] is True
     assert "More than 100" in result["suggestion"]
+
+
+# ---------------------------------------------------------------------------
+# _seed_doc_with_chunk helper
+# ---------------------------------------------------------------------------
+
+
+async def _seed_doc_with_chunk(
+    db_session: AsyncSession,
+    *,
+    title: str,
+    metadata: dict | None = None,
+    text: str = "body text",
+) -> Document:
+    """Like _seed_doc but also adds a chunk so FTS queries can match."""
+    doc = await _seed_doc(db_session, title=title, metadata=metadata or {})
+    db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text=text, language="english"))
+    await db_session.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# _query_documents_by_date tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_earliest_orders_by_tika_date_ascending(db_session):
+    older = await _seed_doc_with_chunk(
+        db_session,
+        title="Older email",
+        metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}},
+    )
+    newer = await _seed_doc_with_chunk(
+        db_session,
+        title="Newer email",
+        metadata={"tika": {"created_at": "2001-08-14T08:34:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=10)
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    # Older first when direction=earliest. Other test fixtures may add docs
+    # too (autouse cleanup), so only assert the relative order of these two.
+    assert doc_ids.index(str(older.doc_id)) < doc_ids.index(str(newer.doc_id))
+
+
+@pytest.mark.asyncio
+async def test_latest_orders_by_date_descending(db_session):
+    older = await _seed_doc_with_chunk(
+        db_session,
+        title="Older",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    newer = await _seed_doc_with_chunk(
+        db_session,
+        title="Newer",
+        metadata={"tika": {"created_at": "2024-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="latest", limit=10)
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    assert doc_ids.index(str(newer.doc_id)) < doc_ids.index(str(older.doc_id))
+
+
+@pytest.mark.asyncio
+async def test_query_filters_to_fts_matching_docs(db_session):
+    cali = await _seed_doc_with_chunk(
+        db_session,
+        title="California email",
+        metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}},
+        text="discussion about California regulators",
+    )
+    await _seed_doc_with_chunk(
+        db_session,
+        title="Unrelated",
+        metadata={"tika": {"created_at": "1999-10-14T00:00:00Z"}},
+        text="discussion about something else entirely",
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", query="California", limit=10)
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(cali.doc_id) in doc_ids
+    assert len(doc_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_metadata_filter_applied(db_session):
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Pinnacle contract",
+        metadata={
+            "tika": {"created_at": "2024-01-01T00:00:00Z"},
+            "sidecar": {"vendor": "Pinnacle Tech Solutions"},
+        },
+    )
+    await _seed_doc_with_chunk(
+        db_session,
+        title="Other contract",
+        metadata={
+            "tika": {"created_at": "2024-01-01T00:00:00Z"},
+            "sidecar": {"vendor": "Other Vendor"},
+        },
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session,
+        direction="earliest",
+        metadata_filter={"sidecar.vendor": "Pinnacle Tech Solutions"},
+        limit=10,
+    )
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    assert doc_ids == [str(target.doc_id)]
+
+
+@pytest.mark.asyncio
+async def test_after_filter_bounds_results(db_session):
+    early = await _seed_doc_with_chunk(
+        db_session,
+        title="Early",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    late = await _seed_doc_with_chunk(
+        db_session,
+        title="Late",
+        metadata={"tika": {"created_at": "2025-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", after="2024-01-01", limit=10)
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(late.doc_id) in doc_ids
+    assert str(early.doc_id) not in doc_ids
+
+
+@pytest.mark.asyncio
+async def test_before_filter_bounds_results(db_session):
+    early = await _seed_doc_with_chunk(
+        db_session,
+        title="Early",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    late = await _seed_doc_with_chunk(
+        db_session,
+        title="Late",
+        metadata={"tika": {"created_at": "2025-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="latest", before="2024-01-01", limit=10)
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(early.doc_id) in doc_ids
+    assert str(late.doc_id) not in doc_ids
+
+
+@pytest.mark.asyncio
+async def test_date_source_label_reflects_priority_chain(db_session):
+    tika_doc = await _seed_doc_with_chunk(
+        db_session,
+        title="Tika source",
+        metadata={"tika": {"created_at": "2020-01-01T00:00:00Z"}},
+    )
+    fm_doc = await _seed_doc_with_chunk(
+        db_session,
+        title="FM source",
+        metadata={"frontmatter": {"date": "2020-02-01"}},
+    )
+    sc_doc = await _seed_doc_with_chunk(
+        db_session,
+        title="Sidecar source",
+        metadata={"sidecar": {"date": "2020-03-01"}},
+    )
+    ingest_only = await _seed_doc_with_chunk(db_session, title="Ingest only")
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=20)
+    source_by_id = {str(d.doc_id): src for d, _, src in rows}
+    assert source_by_id[str(tika_doc.doc_id)] == "tika.created_at"
+    assert source_by_id[str(fm_doc.doc_id)] == "frontmatter.date"
+    assert source_by_id[str(sc_doc.doc_id)] == "sidecar.date"
+    assert source_by_id[str(ingest_only.doc_id)] == "ingest"
+
+
+@pytest.mark.asyncio
+async def test_explicit_date_field_skips_fallback(db_session):
+    """date_field='sidecar.date' means docs without sidecar.date are sorted by NULL
+    (PG sorts NULLs LAST asc / FIRST desc), not by Tika even if Tika exists."""
+    sc_only = await _seed_doc_with_chunk(
+        db_session,
+        title="Sidecar only",
+        metadata={"sidecar": {"date": "2020-01-01"}},
+    )
+    tika_only = await _seed_doc_with_chunk(
+        db_session,
+        title="Tika only",
+        metadata={"tika": {"created_at": "2010-01-01T00:00:00Z"}},
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", date_field="sidecar.date", limit=10)
+    # sc_only is the first non-NULL date when sorting by sidecar.date asc;
+    # tika_only is NULL on that field.
+    doc_ids = [str(d.doc_id) for d, _, _ in rows]
+    sc_idx = doc_ids.index(str(sc_only.doc_id))
+    tika_idx = doc_ids.index(str(tika_only.doc_id))
+    assert sc_idx < tika_idx
+    # date_source label should reflect the explicit choice for the matching doc.
+    source_by_id = {str(d.doc_id): src for d, _, src in rows}
+    assert source_by_id[str(sc_only.doc_id)] == "sidecar.date"
+
+
+@pytest.mark.asyncio
+async def test_limit_respected(db_session):
+    for i in range(5):
+        await _seed_doc_with_chunk(
+            db_session,
+            title=f"Doc {i}",
+            metadata={"tika": {"created_at": f"2024-01-{i + 1:02d}T00:00:00Z"}},
+        )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=3)
+    assert len(rows) == 3
+
+
+@pytest.mark.asyncio
+async def test_by_date_excludes_inactive_documents(db_session):
+    doc = await _seed_doc_with_chunk(
+        db_session,
+        title="Will be deleted",
+        metadata={"tika": {"created_at": "2024-01-01T00:00:00Z"}},
+    )
+    doc.status = "deleted"
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=10)
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(doc.doc_id) not in doc_ids

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -1,0 +1,184 @@
+"""Algorithm + integration tests for src/harbor_clerk/mcp_lookup_tools.py.
+
+Task 2 (this file) covers candidate matching for verify_identifier:
+title + canonical_filename ILIKE; metadata.tika.title equals; identifier-like
+metadata key equals across sidecar/frontmatter.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.mcp_lookup_tools import _find_candidates
+from harbor_clerk.models import Document
+from harbor_clerk.models.enums import PipelineStatus
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _seed_doc(
+    db_session: AsyncSession,
+    *,
+    title: str,
+    canonical_filename: str | None = None,
+    metadata: dict | None = None,
+) -> Document:
+    doc = Document(
+        title=title,
+        canonical_filename=canonical_filename,
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        doc_metadata=metadata or {},
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Matching tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_matches_returns_empty_list(db_session):
+    await _seed_doc(db_session, title="Unrelated Doc")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "nothing-matches")
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_matches_by_title_contains(db_session):
+    target = await _seed_doc(db_session, title="Pinnacle Vendor Contract")
+    await _seed_doc(db_session, title="Unrelated")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_canonical_filename_contains(db_session):
+    target = await _seed_doc(db_session, title="Doc One", canonical_filename="0131_vendor_contract.pdf")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "vendor_contract")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_are_case_insensitive(db_session):
+    target = await _seed_doc(db_session, title="Pinnacle Vendor Contract")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "PINNACLE")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_whitespace_normalized_in_input(db_session):
+    target = await _seed_doc(db_session, title="Pinnacle Vendor Contract")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "  pinnacle   vendor  ")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_tika_title_equals(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="raw-filename",
+        metadata={"tika": {"title": "Pinnacle Vendor Contract"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle Vendor Contract")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_sidecar_identifier_key_equals(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Some doc",
+        metadata={"sidecar": {"contract_id": "K-2025-031", "vendor": "Acme"}},
+    )
+    # Negative: another doc has the same value in a non-id key — must NOT match.
+    await _seed_doc(
+        db_session,
+        title="Other doc",
+        metadata={"sidecar": {"vendor": "K-2025-031"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "K-2025-031")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_nested_identifier_key(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Some doc",
+        metadata={"sidecar": {"contract": {"id": "K-2025-031"}}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "K-2025-031")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_matches_by_list_valued_identifier_key(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Some doc",
+        metadata={"frontmatter": {"order_id": ["K-1", "K-2"]}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "K-2")
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_deduplicates_when_multiple_fields_match(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract",
+        canonical_filename="pinnacle-vendor-contract.pdf",
+        metadata={"tika": {"title": "Pinnacle Vendor Contract"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle Vendor Contract")
+    # All three columns match this doc; result must contain it once.
+    assert [c.doc_id for c in candidates] == [target.doc_id]
+
+
+@pytest.mark.asyncio
+async def test_excludes_inactive_documents(db_session):
+    doc = await _seed_doc(db_session, title="Pinnacle")
+    doc.status = "deleted"
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle")
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_caps_at_100_candidates(db_session):
+    """100 docs with a shared substring — result is capped at 100."""
+    for i in range(105):
+        await _seed_doc(db_session, title=f"Pinnacle {i:03d}")
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "Pinnacle")
+    assert len(candidates) == 100

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -10,7 +10,7 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from harbor_clerk.mcp_lookup_tools import _find_candidates
+from harbor_clerk.mcp_lookup_tools import _find_candidates, verify_identifier
 from harbor_clerk.models import Document
 from harbor_clerk.models.enums import PipelineStatus
 
@@ -182,3 +182,109 @@ async def test_caps_at_100_candidates(db_session):
 
     candidates = await _find_candidates(db_session, "Pinnacle")
     assert len(candidates) == 100
+
+
+# ---------------------------------------------------------------------------
+# verify_identifier response-shape tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_not_found_returns_status_not_found(db_session):
+    await _seed_doc(db_session, title="Unrelated")
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "nothing-matches")
+    assert result == {"status": "not_found", "identifier": "nothing-matches"}
+
+
+@pytest.mark.asyncio
+async def test_unique_match_returns_status_unique(db_session):
+    target = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract",
+        canonical_filename="0131_vendor_contract.pdf",
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Vendor Contract")
+    assert result["status"] == "unique"
+    assert result["match"]["doc_id"] == str(target.doc_id)
+    assert result["match"]["title"] == "Pinnacle Vendor Contract"
+    assert result["match"]["canonical_filename"] == "0131_vendor_contract.pdf"
+    assert result["match"]["discriminating_fields"] == {}
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_match_with_discriminating_fields(db_session):
+    a = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract A",
+        metadata={"sidecar": {"vendor": "Pinnacle Tech Solutions", "term_months": 24}},
+    )
+    b = await _seed_doc(
+        db_session,
+        title="Pinnacle Vendor Contract B",
+        metadata={"sidecar": {"vendor": "Pinnacle Industries", "term_months": 36}},
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Vendor Contract")
+    assert result["status"] == "ambiguous"
+    assert result["count"] == 2
+    ids = {c["doc_id"] for c in result["candidates"]}
+    assert ids == {str(a.doc_id), str(b.doc_id)}
+
+    # Per-candidate discriminating_fields should carry that candidate's own values.
+    for c in result["candidates"]:
+        assert "sidecar.vendor" in c["discriminating_fields"]
+        assert "sidecar.term_months" in c["discriminating_fields"]
+    suggestion = result["suggestion"]
+    assert "sidecar.vendor" in suggestion or "sidecar.term_months" in suggestion
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_with_no_differing_fields_uses_fallback_suggestion(db_session):
+    await _seed_doc(
+        db_session,
+        title="Pinnacle Contract Alpha",
+        metadata={"sidecar": {"vendor": "Same Vendor"}},
+    )
+    await _seed_doc(
+        db_session,
+        title="Pinnacle Contract Beta",
+        metadata={"sidecar": {"vendor": "Same Vendor"}},
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Contract")
+    assert result["status"] == "ambiguous"
+    for c in result["candidates"]:
+        assert c["discriminating_fields"] == {}
+    assert "identical" in result["suggestion"].lower()
+
+
+@pytest.mark.asyncio
+async def test_empty_identifier_returns_error(db_session):
+    result = await verify_identifier(db_session, "")
+    assert "error" in result
+    assert "non-empty" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_identifier_returns_error(db_session):
+    result = await verify_identifier(db_session, "   ")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_overflow_flag_set_when_cap_exceeded(db_session):
+    for i in range(105):
+        await _seed_doc(db_session, title=f"Pinnacle {i:03d}")
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle")
+    assert result["status"] == "ambiguous"
+    assert result["count"] == 100
+    assert result["overflow"] is True
+    assert "More than 100" in result["suggestion"]

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -10,7 +10,12 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from harbor_clerk.mcp_lookup_tools import _find_candidates, _query_documents_by_date, verify_identifier
+from harbor_clerk.mcp_lookup_tools import (
+    _find_candidates,
+    _query_documents_by_date,
+    documents_by_date,
+    verify_identifier,
+)
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.models.enums import PipelineStatus
 
@@ -572,3 +577,83 @@ async def test_metadata_filter_list_value_match(db_session):
     )
     doc_ids = {str(d.doc_id) for d, _, _ in rows}
     assert str(target.doc_id) in doc_ids
+
+
+# ---------------------------------------------------------------------------
+# documents_by_date response-shape tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_response_shape(db_session):
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Pinnacle Doc",
+        metadata={"tika": {"created_at": "2024-06-15T12:00:00Z"}},
+    )
+    await db_session.flush()
+
+    result = await documents_by_date(db_session, direction="earliest", limit=10)
+    assert result["direction"] == "earliest"
+    assert isinstance(result["count"], int)
+    assert any(r["doc_id"] == str(target.doc_id) for r in result["results"])
+    row = next(r for r in result["results"] if r["doc_id"] == str(target.doc_id))
+    assert row["title"] == "Pinnacle Doc"
+    assert row["date"] == "2024-06-15T12:00:00+00:00"
+    assert row["date_source"] == "tika.created_at"
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_count_matches_results_length(db_session):
+    for i in range(3):
+        await _seed_doc_with_chunk(
+            db_session,
+            title=f"Doc {i}",
+            metadata={"tika": {"created_at": f"2024-01-{i + 1:02d}T00:00:00Z"}},
+        )
+    await db_session.flush()
+
+    result = await documents_by_date(db_session, direction="earliest", limit=2)
+    assert result["count"] == 2
+    assert len(result["results"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_empty_results(db_session):
+    """No active docs at all — return {count: 0, results: []}, never an error."""
+    result = await documents_by_date(db_session, direction="earliest", limit=10)
+    assert result["direction"] == "earliest"
+    # We can't assert count == 0 because other tests may seed docs in the
+    # same DB session; instead assert the shape is non-error.
+    assert "error" not in result
+    assert "results" in result
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_direction_returns_error(db_session):
+    result = await documents_by_date(db_session, direction="sideways", limit=10)
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_date_field_returns_error(db_session):
+    result = await documents_by_date(db_session, direction="earliest", date_field="bogus.field", limit=10)
+    assert "error" in result
+    assert "tika.created_at" in result["error"]  # accepted values listed
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_after_returns_error(db_session):
+    result = await documents_by_date(db_session, direction="earliest", after="not-a-date", limit=10)
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_invalid_metadata_filter_returns_error(db_session):
+    result = await documents_by_date(
+        db_session,
+        direction="earliest",
+        metadata_filter={"too.many.dots": "x"},
+        limit=10,
+    )
+    assert "error" in result

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -187,6 +187,43 @@ async def test_excludes_inactive_documents(db_session):
 
 
 @pytest.mark.asyncio
+async def test_metadata_scan_cap_still_finds_match_among_many_non_matching_docs(db_session):
+    """Regression for the unbounded metadata scan.
+
+    Seed 99 active docs all with non-empty metadata but no matching
+    identifier key, then one doc that DOES match via a sidecar contract_id.
+    With LIMIT 100 on the metadata scan, all 100 are fetched and the
+    matching doc (inserted last but within the 100-row window) is found.
+    _find_candidates must still return the matching doc, and the total
+    result count must be bounded by _VERIFY_CANDIDATE_CAP.
+
+    The regression value is in the LIMIT: without it, a corpus with 10k+
+    metadata docs would load them all into memory every call.
+    """
+    # 99 non-matching docs with non-empty metadata (total with the matching
+    # doc = 100, within the LIMIT 100 window).
+    for i in range(99):
+        await _seed_doc(
+            db_session,
+            title=f"NoMatch {i:03d}",
+            metadata={"sidecar": {"vendor": f"Vendor {i}"}},
+        )
+    # One doc that matches only via the Python-side identifier-key walk.
+    matching = await _seed_doc(
+        db_session,
+        title="Unique Title XZQ",
+        metadata={"sidecar": {"contract_id": "UNIQUE-XZQ-9999"}},
+    )
+    await db_session.flush()
+
+    candidates = await _find_candidates(db_session, "UNIQUE-XZQ-9999")
+    # The matching doc must be found despite the large non-matching pool.
+    assert any(c.doc_id == matching.doc_id for c in candidates)
+    # Total candidates must be bounded (at most _VERIFY_CANDIDATE_CAP).
+    assert len(candidates) <= 100
+
+
+@pytest.mark.asyncio
 async def test_caps_at_100_candidates(db_session):
     """100 docs with a shared substring — result is capped at 100."""
     for i in range(105):
@@ -275,6 +312,39 @@ async def test_ambiguous_with_no_differing_fields_uses_fallback_suggestion(db_se
     for c in result["candidates"]:
         assert c["discriminating_fields"] == {}
     assert "identical" in result["suggestion"].lower()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_with_nested_metadata_uses_nested_suggestion(db_session):
+    """When two docs are ambiguous and the discriminating info is nested in a
+    way the top-level projection can't see, the suggestion must mention
+    'nested', NOT 'identical discriminating metadata'.
+
+    Both docs match by title prefix. Doc A has nested metadata under
+    sidecar.contract (a dict-valued leaf). Doc B has flat sidecar metadata
+    on a different key. Because the path sets don't intersect, _find_differing
+    _metadata_fields returns empty — but _has_nested_metadata detects the dict
+    leaf on doc A and routes to the nested-aware suggestion branch.
+    """
+    # Doc A: nested sidecar metadata — sidecar.contract is a dict.
+    await _seed_doc(
+        db_session,
+        title="Pinnacle Nested Alpha",
+        metadata={"sidecar": {"contract": {"id": "K-2025-031"}}},
+    )
+    # Doc B: flat sidecar metadata on a DIFFERENT key — no common path with A.
+    await _seed_doc(
+        db_session,
+        title="Pinnacle Nested Beta",
+        metadata={"sidecar": {"vendor": "Acme Corp"}},
+    )
+    await db_session.flush()
+
+    result = await verify_identifier(db_session, "Pinnacle Nested")
+    assert result["status"] == "ambiguous"
+    suggestion = result["suggestion"].lower()
+    assert "nested" in suggestion
+    assert "identical" not in suggestion
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -5,16 +5,24 @@ title + canonical_filename ILIKE; metadata.tika.title equals; identifier-like
 metadata key equals across sidecar/frontmatter.
 """
 
+import json
 import uuid
+from contextlib import asynccontextmanager, contextmanager
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from harbor_clerk.api.deps import Principal
 from harbor_clerk.mcp_lookup_tools import (
     _find_candidates,
     _query_documents_by_date,
     documents_by_date,
     verify_identifier,
+)
+from harbor_clerk.mcp_server import (
+    _mcp_principal,
+    kb_documents_by_date,
+    kb_verify_identifier,
 )
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.models.enums import PipelineStatus
@@ -657,3 +665,61 @@ async def test_documents_by_date_invalid_metadata_filter_returns_error(db_sessio
         limit=10,
     )
     assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP-layer integration tests (Task 6)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _principal_in_context(user):
+    token = _mcp_principal.set(Principal(type="user", id=user.user_id, role="admin"))
+    try:
+        yield
+    finally:
+        _mcp_principal.reset(token)
+
+
+@pytest.fixture
+async def mock_session_factory(db_session, _engine, monkeypatch):
+    conn = await db_session.connection()
+
+    @asynccontextmanager
+    async def _factory():
+        session = AsyncSession(bind=conn, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.async_session_factory", _factory)
+
+
+@pytest.mark.asyncio
+async def test_kb_verify_identifier_unique_end_to_end(client, admin_user, db_session, mock_session_factory):
+    target = await _seed_doc(db_session, title="Singular Pinnacle Doc")
+    await db_session.flush()
+
+    with _principal_in_context(admin_user):
+        raw = await kb_verify_identifier(identifier="Singular Pinnacle Doc")
+    parsed = json.loads(raw)
+    assert parsed["status"] == "unique"
+    assert parsed["match"]["doc_id"] == str(target.doc_id)
+
+
+@pytest.mark.asyncio
+async def test_kb_documents_by_date_end_to_end(client, admin_user, db_session, mock_session_factory):
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Earliest doc",
+        metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}},
+        text="discussion of California regulators",
+    )
+    await db_session.flush()
+
+    with _principal_in_context(admin_user):
+        raw = await kb_documents_by_date(direction="earliest", query="California", limit=5)
+    parsed = json.loads(raw)
+    assert parsed["direction"] == "earliest"
+    assert any(r["doc_id"] == str(target.doc_id) for r in parsed["results"])

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -529,3 +529,46 @@ async def test_by_date_excludes_inactive_documents(db_session):
     rows = await _query_documents_by_date(db_session, direction="earliest", limit=10)
     doc_ids = {str(d.doc_id) for d, _, _ in rows}
     assert str(doc.doc_id) not in doc_ids
+
+
+@pytest.mark.asyncio
+async def test_malformed_tika_date_skipped_not_crash(db_session):
+    """Doc with a non-ISO Tika date should fall through to next source,
+    not abort the query with a 500."""
+    bad = await _seed_doc_with_chunk(
+        db_session,
+        title="Bad date doc",
+        metadata={
+            "tika": {"created_at": "N/A"},
+            "sidecar": {"date": "2024-01-01"},
+        },
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(db_session, direction="earliest", limit=10)
+    source_by_id = {str(d.doc_id): src for d, _, src in rows}
+    # Tika date couldn't parse → fell through to sidecar.
+    assert source_by_id[str(bad.doc_id)] == "sidecar.date"
+
+
+@pytest.mark.asyncio
+async def test_metadata_filter_list_value_match(db_session):
+    """metadata_filter on a list-valued metadata field must match (parity with search.py)."""
+    target = await _seed_doc_with_chunk(
+        db_session,
+        title="Tagged doc",
+        metadata={
+            "tika": {"created_at": "2024-01-01T00:00:00Z"},
+            "frontmatter": {"tags": ["alpha", "beta"]},
+        },
+    )
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session,
+        direction="earliest",
+        metadata_filter={"frontmatter.tags": "alpha"},
+        limit=10,
+    )
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(target.doc_id) in doc_ids

--- a/tests/test_mcp_tool_descriptions.py
+++ b/tests/test_mcp_tool_descriptions.py
@@ -6,6 +6,7 @@ from harbor_clerk.mcp_server import (
     kb_batch_search,
     kb_corpus_overview,
     kb_document_outline,
+    kb_documents_by_date,
     kb_entity_cooccurrence,
     kb_entity_overview,
     kb_entity_search,
@@ -19,6 +20,7 @@ from harbor_clerk.mcp_server import (
     kb_reprocess,
     kb_search,
     kb_system_health,
+    kb_verify_identifier,
 )
 
 
@@ -173,3 +175,36 @@ def test_kb_batch_search_signature_accepts_metadata_filter():
 
     sig = inspect.signature(kb_batch_search)
     assert "metadata_filter" in sig.parameters
+
+
+# ── Lookup tier (PR-E) ────────────────────────────────────────────────
+
+
+def test_kb_verify_identifier_docstring_has_four_parts():
+    doc = kb_verify_identifier.__doc__ or ""
+    # Same 4-part convention as PR-D: section headers with trailing colon.
+    assert "What you get back" in doc or "What it returns" in doc
+    assert "When to" in doc
+    assert "How to decline" in doc or "Decline" in doc
+
+
+def test_kb_verify_identifier_mentions_key_affordances():
+    doc = (kb_verify_identifier.__doc__ or "").lower()
+    assert "verify" in doc
+    assert "before" in doc  # "use before quoting" / "before you cite"
+    assert "ambiguous" in doc or "ambiguity" in doc
+    assert "not_found" in doc
+
+
+def test_kb_documents_by_date_docstring_has_four_parts():
+    doc = kb_documents_by_date.__doc__ or ""
+    assert "What you get back" in doc or "What it returns" in doc
+    assert "When to" in doc
+    assert "How to decline" in doc or "Decline" in doc
+
+
+def test_kb_documents_by_date_mentions_key_affordances():
+    doc = (kb_documents_by_date.__doc__ or "").lower()
+    assert "earliest" in doc
+    assert "latest" in doc
+    assert "date_source" in doc

--- a/tests/test_metadata_dates.py
+++ b/tests/test_metadata_dates.py
@@ -1,0 +1,105 @@
+"""Unit tests for src/harbor_clerk/metadata_dates.py::effective_date()."""
+
+from datetime import UTC, datetime
+
+from harbor_clerk.metadata_dates import effective_date
+
+
+class _Doc:
+    """Stand-in for the Document model — only fields effective_date reads.
+
+    Using a tiny dataclass-like helper instead of importing Document keeps
+    this file a pure unit test (no DB, no SQLAlchemy fixtures).
+    """
+
+    def __init__(self, doc_metadata=None, created_at=None):
+        self.doc_metadata = doc_metadata
+        self.created_at = created_at
+
+
+def test_uses_tika_when_present():
+    doc = _Doc(doc_metadata={"tika": {"created_at": "1999-10-13T08:34:00Z"}})
+    dt, label = effective_date(doc)
+    assert dt == datetime(1999, 10, 13, 8, 34, tzinfo=UTC)
+    assert label == "tika.created_at"
+
+
+def test_prefers_tika_over_frontmatter_and_sidecar():
+    doc = _Doc(
+        doc_metadata={
+            "tika": {"created_at": "2020-01-01T00:00:00Z"},
+            "frontmatter": {"date": "2010-01-01"},
+            "sidecar": {"date": "2015-01-01"},
+        }
+    )
+    dt, label = effective_date(doc)
+    assert dt.year == 2020
+    assert label == "tika.created_at"
+
+
+def test_falls_through_to_frontmatter():
+    doc = _Doc(doc_metadata={"frontmatter": {"date": "2025-04-19"}})
+    dt, label = effective_date(doc)
+    assert dt == datetime(2025, 4, 19, tzinfo=UTC)
+    assert label == "frontmatter.date"
+
+
+def test_falls_through_to_sidecar():
+    doc = _Doc(doc_metadata={"sidecar": {"date": "2024-08-01T12:00:00+00:00"}})
+    dt, label = effective_date(doc)
+    assert dt == datetime(2024, 8, 1, 12, 0, tzinfo=UTC)
+    assert label == "sidecar.date"
+
+
+def test_falls_through_to_ingest():
+    ingest = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+    doc = _Doc(doc_metadata={}, created_at=ingest)
+    dt, label = effective_date(doc)
+    assert dt == ingest
+    assert label == "ingest"
+
+
+def test_iso_without_timezone_assumed_utc():
+    doc = _Doc(doc_metadata={"tika": {"created_at": "2024-01-15T10:00:00"}})
+    dt, _ = effective_date(doc)
+    assert dt is not None
+    assert dt.tzinfo is not None
+    assert dt == datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+
+
+def test_date_only_string_parses():
+    doc = _Doc(doc_metadata={"frontmatter": {"date": "2024-01-15"}})
+    dt, _ = effective_date(doc)
+    assert dt == datetime(2024, 1, 15, tzinfo=UTC)
+
+
+def test_naive_datetime_object_assumed_utc():
+    doc = _Doc(doc_metadata={"sidecar": {"date": datetime(2024, 2, 2)}})
+    dt, _ = effective_date(doc)
+    assert dt == datetime(2024, 2, 2, tzinfo=UTC)
+
+
+def test_unparseable_string_falls_through_to_next_source():
+    doc = _Doc(
+        doc_metadata={"tika": {"created_at": "not-a-date"}},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    dt, label = effective_date(doc)
+    assert label == "ingest"
+    assert dt.year == 2026
+
+
+def test_all_sources_missing_returns_none_and_none_label():
+    doc = _Doc(doc_metadata={}, created_at=None)
+    dt, label = effective_date(doc)
+    assert dt is None
+    assert label == "none"
+
+
+def test_none_doc_metadata_falls_through_to_ingest():
+    """doc_metadata=None should not raise — treat as empty dict."""
+    ingest = datetime(2026, 1, 1, tzinfo=UTC)
+    doc = _Doc(doc_metadata=None, created_at=ingest)
+    dt, label = effective_date(doc)
+    assert label == "ingest"
+    assert dt == ingest


### PR DESCRIPTION
## Summary

Adds two structured-lookup MCP tools (with matching `harbor-clerk` CLI subcommands) targeting reproducible failure modes in the PR-A/B/C answer-eval runs:

- **`kb_verify_identifier`** — proactive fabrication-prevention. Given an identifier string, returns `not_found` / `unique` / `ambiguous` with per-candidate `discriminating_fields`. Sharp affordance to use BEFORE quoting a specific named document.
- **`kb_documents_by_date`** — date-bounded lookups with optional FTS query, metadata filter, and direction (earliest / latest). Smart date-field discovery chain: `metadata.tika.created_at → metadata.frontmatter.date → metadata.sidecar.date → documents.created_at`.

Both tools live in a single new `src/harbor_clerk/mcp_lookup_tools.py` module with a shared `src/harbor_clerk/metadata_dates.py` helper, MCP wrappers in `mcp_server.py`, and CLI peers under `src/harbor_clerk/cli/commands/`.

## Why this PR exists (eval-failure motivation)

**Enron lookups (`reports/enron-phase2a/detail.json`)** — both `lookup` items scored 0/2/0:

- `enron-lookup-earliest-california`: Sonnet picked July 30, 2000 instead of October 13, 1999. Similarity ranking can't surface the actual earliest doc.
- `enron-lookup-skilling-last-pre-resign`: Sonnet picked "Memo from Jeff Skilling" (Teesside) instead of "Please Plan to Attend". Same problem on the "latest" side.

Both failures share a root cause: no tool returns docs sorted by date with an optional content filter. `kb_documents_by_date` is the direct fix.

**Synthetic boundary-doc lookups (`reports/synthetic-phase2b/detail.json`)** — 10 / 26 lookups scored ≤2 on correctness. Recurring pattern: model conflates multiple instances of an identifier ("onboarding letters", "vendor contracts", "policy versions"). PR-D's `discriminator_hint` addresses the reactive case (kb_search returned ambiguous hits); `kb_verify_identifier` adds the proactive lever (model can verify before answering at all).

## What's in it

### Backend
- `src/harbor_clerk/metadata_dates.py` — `effective_date(doc) → (datetime | None, source_label)` helper. Walks the priority chain; returns the source field used.
- `src/harbor_clerk/mcp_lookup_tools.py` — implementations of `verify_identifier()` + `documents_by_date()`. Reuses PR-D's `_find_differing_metadata_fields` for the discriminating-fields projection. Reuses PR-F's `Document.doc_metadata` JSONB column.
- `src/harbor_clerk/mcp_server.py` — registers `kb_verify_identifier` + `kb_documents_by_date` MCP tools with PR-D-style 4-part docstrings (When to call / What you get back / How to decline).

### CLI (parity with PR #397)
- `src/harbor_clerk/cli/commands/verify_identifier.py`
- `src/harbor_clerk/cli/commands/documents_by_date.py`
- `src/harbor_clerk/cli/help/verify-identifier.txt` + `documents-by-date.txt`
- Text renderers in `src/harbor_clerk/cli/output.py`
- Registered in `src/harbor_clerk/cli/commands/__init__.py::_COMMAND_NAMES` (now 18 commands)
- `tests/cli/test_main.py` count-assertion bumped 17 → 18

### Tests
- `tests/test_metadata_dates.py` — 11 unit tests for the date-discovery helper
- `tests/test_mcp_lookup_tools.py` — 42 tests covering matching, response shapes, SQL query, date discovery, metadata-filter parity with `search.py`, malformed-date safety, nested-key suggestion text, end-to-end MCP wiring
- `tests/test_mcp_tool_descriptions.py` — 4 docstring pin tests
- `tests/cli/test_commands_verify_identifier.py` — 6 CLI command tests
- `tests/cli/test_commands_documents_by_date.py` — 10 CLI command tests
- `tests/cli/test_e2e.py` — 3 `--help` smoke tests
- Total new tests: ~76; full suite: **1121 passed, 23 skipped**

## Defensive design notes

- **JSONB cast safety**: a malformed Tika date (e.g., `"N/A"`) used to abort the entire date-sort query. Fixed by wrapping each per-slot cast in a regex-guarded `CASE WHEN text ~ '^\d{4}-\d{2}-\d{2}' THEN CAST(...) ELSE NULL`. The source-label CASE uses the same guarded expression so the label and the picked date always agree on which slot won.
- **metadata_filter parity with `search.py`**: inlined the `@>` containment OR `?` existence pattern to match `kb_search`'s behavior exactly. Cross-reference comment added so future divergence is obvious.
- **Bounded metadata scan**: the secondary metadata walk in `_find_candidates` is now `LIMIT _VERIFY_CANDIDATE_CAP` (100). Without the cap, the function loaded every active doc with non-empty metadata into Python on each call — DoS risk on large corpora.
- **Nested-match suggestion text**: when a candidate matched via a nested identifier key, the top-level discriminating-fields projection may be empty for that candidate. Suggestion text now distinguishes "candidates have nested distinguishing metadata" from the original "candidates have identical metadata" case so the affordance to the model isn't misleading.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_macos_smoke.py` — 1121 passed, 23 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 395 files already formatted
- [x] Fresh-eyes review (feature-dev:code-reviewer, minimal prompt, no carve-outs) — 2 ≥80-confidence findings addressed in commit `675982b`
- [ ] **User to rebuild the app and verify** the live MCP responses for `kb_verify_identifier` and `kb_documents_by_date` against the loaded Enron + synthetic corpus

## Spec + plan

- **Spec:** `docs/superpowers/specs/2026-05-24-mcp-verify-identifier-and-documents-by-date-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-24-mcp-verify-identifier-and-documents-by-date.md`

## Out of scope / follow-ups

Captured in the spec's "Out of scope" section and queued in `pr_followups.md`:

- **Numeric/range comparators on metadata** (`>=`, `<`, `between`, `in`) — still deferred per PR-F's spec; `after`/`before` for dates is the most-common-case partial answer.
- **Folder-path-as-metadata** for date discovery — separate config-story PR.
- **`kb_count_matches`** — pure count tool punted; revisit if eval surfaces the need.
- **Localized / natural-language date parsing** — ISO only for v1.
- **Sidecar identifier-key regex refinement** — current pattern catches common naming; widen if eval misses fields like `bates`, `docket`, `policy_no`, `claim_number`.
- **`verify_identifier` `fields=` param** — let the model choose which fields to search. Punted; v1 hardcodes the field set.
- **Push the identifier-key match into SQL** — current impl Python-walks a `LIMIT 100` slice. For corpora >>10k docs, the secondary scan could become a hot spot even with the cap; pushing the walk into a JSONB path expression would be more scalable.
- **Nested-key `discriminating_fields` projection** — if a candidate matched via `sidecar.contract.id` (nested), the current top-level-paths projection may show empty discriminating_fields for that candidate. Suggestion text now flags this case clearly; a richer fix would have `_find_candidates` return matched paths so `verify_identifier` can surface them directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
