### PR TITLE
fix(macos): Install button silently no-ops when CLI toggle is off

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
@@ -219,13 +219,13 @@ struct PreferencesWindow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    if enableCliAccess {
-                        CliShimRow()
-                    } else {
-                        CliShimRow()
-                            .disabled(true)
-                            .help("Enable the toggle above before installing the shim.")
-                    }
+                    // Shim install is a client-side convenience — it drops a
+                    // small shell script at ~/.local/bin/harbor-clerk that
+                    // delegates to the bundled Python. The CLI toggle above
+                    // is the actual access gate (server-side 403). Decoupling
+                    // them means the Install button always fires; a user can
+                    // pre-stage the binary and flip the toggle later.
+                    CliShimRow()
 
                     if !allowRemoteWeb && !allowRemoteMCP {
                         Text("Harbor Clerk is only accessible from this Mac.")


### PR DESCRIPTION
## Summary

Fixes a reported bug: the **Install** button in Harbor Clerk Server's Preferences → Network Access section doesn't do anything when clicked.

## Root cause

`PreferencesWindow.swift` wrapped `CliShimRow` in:

```swift
if enableCliAccess {
    CliShimRow()
} else {
    CliShimRow()
        .disabled(true)
        .help("Enable the toggle above before installing the shim.")
}
```

SwiftUI's `.disabled(true)` cascades to every interactive element in the view — including the Install button. When the CLI toggle is off, the button silently fails to fire on click. With `.buttonStyle(.borderedProminent)` the disabled state isn't visually obvious, so the button looks clickable but the action never runs.

## Why decouple, not just "more obvious disable"

The gating is also wrong conceptually:

- The shim is a **client-side convenience** — drops a small shell script at `~/.local/bin/harbor-clerk` that delegates to the bundled Python.
- The actual **CLI access gate is server-side** — `MCPAuthMiddleware` returns HTTP 403 (with the helpful "Enable in System Settings → Integrations" hint) when `enable_cli_access` is false.

Coupling Install to the toggle conflated two independent concerns. A user might reasonably want to pre-stage the binary and flip the access toggle later — there's no risk because the server gate is the actual access boundary. If they run `harbor-clerk` while the toggle is off, they get the server-side 403 with a clear remediation message.

## Change

Removed the if/else wrapper; `CliShimRow()` is always rendered enabled. Added an inline code comment explaining the decoupling so this doesn't get re-coupled by accident.

## Test plan

- [x] `xcodebuild ... HarborClerkServer build` — BUILD SUCCEEDED locally on Xcode 26.5
- [x] `xcodebuild ... -only-testing:HarborClerkServerTests/CliShimInstallerTests test` — 14 passed, 0 failures
- [ ] Manual: open Preferences with CLI toggle OFF, click Install, confirm the shim is written to `~/.local/bin/harbor-clerk` and status flips to "Installed at ...". Then toggle CLI on, run `harbor-clerk --help`, confirm the 16 subcommands list. Then toggle CLI off, run `harbor-clerk system-health`, confirm exit code 3 with the "Enable in System Settings → Integrations" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
