### PR TITLE
fix(macos): bake HARBOR_CLERK_URL into shim + clarify toggle UX

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/CliShimInstaller.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/CliShimInstaller.swift
@@ -4,17 +4,25 @@ import Foundation
 enum CliShimStatus: Equatable {
     /// No shim file exists (or it exists but isn't ours).
     case notInstalled
-    /// Our shim is present and its embedded bundle path matches the current app.
+    /// Our shim is present and its embedded bundle path + API URL match current settings.
     case installed(path: String)
-    /// Our shim is present but points to a different bundle path (app moved / reinstalled).
+    /// Our shim is present but the embedded bundle path or API URL is stale
+    /// (app moved, reinstalled, or apiPort changed in Preferences).
     case installedOutdated(path: String, currentBundle: String)
 }
 
 /// Installs and manages the `harbor-clerk` CLI shim at `~/.local/bin/harbor-clerk`.
 ///
 /// The shim is a small shell script that delegates to the bundled Python venv.
-/// `BUNDLE_RESOURCES` is baked in at install time from `Bundle.main.resourceURL`;
-/// if the user moves the app they must re-install to refresh the path.
+/// `BUNDLE_RESOURCES` and `HARBOR_CLERK_URL` are baked in at install time from
+/// `Bundle.main.resourceURL` and `AppSettings.shared.apiPort` respectively.
+/// If the user moves the app or changes the API port they must re-install via
+/// Preferences to refresh the shim — `currentStatus()` reports `installedOutdated`
+/// in either case so the UI button surfaces "Re-install".
+///
+/// The `HARBOR_CLERK_URL` line uses `${VAR:-default}` so the user can still
+/// override it in their shell for unusual deployments (e.g. pointing the CLI
+/// at a different Harbor Clerk instance on the network).
 ///
 /// No privileged code is required — `~/.local/bin` is under the user's home directory.
 final class CliShimInstaller {
@@ -53,19 +61,48 @@ final class CliShimInstaller {
             .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
 
         let currentBundle = Bundle.main.resourceURL!.path
+        let currentPort = AppSettings.shared.apiPort
 
-        if embeddedBundle == currentBundle {
+        // Detect "stale port": the shim's baked-in URL no longer matches the
+        // configured apiPort. Older shims (pre-this-feature) had no URL line
+        // at all — treat them as outdated so the user gets prompted to re-install.
+        let embeddedPort = extractEmbeddedApiPort(from: contents)
+
+        if embeddedBundle == currentBundle && embeddedPort == currentPort {
             return .installed(path: url.path)
         } else {
             return .installedOutdated(path: url.path, currentBundle: currentBundle)
         }
     }
 
+    /// Parse the integer port from the `export HARBOR_CLERK_URL=...` line in a shim.
+    /// Returns nil if the URL line is absent or unparseable — `currentStatus`
+    /// then treats the shim as outdated.
+    static func extractEmbeddedApiPort(from shimContents: String) -> Int? {
+        guard let urlLine = shimContents.components(separatedBy: "\n").first(where: { $0.hasPrefix("export HARBOR_CLERK_URL=") }) else {
+            return nil
+        }
+        // The line shape is: export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:PORT}"
+        // Find the default-value substring after ":-" and parse the trailing port.
+        guard let defaultMarker = urlLine.range(of: ":-http"),
+              let closeBrace = urlLine.range(of: "}", range: defaultMarker.upperBound..<urlLine.endIndex) else {
+            return nil
+        }
+        let defaultUrl = String(urlLine[defaultMarker.upperBound..<closeBrace.lowerBound])
+        // defaultUrl is now something like "://localhost:8100" — take the last colon-separated component.
+        guard let portString = defaultUrl.split(separator: ":").last,
+              let port = Int(portString) else {
+            return nil
+        }
+        return port
+    }
+
     /// Write the shim to `~/.local/bin/harbor-clerk`, creating the directory if needed.
     /// Sets executable permissions (0o755) after writing.
     static func install() throws {
         let bundle = Bundle.main.resourceURL!.path
-        let shim = makeShimContent(bundleResources: bundle)
+        let apiPort = AppSettings.shared.apiPort
+        let shim = makeShimContent(bundleResources: bundle, apiPort: apiPort)
 
         let dir = shimPath.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
@@ -88,16 +125,21 @@ final class CliShimInstaller {
 
     // MARK: - Internal helpers
 
-    /// Generate the shim script content with `BUNDLE_RESOURCES` baked in.
-    static func makeShimContent(bundleResources: String) -> String {
+    /// Generate the shim script content with `BUNDLE_RESOURCES` and the
+    /// default API URL baked in. The URL line uses `${VAR:-default}` so a
+    /// user can still override `HARBOR_CLERK_URL` in their shell for unusual
+    /// deployments (e.g. pointing the CLI at a different Harbor Clerk
+    /// instance on the network).
+    static func makeShimContent(bundleResources: String, apiPort: Int) -> String {
         return """
         #!/bin/sh
         # harbor-clerk — installed by Harbor Clerk Server
         # Invokes the bundled Python via Harbor Clerk Server.app's venv.
-        # Re-install via Preferences if you move or reinstall the app.
+        # Re-install via Preferences if you move/reinstall the app or change the API port.
         BUNDLE_RESOURCES="\(bundleResources)"
         export PATH="$BUNDLE_RESOURCES/venv/bin:/usr/bin:/bin"
         export PYTHONPATH="$BUNDLE_RESOURCES/venv/lib"
+        export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:\(apiPort)}"
         exec "$BUNDLE_RESOURCES/venv/bin/python" -m harbor_clerk.cli.main "$@"
         """
     }

--- a/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
@@ -44,6 +44,12 @@ private struct CliShimRow: View {
             Text("Add the snippet above to ~/.zshrc (or ~/.bashrc) if harbor-clerk isn't found on your PATH.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            // API key is the per-client credential — the shim bakes in the
+            // server URL, but each agent still needs its own key.
+            Text("Each agent also needs an API key — pass `--api-key hc_...` or set `HARBOR_CLERK_API_KEY`. Mint a key in System Settings → API Keys (in the web app).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
         .padding(.vertical, 4)
     }
@@ -215,7 +221,7 @@ struct PreferencesWindow: View {
                             // effect within seconds without touching the restart banner.
                             AppSettings.shared.enableCliAccess = newValue
                         }
-                    Text("Let agent harnesses (Claude Code, Codex, etc.) query documents via the harbor-clerk CLI. Does not require a service restart.")
+                    Text("Master switch for the harbor-clerk CLI (Claude Code, Codex, etc.). Like the MCP toggle above, individual clients still authenticate with API keys minted in System Settings → API Keys. No service restart required.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 

--- a/macos/HarborClerkServer/HarborClerkServerTests/CliShimInstallerTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/CliShimInstallerTests.swift
@@ -40,27 +40,68 @@ final class CliShimInstallerTests: XCTestCase {
     // MARK: - makeShimContent
 
     func testShimContentContainsMarker() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/tmp/fake.app/Contents/Resources")
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/tmp/fake.app/Contents/Resources", apiPort: 8100)
         XCTAssertTrue(content.contains("# harbor-clerk — installed by Harbor Clerk Server"),
                       "Shim must contain the identity marker so status detection recognises it")
     }
 
     func testShimContentContainsBundleResourcesLine() {
         let bundle = "/fake/Harbor Clerk Server.app/Contents/Resources"
-        let content = CliShimInstaller.makeShimContent(bundleResources: bundle)
+        let content = CliShimInstaller.makeShimContent(bundleResources: bundle, apiPort: 8100)
         XCTAssertTrue(content.contains("BUNDLE_RESOURCES=\"\(bundle)\""),
                       "Shim must embed BUNDLE_RESOURCES with the provided path")
     }
 
     func testShimContentIsExecutableScript() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x")
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
         XCTAssertTrue(content.hasPrefix("#!/bin/sh"), "Shim must start with a sh shebang")
     }
 
     func testShimContentDelegatesViaExec() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x")
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
         XCTAssertTrue(content.contains("exec \"$BUNDLE_RESOURCES/venv/bin/python\" -m harbor_clerk.cli.main \"$@\""),
                       "Shim must exec python with the correct module and forward args")
+    }
+
+    // MARK: - HARBOR_CLERK_URL default
+
+    func testShimContentEmbedsApiUrlAsDefault() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+        XCTAssertTrue(
+            content.contains(#"export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:8100}""#),
+            "Shim must bake in the apiPort as the default HARBOR_CLERK_URL using ${VAR:-default} so users can still override in their shell"
+        )
+    }
+
+    func testShimContentUsesProvidedPort() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 9999)
+        XCTAssertTrue(
+            content.contains("http://localhost:9999}"),
+            "Shim must reflect the apiPort passed in, not a hardcoded default"
+        )
+    }
+
+    func testExtractEmbeddedApiPortRoundTrip() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+        XCTAssertEqual(CliShimInstaller.extractEmbeddedApiPort(from: content), 8100)
+    }
+
+    func testExtractEmbeddedApiPortRoundTripNonDefault() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 12345)
+        XCTAssertEqual(CliShimInstaller.extractEmbeddedApiPort(from: content), 12345)
+    }
+
+    func testExtractEmbeddedApiPortReturnsNilForLegacyShim() {
+        // Old shims (pre-URL-baking) have no `export HARBOR_CLERK_URL=` line.
+        let legacy = """
+        #!/bin/sh
+        # harbor-clerk — installed by Harbor Clerk Server
+        BUNDLE_RESOURCES="/x"
+        export PATH="$BUNDLE_RESOURCES/venv/bin:/usr/bin:/bin"
+        exec "$BUNDLE_RESOURCES/venv/bin/python" -m harbor_clerk.cli.main "$@"
+        """
+        XCTAssertNil(CliShimInstaller.extractEmbeddedApiPort(from: legacy),
+                     "Legacy shim without a URL line should parse as nil so currentStatus marks it outdated")
     }
 
     // MARK: - Status detection helpers (shimPath-independent)
@@ -71,7 +112,7 @@ final class CliShimInstallerTests: XCTestCase {
         // We test the internal logic by manually checking content parsing
         // (can't inject shimPath, so we verify make/parse round-trip)
         let bundle = "/my/bundle"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle, apiPort: 8100)
 
         // Simulate the parse that currentStatus() does
         XCTAssertTrue(shim.contains("# harbor-clerk — installed by Harbor Clerk Server"))
@@ -97,7 +138,7 @@ final class CliShimInstallerTests: XCTestCase {
         let shimURL = nestedDir.appendingPathComponent("harbor-clerk")
 
         try FileManager.default.createDirectory(at: nestedDir, withIntermediateDirectories: true)
-        let shim = CliShimInstaller.makeShimContent(bundleResources: "/test/bundle")
+        let shim = CliShimInstaller.makeShimContent(bundleResources: "/test/bundle", apiPort: 8100)
         try shim.write(to: shimURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shimURL.path)
 
@@ -106,7 +147,7 @@ final class CliShimInstallerTests: XCTestCase {
 
     func testInstallWritesCorrectContent() throws {
         let bundle = "/Applications/Harbor Clerk Server.app/Contents/Resources"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle, apiPort: 8100)
         try shim.write(to: fakeShimPath, atomically: true, encoding: .utf8)
 
         let written = try String(contentsOf: fakeShimPath, encoding: .utf8)
@@ -115,7 +156,7 @@ final class CliShimInstallerTests: XCTestCase {
     }
 
     func testInstallSetsExecutablePermissions() throws {
-        let shim = CliShimInstaller.makeShimContent(bundleResources: "/x")
+        let shim = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
         try shim.write(to: fakeShimPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeShimPath.path)
 
@@ -129,7 +170,7 @@ final class CliShimInstallerTests: XCTestCase {
     func testInstalledStatusAfterWritingMatchingShim() throws {
         // Write a shim that matches Bundle.main.resourceURL
         let currentBundle = Bundle.main.resourceURL?.path ?? "/fake/bundle"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: currentBundle)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: currentBundle, apiPort: 8100)
 
         // Write to the real shimPath (which points to ~/.local/bin/harbor-clerk)
         // ONLY if shimPath == ~/.local/bin/harbor-clerk and we definitely want to
@@ -145,7 +186,7 @@ final class CliShimInstallerTests: XCTestCase {
     func testInstalledOutdatedWhenBundlePathDiffers() throws {
         let staleBundle = "/old/path/Harbor Clerk Server.app/Contents/Resources"
         let currentBundle = Bundle.main.resourceURL?.path ?? "/new/bundle"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: staleBundle)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: staleBundle, apiPort: 8100)
 
         let lines = shim.components(separatedBy: "\n")
         let bundleLine = lines.first(where: { $0.hasPrefix("BUNDLE_RESOURCES=") })!
@@ -179,7 +220,7 @@ final class CliShimInstallerTests: XCTestCase {
     func testUninstallRemovesOurShimFile() throws {
         // Write our shim to a temp path and remove it manually (simulating what
         // uninstall() does when it detects .installed or .installedOutdated)
-        let ourShim = CliShimInstaller.makeShimContent(bundleResources: "/test")
+        let ourShim = CliShimInstaller.makeShimContent(bundleResources: "/test", apiPort: 8100)
         try ourShim.write(to: fakeShimPath, atomically: true, encoding: .utf8)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: fakeShimPath.path))


### PR DESCRIPTION
## Summary

Two related fixes to the menubar CLI integration, reported during smoke-testing of #400:

1. **`harbor-clerk` returns "Connection refused"** when the user runs it from a terminal.
2. **The "Allow harbor-clerk CLI" toggle's purpose isn't clear** if an API key is also required.

## (1) Connection refused

```
$ harbor-clerk search --api-key hc_... bankruptcy
harbor-clerk: [Errno 61] Connection refused
```

The CLI's default URL is `https://localhost` (port 443), but the macOS API server runs at `http://localhost:<apiPort>` (default 8100, plain HTTP — there's no Caddy on native). Without `HARBOR_CLERK_URL` explicitly set, every CLI invocation hits the wrong port and fails.

**Fix:** `CliShimInstaller` now bakes the URL into the shim at install time, reading `AppSettings.shared.apiPort`:

```sh
export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:8100}"
```

The `${VAR:-default}` idiom preserves the user's ability to override in their shell (e.g. pointing at a different Harbor Clerk instance on the network) while making the common case "just work."

`currentStatus()` now also parses the embedded port and returns `.installedOutdated` when it no longer matches the configured `apiPort` — so if the user changes the port in Preferences, the "Re-install" button surfaces automatically. Legacy shims (without the URL line) also parse as outdated.

## (2) Toggle vs API key

The previous caption — "Let agent harnesses (Claude Code, Codex, etc.) query documents via the harbor-clerk CLI. Does not require a service restart." — didn't explain that API keys are still required, or what the toggle adds on top of the keys.

Yes, API keys are intentionally required — same auth model as MCP. The toggle is a **master kill switch** sitting on top, identical in shape to the sibling "Allow remote model connections (MCP)" toggle right above it:

- An admin can disable *all* CLI traffic without revoking API keys (which would also break MCP).
- Defense in depth: even a leaked key can't be used via CLI unless an admin enabled the feature.
- Default-off matches MCP's `allowRemoteMCP` pattern.

**Fix:** Reframed the caption to make this explicit: "Master switch for the harbor-clerk CLI (Claude Code, Codex, etc.). Like the MCP toggle above, individual clients still authenticate with API keys minted in System Settings → API Keys. No service restart required."

Also added a parallel hint inside `CliShimRow` after the PATH snippet so a user installing the shim knows the next step is minting a key.

## Test plan

- [x] `xcodebuild ... -only-testing:HarborClerkServerTests/CliShimInstallerTests test` → **19 passed, 0 failures** (14 pre-existing + 5 new: URL embedding present, port round-trip with default, port round-trip with non-default port, legacy shim parses as nil port, port-mismatch triggers outdated)
- [ ] Manual: re-install the shim via Preferences after pulling this build. Verify `~/.local/bin/harbor-clerk` now contains the `export HARBOR_CLERK_URL=...` line. Run `harbor-clerk system-health --api-key hc_...` and confirm it returns a JSON response (not Connection refused).
- [ ] Manual: change `api_port` to a non-default value in config.json, observe that the install row flips to "Installed but stale — re-install to update."
- [ ] Manual: read the new toggle caption — confirm it answers "what does this toggle do vs. the API key" and "where do I get an API key."

## Note on CLAUDE.md

The "Key API Surface" entry for `harbor-clerk` still says "server restart required" — that became stale when carry-over 3 made the gate runtime-mutable on macOS. I'll fix that in a follow-up rather than expand this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
