### PR TITLE
chore(deps): extend dependabot to embedder workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-  - package-ecosystem: pip
-    directory: "/scripts/test_corpora"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/frontend"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/embedder"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/scripts/test_corpora"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
## Summary

- [`.github/dependabot.yml`](.github/dependabot.yml) only listed `/` (pip) and `/frontend` (npm). The `/embedder` workspace has its own `pyproject` + `uv.lock` (tracked in git) and was unlisted.
- Security alerts still fire repo-wide, so vulnerable deps in `/embedder` appeared in the Dependabot alerts dashboard — but no auto-PRs landed. That gap is how the embedder's vulnerable `starlette==0.52.1` (CVE-2026-48710) went uncaught until a manual audit (now patched in #405).
- Adding `/embedder` as a weekly pip ecosystem with the same 10-PR cap.
- (Originally also included `/scripts/test_corpora`; dropped in the follow-up commit — that `uv.lock` is gitignored and 404s on the default branch, so Dependabot has no manifest to scan there.)

## Test plan

- [x] YAML lints cleanly; format matches existing entries exactly
- [ ] Once merged, watch the Dependabot tab — within a week, alerts should produce auto-PRs against `/embedder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
