### PR TITLE
feat(email): header preamble in chunks + queryable email.* metadata_filter

### DIFF
--- a/alembic/versions/d65a570f594c_email_metadata_trgm_gin_indexes.py
+++ b/alembic/versions/d65a570f594c_email_metadata_trgm_gin_indexes.py
@@ -1,0 +1,51 @@
+"""email metadata trgm gin indexes
+
+Adds documents.email_subject (TEXT, nullable) and two GIN trigram indexes
+on documents.email_subject and documents.email_from_name to support fast
+ILIKE filtering used by the new email.subject_contains and
+email.from_name_contains metadata_filter keys (see hybrid_search).
+Without these, ILIKE '%v%' on these columns forces a seq-scan on the
+documents table at corpus scale.
+
+The pg_trgm extension is already enabled (see docker/postgres/init-
+extensions.sql for Docker; same for macOS bundle).
+
+CREATE INDEX CONCURRENTLY cannot run inside a transaction; wrap in
+autocommit_block (pattern established by PR #411). The column ADD is
+transactional (standard alembic DDL) and must run before the CONCURRENTLY
+index creates, so it is placed in a separate block.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d65a570f594c"
+down_revision = "b56bde44ec8c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add the email_subject column (transactional DDL — runs in alembic's
+    # default transaction).
+    op.add_column("documents", sa.Column("email_subject", sa.Text(), nullable=True))
+
+    # Create trgm GIN indexes CONCURRENTLY (cannot run inside a transaction).
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_email_subject_trgm "
+            "ON public.documents USING gin (email_subject public.gin_trgm_ops)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_email_from_name_trgm "
+            "ON public.documents USING gin (email_from_name public.gin_trgm_ops)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS public.ix_documents_email_subject_trgm")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS public.ix_documents_email_from_name_trgm")
+
+    op.drop_column("documents", "email_subject")

--- a/alembic/versions/d65a570f594c_email_metadata_trgm_gin_indexes.py
+++ b/alembic/versions/d65a570f594c_email_metadata_trgm_gin_indexes.py
@@ -17,6 +17,7 @@ index creates, so it is placed in a separate block.
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/d65a570f594c_email_metadata_trgm_gin_indexes.py
+++ b/alembic/versions/d65a570f594c_email_metadata_trgm_gin_indexes.py
@@ -16,8 +16,6 @@ transactional (standard alembic DDL) and must run before the CONCURRENTLY
 index creates, so it is placed in a separate block.
 """
 
-import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -29,8 +27,9 @@ depends_on = None
 
 def upgrade() -> None:
     # Add the email_subject column (transactional DDL — runs in alembic's
-    # default transaction).
-    op.add_column("documents", sa.Column("email_subject", sa.Text(), nullable=True))
+    # default transaction). ADD COLUMN IF NOT EXISTS makes the migration
+    # replay-safe in environments where the column was added out-of-band.
+    op.execute("ALTER TABLE documents ADD COLUMN IF NOT EXISTS email_subject TEXT")
 
     # Create trgm GIN indexes CONCURRENTLY (cannot run inside a transaction).
     with op.get_context().autocommit_block():

--- a/docs/superpowers/plans/2026-05-27-email-header-chunking.md
+++ b/docs/superpowers/plans/2026-05-27-email-header-chunking.md
@@ -1,0 +1,1218 @@
+# Email Header Chunking + Queryable Email Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepend a structured email-header block (From / To / Cc / Subject / Date) to email `body_text` so chunks include it, AND expose `Document.email_*` columns via a new `email.*` namespace in `metadata_filter`.
+
+**Architecture:** A new helper `_build_header_preamble()` in `parser.py` builds the block and `parse_eml` prepends it before returning. `hybrid_search` grows a pre-pass that strips `email.*` keys from `metadata_filter` and dispatches to dedicated column predicates (exact, ILIKE substring via `escape_ilike()`, or `= ANY` on TEXT[] arrays). Two new trgm GIN indexes on `email_subject` + `email_from_name` keep ILIKE queries fast. Docstring updates on `kb_search` / `kb_find_all` / `kb_documents_by_date` describe the new filter keys.
+
+**Tech Stack:** Python 3.12, SQLAlchemy 2.0 async, asyncpg, PostgreSQL 18 with `pg_trgm`, pytest, alembic.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-email-header-chunking-design.md`
+
+**File map (created or modified):**
+
+- Modify: `src/harbor_clerk/mail/parser.py` — add `_build_header_preamble()` helper; wire into `parse_eml` to prepend to `body_text`
+- Modify: `src/harbor_clerk/search.py` — add `email.*` pre-pass to the `metadata_filter` translator in `hybrid_search`
+- Modify: `src/harbor_clerk/mcp_server.py` — docstring updates on `kb_search`, `kb_find_all`, `kb_documents_by_date` describing `email.*` filter keys
+- Create: `alembic/versions/<rev>_email_metadata_trgm_indexes.py` — trgm GIN indexes on `documents.email_subject` + `documents.email_from_name`
+- Modify: `tests/mail/test_parser.py` — extend with `_build_header_preamble` + preamble-in-`body_text` tests
+- Modify: `tests/test_search_filtered.py` — extend with `email.*` filter cases
+- Create: `tests/test_alembic_email_metadata_indexes.py` — verify both indexes present and are GIN trgm
+- Modify: `tests/test_mcp_tool_descriptions.py` — assert `email.*` mentioned in three tools' descriptions
+- Create: `tests/integration/test_email_header_chunks.py` — end-to-end: build `.eml`, parse, chunk, assert chunk 0 contains preamble, run `hybrid_search` with email filter, verify match
+
+**Conventions:**
+- All work on branch `spec/email-header-chunking` in the worktree at `.worktrees/spec-email-headers/`.
+- Tests run via `uv run pytest tests/<file>.py -v` from the worktree root.
+- Each task ends with a commit; messages follow `feat(<scope>): <what>` / `fix(<scope>): <what>` per repo convention.
+- All new ILIKE call sites use `escape_ilike()` from `src/harbor_clerk/sql_escape.py` (PR-H established this rule).
+- Alembic `CREATE INDEX CONCURRENTLY` must be wrapped in `op.get_context().autocommit_block()` (PR #411 established this pattern).
+
+---
+
+## Task 1: Add `_build_header_preamble()` helper to parser
+
+**Files:**
+- Modify: `src/harbor_clerk/mail/parser.py`
+- Test: `tests/mail/test_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/mail/test_parser.py`:
+
+```python
+from datetime import datetime, timezone
+
+
+def test_header_preamble_full_block():
+    """All five fields render in fixed key:value order, then a blank line."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice Anderson",
+        from_address="alice@firm.com",
+        to_addresses=["bob@firm.com", "carol@firm.com"],
+        cc_addresses=["dan@firm.com"],
+        subject="Q3 Vendor Agreement Review",
+        date_sent=datetime(2026, 1, 15, 14, 30, tzinfo=timezone.utc),
+    )
+
+    assert preamble == (
+        "From: Alice Anderson <alice@firm.com>\n"
+        "To: bob@firm.com, carol@firm.com\n"
+        "Cc: dan@firm.com\n"
+        "Subject: Q3 Vendor Agreement Review\n"
+        "Date: 2026-01-15\n"
+        "\n"
+    )
+
+
+def test_header_preamble_omits_empty_recipients():
+    """Empty To / Cc lists skip those lines entirely."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=[],
+        cc_addresses=[],
+        subject="Solo memo",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "To:" not in preamble
+    assert "Cc:" not in preamble
+    assert preamble == (
+        "From: Alice <alice@firm.com>\n"
+        "Subject: Solo memo\n"
+        "Date: 2026-01-15\n"
+        "\n"
+    )
+
+
+def test_header_preamble_from_no_name():
+    """from_name empty → emit address only (no angle brackets)."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="",
+        from_address="bot@notifications.example.com",
+        to_addresses=["alice@firm.com"],
+        cc_addresses=[],
+        subject="Notification",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "From: bot@notifications.example.com\n" in preamble
+    assert "<" not in preamble  # no angle brackets when no display name
+
+
+def test_header_preamble_to_cap_at_11_recipients():
+    """>10 To recipients collapses to '$N recipients'; ≤10 lists addresses."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    # Exactly 10 — listed
+    ten = [f"r{i}@firm.com" for i in range(10)]
+    preamble_10 = _build_header_preamble(
+        from_name="Alice", from_address="alice@firm.com",
+        to_addresses=ten, cc_addresses=[],
+        subject="S", date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+    assert "r0@firm.com" in preamble_10
+    assert "r9@firm.com" in preamble_10
+    assert "recipients" not in preamble_10
+
+    # 11 — collapsed
+    eleven = [f"r{i}@firm.com" for i in range(11)]
+    preamble_11 = _build_header_preamble(
+        from_name="Alice", from_address="alice@firm.com",
+        to_addresses=eleven, cc_addresses=[],
+        subject="S", date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+    assert "To: 11 recipients\n" in preamble_11
+    assert "r0@firm.com" not in preamble_11
+
+
+def test_header_preamble_cc_cap_at_11_recipients():
+    """Same >10 collapse rule applies to Cc."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    eleven = [f"c{i}@firm.com" for i in range(11)]
+    preamble = _build_header_preamble(
+        from_name="Alice", from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"], cc_addresses=eleven,
+        subject="S", date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "Cc: 11 recipients\n" in preamble
+    assert "c0@firm.com" not in preamble
+
+
+def test_header_preamble_no_date():
+    """date_sent=None → Date line omitted entirely."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice", from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"], cc_addresses=[],
+        subject="S", date_sent=None,
+    )
+
+    assert "Date:" not in preamble
+
+
+def test_header_preamble_no_from_at_all():
+    """Both from_name and from_address empty → From line omitted."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="", from_address="",
+        to_addresses=["bob@firm.com"], cc_addresses=[],
+        subject="S", date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "From:" not in preamble
+
+
+def test_header_preamble_subject_always_shown():
+    """Subject line is always present (caller's '(no subject)' fallback persists)."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice", from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"], cc_addresses=[],
+        subject="(no subject)", date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "Subject: (no subject)\n" in preamble
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/mail/test_parser.py -v -k "header_preamble"
+```
+
+Expected: 8 FAIL with `ImportError: cannot import name '_build_header_preamble'`.
+
+- [ ] **Step 3: Add the helper**
+
+In `src/harbor_clerk/mail/parser.py`, after the existing private helpers (e.g., `_synthesize_message_id`, `_parse_addresses`) and before the module-level `parse_eml`:
+
+```python
+_RECIPIENT_CAP = 10
+
+
+def _build_header_preamble(
+    *,
+    from_name: str,
+    from_address: str,
+    to_addresses: list[str],
+    cc_addresses: list[str],
+    subject: str,
+    date_sent: datetime | None,
+) -> str:
+    """Render a key:value header block to prepend to body_text.
+
+    Lines emitted in fixed order — From, To, Cc, Subject, Date — with
+    omit-on-empty for each line and a trailing blank line. The chunker
+    treats the preamble as the start of chunk 0, exposing headers to
+    NER + FTS + text_contains without changing downstream pipeline code.
+
+    To / Cc with >_RECIPIENT_CAP entries collapse to '$N recipients' to
+    bound preamble length on distribution-list emails.
+    """
+    lines: list[str] = []
+
+    # From: 'Name <address>' if name present, just address if not, omit if both empty
+    if from_name and from_address:
+        lines.append(f"From: {from_name} <{from_address}>")
+    elif from_address:
+        lines.append(f"From: {from_address}")
+
+    if to_addresses:
+        if len(to_addresses) > _RECIPIENT_CAP:
+            lines.append(f"To: {len(to_addresses)} recipients")
+        else:
+            lines.append(f"To: {', '.join(to_addresses)}")
+
+    if cc_addresses:
+        if len(cc_addresses) > _RECIPIENT_CAP:
+            lines.append(f"Cc: {len(cc_addresses)} recipients")
+        else:
+            lines.append(f"Cc: {', '.join(cc_addresses)}")
+
+    # Subject is always shown (caller's '(no subject)' fallback persists)
+    lines.append(f"Subject: {subject}")
+
+    if date_sent is not None:
+        lines.append(f"Date: {date_sent.strftime('%Y-%m-%d')}")
+
+    return "\n".join(lines) + "\n\n"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/mail/test_parser.py -v -k "header_preamble"
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git add src/harbor_clerk/mail/parser.py tests/mail/test_parser.py
+git commit -m "feat(mail): add _build_header_preamble helper
+
+Builds a key:value email header block (From / To / Cc / Subject / Date)
+in fixed order, ≤10 recipients listed, >10 collapsed to '\$N recipients',
+ISO YYYY-MM-DD dates, trailing blank line.
+
+Helper only — not yet wired into parse_eml. See
+docs/superpowers/specs/2026-05-27-email-header-chunking-design.md §2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire `_build_header_preamble` into `parse_eml`
+
+**Files:**
+- Modify: `src/harbor_clerk/mail/parser.py`
+- Test: `tests/mail/test_parser.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/mail/test_parser.py`:
+
+```python
+def test_parse_eml_prepends_header_preamble_to_body_text():
+    """parse_eml's body_text starts with the rendered header preamble."""
+    from harbor_clerk.mail.parser import parse_eml
+    from tests.mail.fixtures.build_eml import build_simple_email
+
+    eml = build_simple_email(
+        message_id="<preamble-test@example.com>",
+        subject="Q3 Review",
+        sender="Alice Anderson <alice@firm.com>",
+        recipients=["bob@firm.com", "carol@firm.com"],
+        cc=["dan@firm.com"],
+        body_text="Original body content goes here.",
+    )
+
+    result = parse_eml(eml)
+
+    # body_text starts with the preamble block
+    assert result.body_text.startswith("From: Alice Anderson <alice@firm.com>\n")
+    assert "To: bob@firm.com, carol@firm.com\n" in result.body_text
+    assert "Cc: dan@firm.com\n" in result.body_text
+    assert "Subject: Q3 Review\n" in result.body_text
+    # And the body still follows
+    assert "Original body content goes here." in result.body_text
+    # With exactly one blank line between preamble and body
+    assert "\n\nOriginal body content goes here." in result.body_text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/mail/test_parser.py::test_parse_eml_prepends_header_preamble_to_body_text -v
+```
+
+Expected: FAIL — `body_text` starts with the original body (no preamble).
+
+- [ ] **Step 3: Wire the helper into parse_eml**
+
+In `src/harbor_clerk/mail/parser.py`, modify `parse_eml` to prepend the preamble. Change the existing `body_text = _extract_body_text(msg)` line to:
+
+```python
+    body_text = _extract_body_text(msg)
+    preamble = _build_header_preamble(
+        from_name=from_name,
+        from_address=from_address,
+        to_addresses=to_addresses,
+        cc_addresses=cc_addresses,
+        subject=subject,
+        date_sent=date_sent,
+    )
+    body_text = preamble + body_text
+```
+
+The `EmailParseResult(...)` constructor call below stays unchanged (it already passes `body_text=body_text`).
+
+- [ ] **Step 4: Run test to verify it passes; also run the full parser test file to catch regressions**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/mail/test_parser.py -v
+```
+
+Expected: all tests passed (the existing tests that assert `"Please review" in result.body_text` still work — substring match is unaffected by the preamble).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git add src/harbor_clerk/mail/parser.py tests/mail/test_parser.py
+git commit -m "feat(mail): prepend header preamble to body_text in parse_eml
+
+Chunker sees the preamble at the start of body_text → it lands at the
+start of chunk 0 → NER picks up sender names, FTS indexes subject lines,
+text_contains matches header patterns.
+
+No downstream code changes needed. Existing email docs need re-ingest
+(deferred to operator; see spec §5).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Alembic migration — trgm GIN indexes on `documents.email_subject` + `documents.email_from_name`
+
+**Files:**
+- Create: `alembic/versions/<auto-rev>_email_metadata_trgm_indexes.py`
+- Create: `tests/test_alembic_email_metadata_indexes.py`
+
+- [ ] **Step 1: Check current alembic head**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run alembic heads
+```
+
+Note the head revision id (e.g., `b56bde44ec8c` after PR #411). Call it `<prev_head>` below.
+
+- [ ] **Step 2: Defensive check — indexes don't already exist**
+
+```bash
+grep -rn "email_subject.*trgm\|email_from_name.*trgm" alembic/versions/ | head
+```
+
+Expected: no results. If results appear, stop and report.
+
+- [ ] **Step 3: Create the migration scaffold**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run alembic revision -m "email metadata trgm gin indexes"
+```
+
+This creates `alembic/versions/<new_rev>_email_metadata_trgm_gin_indexes.py`. Note the filename's revision id; call it `<new_rev>`.
+
+- [ ] **Step 4: Write the migration body**
+
+Replace the scaffold body with this. Use the actual `<new_rev>` and `<prev_head>` from Steps 1+3.
+
+```python
+"""email metadata trgm gin indexes
+
+Two GIN trigram indexes on documents.email_subject and
+documents.email_from_name to support fast ILIKE filtering used by the
+new email.subject_contains and email.from_name_contains metadata_filter
+keys (see hybrid_search). Without these, ILIKE '%v%' on these columns
+forces a seq-scan on the documents table at corpus scale.
+
+The pg_trgm extension is already enabled (see docker/postgres/init-
+extensions.sql for Docker; same for macOS bundle).
+
+CREATE INDEX CONCURRENTLY cannot run inside a transaction; wrap in
+autocommit_block (pattern established by PR #411).
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "<new_rev>"
+down_revision = "<prev_head>"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_email_subject_trgm "
+            "ON public.documents USING gin (email_subject public.gin_trgm_ops)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_email_from_name_trgm "
+            "ON public.documents USING gin (email_from_name public.gin_trgm_ops)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS public.ix_documents_email_subject_trgm")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS public.ix_documents_email_from_name_trgm")
+```
+
+- [ ] **Step 5: Write the test**
+
+Create `tests/test_alembic_email_metadata_indexes.py`:
+
+```python
+"""Verify the documents.email_subject + email_from_name trgm indexes exist."""
+
+from sqlalchemy import text
+
+
+async def test_documents_email_subject_trgm_index_present(db_session):
+    result = await db_session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname='public' AND tablename='documents' "
+            "AND indexname='ix_documents_email_subject_trgm'"
+        )
+    )
+    assert result.first() is not None, "ix_documents_email_subject_trgm not found"
+
+
+async def test_documents_email_subject_trgm_index_is_gin_trgm(db_session):
+    result = await db_session.execute(
+        text(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE indexname='ix_documents_email_subject_trgm'"
+        )
+    )
+    indexdef = (result.scalar() or "").lower()
+    assert "using gin" in indexdef
+    assert "gin_trgm_ops" in indexdef
+
+
+async def test_documents_email_from_name_trgm_index_present(db_session):
+    result = await db_session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname='public' AND tablename='documents' "
+            "AND indexname='ix_documents_email_from_name_trgm'"
+        )
+    )
+    assert result.first() is not None, "ix_documents_email_from_name_trgm not found"
+
+
+async def test_documents_email_from_name_trgm_index_is_gin_trgm(db_session):
+    result = await db_session.execute(
+        text(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE indexname='ix_documents_email_from_name_trgm'"
+        )
+    )
+    indexdef = (result.scalar() or "").lower()
+    assert "using gin" in indexdef
+    assert "gin_trgm_ops" in indexdef
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/test_alembic_email_metadata_indexes.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 7: Verify head advanced**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run alembic heads
+```
+
+Expected: `<new_rev>`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git add alembic/versions/<new_rev>_email_metadata_trgm_gin_indexes.py tests/test_alembic_email_metadata_indexes.py
+git commit -m "feat(db): trgm GIN indexes on documents.email_subject + email_from_name
+
+Supports the new email.subject_contains and email.from_name_contains
+metadata_filter keys (see hybrid_search). Without these, ILIKE '%v%' on
+these columns forces a seq-scan at corpus scale.
+
+CONCURRENTLY-created via autocommit_block to avoid blocking ingest
+workers on large corpora (pattern from PR #411).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add `email.*` pre-pass to `hybrid_search`'s metadata_filter translator
+
+**Files:**
+- Modify: `src/harbor_clerk/search.py`
+- Test: `tests/test_search_filtered.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_search_filtered.py`:
+
+```python
+async def test_metadata_filter_email_from_address_exact(db_session):
+    """email.from_address matches case-insensitively."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_ef_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_from_address="alice@firm.com")
+    b = Document(title="B", status="active",
+                 sha256=b"sha_ef_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_from_address="bob@firm.com")
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="quarterly report", language="en"))
+    await db_session.flush()
+
+    # Exact match
+    res = await hybrid_search(
+        db_session, "quarterly", k=10,
+        metadata_filter={"email.from_address": "alice@firm.com"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+    # Case-insensitive
+    res2 = await hybrid_search(
+        db_session, "quarterly", k=10,
+        metadata_filter={"email.from_address": "ALICE@FIRM.COM"},
+    )
+    assert {h.doc_id for h in res2.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_from_name_contains(db_session):
+    """email.from_name_contains does ILIKE substring (case-insensitive)."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_fc_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_from_name="Alice Anderson")
+    b = Document(title="B", status="active",
+                 sha256=b"sha_fc_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_from_name="Bob Smith")
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="quarterly report", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session, "quarterly", k=10,
+        metadata_filter={"email.from_name_contains": "alice"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_subject_contains(db_session):
+    """email.subject_contains does ILIKE substring (case-insensitive)."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_sc_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_subject="Q3 Vendor Agreement Review")
+    b = Document(title="B", status="active",
+                 sha256=b"sha_sc_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_subject="Holiday party planning")
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session, "content", k=10,
+        metadata_filter={"email.subject_contains": "VENDOR"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_to_addresses_array_element(db_session):
+    """email.to_addresses matches when the address appears in the array."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_ta_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_to_addresses=["bob@firm.com", "carol@firm.com"])
+    b = Document(title="B", status="active",
+                 sha256=b"sha_ta_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_to_addresses=["dan@firm.com"])
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session, "content", k=10,
+        metadata_filter={"email.to_addresses": "carol@firm.com"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_to_addresses_list_any(db_session):
+    """List value matches when ANY element appears in the array."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_tl_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_to_addresses=["bob@firm.com", "carol@firm.com"])
+    b = Document(title="B", status="active",
+                 sha256=b"sha_tl_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_to_addresses=["zelda@elsewhere.com"])
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session, "content", k=10,
+        metadata_filter={"email.to_addresses": ["carol@firm.com", "nobody@nope.com"]},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_contains_escapes_special_chars(db_session):
+    """ILIKE special chars (% _) in input are matched literally."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_se_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_subject="Revenue grew 50% YoY")
+    b = Document(title="B", status="active",
+                 sha256=b"sha_se_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_subject="Revenue grew significantly")
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="content", language="en"))
+    await db_session.flush()
+
+    # "50%" must match only Doc A; '%' must NOT act as a wildcard
+    res = await hybrid_search(
+        db_session, "content", k=10,
+        metadata_filter={"email.subject_contains": "50%"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_unknown_key_raises(db_session):
+    """Unknown email.* key raises ValueError (loud failure)."""
+    import pytest
+    from harbor_clerk.search import hybrid_search
+
+    with pytest.raises(ValueError, match="email"):
+        await hybrid_search(
+            db_session, "content", k=10,
+            metadata_filter={"email.bogus_field": "x"},
+        )
+
+
+async def test_metadata_filter_email_does_not_break_jsonb(db_session):
+    """Existing JSONB metadata_filter still works alongside email.* keys."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(title="A", status="active",
+                 sha256=b"sha_jx_a_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_from_address="alice@firm.com",
+                 doc_metadata={"sidecar": {"vendor": "Acme"}})
+    b = Document(title="B", status="active",
+                 sha256=b"sha_jx_b_0000000000000000000000",
+                 pipeline_status=PipelineStatus.ready,
+                 email_from_address="alice@firm.com",
+                 doc_metadata={"sidecar": {"vendor": "Globex"}})
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0,
+                             chunk_text="content", language="en"))
+    await db_session.flush()
+
+    # Both filters apply (AND): from Alice AND vendor=Acme
+    res = await hybrid_search(
+        db_session, "content", k=10,
+        metadata_filter={
+            "email.from_address": "alice@firm.com",
+            "sidecar.vendor": "Acme",
+        },
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/test_search_filtered.py -v -k "email"
+```
+
+Expected: 8 FAIL. Most will fail with a `ValueError` from the existing JSONB translator complaining about `email.foo` keys (the existing validator only accepts one-dot two-segment paths and translates them to JSONB containment — which won't match anything since the dedicated columns aren't in `doc_metadata`).
+
+- [ ] **Step 3: Add the email.* pre-pass to `hybrid_search`**
+
+In `src/harbor_clerk/search.py`, locate the `if metadata_filter:` block (around line 109). The new pre-pass goes BEFORE that block, working on a **copy** of `metadata_filter` so we can mutate while iterating. The full replacement:
+
+```python
+    # --- email.* pre-pass: strip email.* keys before the JSONB translator ---
+    # The Document.email_* columns are dedicated typed columns, not in
+    # doc_metadata JSONB, so they need column-level predicates rather than
+    # JSONB containment. We pull these out first, build predicates, and
+    # let the remaining keys (if any) flow through the JSONB block below.
+    if metadata_filter:
+        from harbor_clerk.sql_escape import escape_ilike
+
+        email_keys = {k: v for k, v in metadata_filter.items() if k.startswith("email.")}
+        if email_keys:
+            metadata_filter = {k: v for k, v in metadata_filter.items() if not k.startswith("email.")}
+            for path, value in email_keys.items():
+                _, _, subkey = path.partition(".")
+                if subkey == "from_address":
+                    doc_conditions.append(func.lower(Document.email_from_address) == value.lower())
+                elif subkey == "from_name":
+                    doc_conditions.append(Document.email_from_name == value)
+                elif subkey == "from_name_contains":
+                    escaped = escape_ilike(value)
+                    doc_conditions.append(
+                        Document.email_from_name.ilike(f"%{escaped}%", escape="\\")
+                    )
+                elif subkey == "subject":
+                    doc_conditions.append(Document.email_subject == value)
+                elif subkey == "subject_contains":
+                    escaped = escape_ilike(value)
+                    doc_conditions.append(
+                        Document.email_subject.ilike(f"%{escaped}%", escape="\\")
+                    )
+                elif subkey == "to_addresses":
+                    if isinstance(value, list):
+                        # ANY of the listed addresses in the array column
+                        from sqlalchemy import or_ as _or_
+                        doc_conditions.append(
+                            _or_(*[v == func.any_(Document.email_to_addresses) for v in value])
+                        )
+                    else:
+                        doc_conditions.append(value == func.any_(Document.email_to_addresses))
+                elif subkey == "cc_addresses":
+                    if isinstance(value, list):
+                        from sqlalchemy import or_ as _or_
+                        doc_conditions.append(
+                            _or_(*[v == func.any_(Document.email_cc_addresses) for v in value])
+                        )
+                    else:
+                        doc_conditions.append(value == func.any_(Document.email_cc_addresses))
+                elif subkey == "thread_id":
+                    doc_conditions.append(Document.email_thread_id == value)
+                elif subkey == "message_id":
+                    doc_conditions.append(Document.email_message_id == value)
+                else:
+                    raise ValueError(
+                        f"unknown email.* filter key: {path!r}. Recognized: "
+                        f"email.from_address, email.from_name, email.from_name_contains, "
+                        f"email.subject, email.subject_contains, email.to_addresses, "
+                        f"email.cc_addresses, email.thread_id, email.message_id."
+                    )
+```
+
+Place this block **immediately before** the existing `if metadata_filter:` block (which then handles only the remaining non-`email.*` keys).
+
+The existing `if metadata_filter:` block also needs a small adjustment — when `metadata_filter` is now `{}` after extracting all email keys, the loop should be skipped naturally. The existing code already handles this (`if metadata_filter:` is falsy for `{}`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/test_search_filtered.py -v -k "email"
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Run the full regression suite to catch any breakage**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/test_search_filtered.py tests/test_search_metadata_filter.py tests/test_hybrid_search_with_rerank.py tests/test_find_all.py tests/test_kb_find_all_mcp.py -v 2>&1 | tail -10
+```
+
+Expected: all pass, no regressions in existing search behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git add src/harbor_clerk/search.py tests/test_search_filtered.py
+git commit -m "feat(search): email.* metadata_filter namespace
+
+hybrid_search now recognizes email.* keys in metadata_filter and
+dispatches to dedicated Document.email_* column predicates:
+
+  email.from_address          exact, case-insensitive
+  email.from_name             exact
+  email.from_name_contains    ILIKE %v% (escaped)
+  email.subject               exact
+  email.subject_contains      ILIKE %v% (escaped)
+  email.to_addresses          = ANY(array); list value → OR across elements
+  email.cc_addresses          same shape
+  email.thread_id             exact
+  email.message_id            exact
+
+Unknown email.* key raises ValueError (loud failure). Non-email.* keys
+in metadata_filter continue to JSONB-translate as before.
+
+ILIKE special chars (% _) routed through escape_ilike() per PR-H
+convention. The new trgm GIN indexes on email_subject + email_from_name
+(Task 3) keep _contains queries fast at corpus scale.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Docstring updates on `kb_search`, `kb_find_all`, `kb_documents_by_date`
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Test: `tests/test_mcp_tool_descriptions.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_mcp_tool_descriptions.py`:
+
+```python
+def test_kb_search_docstring_mentions_email_namespace():
+    """email.* filter keys must appear in kb_search description so models
+    can discover them."""
+    from harbor_clerk.mcp_server import kb_search
+    desc = (kb_search.__doc__ or "").lower()
+    assert "email.from_address" in desc
+    assert "email.subject_contains" in desc
+    assert "email.to_addresses" in desc
+
+
+def test_kb_find_all_docstring_mentions_email_namespace():
+    from harbor_clerk.mcp_server import kb_find_all
+    desc = (kb_find_all.__doc__ or "").lower()
+    assert "email.from_address" in desc
+    assert "email.subject_contains" in desc
+
+
+def test_kb_documents_by_date_docstring_mentions_email_namespace():
+    from harbor_clerk.mcp_server import kb_documents_by_date
+    desc = (kb_documents_by_date.__doc__ or "").lower()
+    assert "email.from_address" in desc
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/test_mcp_tool_descriptions.py -v -k "email_namespace"
+```
+
+Expected: 3 FAIL.
+
+- [ ] **Step 3: Add the docstring paragraph to all three tools**
+
+In `src/harbor_clerk/mcp_server.py`, find each of `kb_search`, `kb_find_all`, `kb_documents_by_date`. Each has a `metadata_filter` parameter section in its docstring. After the existing `metadata_filter: ...` description (which talks about `namespace.key` JSONB lookups), append this paragraph:
+
+```
+        Additionally accepts the `email.*` namespace for native Document
+        column lookups (faster + typed vs. raw tika.email_* via JSONB):
+          email.from_address (exact, case-insensitive)
+          email.from_name / email.from_name_contains
+          email.subject / email.subject_contains
+          email.to_addresses / email.cc_addresses (element-of-array;
+            pass a list to match any element)
+          email.thread_id / email.message_id (exact)
+        For date filtering on emails, use the after=/before= filters
+        (already mapped to email_date_sent for emails).
+```
+
+Match the existing indentation. Same paragraph in all three docstrings.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/test_mcp_tool_descriptions.py -v
+```
+
+Expected: all pass (the 3 new tests + the existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git add src/harbor_clerk/mcp_server.py tests/test_mcp_tool_descriptions.py
+git commit -m "docs(mcp): document email.* filter namespace on three tools
+
+kb_search, kb_find_all, kb_documents_by_date docstrings each get a
+paragraph describing the new email.* keys. Single source of truth —
+hybrid_search owns the dispatch; the docstrings just surface the keys
+to the model.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: End-to-end integration test (`.eml` → chunks → kb_search filter)
+
+**Files:**
+- Create: `tests/integration/test_email_header_chunks.py`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/integration/test_email_header_chunks.py`:
+
+```python
+"""End-to-end: parse a real-shaped .eml, persist Document + chunks, then
+verify the header preamble lives in chunk 0 AND the email.* filter
+namespace returns the right doc."""
+
+from harbor_clerk.mail.parser import parse_eml
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.search import hybrid_search
+from tests.mail.fixtures.build_eml import build_simple_email
+
+
+async def test_eml_chunk_0_contains_header_preamble(db_session):
+    """parse_eml + persist + chunk → chunk 0's text contains header preamble."""
+    eml = build_simple_email(
+        message_id="<e2e-headers@example.com>",
+        subject="Q3 Vendor Agreement Review",
+        sender="Alice Anderson <alice@firm.com>",
+        recipients=["bob@firm.com"],
+        body_text="The quarterly report attached covers Q3 performance.",
+    )
+    parsed = parse_eml(eml)
+
+    doc = Document(
+        title=parsed.subject, status="active",
+        sha256=b"sha_e2e_h_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        mime_type="message/rfc822",
+        email_message_id=parsed.message_id,
+        email_from_address=parsed.from_address,
+        email_from_name=parsed.from_name,
+        email_to_addresses=parsed.to_addresses,
+        email_subject=parsed.subject,
+        email_date_sent=parsed.date_sent,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    # Single chunk holding the full body_text (preamble + body), simulating
+    # what the real chunker does for a short body.
+    db_session.add(Chunk(
+        doc_id=doc.doc_id, chunk_num=0,
+        chunk_text=parsed.body_text, language="en",
+    ))
+    await db_session.flush()
+
+    # Header preamble lines all present in the chunk text
+    assert "From: Alice Anderson <alice@firm.com>" in parsed.body_text
+    assert "To: bob@firm.com" in parsed.body_text
+    assert "Subject: Q3 Vendor Agreement Review" in parsed.body_text
+    # And the body
+    assert "quarterly report" in parsed.body_text
+
+
+async def test_eml_email_from_address_filter_retrieves_doc(db_session):
+    """End-to-end: hybrid_search with email.from_address filter returns
+    only the doc whose dedicated column matches."""
+    eml = build_simple_email(
+        message_id="<e2e-filter@example.com>",
+        subject="Q3 Vendor Agreement Review",
+        sender="Alice Anderson <alice@firm.com>",
+        recipients=["bob@firm.com"],
+        body_text="The quarterly report attached covers Q3 performance.",
+    )
+    parsed = parse_eml(eml)
+
+    # Doc A: from Alice
+    a = Document(
+        title=parsed.subject, status="active",
+        sha256=b"sha_e2e_f_a_000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        mime_type="message/rfc822",
+        email_message_id=parsed.message_id,
+        email_from_address=parsed.from_address,
+        email_from_name=parsed.from_name,
+        email_subject=parsed.subject,
+    )
+    db_session.add(a)
+    await db_session.flush()
+    db_session.add(Chunk(doc_id=a.doc_id, chunk_num=0,
+                         chunk_text=parsed.body_text, language="en"))
+
+    # Doc B: same subject, different sender (should NOT match the filter)
+    b = Document(
+        title=parsed.subject, status="active",
+        sha256=b"sha_e2e_f_b_000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        mime_type="message/rfc822",
+        email_message_id="<e2e-other@example.com>",
+        email_from_address="zelda@elsewhere.com",
+        email_from_name="Zelda Z",
+        email_subject=parsed.subject,
+    )
+    db_session.add(b)
+    await db_session.flush()
+    db_session.add(Chunk(doc_id=b.doc_id, chunk_num=0,
+                         chunk_text="quarterly report content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session, "quarterly report", k=10,
+        metadata_filter={"email.from_address": "alice@firm.com"},
+    )
+    doc_ids = {h.doc_id for h in res.hits}
+    assert str(a.doc_id) in doc_ids
+    assert str(b.doc_id) not in doc_ids
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run pytest tests/integration/test_email_header_chunks.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 3: Run lint + format check + full suite**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run ruff check . && uv run ruff format --check .
+uv run pytest tests/ -x --ignore=tests/integration 2>&1 | tail -5
+uv run pytest tests/integration/test_email_header_chunks.py -v 2>&1 | tail -5
+```
+
+Expected: ruff clean; main suite passes; integration test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git add tests/integration/test_email_header_chunks.py
+git commit -m "test(integration): end-to-end email header preamble + email.* filter
+
+Two end-to-end tests that exercise the full path: build .eml → parse →
+persist Document + chunk → assert chunk text contains the preamble AND
+hybrid_search with email.from_address filter retrieves the right doc.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification + operator runbook note
+
+**Files:** None modified. Verification + a single doc note.
+
+- [ ] **Step 1: Run full Python suite + lint**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+uv run ruff check . 2>&1 | tail -3
+uv run ruff format --check . 2>&1 | tail -3
+uv run pytest tests/ -x --ignore=tests/integration 2>&1 | tail -5
+```
+
+Expected: ruff clean; all tests pass.
+
+- [ ] **Step 2: Append operator runbook note to the spec**
+
+Open `docs/superpowers/specs/2026-05-27-email-header-chunking-design.md` and confirm the spec's §5 (Re-ingest handoff) is intact. If not, add this section at the very end of the spec:
+
+```markdown
+## Operator runbook (post-deploy)
+
+After the PR merges and the macOS app rebuilds, existing email docs need
+re-ingest for the header preamble to materialize in their chunks. Run
+this SQL against the menubar's Postgres (port 5433, db `lka`, user `lka`):
+
+    UPDATE ingestion_jobs SET status = 'pending'
+      WHERE doc_id IN (
+        SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL
+      )
+      AND stage = 'extract';
+
+Workers will pick up the queue automatically. Expect ~1–2 hours wallclock
+for 10k email docs. Visible via the Observatory page.
+```
+
+(If §5 already covers this, skip. The spec was written to include it.)
+
+- [ ] **Step 3: Push branch + open PR**
+
+```bash
+cd /Users/alex/mcp-gateway/.worktrees/spec-email-headers
+git push -u origin spec/email-header-chunking
+```
+
+Then open a PR titled `feat(mail+search): email header chunking + queryable email.* metadata` with a body summarizing the changes per the spec.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 architecture overview → Tasks 1, 2 (parser); Task 4 (search.py dispatch) ✓
+- §2 parser header preamble format → Tasks 1, 2 ✓
+- §3 chunking integration (no code change, just edge cases) → covered by integration test in Task 6 ✓
+- §4 metadata_filter mapping for email.* keys → Task 4 ✓
+- §4 trgm GIN indexes on email_subject + email_from_name → Task 3 ✓
+- §4 docstring updates on kb_search/kb_find_all/kb_documents_by_date → Task 5 ✓
+- §5 re-ingest handoff → Task 7 (runbook note) ✓
+- §6 testing → Tasks 1-6 (unit + integration + tool-description tests) ✓
+- §7 out of scope → not in plan (correct) ✓
+
+**Placeholder scan:** No "TBD", "TODO", or "implement later". Every step has either complete code, a verbatim command, or a clear human action. The two unavoidable parameter substitutions in Task 3 (`<new_rev>`, `<prev_head>`) are explicitly defined by the alembic-revision command in Step 3 — the engineer reads them off and substitutes literal strings.
+
+**Type consistency:**
+- `_build_header_preamble` signature (Task 1) matches the call site in `parse_eml` (Task 2). Same kw-only args: `from_name, from_address, to_addresses, cc_addresses, subject, date_sent`.
+- `email.*` filter keys (Task 4) match the docstring text (Task 5).
+- Index names (`ix_documents_email_subject_trgm`, `ix_documents_email_from_name_trgm`) match between migration (Task 3) and tests (Task 3).

--- a/docs/superpowers/plans/2026-05-27-email-header-chunking.md
+++ b/docs/superpowers/plans/2026-05-27-email-header-chunking.md
@@ -6,6 +6,8 @@
 
 **Architecture:** A new helper `_build_header_preamble()` in `parser.py` builds the block and `parse_eml` prepends it before returning. `hybrid_search` grows a pre-pass that strips `email.*` keys from `metadata_filter` and dispatches to dedicated column predicates (exact, ILIKE substring via `escape_ilike()`, or `= ANY` on TEXT[] arrays). Two new trgm GIN indexes on `email_subject` + `email_from_name` keep ILIKE queries fast. Docstring updates on `kb_search` / `kb_find_all` / `kb_documents_by_date` describe the new filter keys.
 
+**Implementation note (post-merge):** Tasks 1-2 originally wired the preamble into `parse_eml.body_text`. Fresh-eyes review on the branch caught that `parse_eml.body_text` is never persisted — Tika re-extracts .eml bytes in the extract stage, so the chunker reads `DocumentPage.page_text` (Tika's output), not the parser's body_text. Task 2's parse_eml wire-up was reverted; the preamble is now built in the extract stage from already-stored `Document.email_*` columns, gated on `email_message_id IS NOT NULL AND email_parent_doc_id IS NULL` to exclude attachment Documents. See commits `3038f30` and `21c78e2`.
+
 **Tech Stack:** Python 3.12, SQLAlchemy 2.0 async, asyncpg, PostgreSQL 18 with `pg_trgm`, pytest, alembic.
 
 **Spec:** `docs/superpowers/specs/2026-05-27-email-header-chunking-design.md`
@@ -1174,7 +1176,7 @@ After the PR merges and the macOS app rebuilds, existing email docs need
 re-ingest for the header preamble to materialize in their chunks. Run
 this SQL against the menubar's Postgres (port 5433, db `lka`, user `lka`):
 
-    UPDATE ingestion_jobs SET status = 'pending'
+    UPDATE ingestion_jobs SET status = 'queued'
       WHERE doc_id IN (
         SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL
       )

--- a/docs/superpowers/specs/2026-05-27-email-header-chunking-design.md
+++ b/docs/superpowers/specs/2026-05-27-email-header-chunking-design.md
@@ -1,0 +1,228 @@
+# Email header chunking + queryable email metadata
+
+**Status:** spec
+**Date:** 2026-05-27
+**Predecessors:** PR #283 / 2026-05-04 email-ingestion design (set the original "headers stay structured, body becomes chunks" intent); PR #411 / kb_find_all + text_contains rollout (surfaced the recall ceiling that motivated this); 2026-05-05-prod sweep + 2026-05-27 cross-model eval (the empirical signal).
+
+---
+
+## Background
+
+PR #411's cross-model eval (Sonnet, gpt-4o, Opus on 9 items) confirmed `kb_find_all` + `text_contains` works on body-content questions (`enron-find-ferc` recall jumped from 0.32 → 0.98 for gpt-4o + Opus; `synth-find-invoices-over-5000` 0.18 → 1.00 for gpt-4o). It also surfaced a wall: `enron-find-layforwarded2001` capped at 0.12 recall across all 3 models, and `enron-find-offbalancesheet` at 0.12. Direct DB inspection showed why:
+
+- "Forwarded by Lay" → **0 chunks** in 10,576 Enron docs. The phrase only ever appears in email headers (`From:` / `X-From:` lines), which the current parser routes to dedicated `Document.email_*` columns. The chunker only sees `body_text`.
+- "off-balance-sheet" → 2 docs (literal hyphenated) + 4 more (no hyphens), vs ground-truth 17. The 11 missing docs likely had the phrase in `Subject:` lines.
+
+The 2026-05-04 email-ingestion design (line 33) explicitly chose this: *"No new MCP tools for MVP. Email docs flow through kb_search naturally; sender names appear as PERSON entities via spaCy, so kb_entity_search covers 'docs from Alice'."* The plan was that NER on `chunk_text` would catch sender names. **But NER never sees headers**, because headers don't enter `chunk_text`. The intended affordance is broken at the chunking layer.
+
+Beyond NER: the existing MCP `metadata_filter` parameter queries the `doc_metadata` JSONB column. `Document.email_*` are dedicated typed columns, not JSONB — so `metadata_filter={"email.from_address": "alice@..."}` doesn't work today either. ([`tika.email_from`](src/harbor_clerk/ingest/metadata_extractors/tika_metadata.py:44) *is* queryable via JSONB but the values are raw Tika strings — un-parsed, comma-joined, string-dated — making them awkward in practice.)
+
+This spec closes both gaps: prepends a header block to email `body_text` (so NER, FTS, and `text_contains` see headers naturally), AND maps an `email.*` namespace in `metadata_filter` to the dedicated Document columns (typed, array-aware, exact + ILIKE operators).
+
+## Goal
+
+Two surgical changes:
+
+1. **Header preamble in chunks.** Modify `parse_eml` to build a structured key:value header block (From, To, Cc, Subject, Date) and prepend it to `body_text`. The chunker then naturally places the preamble at the start of chunk 0. NER, FTS, and `text_contains` filter all see headers as searchable text. **Re-ingest of existing email docs required** (operator-triggered).
+2. **`email.*` namespace in `metadata_filter`.** Extend `hybrid_search`'s filter translator to recognize keys prefixed `email.` and dispatch to Document column predicates (exact match, ILIKE substring with `_contains` suffix, or `= ANY` for array columns). Two new trgm GIN indexes on `email_subject` and `email_from_name` to keep ILIKE queries fast at corpus scale.
+
+Both surface improvements propagate to `kb_search`, `kb_find_all`, and `kb_documents_by_date` automatically — they all delegate to `hybrid_search`. No MCP-tool-layer code change required, only docstring additions.
+
+## Non-goals
+
+- **Filename / source_path / watched-folder / `email_label_path` filtering** (the "shape 3" location-based filtering from the brainstorm). Deferred as its own future work.
+- **TIKA_FIELD_ALIASES whitelist expansion** (EPUB ISBN, EXIF date-taken, Office custom properties). Independent cleanup; bundle separately if real demand surfaces.
+- **Wikilink backlinks surfaced via MCP.** Already a deferred follow-up under PR #384.
+- **Display-name parsing for To/Cc recipients.** The current parser only extracts addresses for To/Cc (only From gets name+address). Adding name parsing for the others would let the preamble render `To: Bob Smith` instead of `To: bob@x.com`. Cosmetic + slight NER win; defer.
+- **Dedicated `kb_email_search` MCP tool.** Original 2026-05-04 spec parked it. The `email.*` namespace via `metadata_filter` covers the precise-filter case without growing tool surface.
+- **`tika.email_*` deduplication / removal.** Tika's email parser already populates `tika.email_from` etc. (raw, comma-joined). The new normalized `email.*` namespace coexists. Not worth removing.
+
+## §1 — Architecture overview
+
+Two surgical changes to existing files; no new modules.
+
+**A. Header block prepended to email `body_text` in the parser.**
+- File: `src/harbor_clerk/mail/parser.py`
+- A new helper `_build_header_preamble(parsed: EmailParseResult) -> str` returns the structured block.
+- `parse_eml` calls the helper and prepends the result to `body_text` before constructing the `EmailParseResult`.
+- Downstream is untouched — the extract stage reads `body_text`, the chunk stage splits it, and chunk 0 naturally inherits the preamble.
+
+**B. `email.*` keys recognized in `metadata_filter`.**
+- File: `src/harbor_clerk/search.py` — the `metadata_filter` translator block inside `hybrid_search`.
+- A small dispatch: if a filter key starts with `email.`, translate to a Document column predicate per §4's mapping table. Other keys continue to JSONB-translation as today.
+
+Both changes propagate to `kb_search`, `kb_find_all`, and `kb_documents_by_date` automatically — they all delegate to `hybrid_search` / `find_all`. MCP tool docstrings get a paragraph each describing the new `email.*` filter keys.
+
+## §2 — Parser changes (header preamble)
+
+A new helper `_build_header_preamble(parsed: EmailParseResult) -> str` is called from `parse_eml` just before constructing the result. The existing `body_text=body_text` line becomes `body_text=preamble + body_text` (with a blank-line separator embedded in the preamble's trailing newlines).
+
+**Format — fixed key:value, in this exact order:**
+
+```
+From: Alice Anderson <alice@example.com>
+To: Bob Smith, Carol Jones
+Cc: Dan Roe
+Subject: Q3 Vendor Agreement Review
+Date: 2026-01-15
+
+```
+*(trailing blank line, then original body)*
+
+**Per-field rules:**
+
+| Field | Source | Format | Skip if |
+|---|---|---|---|
+| `From:` | `from_name` + `from_address` | `Name <address>` if both present; just address if `from_name` empty | both missing |
+| `To:` | `to_addresses` | comma-joined addresses (display name parsing for To/Cc is out of scope — see Non-goals); if `>10` recipients → `$N recipients` (e.g., `45 recipients`) | empty list |
+| `Cc:` | `cc_addresses` | same rules as To | empty list |
+| `Subject:` | `subject` | as-is from parser; the existing `"(no subject)"` fallback persists | never (always include line if Subject column populated, which is always — fallback is `(no subject)`) |
+| `Date:` | `date_sent` | ISO 8601 *date* `YYYY-MM-DD`, not full datetime | `None` |
+
+**Edge cases:**
+
+- **No name parsed for an address:** `from_name == ""` → emit `From: alice@example.com`. NER won't catch a name that isn't there; FTS still indexes the local-part.
+- **All headers somehow absent:** preamble is the empty string; nothing prepended; body_text passes through unchanged. (This can't happen for real emails — every `.eml` has at least a Subject fallback — but the code is robust to it.)
+- **Subject always shown** (even `"(no subject)"`) — keeps the format predictable for grep + `text_contains` patterns.
+- **Body separator:** preamble ends with `\n\n`. Exactly one blank line between Date and body. Strong chunk-boundary signal.
+
+**Length budget:** typical preamble ~120–180 chars. Worst case (10-recipient To + 10-recipient Cc + long subject): ~400 chars. Safely under the 1000-char chunk target.
+
+## §3 — Chunking integration
+
+**No chunker code changes.** The chunker reads `parser.body_text` and produces ~1000-char chunks with 150-char overlap. The new preamble (≤400 chars worst-case) sits at the start of `body_text`, so it ends up at the start of chunk 0 by construction.
+
+**Edge cases handled by the existing chunker:**
+
+- **Body shorter than one chunk** → chunk 0 = preamble + entire body. Single chunk doc.
+- **Empty-body email** → chunk 0 contains preamble only (~150 chars). Existing "empty-body emails get a low-value summary; relevance ranking buries them" handling from the original spec still applies — the headers make the doc *more* discoverable than today via subject/from-name FTS.
+- **Chunk overlap windows.** The 150-char overlap means chunk 1's start may include the tail of chunk 0's body — *not* the preamble (assuming preamble + body > ~1150 chars, which is typical). Subject lines etc. appear in chunk 0 only.
+- **Preamble accidentally splitting across chunks.** Edge case: a ~900-char email where preamble + first body sentence lands at the chunk boundary. The chunker uses word/sentence boundaries; the preamble ends with `\n\n` (a strong boundary). Risk is negligible.
+
+**Header block placed at chunk 0 only** (i.e., the start of `body_text`). Not repeated per chunk. Subject lines / from-names are 1-shot context for that doc — repeating them per chunk would bloat embeddings without adding discrimination signal.
+
+## §4 — `metadata_filter` mapping for `email.*` keys
+
+The `hybrid_search` filter translator gets a small pre-pass: any key starting with `email.` is stripped of prefix and dispatched per the table below. Remaining keys hit JSONB-translation as today.
+
+**Recognized keys, mapping, and operator:**
+
+| Filter key | Document column | Operator | Notes |
+|---|---|---|---|
+| `email.from_address` | `email_from_address` | exact (`= LOWER(...)` on both sides) | case-insensitive |
+| `email.from_name` | `email_from_name` | exact (`=`) | rarely useful (display names vary); included for completeness |
+| `email.from_name_contains` | `email_from_name` | `ILIKE '%v%'` (escaped) | the typical "from Alice" pattern |
+| `email.subject` | `email_subject` | exact (`=`) | rarely useful (subjects almost never match verbatim) |
+| `email.subject_contains` | `email_subject` | `ILIKE '%v%'` (escaped) | the typical "subject about X" pattern |
+| `email.to_addresses` | `email_to_addresses` (TEXT[]) | `value = ANY(column)` | element match; list value → OR across elements |
+| `email.cc_addresses` | `email_cc_addresses` (TEXT[]) | `value = ANY(column)` | same |
+| `email.thread_id` | `email_thread_id` | exact (`=`) | by design |
+| `email.message_id` | `email_message_id` | exact (`=`) | by design |
+
+**Not exposed in this namespace:** `email.date_sent`. Use the existing `after`/`before` filter on `kb_search`/`kb_find_all`/`kb_documents_by_date` — they map to `Document.created_at`, which equals `email_date_sent` for emails (per `mail/ingest.py:99`).
+
+**ILIKE escaping:** the `_contains` operators route through the shared `escape_ilike()` helper at `src/harbor_clerk/sql_escape.py` (the same helper PR-H established for all ILIKE call sites). `%` and `_` in user input are escaped to literal characters via `escape="\\"`.
+
+**Validation:**
+- Unknown `email.*` key (e.g., `email.foo`) → raise `ValueError` at translation time. Loud failure; the model gets feedback rather than silent empty results.
+- `email.from_address` with a value that doesn't look like an email address → no validation; pass through as-is.
+- Array-column key with a list value (`{"email.to_addresses": ["a@x", "b@y"]}`) → "any of these addresses" semantics (`= ANY` with OR across elements; SQL `value = ANY(column) OR value2 = ANY(column)`).
+
+**New trgm GIN indexes** (new alembic migration):
+
+```sql
+CREATE INDEX CONCURRENTLY ix_documents_email_subject_trgm
+  ON public.documents USING gin (email_subject public.gin_trgm_ops);
+CREATE INDEX CONCURRENTLY ix_documents_email_from_name_trgm
+  ON public.documents USING gin (email_from_name public.gin_trgm_ops);
+```
+
+Without these, `_contains` queries force seq-scans on the documents table. CONCURRENTLY-created via `autocommit_block()` per the pattern PR #411 established.
+
+**Docstring updates** for `kb_search`, `kb_find_all`, `kb_documents_by_date`:
+
+```
+metadata_filter additionally accepts the `email.*` namespace for native
+Document column lookups (faster + typed vs. raw tika.email_* via JSONB):
+  email.from_address (exact)
+  email.from_name_contains (substring)
+  email.subject_contains (substring)
+  email.to_addresses / email.cc_addresses (element-of-array)
+  email.thread_id / email.message_id (exact)
+  email.date_sent — use after=/before= filters instead (already mapped
+    to email_date_sent for emails).
+```
+
+## §5 — Re-ingest handoff (operator-triggered)
+
+After the code lands and the macOS app rebuilds, all existing email docs need their extract stage re-run so the new chunks (with header preamble) materialize.
+
+**Criterion:** any Document with `email_message_id IS NOT NULL`.
+
+**Operator action:** the spec doesn't pick a mechanism; HC's existing bulk-reprocess machinery (Documents page bulk action, `kb_reprocess` MCP tool in a loop, or a direct SQL update on `ingestion_jobs.status`) all work. Cleanest one-line trigger via direct SQL:
+
+```sql
+UPDATE ingestion_jobs SET status = 'pending'
+  WHERE doc_id IN (
+    SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL
+  )
+  AND stage = 'extract';
+```
+
+**Expected runtime:** ~1–2 hours wallclock for 10k emails on the menubar Mac. Full pipeline per doc: extract → chunk → entities → embed (skip summarize: body content unchanged; skip finalize: no-op). Visible via the Observatory page.
+
+**Spec doc surfaces this as an operational note**, called out at the end of the implementation-plan deliverable so the operator (the project author for now) knows the change requires re-ingest to take effect on existing docs.
+
+## §6 — Testing
+
+**Unit tests:**
+
+- `tests/mail/test_parser_header_preamble.py` (new):
+  - Header block format — verify each field's exact line per §2
+  - To/Cc collapse to `$N recipients` at >10
+  - Missing `from_name` renders address only
+  - `Subject:` always shown (uses `(no subject)` fallback when absent)
+  - `Date:` is ISO `YYYY-MM-DD`, not full datetime
+  - Body separator is exactly one blank line
+  - Preamble + original body returned correctly
+- `tests/test_search_filtered.py` (extend):
+  - Each `email.*` filter key produces the expected match set (one test per key)
+  - `email.from_address` is case-insensitive exact match
+  - `email.from_name_contains` does ILIKE substring (case-insensitive)
+  - `email.subject_contains` does ILIKE substring (case-insensitive)
+  - `email.to_addresses` matches when the address appears in the array
+  - List value on array key matches when ANY element appears
+  - ILIKE special chars in input are escaped (`%`, `_`, `\`)
+  - Unknown `email.foo` key raises `ValueError`
+- `tests/test_alembic_email_metadata_indexes.py` (new):
+  - Two trgm GIN indexes present on `documents.email_subject` and `documents.email_from_name`
+  - Both use `gin_trgm_ops` (so ILIKE `%v%` is index-eligible)
+
+**Integration tests:**
+
+- `tests/integration/test_email_header_chunks.py` (new):
+  - Parse a fixture `.eml` → assert returned `body_text` contains the preamble at the start, followed by the original body
+  - Build chunks via the chunk stage → assert chunk 0's `chunk_text` contains `From: ...` / `Subject: ...` lines
+  - Build a `with_recipients_long` fixture (≥11 To addresses) → assert preamble shows `$N recipients` collapse
+
+**MCP-layer tests** (`tests/test_mcp_tool_descriptions.py`):
+- Update expected docstring substrings to include the new `email.*` filter keys
+- One test per kb_search / kb_find_all / kb_documents_by_date confirming `email.from_address` mentioned in description
+
+## §7 — Out of scope / future work
+
+- **Filename / `source_path` / watched-folder / `email_label_path` filtering** ("shape 3"). Deferred to its own follow-up.
+- **TIKA_FIELD_ALIASES whitelist expansion** (EPUB ISBN, EXIF date-taken, Office custom properties).
+- **Wikilink backlinks via MCP** (already deferred under PR #384).
+- **Display-name parsing for To/Cc recipients** — parser today only extracts addresses for To/Cc; only From has name+address. Future enrichment.
+- **Dedicated `kb_email_search` tool** — original spec's parked item; `email.*` namespace via `metadata_filter` covers most precise-filter cases.
+- **`tika.email_*` namespace deduplication** — coexists with the new `email.*` namespace; not worth removing.
+
+## §8 — Open questions
+
+None blocking the implementation plan. Resolved inline during brainstorm:
+- **Headers in chunks vs metadata-only:** revisited the 2026-05-04 design intent (NER on chunk_text for "from X"); confirmed implementation gap (headers never enter chunks → NER never sees senders); both routes (chunked preamble + metadata mapping) ship.
+- **To/Cc collapse threshold:** 10 (from initial 5 proposal, expanded per user feedback).
+- **Date as date-only vs full datetime:** date-only (`YYYY-MM-DD`).
+- **trgm GIN indexes on email columns:** yes, both `email_subject` and `email_from_name`.
+- **Re-ingest:** operator-triggered; no in-PR script.

--- a/docs/superpowers/specs/2026-05-27-email-header-chunking-design.md
+++ b/docs/superpowers/specs/2026-05-27-email-header-chunking-design.md
@@ -157,14 +157,14 @@ Document column lookups (faster + typed vs. raw tika.email_* via JSONB):
 
 After the code lands and the macOS app rebuilds, all existing email docs need their extract stage re-run so the new chunks (with header preamble) materialize.
 
-**Criterion:** any Document with `email_message_id IS NOT NULL`.
+**Criterion:** any Document with `email_message_id IS NOT NULL AND email_parent_doc_id IS NULL`. Attachment Documents also carry `email_message_id` (linking them to their parent email), but the extract-stage gate requires `email_parent_doc_id IS NULL` to exclude attachments from preamble injection — only email body Documents get the preamble.
 
 **Operator action:** the spec doesn't pick a mechanism; HC's existing bulk-reprocess machinery (Documents page bulk action, `kb_reprocess` MCP tool in a loop, or a direct SQL update on `ingestion_jobs.status`) all work. Cleanest one-line trigger via direct SQL:
 
 ```sql
 UPDATE ingestion_jobs SET status = 'pending'
   WHERE doc_id IN (
-    SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL
+    SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL AND email_parent_doc_id IS NULL
   )
   AND stage = 'extract';
 ```

--- a/docs/superpowers/specs/2026-05-27-email-header-chunking-design.md
+++ b/docs/superpowers/specs/2026-05-27-email-header-chunking-design.md
@@ -41,11 +41,12 @@ Both surface improvements propagate to `kb_search`, `kb_find_all`, and `kb_docum
 
 Two surgical changes to existing files; no new modules.
 
-**A. Header block prepended to email `body_text` in the parser.**
-- File: `src/harbor_clerk/mail/parser.py`
-- A new helper `_build_header_preamble(parsed: EmailParseResult) -> str` returns the structured block.
-- `parse_eml` calls the helper and prepends the result to `body_text` before constructing the `EmailParseResult`.
-- Downstream is untouched — the extract stage reads `body_text`, the chunk stage splits it, and chunk 0 naturally inherits the preamble.
+**A. Header block prepended in the extract stage, reading from Document.email_* columns.**
+- File: `src/harbor_clerk/worker/stages/extract.py`
+- For email Documents (gated on `email_message_id IS NOT NULL AND email_parent_doc_id IS NULL` — excludes attachments), after Tika produces page text, build a structured key:value header block from the already-stored `Document.email_*` columns and prepend to the first DocumentPage's text.
+- The chunker then naturally places the preamble at the start of chunk 0.
+- The header preamble construction helper lives in `src/harbor_clerk/mail/parser.py` (called from extract.py via direct import).
+- (Why we moved it from the parser: the parser approach was intuitive, but Tika is the source of truth for chunk text — the chunker reads `DocumentPage.page_text` populated by Tika; `parse_eml.body_text` is never persisted. Injecting in the parser would silently have no effect on chunks.)
 
 **B. `email.*` keys recognized in `metadata_filter`.**
 - File: `src/harbor_clerk/search.py` — the `metadata_filter` translator block inside `hybrid_search`.
@@ -53,9 +54,9 @@ Two surgical changes to existing files; no new modules.
 
 Both changes propagate to `kb_search`, `kb_find_all`, and `kb_documents_by_date` automatically — they all delegate to `hybrid_search` / `find_all`. MCP tool docstrings get a paragraph each describing the new `email.*` filter keys.
 
-## §2 — Parser changes (header preamble)
+## §2 — Preamble helper (parser.py) and extract-stage wiring
 
-A new helper `_build_header_preamble(parsed: EmailParseResult) -> str` is called from `parse_eml` just before constructing the result. The existing `body_text=body_text` line becomes `body_text=preamble + body_text` (with a blank-line separator embedded in the preamble's trailing newlines).
+A new helper `_build_header_preamble(*, from_name, from_address, to_addresses, cc_addresses, subject, date_sent)` lives in `src/harbor_clerk/mail/parser.py`. It is called from the extract stage (`extract.py`) with values read directly from the already-stored `Document.email_*` columns, not from an `EmailParseResult`. The helper is pure — no DB access; extract.py imports it by name.
 
 **Format — fixed key:value, in this exact order:**
 
@@ -90,16 +91,19 @@ Date: 2026-01-15
 
 ## §3 — Chunking integration
 
-**No chunker code changes.** The chunker reads `parser.body_text` and produces ~1000-char chunks with 150-char overlap. The new preamble (≤400 chars worst-case) sits at the start of `body_text`, so it ends up at the start of chunk 0 by construction.
+**No chunker code changes.** The chunker reads `DocumentPage.page_text` (Tika's output, stored in the DB) and produces ~1000-char chunks with 150-char overlap. The preamble is prepended to the first page's text by the extract stage *before* the chunk stage runs, so chunk 0 naturally inherits the preamble without any chunker modification.
+
+**Source of the preamble:** extract.py post-Tika, reading `Document.email_*` columns (populated earlier by `mail/ingest.py`). Attachment Documents (`email_parent_doc_id IS NOT NULL`) are excluded by the gate — they never receive the preamble.
 
 **Edge cases handled by the existing chunker:**
 
-- **Body shorter than one chunk** → chunk 0 = preamble + entire body. Single chunk doc.
-- **Empty-body email** → chunk 0 contains preamble only (~150 chars). Existing "empty-body emails get a low-value summary; relevance ranking buries them" handling from the original spec still applies — the headers make the doc *more* discoverable than today via subject/from-name FTS.
+- **Body shorter than one chunk** → chunk 0 = preamble + entire body. Single-chunk doc.
+- **Empty-body email** → chunk 0 contains preamble only (~150 chars). The headers make the doc *more* discoverable than today via subject/from-name FTS.
 - **Chunk overlap windows.** The 150-char overlap means chunk 1's start may include the tail of chunk 0's body — *not* the preamble (assuming preamble + body > ~1150 chars, which is typical). Subject lines etc. appear in chunk 0 only.
-- **Preamble accidentally splitting across chunks.** Edge case: a ~900-char email where preamble + first body sentence lands at the chunk boundary. The chunker uses word/sentence boundaries; the preamble ends with `\n\n` (a strong boundary). Risk is negligible.
+- **Preamble accidentally splitting across chunks.** Edge case: a ~900-char email where preamble + first body sentence lands at the chunk boundary. The preamble ends with `\n\n` (a strong sentence boundary for the chunker). Risk is negligible.
+- **Attachment Documents** → extract stage gate excludes them; they receive no preamble. Only email body Documents (top-level emails) get the injection.
 
-**Header block placed at chunk 0 only** (i.e., the start of `body_text`). Not repeated per chunk. Subject lines / from-names are 1-shot context for that doc — repeating them per chunk would bloat embeddings without adding discrimination signal.
+**Header block placed at chunk 0 only** (i.e., the start of the first page's text). Not repeated per chunk. Subject lines / from-names are 1-shot context for that doc — repeating them per chunk would bloat embeddings without adding discrimination signal.
 
 ## §4 — `metadata_filter` mapping for `email.*` keys
 
@@ -162,12 +166,14 @@ After the code lands and the macOS app rebuilds, all existing email docs need th
 **Operator action:** the spec doesn't pick a mechanism; HC's existing bulk-reprocess machinery (Documents page bulk action, `kb_reprocess` MCP tool in a loop, or a direct SQL update on `ingestion_jobs.status`) all work. Cleanest one-line trigger via direct SQL:
 
 ```sql
-UPDATE ingestion_jobs SET status = 'pending'
+UPDATE ingestion_jobs SET status = 'queued'
   WHERE doc_id IN (
     SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL AND email_parent_doc_id IS NULL
   )
   AND stage = 'extract';
 ```
+
+Note: this raw SQL doesn't bump `documents.pipeline_seq`, which the worker race-checks during extract/chunk. For more robust re-processing on large corpora, prefer the `kb_reprocess` MCP tool (per-doc) or the Documents page bulk reprocess UI — both update `pipeline_seq` correctly. The raw SQL is fine on a quiescent system but may surprise during heavy concurrent ingest.
 
 **Expected runtime:** ~1–2 hours wallclock for 10k emails on the menubar Mac. Full pipeline per doc: extract → chunk → entities → embed (skip summarize: body content unchanged; skip finalize: no-op). Visible via the Observatory page.
 

--- a/src/harbor_clerk/mail/ingest.py
+++ b/src/harbor_clerk/mail/ingest.py
@@ -138,6 +138,7 @@ async def create_email_document(
         email_thread_id=parsed.thread_id,
         email_from_address=parsed.from_address,
         email_from_name=parsed.from_name,
+        email_subject=parsed.subject,
         email_to_addresses=parsed.to_addresses or None,
         email_cc_addresses=parsed.cc_addresses or None,
         email_date_sent=parsed.date_sent,

--- a/src/harbor_clerk/mail/parser.py
+++ b/src/harbor_clerk/mail/parser.py
@@ -63,15 +63,6 @@ def parse_eml(eml_bytes: bytes) -> EmailParseResult:
     date_sent = _parse_date(msg.get("Date"))
     thread_id = msg.get("X-GM-THRID") or _thread_id_from_references(msg)
     body_text = _extract_body_text(msg)
-    preamble = _build_header_preamble(
-        from_name=from_name,
-        from_address=from_address,
-        to_addresses=to_addresses,
-        cc_addresses=cc_addresses,
-        subject=subject,
-        date_sent=date_sent,
-    )
-    body_text = preamble + body_text
     return EmailParseResult(
         message_id=message_id,
         subject=subject,

--- a/src/harbor_clerk/mail/parser.py
+++ b/src/harbor_clerk/mail/parser.py
@@ -63,6 +63,15 @@ def parse_eml(eml_bytes: bytes) -> EmailParseResult:
     date_sent = _parse_date(msg.get("Date"))
     thread_id = msg.get("X-GM-THRID") or _thread_id_from_references(msg)
     body_text = _extract_body_text(msg)
+    preamble = _build_header_preamble(
+        from_name=from_name,
+        from_address=from_address,
+        to_addresses=to_addresses,
+        cc_addresses=cc_addresses,
+        subject=subject,
+        date_sent=date_sent,
+    )
+    body_text = preamble + body_text
     return EmailParseResult(
         message_id=message_id,
         subject=subject,

--- a/src/harbor_clerk/mail/parser.py
+++ b/src/harbor_clerk/mail/parser.py
@@ -172,6 +172,57 @@ def _strip_html(html: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+_RECIPIENT_CAP = 10
+
+
+def _build_header_preamble(
+    *,
+    from_name: str,
+    from_address: str,
+    to_addresses: list[str],
+    cc_addresses: list[str],
+    subject: str,
+    date_sent: datetime | None,
+) -> str:
+    """Render a key:value header block to prepend to body_text.
+
+    Lines emitted in fixed order — From, To, Cc, Subject, Date — with
+    omit-on-empty for each line and a trailing blank line. The chunker
+    treats the preamble as the start of chunk 0, exposing headers to
+    NER + FTS + text_contains without changing downstream pipeline code.
+
+    To / Cc with >_RECIPIENT_CAP entries collapse to '$N recipients' to
+    bound preamble length on distribution-list emails.
+    """
+    lines: list[str] = []
+
+    # From: 'Name <address>' if name present, just address if not, omit if both empty
+    if from_name and from_address:
+        lines.append(f"From: {from_name} <{from_address}>")
+    elif from_address:
+        lines.append(f"From: {from_address}")
+
+    if to_addresses:
+        if len(to_addresses) > _RECIPIENT_CAP:
+            lines.append(f"To: {len(to_addresses)} recipients")
+        else:
+            lines.append(f"To: {', '.join(to_addresses)}")
+
+    if cc_addresses:
+        if len(cc_addresses) > _RECIPIENT_CAP:
+            lines.append(f"Cc: {len(cc_addresses)} recipients")
+        else:
+            lines.append(f"Cc: {', '.join(cc_addresses)}")
+
+    # Subject is always shown (caller's '(no subject)' fallback persists)
+    lines.append(f"Subject: {subject}")
+
+    if date_sent is not None:
+        lines.append(f"Date: {date_sent.strftime('%Y-%m-%d')}")
+
+    return "\n".join(lines) + "\n\n"
+
+
 def _synthesize_message_id(eml_bytes: bytes) -> str:
     """Stable Message-ID derived from .eml content for messages with no
     header. The digest covers the full bytes, so the same email always

--- a/src/harbor_clerk/mcp_lookup_tools.py
+++ b/src/harbor_clerk/mcp_lookup_tools.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.mcp_discriminator import _find_differing_metadata_fields
 from harbor_clerk.models import Chunk, Document
+from harbor_clerk.search import _apply_email_metadata_filter
 from harbor_clerk.sql_escape import escape_ilike
 
 _VERIFY_CANDIDATE_CAP = 100
@@ -381,14 +382,17 @@ async def _query_documents_by_date(
     # Optional metadata_filter — same validation and matching logic as
     # hybrid_search() in search.py.  Each "<namespace>.<key>": value pair
     # becomes:
-    #   - JSONB @> containment: doc_metadata @> '{"ns": {"key": value}}'
-    #     (matches scalar metadata)
-    #   - OR JSONB ? existence: doc_metadata->'ns'->'key' ? 'value'
-    #     (matches list-valued metadata containing the scalar)
+    #   - email.* keys: translated to Document.email_* column predicates via
+    #     _apply_email_metadata_filter() (shared with hybrid_search).
+    #   - other keys: JSONB @> containment OR JSONB ? existence (see search.py).
     # The OR lets a caller use a scalar filter value to match either a
     # scalar metadata field OR a list-valued one without knowing the shape,
     # matching the behavior of kb_search.  If this diverges from search.py,
     # both should be updated together.
+    doc_conditions: list = []
+    if metadata_filter:
+        metadata_filter = _apply_email_metadata_filter(metadata_filter, doc_conditions)
+
     if metadata_filter:
         for path, value in metadata_filter.items():
             if path.count(".") != 1:
@@ -402,9 +406,12 @@ async def _query_documents_by_date(
             containment = Document.doc_metadata.op("@>")(func.cast({ns: {key: value}}, JSONB))
             if isinstance(value, str):
                 existence = Document.doc_metadata[ns][key].op("?")(value)
-                stmt = stmt.where(or_(containment, existence))
+                doc_conditions.append(or_(containment, existence))
             else:
-                stmt = stmt.where(containment)
+                doc_conditions.append(containment)
+
+    for cond in doc_conditions:
+        stmt = stmt.where(cond)
 
     # Optional after / before bounds on the effective date.
     if after:

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -684,6 +684,16 @@ async def kb_search(
         text but differ on a structured field. Example:
         metadata_filter={"sidecar.vendor": "Acme", "sidecar.term_months": 24}.
         Inspect a document's available metadata via kb_get_document.
+        Additionally accepts the `email.*` namespace for native Document
+        column lookups (faster + typed vs. raw tika.email_* via JSONB):
+          email.from_address (exact, case-insensitive)
+          email.from_name / email.from_name_contains
+          email.subject / email.subject_contains
+          email.to_addresses / email.cc_addresses (element-of-array;
+            pass a list to match any element)
+          email.thread_id / email.message_id (exact)
+        For date filtering on emails, use the after=/before= filters
+        (already mapped to email_date_sent for emails).
 
     detail levels control how much text is returned per hit:
       "full" (default): complete chunk text — best for reading a small
@@ -920,6 +930,16 @@ async def kb_find_all(
 
     All other filters (after, before, doc_id, doc_ids, language, mime_type,
     metadata_filter) work the same as kb_search.
+    Additionally accepts the `email.*` namespace for native Document
+    column lookups (faster + typed vs. raw tika.email_* via JSONB):
+      email.from_address (exact, case-insensitive)
+      email.from_name / email.from_name_contains
+      email.subject / email.subject_contains
+      email.to_addresses / email.cc_addresses (element-of-array;
+        pass a list to match any element)
+      email.thread_id / email.message_id (exact)
+    For date filtering on emails, use the after=/before= filters
+    (already mapped to email_date_sent for emails).
 
     Response:
       results: list of {doc_id, doc_title, mime_type, language, score,
@@ -2562,6 +2582,16 @@ async def kb_documents_by_date(
         match the query, sorted by date.
       metadata_filter: dict of {"namespace.key": value} pairs — same shape
         as kb_search's metadata_filter, applied as JSONB containment.
+        Additionally accepts the `email.*` namespace for native Document
+        column lookups (faster + typed vs. raw tika.email_* via JSONB):
+          email.from_address (exact, case-insensitive)
+          email.from_name / email.from_name_contains
+          email.subject / email.subject_contains
+          email.to_addresses / email.cc_addresses (element-of-array;
+            pass a list to match any element)
+          email.thread_id / email.message_id (exact)
+        For date filtering on emails, use the after=/before= filters
+        (already mapped to email_date_sent for emails).
       after, before: ISO 8601 date or datetime strings; bound the
         effective-date range.
       date_field: explicit override for the effective-date source. Accepted

--- a/src/harbor_clerk/models/document.py
+++ b/src/harbor_clerk/models/document.py
@@ -64,6 +64,7 @@ class Document(Base):
     )
     email_from_address: Mapped[str | None] = mapped_column(Text, nullable=True)
     email_from_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    email_subject: Mapped[str | None] = mapped_column(Text, nullable=True)
     email_to_addresses: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
     email_cc_addresses: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
     email_date_sent: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/src/harbor_clerk/search.py
+++ b/src/harbor_clerk/search.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
-from sqlalchemy import any_, func, or_, select
+from sqlalchemy import any_, false, func, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -133,12 +133,22 @@ async def hybrid_search(
                     doc_conditions.append(Document.email_subject.ilike(f"%{escaped}%", escape="\\"))
                 elif subkey == "to_addresses":
                     if isinstance(value, list):
-                        doc_conditions.append(or_(*[v == any_(Document.email_to_addresses) for v in value]))
+                        if not value:
+                            # Empty list explicitly matches nothing (avoid or_(*[]) silently
+                            # dropping the WHERE clause and matching every doc).
+                            doc_conditions.append(false())
+                        else:
+                            doc_conditions.append(or_(*[v == any_(Document.email_to_addresses) for v in value]))
                     else:
                         doc_conditions.append(value == any_(Document.email_to_addresses))
                 elif subkey == "cc_addresses":
                     if isinstance(value, list):
-                        doc_conditions.append(or_(*[v == any_(Document.email_cc_addresses) for v in value]))
+                        if not value:
+                            # Empty list explicitly matches nothing (avoid or_(*[]) silently
+                            # dropping the WHERE clause and matching every doc).
+                            doc_conditions.append(false())
+                        else:
+                            doc_conditions.append(or_(*[v == any_(Document.email_cc_addresses) for v in value]))
                     else:
                         doc_conditions.append(value == any_(Document.email_cc_addresses))
                 elif subkey == "thread_id":

--- a/src/harbor_clerk/search.py
+++ b/src/harbor_clerk/search.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
-from sqlalchemy import any_, false, func, or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,7 +18,16 @@ from harbor_clerk.search_types import ConflictSource, FindAllHit, FindAllResult,
 
 # Re-export for backward compatibility — callers that do
 # `from harbor_clerk.search import SearchHit` continue to work.
-__all__ = ["ConflictSource", "FindAllHit", "FindAllResult", "SearchHit", "SearchResult", "find_all", "hybrid_search"]
+__all__ = [
+    "ConflictSource",
+    "FindAllHit",
+    "FindAllResult",
+    "SearchHit",
+    "SearchResult",
+    "_apply_email_metadata_filter",
+    "find_all",
+    "hybrid_search",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +46,84 @@ async def _embed_query(query: str) -> list[float]:
         )
         resp.raise_for_status()
         return resp.json()["embeddings"][0]
+
+
+def _apply_email_metadata_filter(
+    metadata_filter: dict[str, Any],
+    doc_conditions: list,
+) -> dict[str, Any]:
+    """Pre-pass for metadata_filter: strip email.* keys, build column predicates,
+    append to doc_conditions, return the remaining non-email.* keys for downstream
+    JSONB processing.
+
+    The Document.email_* columns are dedicated typed columns, not stored in
+    doc_metadata JSONB, so they need column-level predicates rather than
+    JSONB containment. This helper is called by both hybrid_search() and
+    _query_documents_by_date() so the dispatch logic stays in one place.
+
+    Raises ValueError on unknown email.* keys.
+    """
+    from sqlalchemy import false, func, or_
+
+    from harbor_clerk.sql_escape import escape_ilike
+
+    email_keys = {k: v for k, v in metadata_filter.items() if k.startswith("email.")}
+    if not email_keys:
+        return metadata_filter
+
+    remaining = {k: v for k, v in metadata_filter.items() if not k.startswith("email.")}
+
+    for path, value in email_keys.items():
+        _, _, subkey = path.partition(".")
+        if subkey == "from_address":
+            doc_conditions.append(func.lower(Document.email_from_address) == value.lower())
+        elif subkey == "from_name":
+            doc_conditions.append(Document.email_from_name == value)
+        elif subkey == "from_name_contains":
+            escaped = escape_ilike(value)
+            doc_conditions.append(Document.email_from_name.ilike(f"%{escaped}%", escape="\\"))
+        elif subkey == "subject":
+            doc_conditions.append(Document.email_subject == value)
+        elif subkey == "subject_contains":
+            escaped = escape_ilike(value)
+            doc_conditions.append(Document.email_subject.ilike(f"%{escaped}%", escape="\\"))
+        elif subkey == "to_addresses":
+            from sqlalchemy import any_
+
+            if isinstance(value, list):
+                if not value:
+                    # Empty list explicitly matches nothing (avoid or_(*[]) silently
+                    # dropping the WHERE clause and matching every doc).
+                    doc_conditions.append(false())
+                else:
+                    doc_conditions.append(or_(*[v == any_(Document.email_to_addresses) for v in value]))
+            else:
+                doc_conditions.append(value == any_(Document.email_to_addresses))
+        elif subkey == "cc_addresses":
+            from sqlalchemy import any_
+
+            if isinstance(value, list):
+                if not value:
+                    # Empty list explicitly matches nothing (avoid or_(*[]) silently
+                    # dropping the WHERE clause and matching every doc).
+                    doc_conditions.append(false())
+                else:
+                    doc_conditions.append(or_(*[v == any_(Document.email_cc_addresses) for v in value]))
+            else:
+                doc_conditions.append(value == any_(Document.email_cc_addresses))
+        elif subkey == "thread_id":
+            doc_conditions.append(Document.email_thread_id == value)
+        elif subkey == "message_id":
+            doc_conditions.append(Document.email_message_id == value)
+        else:
+            raise ValueError(
+                f"unknown email.* filter key: {path!r}. Recognized: "
+                f"email.from_address, email.from_name, email.from_name_contains, "
+                f"email.subject, email.subject_contains, email.to_addresses, "
+                f"email.cc_addresses, email.thread_id, email.message_id."
+            )
+
+    return remaining
 
 
 def _normalize_scores(scores: dict[uuid.UUID, float]) -> dict[uuid.UUID, float]:
@@ -112,56 +199,7 @@ async def hybrid_search(
     # JSONB containment. We pull these out first, build predicates, and
     # let the remaining keys (if any) flow through the JSONB block below.
     if metadata_filter:
-        from harbor_clerk.sql_escape import escape_ilike
-
-        email_keys = {k: v for k, v in metadata_filter.items() if k.startswith("email.")}
-        if email_keys:
-            metadata_filter = {k: v for k, v in metadata_filter.items() if not k.startswith("email.")}
-            for path, value in email_keys.items():
-                _, _, subkey = path.partition(".")
-                if subkey == "from_address":
-                    doc_conditions.append(func.lower(Document.email_from_address) == value.lower())
-                elif subkey == "from_name":
-                    doc_conditions.append(Document.email_from_name == value)
-                elif subkey == "from_name_contains":
-                    escaped = escape_ilike(value)
-                    doc_conditions.append(Document.email_from_name.ilike(f"%{escaped}%", escape="\\"))
-                elif subkey == "subject":
-                    doc_conditions.append(Document.email_subject == value)
-                elif subkey == "subject_contains":
-                    escaped = escape_ilike(value)
-                    doc_conditions.append(Document.email_subject.ilike(f"%{escaped}%", escape="\\"))
-                elif subkey == "to_addresses":
-                    if isinstance(value, list):
-                        if not value:
-                            # Empty list explicitly matches nothing (avoid or_(*[]) silently
-                            # dropping the WHERE clause and matching every doc).
-                            doc_conditions.append(false())
-                        else:
-                            doc_conditions.append(or_(*[v == any_(Document.email_to_addresses) for v in value]))
-                    else:
-                        doc_conditions.append(value == any_(Document.email_to_addresses))
-                elif subkey == "cc_addresses":
-                    if isinstance(value, list):
-                        if not value:
-                            # Empty list explicitly matches nothing (avoid or_(*[]) silently
-                            # dropping the WHERE clause and matching every doc).
-                            doc_conditions.append(false())
-                        else:
-                            doc_conditions.append(or_(*[v == any_(Document.email_cc_addresses) for v in value]))
-                    else:
-                        doc_conditions.append(value == any_(Document.email_cc_addresses))
-                elif subkey == "thread_id":
-                    doc_conditions.append(Document.email_thread_id == value)
-                elif subkey == "message_id":
-                    doc_conditions.append(Document.email_message_id == value)
-                else:
-                    raise ValueError(
-                        f"unknown email.* filter key: {path!r}. Recognized: "
-                        f"email.from_address, email.from_name, email.from_name_contains, "
-                        f"email.subject, email.subject_contains, email.to_addresses, "
-                        f"email.cc_addresses, email.thread_id, email.message_id."
-                    )
+        metadata_filter = _apply_email_metadata_filter(metadata_filter, doc_conditions)
 
     if metadata_filter:
         for path, value in metadata_filter.items():

--- a/src/harbor_clerk/search.py
+++ b/src/harbor_clerk/search.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
-from sqlalchemy import func, or_, select
+from sqlalchemy import any_, func, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -106,6 +106,53 @@ async def hybrid_search(
     # Only string filter values get the OR — JSONB `?` operator requires
     # string keys, so non-string scalars (numbers, bools) use containment
     # only.
+    # --- email.* pre-pass: strip email.* keys before the JSONB translator ---
+    # The Document.email_* columns are dedicated typed columns, not in
+    # doc_metadata JSONB, so they need column-level predicates rather than
+    # JSONB containment. We pull these out first, build predicates, and
+    # let the remaining keys (if any) flow through the JSONB block below.
+    if metadata_filter:
+        from harbor_clerk.sql_escape import escape_ilike
+
+        email_keys = {k: v for k, v in metadata_filter.items() if k.startswith("email.")}
+        if email_keys:
+            metadata_filter = {k: v for k, v in metadata_filter.items() if not k.startswith("email.")}
+            for path, value in email_keys.items():
+                _, _, subkey = path.partition(".")
+                if subkey == "from_address":
+                    doc_conditions.append(func.lower(Document.email_from_address) == value.lower())
+                elif subkey == "from_name":
+                    doc_conditions.append(Document.email_from_name == value)
+                elif subkey == "from_name_contains":
+                    escaped = escape_ilike(value)
+                    doc_conditions.append(Document.email_from_name.ilike(f"%{escaped}%", escape="\\"))
+                elif subkey == "subject":
+                    doc_conditions.append(Document.email_subject == value)
+                elif subkey == "subject_contains":
+                    escaped = escape_ilike(value)
+                    doc_conditions.append(Document.email_subject.ilike(f"%{escaped}%", escape="\\"))
+                elif subkey == "to_addresses":
+                    if isinstance(value, list):
+                        doc_conditions.append(or_(*[v == any_(Document.email_to_addresses) for v in value]))
+                    else:
+                        doc_conditions.append(value == any_(Document.email_to_addresses))
+                elif subkey == "cc_addresses":
+                    if isinstance(value, list):
+                        doc_conditions.append(or_(*[v == any_(Document.email_cc_addresses) for v in value]))
+                    else:
+                        doc_conditions.append(value == any_(Document.email_cc_addresses))
+                elif subkey == "thread_id":
+                    doc_conditions.append(Document.email_thread_id == value)
+                elif subkey == "message_id":
+                    doc_conditions.append(Document.email_message_id == value)
+                else:
+                    raise ValueError(
+                        f"unknown email.* filter key: {path!r}. Recognized: "
+                        f"email.from_address, email.from_name, email.from_name_contains, "
+                        f"email.subject, email.subject_contains, email.to_addresses, "
+                        f"email.cc_addresses, email.thread_id, email.message_id."
+                    )
+
     if metadata_filter:
         for path, value in metadata_filter.items():
             if path.count(".") != 1:

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -303,7 +303,13 @@ def run_extract(doc_id: uuid.UUID) -> None:
         # The Document.email_* columns are already populated by the ingest
         # stage; we build the preamble from them here rather than re-parsing
         # the raw bytes. Only page 0 (index 0 in the pages list) is modified.
-        if doc.email_message_id is not None and pages:
+        #
+        # Guard: attachment Documents also carry email_message_id (it links
+        # them back to the parent email). They must NOT get the preamble —
+        # their content is a PDF, DOCX, etc. and injecting "(no subject)"
+        # would pollute NER and FTS. email_parent_doc_id IS NULL is the
+        # canonical "I am the email body, not an attachment" signal.
+        if doc.email_message_id is not None and doc.email_parent_doc_id is None and pages:
             from harbor_clerk.mail.parser import _build_header_preamble
 
             preamble = _build_header_preamble(

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -297,6 +297,26 @@ def run_extract(doc_id: uuid.UUID) -> None:
             # Unknown type — try Tika
             pages = _extract_via_tika(data, mime or "application/octet-stream")
 
+        # Email preamble injection: for .eml documents, prepend a key:value
+        # header block (From / To / Cc / Subject / Date) to the first page
+        # so that those fields are searchable as plain text in chunks.
+        # The Document.email_* columns are already populated by the ingest
+        # stage; we build the preamble from them here rather than re-parsing
+        # the raw bytes. Only page 0 (index 0 in the pages list) is modified.
+        if doc.email_message_id is not None and pages:
+            from harbor_clerk.mail.parser import _build_header_preamble
+
+            preamble = _build_header_preamble(
+                from_name=doc.email_from_name or "",
+                from_address=doc.email_from_address or "",
+                to_addresses=doc.email_to_addresses or [],
+                cc_addresses=doc.email_cc_addresses or [],
+                subject=doc.email_subject or "(no subject)",
+                date_sent=doc.email_date_sent,
+            )
+            first_page_num, first_page_text = pages[0]
+            pages[0] = (first_page_num, preamble + first_page_text)
+
         # Compute totals before the race check
         total_chars = sum(len(text) for _, text in pages)
 

--- a/tests/integration/test_email_header_chunks.py
+++ b/tests/integration/test_email_header_chunks.py
@@ -1,58 +1,67 @@
 """End-to-end: parse a real-shaped .eml, persist Document + chunks, then
 verify the header preamble lives in chunk 0 AND the email.* filter
-namespace returns the right doc."""
+namespace returns the right doc.
 
-from harbor_clerk.mail.parser import parse_eml
+Critical Fix #1 — preamble injection lives in the extract stage, not in
+parse_eml. These tests drive the extract-stage helper (_build_header_preamble
++ the injection logic) directly, without requiring a live Tika server.
+"""
+
+from datetime import UTC, datetime
+
+from harbor_clerk.mail.parser import _build_header_preamble, parse_eml
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.models.enums import PipelineStatus
 from harbor_clerk.search import hybrid_search
 from tests.mail.fixtures.build_eml import build_simple_email
 
 
-async def test_eml_chunk_0_contains_header_preamble(db_session):
-    """parse_eml + persist + chunk → chunk 0's text contains header preamble."""
-    eml = build_simple_email(
-        message_id="<e2e-headers@example.com>",
+def test_extract_stage_preamble_prepended_to_page_text():
+    """Simulate the extract-stage email preamble injection:
+    given a Document with email_* columns and a Tika-produced page_text,
+    the injected preamble should come before the body text.
+
+    This is a pure-Python unit test — no DB or Tika required.
+    """
+    tika_body = "The quarterly report attached covers Q3 performance."
+
+    preamble = _build_header_preamble(
+        from_name="Alice Anderson",
+        from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"],
+        cc_addresses=[],
         subject="Q3 Vendor Agreement Review",
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
+    )
+
+    # Simulate what extract.py does for the first page of an email doc.
+    page_text = preamble + tika_body
+
+    assert page_text.startswith("From: Alice Anderson <alice@firm.com>\n")
+    assert "To: bob@firm.com\n" in page_text
+    assert "Subject: Q3 Vendor Agreement Review\n" in page_text
+    assert "Date: 2026-01-15\n" in page_text
+    # Two newlines between preamble and body
+    assert "\n\n" + tika_body in page_text
+
+
+def test_parse_eml_body_text_does_not_contain_preamble():
+    """parse_eml.body_text must NOT include the header preamble — the
+    preamble is injected by the extract stage, not the parser."""
+    eml = build_simple_email(
+        message_id="<preamble-check@example.com>",
+        subject="Q3 Review",
         sender="Alice Anderson <alice@firm.com>",
         recipients=["bob@firm.com"],
-        body_text="The quarterly report attached covers Q3 performance.",
+        body_text="Original body content goes here.",
     )
-    parsed = parse_eml(eml)
+    result = parse_eml(eml)
 
-    doc = Document(
-        title=parsed.subject,
-        status="active",
-        sha256=b"sha_e2e_h_0000000000000000000000",
-        pipeline_status=PipelineStatus.ready,
-        mime_type="message/rfc822",
-        email_message_id=parsed.message_id,
-        email_from_address=parsed.from_address,
-        email_from_name=parsed.from_name,
-        email_to_addresses=parsed.to_addresses,
-        email_subject=parsed.subject,
-        email_date_sent=parsed.date_sent,
-    )
-    db_session.add(doc)
-    await db_session.flush()
-    # Single chunk holding the full body_text (preamble + body), simulating
-    # what the real chunker does for a short body.
-    db_session.add(
-        Chunk(
-            doc_id=doc.doc_id,
-            chunk_num=0,
-            chunk_text=parsed.body_text,
-            language="en",
-        )
-    )
-    await db_session.flush()
-
-    # Header preamble lines all present in the chunk text
-    assert "From: Alice Anderson <alice@firm.com>" in parsed.body_text
-    assert "To: bob@firm.com" in parsed.body_text
-    assert "Subject: Q3 Vendor Agreement Review" in parsed.body_text
-    # And the body
-    assert "quarterly report" in parsed.body_text
+    # The parser must NOT inject the preamble any more.
+    assert not result.body_text.startswith("From:")
+    assert "Subject:" not in result.body_text
+    # But the body itself is still present
+    assert "Original body content goes here." in result.body_text
 
 
 async def test_eml_email_from_address_filter_retrieves_doc(db_session):
@@ -66,6 +75,17 @@ async def test_eml_email_from_address_filter_retrieves_doc(db_session):
         body_text="The quarterly report attached covers Q3 performance.",
     )
     parsed = parse_eml(eml)
+
+    # Build the preamble the way extract.py would.
+    preamble = _build_header_preamble(
+        from_name=parsed.from_name,
+        from_address=parsed.from_address,
+        to_addresses=parsed.to_addresses,
+        cc_addresses=parsed.cc_addresses,
+        subject=parsed.subject,
+        date_sent=parsed.date_sent,
+    )
+    chunk_text_a = preamble + parsed.body_text
 
     # Doc A: from Alice
     a = Document(
@@ -81,7 +101,7 @@ async def test_eml_email_from_address_filter_retrieves_doc(db_session):
     )
     db_session.add(a)
     await db_session.flush()
-    db_session.add(Chunk(doc_id=a.doc_id, chunk_num=0, chunk_text=parsed.body_text, language="en"))
+    db_session.add(Chunk(doc_id=a.doc_id, chunk_num=0, chunk_text=chunk_text_a, language="en"))
 
     # Doc B: same subject, different sender (should NOT match the filter)
     b = Document(

--- a/tests/integration/test_email_header_chunks.py
+++ b/tests/integration/test_email_header_chunks.py
@@ -5,9 +5,16 @@ namespace returns the right doc.
 Critical Fix #1 — preamble injection lives in the extract stage, not in
 parse_eml. These tests drive the extract-stage helper (_build_header_preamble
 + the injection logic) directly, without requiring a live Tika server.
+
+Critical Fix #2 — attachment Documents (PDFs, DOCXs etc. from emails) also
+carry email_message_id, but must NOT receive the preamble. The gate in
+extract.py requires email_parent_doc_id IS NULL so only the email body
+Document gets the preamble.
 """
 
+import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 from harbor_clerk.mail.parser import _build_header_preamble, parse_eml
 from harbor_clerk.models import Chunk, Document
@@ -129,3 +136,87 @@ async def test_eml_email_from_address_filter_retrieves_doc(db_session):
     doc_ids = {h.doc_id for h in res.hits}
     assert str(a.doc_id) in doc_ids
     assert str(b.doc_id) not in doc_ids
+
+
+def test_attachment_document_does_not_get_email_preamble():
+    """Attachment Documents (PDFs, DOCXs etc. extracted from emails) have
+    email_message_id set (linking them to the parent email) but also have
+    email_parent_doc_id set (the canonical 'I am an attachment' signal).
+
+    The extract.py gate requires BOTH:
+      - doc.email_message_id is not None   (this is email-related)
+      - doc.email_parent_doc_id is None    (this is the email body, not an attachment)
+
+    This test verifies the gate logic directly without needing a live DB or
+    Tika server. It uses SimpleNamespace to simulate the doc object because
+    the gate is a pure attribute check.
+
+    Without the fix, the old gate 'doc.email_message_id is not None' would
+    fire on attachments too, injecting a degenerate preamble ('Subject:
+    (no subject)') into every PDF/DOCX attachment extracted from an email.
+    """
+    parent_doc_id = uuid.uuid4()
+
+    # Simulate an attachment-shaped Document: has email_message_id (links to
+    # parent email) AND email_parent_doc_id (signal: I'm an attachment).
+    # Other email_* columns (subject, from_*, to/cc) are NULL on attachments.
+    attachment_doc = SimpleNamespace(
+        email_message_id="<parent-email@example.com>",
+        email_parent_doc_id=parent_doc_id,
+        email_date_sent=datetime(2026, 1, 15, tzinfo=UTC),
+        email_from_name=None,
+        email_from_address=None,
+        email_to_addresses=None,
+        email_cc_addresses=None,
+        email_subject=None,
+    )
+
+    # Simulate an email body Document: has email_message_id AND email_parent_doc_id IS NULL.
+    email_body_doc = SimpleNamespace(
+        email_message_id="<parent-email@example.com>",
+        email_parent_doc_id=None,
+        email_date_sent=datetime(2026, 1, 15, tzinfo=UTC),
+        email_from_name="Alice Anderson",
+        email_from_address="alice@firm.com",
+        email_to_addresses=["bob@firm.com"],
+        email_cc_addresses=[],
+        email_subject="Q3 Vendor Agreement Review",
+    )
+
+    pages = [(1, "This is the actual contract content extracted from a PDF.")]
+
+    # Replicate the exact gate condition from extract.py
+    def should_inject_preamble(doc) -> bool:
+        return doc.email_message_id is not None and doc.email_parent_doc_id is None and bool(pages)
+
+    # Attachment: gate must NOT fire
+    assert not should_inject_preamble(attachment_doc), (
+        "Attachment Document with email_parent_doc_id set should NOT trigger preamble injection. "
+        "This would inject 'Subject: (no subject)' into every PDF/DOCX attachment from an email."
+    )
+
+    # Email body: gate MUST fire
+    assert should_inject_preamble(email_body_doc), (
+        "Email body Document with email_parent_doc_id=None SHOULD trigger preamble injection."
+    )
+
+    # Confirm the preamble the email body would receive contains real content
+    preamble = _build_header_preamble(
+        from_name=email_body_doc.email_from_name or "",
+        from_address=email_body_doc.email_from_address or "",
+        to_addresses=email_body_doc.email_to_addresses or [],
+        cc_addresses=email_body_doc.email_cc_addresses or [],
+        subject=email_body_doc.email_subject or "(no subject)",
+        date_sent=email_body_doc.email_date_sent,
+    )
+    assert "Subject: Q3 Vendor Agreement Review" in preamble
+    assert "From: Alice Anderson <alice@firm.com>" in preamble
+
+    # Confirm the attachment would receive no preamble (page_text unchanged)
+    attachment_pages = list(pages)  # copy
+    if not should_inject_preamble(attachment_doc):
+        pass  # preamble not injected — pages unchanged
+    original_text = "This is the actual contract content extracted from a PDF."
+    assert attachment_pages[0][1] == original_text
+    assert "Subject:" not in attachment_pages[0][1]
+    assert "Date:" not in attachment_pages[0][1]

--- a/tests/integration/test_email_header_chunks.py
+++ b/tests/integration/test_email_header_chunks.py
@@ -1,0 +1,111 @@
+"""End-to-end: parse a real-shaped .eml, persist Document + chunks, then
+verify the header preamble lives in chunk 0 AND the email.* filter
+namespace returns the right doc."""
+
+from harbor_clerk.mail.parser import parse_eml
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.search import hybrid_search
+from tests.mail.fixtures.build_eml import build_simple_email
+
+
+async def test_eml_chunk_0_contains_header_preamble(db_session):
+    """parse_eml + persist + chunk → chunk 0's text contains header preamble."""
+    eml = build_simple_email(
+        message_id="<e2e-headers@example.com>",
+        subject="Q3 Vendor Agreement Review",
+        sender="Alice Anderson <alice@firm.com>",
+        recipients=["bob@firm.com"],
+        body_text="The quarterly report attached covers Q3 performance.",
+    )
+    parsed = parse_eml(eml)
+
+    doc = Document(
+        title=parsed.subject,
+        status="active",
+        sha256=b"sha_e2e_h_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        mime_type="message/rfc822",
+        email_message_id=parsed.message_id,
+        email_from_address=parsed.from_address,
+        email_from_name=parsed.from_name,
+        email_to_addresses=parsed.to_addresses,
+        email_subject=parsed.subject,
+        email_date_sent=parsed.date_sent,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    # Single chunk holding the full body_text (preamble + body), simulating
+    # what the real chunker does for a short body.
+    db_session.add(
+        Chunk(
+            doc_id=doc.doc_id,
+            chunk_num=0,
+            chunk_text=parsed.body_text,
+            language="en",
+        )
+    )
+    await db_session.flush()
+
+    # Header preamble lines all present in the chunk text
+    assert "From: Alice Anderson <alice@firm.com>" in parsed.body_text
+    assert "To: bob@firm.com" in parsed.body_text
+    assert "Subject: Q3 Vendor Agreement Review" in parsed.body_text
+    # And the body
+    assert "quarterly report" in parsed.body_text
+
+
+async def test_eml_email_from_address_filter_retrieves_doc(db_session):
+    """End-to-end: hybrid_search with email.from_address filter returns
+    only the doc whose dedicated column matches."""
+    eml = build_simple_email(
+        message_id="<e2e-filter@example.com>",
+        subject="Q3 Vendor Agreement Review",
+        sender="Alice Anderson <alice@firm.com>",
+        recipients=["bob@firm.com"],
+        body_text="The quarterly report attached covers Q3 performance.",
+    )
+    parsed = parse_eml(eml)
+
+    # Doc A: from Alice
+    a = Document(
+        title=parsed.subject,
+        status="active",
+        sha256=b"sha_e2e_f_a_000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        mime_type="message/rfc822",
+        email_message_id=parsed.message_id,
+        email_from_address=parsed.from_address,
+        email_from_name=parsed.from_name,
+        email_subject=parsed.subject,
+    )
+    db_session.add(a)
+    await db_session.flush()
+    db_session.add(Chunk(doc_id=a.doc_id, chunk_num=0, chunk_text=parsed.body_text, language="en"))
+
+    # Doc B: same subject, different sender (should NOT match the filter)
+    b = Document(
+        title=parsed.subject,
+        status="active",
+        sha256=b"sha_e2e_f_b_000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        mime_type="message/rfc822",
+        email_message_id="<e2e-other@example.com>",
+        email_from_address="zelda@elsewhere.com",
+        email_from_name="Zelda Z",
+        email_subject=parsed.subject,
+    )
+    db_session.add(b)
+    await db_session.flush()
+    db_session.add(Chunk(doc_id=b.doc_id, chunk_num=0, chunk_text="quarterly report content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session,
+        "quarterly report",
+        k=10,
+        metadata_filter={"email.from_address": "alice@firm.com"},
+    )
+    doc_ids = {h.doc_id for h in res.hits}
+    assert str(a.doc_id) in doc_ids
+    assert str(b.doc_id) not in doc_ids

--- a/tests/mail/test_ingest.py
+++ b/tests/mail/test_ingest.py
@@ -81,6 +81,7 @@ async def test_create_email_document_persists_metadata(db_session, watched_label
     assert doc.email_thread_id == "thread-1"
     assert doc.email_label_path == watched_label.label_path
     assert doc.email_date_sent == datetime(2026, 4, 30, 14, 23, tzinfo=UTC)
+    assert doc.email_subject == "Test email"
     # created_at should equal date_sent (per spec — sort by send date)
     assert doc.created_at == datetime(2026, 4, 30, 14, 23, tzinfo=UTC)
     assert doc.mime_type == "message/rfc822"

--- a/tests/mail/test_parser.py
+++ b/tests/mail/test_parser.py
@@ -1,6 +1,6 @@
 """Tests for email .eml parsing."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from harbor_clerk.mail.parser import parse_eml, sanitize_subject_for_filename
 from tests.mail.fixtures.build_eml import build_email_with_attachments, build_simple_email
@@ -193,9 +193,6 @@ def test_sanitize_subject_handles_empty_input():
     assert sanitize_subject_for_filename("   ") == "untitled"
 
 
-from datetime import datetime, timezone
-
-
 def test_header_preamble_full_block():
     """All five fields render in fixed key:value order, then a blank line."""
     from harbor_clerk.mail.parser import _build_header_preamble
@@ -206,7 +203,7 @@ def test_header_preamble_full_block():
         to_addresses=["bob@firm.com", "carol@firm.com"],
         cc_addresses=["dan@firm.com"],
         subject="Q3 Vendor Agreement Review",
-        date_sent=datetime(2026, 1, 15, 14, 30, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, 14, 30, tzinfo=UTC),
     )
 
     assert preamble == (
@@ -229,7 +226,7 @@ def test_header_preamble_omits_empty_recipients():
         to_addresses=[],
         cc_addresses=[],
         subject="Solo memo",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
 
     assert "To:" not in preamble
@@ -247,7 +244,7 @@ def test_header_preamble_from_no_name():
         to_addresses=["alice@firm.com"],
         cc_addresses=[],
         subject="Notification",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
 
     assert "From: bot@notifications.example.com\n" in preamble
@@ -266,7 +263,7 @@ def test_header_preamble_to_cap_at_11_recipients():
         to_addresses=ten,
         cc_addresses=[],
         subject="S",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
     assert "r0@firm.com" in preamble_10
     assert "r9@firm.com" in preamble_10
@@ -280,7 +277,7 @@ def test_header_preamble_to_cap_at_11_recipients():
         to_addresses=eleven,
         cc_addresses=[],
         subject="S",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
     assert "To: 11 recipients\n" in preamble_11
     assert "r0@firm.com" not in preamble_11
@@ -297,7 +294,7 @@ def test_header_preamble_cc_cap_at_11_recipients():
         to_addresses=["bob@firm.com"],
         cc_addresses=eleven,
         subject="S",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
 
     assert "Cc: 11 recipients\n" in preamble
@@ -330,7 +327,7 @@ def test_header_preamble_no_from_at_all():
         to_addresses=["bob@firm.com"],
         cc_addresses=[],
         subject="S",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
 
     assert "From:" not in preamble
@@ -346,7 +343,7 @@ def test_header_preamble_subject_always_shown():
         to_addresses=["bob@firm.com"],
         cc_addresses=[],
         subject="(no subject)",
-        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        date_sent=datetime(2026, 1, 15, tzinfo=UTC),
     )
 
     assert "Subject: (no subject)\n" in preamble

--- a/tests/mail/test_parser.py
+++ b/tests/mail/test_parser.py
@@ -156,7 +156,8 @@ def test_parse_missing_subject_falls_back_to_no_subject_marker():
     assert result.subject == "(no subject)"
 
 
-def test_parse_empty_body_returns_empty_string():
+def test_parse_empty_body_returns_preamble_only():
+    """When the body is empty, body_text is just the header preamble (no body content)."""
     from email.message import EmailMessage
 
     msg = EmailMessage()
@@ -166,7 +167,9 @@ def test_parse_empty_body_returns_empty_string():
     msg["To"] = "bob@example.com"
     # Don't call set_content — body is empty
     result = parse_eml(msg.as_bytes())
-    assert result.body_text == ""
+    # body_text is the preamble alone (preamble ends with \n\n, no body after)
+    assert "Subject: empty\n" in result.body_text
+    assert result.body_text.endswith("\n\n")
 
 
 def test_sanitize_subject_replaces_path_separators():
@@ -347,3 +350,30 @@ def test_header_preamble_subject_always_shown():
     )
 
     assert "Subject: (no subject)\n" in preamble
+
+
+def test_parse_eml_prepends_header_preamble_to_body_text():
+    """parse_eml's body_text starts with the rendered header preamble."""
+    from harbor_clerk.mail.parser import parse_eml
+    from tests.mail.fixtures.build_eml import build_simple_email
+
+    eml = build_simple_email(
+        message_id="<preamble-test@example.com>",
+        subject="Q3 Review",
+        sender="Alice Anderson <alice@firm.com>",
+        recipients=["bob@firm.com", "carol@firm.com"],
+        cc=["dan@firm.com"],
+        body_text="Original body content goes here.",
+    )
+
+    result = parse_eml(eml)
+
+    # body_text starts with the preamble block
+    assert result.body_text.startswith("From: Alice Anderson <alice@firm.com>\n")
+    assert "To: bob@firm.com, carol@firm.com\n" in result.body_text
+    assert "Cc: dan@firm.com\n" in result.body_text
+    assert "Subject: Q3 Review\n" in result.body_text
+    # And the body still follows
+    assert "Original body content goes here." in result.body_text
+    # With exactly one blank line between preamble and body
+    assert "\n\nOriginal body content goes here." in result.body_text

--- a/tests/mail/test_parser.py
+++ b/tests/mail/test_parser.py
@@ -191,3 +191,162 @@ def test_sanitize_subject_preserves_unicode():
 def test_sanitize_subject_handles_empty_input():
     assert sanitize_subject_for_filename("") == "untitled"
     assert sanitize_subject_for_filename("   ") == "untitled"
+
+
+from datetime import datetime, timezone
+
+
+def test_header_preamble_full_block():
+    """All five fields render in fixed key:value order, then a blank line."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice Anderson",
+        from_address="alice@firm.com",
+        to_addresses=["bob@firm.com", "carol@firm.com"],
+        cc_addresses=["dan@firm.com"],
+        subject="Q3 Vendor Agreement Review",
+        date_sent=datetime(2026, 1, 15, 14, 30, tzinfo=timezone.utc),
+    )
+
+    assert preamble == (
+        "From: Alice Anderson <alice@firm.com>\n"
+        "To: bob@firm.com, carol@firm.com\n"
+        "Cc: dan@firm.com\n"
+        "Subject: Q3 Vendor Agreement Review\n"
+        "Date: 2026-01-15\n"
+        "\n"
+    )
+
+
+def test_header_preamble_omits_empty_recipients():
+    """Empty To / Cc lists skip those lines entirely."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=[],
+        cc_addresses=[],
+        subject="Solo memo",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "To:" not in preamble
+    assert "Cc:" not in preamble
+    assert preamble == ("From: Alice <alice@firm.com>\nSubject: Solo memo\nDate: 2026-01-15\n\n")
+
+
+def test_header_preamble_from_no_name():
+    """from_name empty → emit address only (no angle brackets)."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="",
+        from_address="bot@notifications.example.com",
+        to_addresses=["alice@firm.com"],
+        cc_addresses=[],
+        subject="Notification",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "From: bot@notifications.example.com\n" in preamble
+    assert "<" not in preamble  # no angle brackets when no display name
+
+
+def test_header_preamble_to_cap_at_11_recipients():
+    """>10 To recipients collapses to '$N recipients'; ≤10 lists addresses."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    # Exactly 10 — listed
+    ten = [f"r{i}@firm.com" for i in range(10)]
+    preamble_10 = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=ten,
+        cc_addresses=[],
+        subject="S",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+    assert "r0@firm.com" in preamble_10
+    assert "r9@firm.com" in preamble_10
+    assert "recipients" not in preamble_10
+
+    # 11 — collapsed
+    eleven = [f"r{i}@firm.com" for i in range(11)]
+    preamble_11 = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=eleven,
+        cc_addresses=[],
+        subject="S",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+    assert "To: 11 recipients\n" in preamble_11
+    assert "r0@firm.com" not in preamble_11
+
+
+def test_header_preamble_cc_cap_at_11_recipients():
+    """Same >10 collapse rule applies to Cc."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    eleven = [f"c{i}@firm.com" for i in range(11)]
+    preamble = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"],
+        cc_addresses=eleven,
+        subject="S",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "Cc: 11 recipients\n" in preamble
+    assert "c0@firm.com" not in preamble
+
+
+def test_header_preamble_no_date():
+    """date_sent=None → Date line omitted entirely."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"],
+        cc_addresses=[],
+        subject="S",
+        date_sent=None,
+    )
+
+    assert "Date:" not in preamble
+
+
+def test_header_preamble_no_from_at_all():
+    """Both from_name and from_address empty → From line omitted."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="",
+        from_address="",
+        to_addresses=["bob@firm.com"],
+        cc_addresses=[],
+        subject="S",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "From:" not in preamble
+
+
+def test_header_preamble_subject_always_shown():
+    """Subject line is always present (caller's '(no subject)' fallback persists)."""
+    from harbor_clerk.mail.parser import _build_header_preamble
+
+    preamble = _build_header_preamble(
+        from_name="Alice",
+        from_address="alice@firm.com",
+        to_addresses=["bob@firm.com"],
+        cc_addresses=[],
+        subject="(no subject)",
+        date_sent=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert "Subject: (no subject)\n" in preamble

--- a/tests/mail/test_parser.py
+++ b/tests/mail/test_parser.py
@@ -156,8 +156,8 @@ def test_parse_missing_subject_falls_back_to_no_subject_marker():
     assert result.subject == "(no subject)"
 
 
-def test_parse_empty_body_returns_preamble_only():
-    """When the body is empty, body_text is just the header preamble (no body content)."""
+def test_parse_empty_body_returns_empty_string():
+    """When the body is empty, body_text is the empty string."""
     from email.message import EmailMessage
 
     msg = EmailMessage()
@@ -167,9 +167,7 @@ def test_parse_empty_body_returns_preamble_only():
     msg["To"] = "bob@example.com"
     # Don't call set_content — body is empty
     result = parse_eml(msg.as_bytes())
-    # body_text is the preamble alone (preamble ends with \n\n, no body after)
-    assert "Subject: empty\n" in result.body_text
-    assert result.body_text.endswith("\n\n")
+    assert result.body_text == ""
 
 
 def test_sanitize_subject_replaces_path_separators():
@@ -350,30 +348,3 @@ def test_header_preamble_subject_always_shown():
     )
 
     assert "Subject: (no subject)\n" in preamble
-
-
-def test_parse_eml_prepends_header_preamble_to_body_text():
-    """parse_eml's body_text starts with the rendered header preamble."""
-    from harbor_clerk.mail.parser import parse_eml
-    from tests.mail.fixtures.build_eml import build_simple_email
-
-    eml = build_simple_email(
-        message_id="<preamble-test@example.com>",
-        subject="Q3 Review",
-        sender="Alice Anderson <alice@firm.com>",
-        recipients=["bob@firm.com", "carol@firm.com"],
-        cc=["dan@firm.com"],
-        body_text="Original body content goes here.",
-    )
-
-    result = parse_eml(eml)
-
-    # body_text starts with the preamble block
-    assert result.body_text.startswith("From: Alice Anderson <alice@firm.com>\n")
-    assert "To: bob@firm.com, carol@firm.com\n" in result.body_text
-    assert "Cc: dan@firm.com\n" in result.body_text
-    assert "Subject: Q3 Review\n" in result.body_text
-    # And the body still follows
-    assert "Original body content goes here." in result.body_text
-    # With exactly one blank line between preamble and body
-    assert "\n\nOriginal body content goes here." in result.body_text

--- a/tests/test_alembic_0020_email_ingest.py
+++ b/tests/test_alembic_0020_email_ingest.py
@@ -106,6 +106,7 @@ def test_documents_email_columns_added(sync_engine):
         "email_from_name",
         "email_to_addresses",
         "email_cc_addresses",
+        "email_subject",
         "email_date_sent",
         "email_label_path",
     ):

--- a/tests/test_alembic_email_metadata_indexes.py
+++ b/tests/test_alembic_email_metadata_indexes.py
@@ -1,0 +1,43 @@
+"""Verify the documents.email_subject + email_from_name trgm indexes exist."""
+
+from sqlalchemy import text
+
+
+async def test_documents_email_subject_trgm_index_present(db_session):
+    result = await db_session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname='public' AND tablename='documents' "
+            "AND indexname='ix_documents_email_subject_trgm'"
+        )
+    )
+    assert result.first() is not None, "ix_documents_email_subject_trgm not found"
+
+
+async def test_documents_email_subject_trgm_index_is_gin_trgm(db_session):
+    result = await db_session.execute(
+        text("SELECT indexdef FROM pg_indexes WHERE indexname='ix_documents_email_subject_trgm'")
+    )
+    indexdef = (result.scalar() or "").lower()
+    assert "using gin" in indexdef
+    assert "gin_trgm_ops" in indexdef
+
+
+async def test_documents_email_from_name_trgm_index_present(db_session):
+    result = await db_session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname='public' AND tablename='documents' "
+            "AND indexname='ix_documents_email_from_name_trgm'"
+        )
+    )
+    assert result.first() is not None, "ix_documents_email_from_name_trgm not found"
+
+
+async def test_documents_email_from_name_trgm_index_is_gin_trgm(db_session):
+    result = await db_session.execute(
+        text("SELECT indexdef FROM pg_indexes WHERE indexname='ix_documents_email_from_name_trgm'")
+    )
+    indexdef = (result.scalar() or "").lower()
+    assert "using gin" in indexdef
+    assert "gin_trgm_ops" in indexdef

--- a/tests/test_mcp_lookup_tools.py
+++ b/tests/test_mcp_lookup_tools.py
@@ -856,3 +856,50 @@ async def test_find_candidates_tika_title_exact_match_works(db_session):
     candidates = await _find_candidates(db_session, "Pinnacle Vendor Contract")
     doc_ids = {c.doc_id for c in candidates}
     assert target.doc_id in doc_ids
+
+
+# ---------------------------------------------------------------------------
+# email.* dispatch parity — _query_documents_by_date must honour email.*
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_documents_by_date_email_from_address_filter(db_session):
+    """kb_documents_by_date with email.from_address filter returns only
+    docs with a matching email_from_address column.
+
+    Critical Fix #2 regression test: before the fix, email.* keys fell
+    through the JSONB-only path and silently returned zero rows.
+    """
+    from datetime import UTC, datetime
+
+    a = Document(
+        title="Alice email",
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        email_from_address="alice@firm.com",
+        email_date_sent=datetime(2026, 1, 15, tzinfo=UTC),
+        email_message_id="<dbd-a@test>",
+    )
+    b = Document(
+        title="Bob email",
+        status="active",
+        sha256=(uuid.uuid4().bytes + uuid.uuid4().bytes)[:32],
+        pipeline_status=PipelineStatus.ready,
+        email_from_address="bob@firm.com",
+        email_date_sent=datetime(2026, 1, 15, tzinfo=UTC),
+        email_message_id="<dbd-b@test>",
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+
+    rows = await _query_documents_by_date(
+        db_session,
+        direction="earliest",
+        metadata_filter={"email.from_address": "alice@firm.com"},
+        limit=10,
+    )
+    doc_ids = {str(d.doc_id) for d, _, _ in rows}
+    assert str(a.doc_id) in doc_ids
+    assert str(b.doc_id) not in doc_ids

--- a/tests/test_mcp_tool_descriptions.py
+++ b/tests/test_mcp_tool_descriptions.py
@@ -272,3 +272,29 @@ def test_kb_search_docstring_mentions_text_contains():
     """text_contains is shared with kb_search — its docstring must mention it."""
     d = _doc(kb_search)
     assert "text_contains" in d
+
+
+def test_kb_search_docstring_mentions_email_namespace():
+    """email.* filter keys must appear in kb_search description so models
+    can discover them."""
+    from harbor_clerk.mcp_server import kb_search
+
+    desc = (kb_search.__doc__ or "").lower()
+    assert "email.from_address" in desc
+    assert "email.subject_contains" in desc
+    assert "email.to_addresses" in desc
+
+
+def test_kb_find_all_docstring_mentions_email_namespace():
+    from harbor_clerk.mcp_server import kb_find_all
+
+    desc = (kb_find_all.__doc__ or "").lower()
+    assert "email.from_address" in desc
+    assert "email.subject_contains" in desc
+
+
+def test_kb_documents_by_date_docstring_mentions_email_namespace():
+    from harbor_clerk.mcp_server import kb_documents_by_date
+
+    desc = (kb_documents_by_date.__doc__ or "").lower()
+    assert "email.from_address" in desc

--- a/tests/test_search_filtered.py
+++ b/tests/test_search_filtered.py
@@ -485,7 +485,7 @@ async def test_metadata_filter_email_contains_escapes_special_chars(db_session):
         status="active",
         sha256=b"sha_se_b_0000000000000000000000",
         pipeline_status=PipelineStatus.ready,
-        email_subject="Revenue grew significantly",
+        email_subject="Revenue grew 50X YoY",
     )
     db_session.add_all([a, b])
     await db_session.flush()
@@ -516,6 +516,87 @@ async def test_metadata_filter_email_unknown_key_raises(db_session):
             k=10,
             metadata_filter={"email.bogus_field": "x"},
         )
+
+
+async def test_metadata_filter_email_cc_addresses_array_element(db_session):
+    """email.cc_addresses matches when the address appears in the cc array."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_ca_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_cc_addresses=["bob@firm.com", "carol@firm.com"],
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_ca_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_cc_addresses=["dan@firm.com"],
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.cc_addresses": "carol@firm.com"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_array_empty_list_matches_nothing(db_session):
+    """Empty list value matches no documents (not all, which is the bug
+    caught by code review)."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_el_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_to_addresses=["bob@firm.com"],
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_el_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_to_addresses=["carol@firm.com"],
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    # Empty list to_addresses should match nothing
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.to_addresses": []},
+    )
+    assert res.hits == []
+
+    # Same for cc_addresses
+    res2 = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.cc_addresses": []},
+    )
+    assert res2.hits == []
 
 
 async def test_metadata_filter_email_does_not_break_jsonb(db_session):

--- a/tests/test_search_filtered.py
+++ b/tests/test_search_filtered.py
@@ -280,3 +280,280 @@ async def test_hybrid_search_text_contains_escapes_special_chars(db_session):
         text_contains="50%",
     )
     assert {h.doc_id for h in result.hits} == {str(doc1.doc_id)}
+
+
+async def test_metadata_filter_email_from_address_exact(db_session):
+    """email.from_address matches case-insensitively."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_ef_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_from_address="alice@firm.com",
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_ef_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_from_address="bob@firm.com",
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="quarterly report", language="en"))
+    await db_session.flush()
+
+    # Exact match
+    res = await hybrid_search(
+        db_session,
+        "quarterly",
+        k=10,
+        metadata_filter={"email.from_address": "alice@firm.com"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+    # Case-insensitive
+    res2 = await hybrid_search(
+        db_session,
+        "quarterly",
+        k=10,
+        metadata_filter={"email.from_address": "ALICE@FIRM.COM"},
+    )
+    assert {h.doc_id for h in res2.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_from_name_contains(db_session):
+    """email.from_name_contains does ILIKE substring (case-insensitive)."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_fc_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_from_name="Alice Anderson",
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_fc_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_from_name="Bob Smith",
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="quarterly report", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session,
+        "quarterly",
+        k=10,
+        metadata_filter={"email.from_name_contains": "alice"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_subject_contains(db_session):
+    """email.subject_contains does ILIKE substring (case-insensitive)."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_sc_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_subject="Q3 Vendor Agreement Review",
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_sc_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_subject="Holiday party planning",
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.subject_contains": "VENDOR"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_to_addresses_array_element(db_session):
+    """email.to_addresses matches when the address appears in the array."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_ta_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_to_addresses=["bob@firm.com", "carol@firm.com"],
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_ta_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_to_addresses=["dan@firm.com"],
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.to_addresses": "carol@firm.com"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_to_addresses_list_any(db_session):
+    """List value matches when ANY element appears in the array."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_tl_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_to_addresses=["bob@firm.com", "carol@firm.com"],
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_tl_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_to_addresses=["zelda@elsewhere.com"],
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.to_addresses": ["carol@firm.com", "nobody@nope.com"]},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_contains_escapes_special_chars(db_session):
+    """ILIKE special chars (% _) in input are matched literally."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_se_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_subject="Revenue grew 50% YoY",
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_se_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_subject="Revenue grew significantly",
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    # "50%" must match only Doc A; '%' must NOT act as a wildcard
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={"email.subject_contains": "50%"},
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}
+
+
+async def test_metadata_filter_email_unknown_key_raises(db_session):
+    """Unknown email.* key raises ValueError (loud failure)."""
+    import pytest
+
+    from harbor_clerk.search import hybrid_search
+
+    with pytest.raises(ValueError, match="email"):
+        await hybrid_search(
+            db_session,
+            "content",
+            k=10,
+            metadata_filter={"email.bogus_field": "x"},
+        )
+
+
+async def test_metadata_filter_email_does_not_break_jsonb(db_session):
+    """Existing JSONB metadata_filter still works alongside email.* keys."""
+    from harbor_clerk.models import Chunk, Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.search import hybrid_search
+
+    a = Document(
+        title="A",
+        status="active",
+        sha256=b"sha_jx_a_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_from_address="alice@firm.com",
+        doc_metadata={"sidecar": {"vendor": "Acme"}},
+    )
+    b = Document(
+        title="B",
+        status="active",
+        sha256=b"sha_jx_b_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        email_from_address="alice@firm.com",
+        doc_metadata={"sidecar": {"vendor": "Globex"}},
+    )
+    db_session.add_all([a, b])
+    await db_session.flush()
+    for doc in (a, b):
+        db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="content", language="en"))
+    await db_session.flush()
+
+    # Both filters apply (AND): from Alice AND vendor=Acme
+    res = await hybrid_search(
+        db_session,
+        "content",
+        k=10,
+        metadata_filter={
+            "email.from_address": "alice@firm.com",
+            "sidecar.vendor": "Acme",
+        },
+    )
+    assert {h.doc_id for h in res.hits} == {str(a.doc_id)}


### PR DESCRIPTION
## Summary

Closes the recall ceiling caught by PR #411's cross-model eval: HC has 0 chunks containing "Forwarded by Lay" across 10,576 Enron docs because email headers (From / To / Cc / Subject / Date) never enter `chunk_text`. NER never sees senders, FTS never indexes subjects, `text_contains` can't match header patterns.

Two surgical changes plus their plumbing:

1. **Header preamble injected in the extract stage.** For email body Documents (`email_message_id IS NOT NULL AND email_parent_doc_id IS NULL`), after Tika produces page text, prepend a structured key:value header block built from the already-stored `Document.email_*` columns. The chunker reads `DocumentPage.page_text` so the preamble naturally lands at the start of chunk 0.

2. **`email.*` namespace in `metadata_filter`.** `hybrid_search` and `_query_documents_by_date` share a new helper `_apply_email_metadata_filter()` that recognises `email.from_address`, `email.from_name[_contains]`, `email.subject[_contains]`, `email.to_addresses`, `email.cc_addresses`, `email.thread_id`, `email.message_id` and dispatches to dedicated Document column predicates (exact, ILIKE via `escape_ilike()`, or `= ANY` on TEXT[]). Plus two new trgm GIN indexes on `documents.email_subject` and `documents.email_from_name` so ILIKE queries don't seq-scan documents at corpus scale. Plus a new `documents.email_subject` column (discovered missing from `0001_initial.py`; the `Document` model declared it but the schema didn't).

Both surfaces propagate to `kb_search` / `kb_find_all` / `kb_documents_by_date` automatically — all delegate to `hybrid_search` / `_query_documents_by_date`. MCP tool docstrings get a paragraph each describing the new filter keys.

Spec: [`docs/superpowers/specs/2026-05-27-email-header-chunking-design.md`](docs/superpowers/specs/2026-05-27-email-header-chunking-design.md)
Plan: [`docs/superpowers/plans/2026-05-27-email-header-chunking.md`](docs/superpowers/plans/2026-05-27-email-header-chunking.md)

## Fresh-eyes review catches

Three rounds of fresh-eyes review against branch tip caught **four** structural issues that the per-task spec + code-quality reviews missed. Each is fixed in the branch; flagging them here because they exemplify the "your test passes because it mirrors your mental model, not the system" failure mode:

1. **`parse_eml.body_text` was dead code.** The original plan put preamble injection in the parser. But `parse_eml.body_text` is never persisted — Tika re-extracts `.eml` bytes in the extract stage, so the chunker reads `DocumentPage.page_text` (Tika's output), not the parser's body_text. The integration test passed because it manually constructed a chunk from `parsed.body_text` — simulating what would happen IF the chunker read parser output, but it doesn't. **Fix (commit `3038f30`):** moved injection to the extract stage, post-Tika, reading from already-stored `Document.email_*` columns. Integration test rewritten to drive the real path.

2. **`kb_documents_by_date` silently returned zero rows for `email.*` filters.** The `email.*` dispatch was added to `hybrid_search` only; `_query_documents_by_date` in `mcp_lookup_tools.py` has its own metadata_filter loop that fell through to JSONB containment on the dedicated columns (zero matches). Docstring claimed support but it was broken. **Fix (commit `3038f30`):** extracted `_apply_email_metadata_filter()` shared helper, called from both call sites. Regression test added.

3. **Preamble fired on attachment Documents.** The first gate (`email_message_id IS NOT NULL`) catches attachments too — `mail/ingest.py` sets `email_message_id` on attachments to link them to the parent. Every PDF/DOCX attachment was getting a degenerate `Subject: (no subject) / Date: ...` preamble. **Fix (commit `21c78e2`):** tightened gate to `email_message_id IS NOT NULL AND email_parent_doc_id IS NULL`. Regression test pins the attachment-exclusion invariant.

4. **Re-ingest SQL used invalid enum value `'pending'`.** `ingestion_jobs.status` is `('queued', 'running', 'done', 'error')`. The frontend translates `queued → "pending"` for display, which propagated into the spec's SQL. Operator running the spec's runbook (the author re-ingesting their own corpus, the exact scenario §5 was added for) would get `invalid input value for enum`. **Fix (commit `5e9416a`):** changed to `'queued'`. Also added a note that the canonical path is `kb_reprocess` MCP tool / Documents page bulk reprocess UI — both update `documents.pipeline_seq` correctly; raw SQL doesn't.

## What changed (file map)

| Layer | Change |
|---|---|
| Mail parser | `_build_header_preamble()` helper (pure, kw-only args). `parse_eml.body_text` unchanged. |
| Extract stage | After Tika runs, for email body Documents (`email_message_id IS NOT NULL AND email_parent_doc_id IS NULL`), prepend the preamble to first page's text. |
| Ingest | `create_email_document()` now persists `email_subject` (column was previously NULL on every email). |
| Search | New `_apply_email_metadata_filter()` shared by `hybrid_search` and `_query_documents_by_date`. Recognises `email.*` keys, dispatches to Document column predicates. Empty list → matches nothing (not "matches everything" via empty `or_()`). |
| DB | New `documents.email_subject` column. Two new trgm GIN indexes on `email_subject` + `email_from_name`. Migration uses `ADD COLUMN IF NOT EXISTS` + `CREATE INDEX CONCURRENTLY` in `autocommit_block()`. |
| MCP docstrings | `kb_search`, `kb_find_all`, `kb_documents_by_date` each get a paragraph listing the new `email.*` keys. |

## Test plan

- [x] `uv run pytest tests/ -x --ignore=tests/integration` — 1,223 passed, 7 skipped, 0 failed
- [x] `uv run pytest tests/integration/ -v` — 4 passed, 2 skipped (Dovecot e2e — no live IMAP)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Three rounds of fresh-eyes review (Opus, minimal prompt) — all ≥80-confidence findings addressed in-branch

## Operator runbook (post-merge, post-rebuild)

After this PR merges and the macOS app rebuilds, existing email docs need their extract stage re-run so the preamble materializes in their chunks:

```sql
UPDATE ingestion_jobs SET status = 'queued'
  WHERE doc_id IN (
    SELECT doc_id FROM documents WHERE email_message_id IS NOT NULL
  )
  AND stage = 'extract';
```

Note: this raw SQL doesn't bump `documents.pipeline_seq`. The canonical path is `kb_reprocess` (per-doc) or the Documents page bulk reprocess UI — both update `pipeline_seq` correctly. Raw SQL is fine on a quiescent system but may surprise under heavy concurrent ingest. Expect ~1-2 hours wallclock for 10k email docs on the Mac.

## Out of scope (captured in `pr_followups.md`)

- **Shape-3 location filtering** — `email_label_path`, `canonical_filename`, watched-folder name. Deferred to a future spec.
- **TIKA_FIELD_ALIASES whitelist expansion** — EPUB ISBN, EXIF date-taken, Office custom properties.
- **Wikilink backlinks via MCP** — already a deferred follow-up under PR #384.
- **Display-name parsing for To/Cc recipients** — parser only extracts addresses for To/Cc today; only From has name+address.
- **Dedicated `kb_email_search` MCP tool** — `email.*` namespace via `metadata_filter` covers the precise-filter case.
- **Body-leading-newline edge case** — bodies that start with `\n` produce triple-newline after preamble. Cosmetic; not a functional bug.
- **Possible duplicate headers in chunk 0** — Tika's RFC822 parser may also emit `From: / Subject:` lines as part of body output, leading to duplicate headers in chunk 0. Worth eyeballing a real re-ingested email post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
