### PR TITLE
feat(scope): folder filter for Ask/Research/Search

### DIFF
--- a/alembic/versions/0005_user_scope_columns.py
+++ b/alembic/versions/0005_user_scope_columns.py
@@ -1,0 +1,47 @@
+"""user scope columns on conversations and research_state
+
+Adds a `scope` JSONB NOT NULL DEFAULT '{}' column to both tables, holding
+the user's folder-filter selection per conversation/run. Forward-compatible
+wrapper object — new scope axes (collection_ids, doc_ids, topic_ids) are
+additive JSON keys with no further DDL.
+
+Revision ID: 0005_user_scope_columns
+Revises: d65a570f594c
+Create Date: 2026-05-27 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0005_user_scope_columns"
+down_revision = "d65a570f594c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "scope",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "research_state",
+        sa.Column(
+            "scope",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("research_state", "scope")
+    op.drop_column("conversations", "scope")

--- a/alembic/versions/0005_user_scope_columns.py
+++ b/alembic/versions/0005_user_scope_columns.py
@@ -11,8 +11,9 @@ Create Date: 2026-05-27 12:00:00.000000
 """
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "0005_user_scope_columns"

--- a/docs/superpowers/plans/2026-05-27-folder-scope-for-local-tools.md
+++ b/docs/superpowers/plans/2026-05-27-folder-scope-for-local-tools.md
@@ -1,0 +1,2417 @@
+# Folder-Scope Filter for Local Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a user-driven folder filter to Ask, Research, and Search — same semantics as `KeyScope.scope_folder_ids` on API keys — with a forward-compatible `scope: {folder_ids: [...]}` wrapper that admits future collection axes additively.
+
+**Architecture:** A new `apply_folder_scope()` query helper (extracted from the existing `apply_key_scope`) is called by both the API-key path and a new user-scope path. A `UserScope` dataclass parallels `KeyScope` and rides on the `Principal` ContextVar through chat / research tool dispatch. Conversations and research_state get a `scope JSONB NOT NULL DEFAULT '{}'` column; search reads scope per-request only.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2 async, Pydantic v2, Alembic, PostgreSQL 18 (JSONB), React 19 + TanStack Query, vitest/RTL on frontend.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-folder-scope-for-local-tools-design.md`
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Confirm branch state**
+
+Run: `git rev-parse --abbrev-ref HEAD && git log --oneline -1`
+Expected: branch `feat/folder-scope-local-tools`, HEAD is the spec commit (`43b92ff docs(spec): folder-scope filter for Ask/Research/Search`).
+
+If not on that branch, run `git checkout feat/folder-scope-local-tools`.
+
+- [ ] **Step 0.2: Confirm uncommitted state is empty (besides the deferred CLI experiment spec)**
+
+Run: `git status -s`
+Expected: only `?? docs/superpowers/specs/2026-05-27-cli-vs-tool-call-small-model-experiment-design.md` (intentionally untracked from earlier).
+
+---
+
+## Task 1: Alembic migration — `conversations.scope` and `research_state.scope`
+
+**Why:** Both Ask and Research persist the user's scope choice on their natural container.
+
+**Files:**
+- Create: `alembic/versions/0005_user_scope_columns.py`
+- Test: covered by Task 2 model tests (the migration upgrade/downgrade is verified by `alembic upgrade head` + `alembic downgrade -1` round-trip).
+
+- [ ] **Step 1.1: Identify current head revision**
+
+Run: `uv run alembic heads`
+Expected: one head, currently `d65a570f594c` (email metadata trgm/GIN indexes, from PR #414). If you see a different revision, confirm the branch has been rebased onto current `origin/main` before continuing — otherwise the migration chain will fork.
+
+- [ ] **Step 1.2: Create the migration file**
+
+Create `alembic/versions/0005_user_scope_columns.py` with:
+
+```python
+"""user scope columns on conversations and research_state
+
+Adds a `scope` JSONB NOT NULL DEFAULT '{}' column to both tables, holding
+the user's folder-filter selection per conversation/run. Forward-compatible
+wrapper object — new scope axes (collection_ids, doc_ids, topic_ids) are
+additive JSON keys with no further DDL.
+
+Revision ID: 0005_user_scope_columns
+Revises: d65a570f594c
+Create Date: 2026-05-27 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0005_user_scope_columns"
+down_revision = "d65a570f594c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "scope",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "research_state",
+        sa.Column(
+            "scope",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("research_state", "scope")
+    op.drop_column("conversations", "scope")
+```
+
+- [ ] **Step 1.3: Apply the migration**
+
+Run: `uv run alembic upgrade head`
+Expected: `INFO  [alembic.runtime.migration] Running upgrade d65a570f594c -> 0005_user_scope_columns, user scope columns on conversations and research_state`.
+
+- [ ] **Step 1.4: Verify the columns exist with the correct default**
+
+Run:
+```bash
+psql "$DATABASE_URL" -c "\d+ conversations" | grep scope
+psql "$DATABASE_URL" -c "\d+ research_state" | grep scope
+```
+Expected: both rows show `scope | jsonb | not null | '{}'::jsonb`.
+
+- [ ] **Step 1.5: Verify downgrade round-trip**
+
+Run: `uv run alembic downgrade -1 && uv run alembic upgrade head`
+Expected: downgrade drops both columns cleanly, upgrade restores them.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add alembic/versions/0005_user_scope_columns.py
+git commit -m "feat(scope): alembic migration for conversations.scope and research_state.scope"
+```
+
+---
+
+## Task 2: ORM model updates — add `scope` field to `Conversation` and `ResearchState`
+
+**Files:**
+- Modify: `src/harbor_clerk/models/conversation.py`
+- Modify: `src/harbor_clerk/models/research_state.py`
+- Test: `tests/test_user_scope_models.py` (new)
+
+- [ ] **Step 2.1: Write the failing model test**
+
+Create `tests/test_user_scope_models.py`:
+
+```python
+"""Tests for the new scope JSONB column on Conversation and ResearchState."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from harbor_clerk.models.conversation import Conversation
+from harbor_clerk.models.research_state import ResearchState
+from harbor_clerk.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_conversation_scope_defaults_to_empty_dict(async_session, admin_user):
+    """A new conversation has scope == {} when not explicitly set."""
+    conv = Conversation(user_id=admin_user.user_id, title="Test")
+    async_session.add(conv)
+    await async_session.commit()
+    await async_session.refresh(conv)
+
+    assert conv.scope == {}
+
+
+@pytest.mark.asyncio
+async def test_conversation_scope_round_trips_folder_ids(async_session, admin_user):
+    """Setting scope persists the JSONB shape correctly."""
+    folder_id = str(uuid.uuid4())
+    conv = Conversation(
+        user_id=admin_user.user_id,
+        title="Scoped",
+        scope={"folder_ids": [folder_id]},
+    )
+    async_session.add(conv)
+    await async_session.commit()
+    await async_session.refresh(conv)
+
+    assert conv.scope == {"folder_ids": [folder_id]}
+
+    # Round-trip via fresh query
+    fetched = (await async_session.execute(
+        select(Conversation).where(Conversation.conversation_id == conv.conversation_id)
+    )).scalar_one()
+    assert fetched.scope == {"folder_ids": [folder_id]}
+
+
+@pytest.mark.asyncio
+async def test_research_state_scope_defaults_to_empty_dict(async_session, admin_user):
+    """A new research_state row has scope == {} when not explicitly set."""
+    conv = Conversation(user_id=admin_user.user_id, title="Research conv", mode="research")
+    async_session.add(conv)
+    await async_session.flush()
+    state = ResearchState(
+        conversation_id=conv.conversation_id,
+        strategy="search",
+        status="queued",
+        max_rounds=5,
+    )
+    async_session.add(state)
+    await async_session.commit()
+    await async_session.refresh(state)
+
+    assert state.scope == {}
+```
+
+- [ ] **Step 2.2: Run the test, verify it fails on the missing attribute**
+
+Run: `uv run pytest tests/test_user_scope_models.py -v`
+Expected: FAIL with `AttributeError: 'Conversation' object has no attribute 'scope'` (or similar).
+
+- [ ] **Step 2.3: Add `scope` to `Conversation`**
+
+Modify `src/harbor_clerk/models/conversation.py`. Add the import and the column:
+
+```python
+import uuid
+from typing import Any
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from harbor_clerk.models.base import Base, created_at, updated_at, uuid_pk
+
+
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    conversation_id: Mapped[uuid_pk]
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.user_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str] = mapped_column(
+        String(200),
+        nullable=False,
+        server_default="New conversation",
+    )
+    mode: Mapped[str] = mapped_column(String(10), nullable=False, server_default="chat")
+    scope: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default="{}",
+        default=dict,
+    )
+    created_at: Mapped[created_at]
+    updated_at: Mapped[updated_at]
+
+    __table_args__ = (Index("ix_conversations_user_updated", "user_id", "updated_at"),)
+```
+
+- [ ] **Step 2.4: Add `scope` to `ResearchState`**
+
+Modify `src/harbor_clerk/models/research_state.py`. Add the column alongside the other JSONB columns:
+
+```python
+    scope: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default="{}",
+        default=dict,
+    )
+```
+
+Place it directly above `citations: Mapped[Any | None] = ...` so related JSON columns sit together.
+
+- [ ] **Step 2.5: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_user_scope_models.py -v`
+Expected: PASS — all three tests.
+
+- [ ] **Step 2.6: Run the full test suite to catch regressions**
+
+Run: `uv run pytest -x --ignore=tests/integration`
+Expected: PASS — no regressions from the model change.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/harbor_clerk/models/conversation.py src/harbor_clerk/models/research_state.py tests/test_user_scope_models.py
+git commit -m "feat(scope): add scope JSONB column to Conversation and ResearchState"
+```
+
+---
+
+## Task 3: Extract `apply_folder_scope` helper from `apply_key_scope`
+
+**Why:** Single source of truth for folder-axis filtering. Both `apply_key_scope` (API-key path) and the new user-scope path call it.
+
+**Files:**
+- Modify: `src/harbor_clerk/api/scope.py`
+- Test: `tests/test_folder_scope_helper.py` (new)
+
+- [ ] **Step 3.1: Write the failing test**
+
+Create `tests/test_folder_scope_helper.py`:
+
+```python
+"""Tests for apply_folder_scope — the pure query builder shared by
+apply_key_scope and the user-side folder filter."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from harbor_clerk.api.scope import apply_folder_scope
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_scope_none_is_noop(async_session, two_folder_corpus):
+    """folder_ids=None returns the query unchanged — all docs visible."""
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, None)
+
+    all_ids = {r[0] for r in (await async_session.execute(query)).all()}
+    scoped_ids = {r[0] for r in (await async_session.execute(scoped)).all()}
+
+    assert scoped_ids == all_ids
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_scope_empty_list_is_noop(async_session, two_folder_corpus):
+    """folder_ids=[] also means no restriction."""
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, [])
+
+    all_ids = {r[0] for r in (await async_session.execute(query)).all()}
+    scoped_ids = {r[0] for r in (await async_session.execute(scoped)).all()}
+
+    assert scoped_ids == all_ids
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_scope_restricts_to_named_folder(async_session, two_folder_corpus):
+    """folder_ids=[folder_a] returns only docs in folder_a."""
+    folder_a, folder_b, docs_in_a, docs_in_b = two_folder_corpus
+
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, [folder_a.folder_id])
+
+    scoped_ids = {r[0] for r in (await async_session.execute(scoped)).all()}
+    expected_ids = {d.doc_id for d in docs_in_a}
+    assert scoped_ids == expected_ids
+
+
+@pytest.mark.asyncio
+async def test_apply_folder_scope_excludes_removed_watched_files(async_session, two_folder_corpus, mark_one_removed):
+    """A WatchedFile in `removed` status no longer surfaces its document."""
+    folder_a, _, _, _ = two_folder_corpus
+    removed_doc_id = await mark_one_removed(folder_a)
+
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, [folder_a.folder_id])
+    scoped_ids = {r[0] for r in (await async_session.execute(scoped)).all()}
+
+    assert removed_doc_id not in scoped_ids
+```
+
+(The `two_folder_corpus` and `mark_one_removed` fixtures are added in step 3.2.)
+
+- [ ] **Step 3.2: Add the fixtures to `tests/conftest.py`**
+
+Append to `tests/conftest.py`:
+
+```python
+import pytest
+from harbor_clerk.models.watched import WatchedFile, WatchedFolder, WatchedFileStatus
+from harbor_clerk.models.document import Document
+
+
+@pytest.fixture
+async def two_folder_corpus(async_session, admin_user):
+    """Create two watched folders, each with 2 active documents."""
+    folder_a = WatchedFolder(label="Folder A", path="/a", auto_discovered=False)
+    folder_b = WatchedFolder(label="Folder B", path="/b", auto_discovered=False)
+    async_session.add_all([folder_a, folder_b])
+    await async_session.flush()
+
+    docs_in_a, docs_in_b = [], []
+    for i, folder in [(0, folder_a), (1, folder_a), (2, folder_b), (3, folder_b)]:
+        d = Document(
+            title=f"Doc {i}",
+            canonical_filename=f"doc{i}.txt",
+            status="active",
+            sha256=bytes(f"{i:032d}", "utf-8")[:32],
+        )
+        async_session.add(d)
+        await async_session.flush()
+        wf = WatchedFile(
+            folder_id=folder.folder_id,
+            doc_id=d.doc_id,
+            relative_path=f"doc{i}.txt",
+            sha256=d.sha256,
+            status=WatchedFileStatus.active,
+        )
+        async_session.add(wf)
+        (docs_in_a if folder is folder_a else docs_in_b).append(d)
+
+    await async_session.commit()
+    return folder_a, folder_b, docs_in_a, docs_in_b
+
+
+@pytest.fixture
+async def mark_one_removed(async_session):
+    """Helper to mark one document's WatchedFile as removed, returning its doc_id."""
+    async def _mark(folder):
+        from sqlalchemy import select
+        wf = (await async_session.execute(
+            select(WatchedFile).where(WatchedFile.folder_id == folder.folder_id).limit(1)
+        )).scalar_one()
+        wf.status = WatchedFileStatus.removed
+        await async_session.commit()
+        return wf.doc_id
+    return _mark
+```
+
+(If `admin_user` and `async_session` fixtures don't already exist in conftest, copy them from `tests/test_scoped_api_keys.py` which has the same pattern.)
+
+- [ ] **Step 3.3: Run the test, verify it fails on missing import**
+
+Run: `uv run pytest tests/test_folder_scope_helper.py -v`
+Expected: FAIL with `ImportError: cannot import name 'apply_folder_scope' from 'harbor_clerk.api.scope'`.
+
+- [ ] **Step 3.4: Extract `apply_folder_scope` in `scope.py`**
+
+Replace the body of `apply_key_scope` to delegate. Edit `src/harbor_clerk/api/scope.py`:
+
+```python
+def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Select:
+    """Filter a Document query to documents whose active WatchedFile lives in any
+    of the given folders. No-op when folder_ids is None or empty.
+
+    Pure query builder — no DB access. Safe to compose with other WHERE clauses.
+    """
+    if not folder_ids:
+        return query
+    watched_doc_ids = select(WatchedFile.doc_id).where(
+        WatchedFile.folder_id.in_(folder_ids),
+        WatchedFile.status == WatchedFileStatus.active,
+    )
+    return query.where(Document.doc_id.in_(watched_doc_ids))
+
+
+def apply_key_scope(query: Select, principal: "Principal") -> Select:
+    """Filter a Document query by the API key's scope (topic OR folder)."""
+    if principal.type != "api_key" or principal.key_scope is None:
+        return query
+    scope = principal.key_scope
+    if scope.is_unrestricted:
+        return query
+
+    conditions = []
+    if scope.scope_topic_ids:
+        conditions.append(Document.topic_id.in_(scope.scope_topic_ids))
+    if scope.scope_folder_ids:
+        try:
+            folder_uuids = [uuid.UUID(fid) for fid in scope.scope_folder_ids]
+        except (ValueError, AttributeError):
+            folder_uuids = []
+        if folder_uuids:
+            # Reuse the folder helper for the folder branch.
+            folder_filter = apply_folder_scope(select(Document.doc_id), folder_uuids)
+            conditions.append(Document.doc_id.in_(folder_filter))
+
+    if not conditions:
+        return query.where(Document.doc_id == uuid.UUID(int=0))
+
+    return query.where(or_(*conditions))
+```
+
+- [ ] **Step 3.5: Run both the new test and the existing key-scope tests**
+
+Run: `uv run pytest tests/test_folder_scope_helper.py tests/test_scoped_api_keys.py -v`
+Expected: PASS — all tests, including the existing key-scope ones (no regression).
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/harbor_clerk/api/scope.py tests/test_folder_scope_helper.py tests/conftest.py
+git commit -m "feat(scope): extract apply_folder_scope helper from apply_key_scope"
+```
+
+---
+
+## Task 4: `UserScope` dataclass + `Principal.user_scope`
+
+**Why:** The chat / research tool dispatch path runs under `Principal(type="user")` today; we need a place to attach the user's folder selection so each MCP tool body can read it from the current Principal.
+
+**Files:**
+- Modify: `src/harbor_clerk/api/scope.py` (add `UserScope`)
+- Modify: `src/harbor_clerk/api/deps.py` (extend `Principal`)
+- Test: `tests/test_user_scope_dataclass.py` (new)
+
+- [ ] **Step 4.1: Write the failing test**
+
+Create `tests/test_user_scope_dataclass.py`:
+
+```python
+"""Tests for UserScope and Principal.user_scope."""
+
+import uuid
+
+import pytest
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import UserScope
+
+
+def test_user_scope_defaults():
+    """Empty UserScope means no restriction (matches KeyScope semantics)."""
+    scope = UserScope()
+    assert scope.folder_ids is None
+    assert scope.is_unrestricted is True
+
+
+def test_user_scope_is_unrestricted_with_empty_list():
+    """folder_ids=[] also unrestricted (matches KeyScope)."""
+    scope = UserScope(folder_ids=[])
+    assert scope.is_unrestricted is True
+
+
+def test_user_scope_with_folders_is_restricted():
+    folder_id = uuid.uuid4()
+    scope = UserScope(folder_ids=[folder_id])
+    assert scope.is_unrestricted is False
+    assert scope.folder_ids == [folder_id]
+
+
+def test_principal_user_scope_defaults_to_none():
+    """API-key principals carry key_scope; user principals carry user_scope. Both default None."""
+    p = Principal(type="user", id=uuid.uuid4(), role="user")
+    assert p.user_scope is None
+    assert p.key_scope is None
+
+
+def test_principal_can_carry_user_scope():
+    folder_id = uuid.uuid4()
+    p = Principal(
+        type="user",
+        id=uuid.uuid4(),
+        role="user",
+        user_scope=UserScope(folder_ids=[folder_id]),
+    )
+    assert p.user_scope is not None
+    assert p.user_scope.folder_ids == [folder_id]
+```
+
+- [ ] **Step 4.2: Run the test, verify it fails on missing import**
+
+Run: `uv run pytest tests/test_user_scope_dataclass.py -v`
+Expected: FAIL with `ImportError: cannot import name 'UserScope'`.
+
+- [ ] **Step 4.3: Add `UserScope` to `scope.py`**
+
+Append to `src/harbor_clerk/api/scope.py`:
+
+```python
+@dataclass
+class UserScope:
+    """Per-request scope for human-user tool calls.
+
+    Distinct from KeyScope: no permission_tier / tool_overrides / rate_limit —
+    human users authenticate via JWT and aren't tool-gated. Only document-axis
+    filters live here. Forward-compatible: collection_ids, doc_ids, topic_ids
+    will be added here additively when Collections ships.
+    """
+
+    folder_ids: list[uuid.UUID] | None = None
+
+    @property
+    def is_unrestricted(self) -> bool:
+        """True when no document-axis filter applies. Both None and [] count."""
+        return not self.folder_ids
+```
+
+- [ ] **Step 4.4: Extend `Principal` in `deps.py`**
+
+Modify `src/harbor_clerk/api/deps.py`:
+
+```python
+from harbor_clerk.api.scope import KeyScope, UserScope
+
+
+@dataclass
+class Principal:
+    type: str
+    id: uuid.UUID
+    role: str
+    key_scope: KeyScope | None = None    # populated for api_key principals only
+    user_scope: UserScope | None = None  # populated for user principals when a scope is active
+```
+
+- [ ] **Step 4.5: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_user_scope_dataclass.py -v`
+Expected: PASS — all 5 tests.
+
+- [ ] **Step 4.6: Run the full suite to catch regressions**
+
+Run: `uv run pytest -x --ignore=tests/integration`
+Expected: PASS.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/harbor_clerk/api/scope.py src/harbor_clerk/api/deps.py tests/test_user_scope_dataclass.py
+git commit -m "feat(scope): add UserScope dataclass and Principal.user_scope field"
+```
+
+---
+
+## Task 5: `ScopeSpec` Pydantic schema
+
+**Why:** Single schema reused by chat / research / search request bodies. `extra="ignore"` makes future axes additive without endpoint version bumps.
+
+**Files:**
+- Create: `src/harbor_clerk/api/schemas/scope.py`
+- Test: `tests/test_scope_spec_schema.py` (new)
+
+- [ ] **Step 5.1: Write the failing test**
+
+Create `tests/test_scope_spec_schema.py`:
+
+```python
+"""Tests for the ScopeSpec Pydantic schema."""
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
+
+def test_empty_scope_spec_round_trips():
+    """ScopeSpec() = empty = no restriction. Round-trips to/from {}."""
+    spec = ScopeSpec()
+    assert spec.folder_ids is None
+    assert spec.model_dump(exclude_none=True) == {}
+
+
+def test_scope_spec_with_folder_ids():
+    folder_id = uuid.uuid4()
+    spec = ScopeSpec(folder_ids=[folder_id])
+    assert spec.folder_ids == [folder_id]
+
+
+def test_scope_spec_accepts_empty_folder_ids_list():
+    """An explicit empty list is valid and equivalent to None per the spec."""
+    spec = ScopeSpec(folder_ids=[])
+    assert spec.folder_ids == []
+
+
+def test_scope_spec_ignores_unknown_keys():
+    """Future axes (collection_ids, doc_ids, etc.) sent by newer clients to an older
+    server must parse without error. extra='ignore' guarantees forward-compat."""
+    spec = ScopeSpec.model_validate(
+        {"folder_ids": [str(uuid.uuid4())], "collection_ids": ["future-key"], "extra_weirdness": 42}
+    )
+    assert spec.folder_ids is not None
+    # The unknown keys are silently dropped.
+    assert "collection_ids" not in spec.model_dump()
+
+
+def test_scope_spec_rejects_non_uuid_folder_ids():
+    """Bad UUIDs should fail validation cleanly with 422."""
+    with pytest.raises(ValidationError):
+        ScopeSpec(folder_ids=["not-a-uuid"])
+```
+
+- [ ] **Step 5.2: Run the test, verify it fails on missing module**
+
+Run: `uv run pytest tests/test_scope_spec_schema.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'harbor_clerk.api.schemas.scope'`.
+
+- [ ] **Step 5.3: Create the `ScopeSpec` schema**
+
+Create `src/harbor_clerk/api/schemas/scope.py`:
+
+```python
+"""Shared scope schema for Ask / Research / Search request bodies.
+
+Forward-compatible wrapper: today only `folder_ids` is honored. Future axes
+(collection_ids, doc_ids, topic_ids) can be added as new optional fields with
+no migration and no endpoint version bump. extra='ignore' on the model lets
+older servers tolerate newer clients sending unknown keys.
+"""
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ScopeSpec(BaseModel):
+    """A user-driven document-visibility scope.
+
+    Empty (`{}`) or all fields None/[] means no restriction — all active
+    documents are visible. When fields are populated, scoping mirrors
+    KeyScope's OR-across-axes semantics (today: only folder_ids).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    folder_ids: list[uuid.UUID] | None = None
+    # Future axes will be added here additively. Examples (not yet active):
+    #   collection_ids: list[uuid.UUID] | None = None
+    #   doc_ids: list[uuid.UUID] | None = None
+    #   topic_ids: list[int] | None = None
+```
+
+- [ ] **Step 5.4: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_scope_spec_schema.py -v`
+Expected: PASS — all 5 tests.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/harbor_clerk/api/schemas/scope.py tests/test_scope_spec_schema.py
+git commit -m "feat(scope): add ScopeSpec Pydantic schema with forward-compat extra='ignore'"
+```
+
+---
+
+## Task 6: Extend `_visible_doc_ids` to honor `user_scope`
+
+**Why:** `_visible_doc_ids()` in `mcp_server.py` is the central function that every MCP tool body calls (directly or via `apply_key_scope`) to determine visibility. Extending it to also recognize `user_scope` gives all 19 MCP tools user-side folder scoping in one place.
+
+**Files:**
+- Modify: `src/harbor_clerk/mcp_server.py:316-329`
+- Test: `tests/test_visible_doc_ids_user_scope.py` (new)
+
+- [ ] **Step 6.1: Write the failing test**
+
+Create `tests/test_visible_doc_ids_user_scope.py`:
+
+```python
+"""Tests for _visible_doc_ids honoring user_scope alongside key_scope."""
+
+import uuid
+
+import pytest
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import UserScope
+from harbor_clerk.mcp_server import _visible_doc_ids
+
+
+@pytest.mark.asyncio
+async def test_visible_doc_ids_user_principal_no_scope_returns_none(async_session, admin_user, two_folder_corpus):
+    """User principal with no user_scope → None (unrestricted)."""
+    p = Principal(type="user", id=admin_user.user_id, role="user")
+    visible = await _visible_doc_ids(async_session, p)
+    assert visible is None
+
+
+@pytest.mark.asyncio
+async def test_visible_doc_ids_user_principal_with_empty_scope_returns_none(async_session, admin_user, two_folder_corpus):
+    """user_scope with folder_ids=[] is unrestricted."""
+    p = Principal(
+        type="user", id=admin_user.user_id, role="user",
+        user_scope=UserScope(folder_ids=[]),
+    )
+    visible = await _visible_doc_ids(async_session, p)
+    assert visible is None
+
+
+@pytest.mark.asyncio
+async def test_visible_doc_ids_user_principal_with_folder_scope_restricts(async_session, admin_user, two_folder_corpus):
+    """user_scope with folder_ids returns only docs in those folders."""
+    folder_a, _, docs_in_a, _ = two_folder_corpus
+    p = Principal(
+        type="user", id=admin_user.user_id, role="user",
+        user_scope=UserScope(folder_ids=[folder_a.folder_id]),
+    )
+    visible = await _visible_doc_ids(async_session, p)
+    expected = {d.doc_id for d in docs_in_a}
+    assert visible == expected
+```
+
+- [ ] **Step 6.2: Run the test, verify it fails (returns None when it shouldn't)**
+
+Run: `uv run pytest tests/test_visible_doc_ids_user_scope.py -v`
+Expected: FAIL on `test_visible_doc_ids_user_principal_with_folder_scope_restricts` — `visible` will be `None` because today's `_visible_doc_ids` only handles API-key principals.
+
+- [ ] **Step 6.3: Extend `_visible_doc_ids`**
+
+Modify `src/harbor_clerk/mcp_server.py` (the function around line 316):
+
+```python
+async def _visible_doc_ids(session: AsyncSession, principal: Principal) -> set[uuid.UUID] | None:
+    """Get the set of doc_ids visible to this principal, or None if unrestricted.
+
+    Returns None when no scope filter applies (API key with no scope, OR human
+    user with no user_scope). Returns the explicit set for scoped keys/users —
+    callers use this to filter results. Only active (non-removed) documents
+    are included.
+    """
+    # API-key path (today's behavior, unchanged)
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        from harbor_clerk.api.scope import apply_key_scope
+
+        query = apply_key_scope(select(Document.doc_id).where(Document.status == "active"), principal)
+        result = await session.execute(query)
+        return {row[0] for row in result.all()}
+
+    # User-scope path (new)
+    if principal.type == "user" and principal.user_scope is not None and not principal.user_scope.is_unrestricted:
+        from harbor_clerk.api.scope import apply_folder_scope
+
+        query = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            principal.user_scope.folder_ids,
+        )
+        result = await session.execute(query)
+        return {row[0] for row in result.all()}
+
+    return None
+```
+
+- [ ] **Step 6.4: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_visible_doc_ids_user_scope.py -v`
+Expected: PASS — all 3 tests.
+
+- [ ] **Step 6.5: Run the broader MCP test suite to confirm no regression in the API-key path**
+
+Run: `uv run pytest tests/test_scoped_api_keys.py tests/test_visible_doc_ids_user_scope.py -v`
+Expected: PASS — both suites pass.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add src/harbor_clerk/mcp_server.py tests/test_visible_doc_ids_user_scope.py
+git commit -m "feat(scope): extend _visible_doc_ids to honor Principal.user_scope"
+```
+
+---
+
+## Task 7: `execute_tool` accepts `user_scope` and attaches it to `Principal`
+
+**Why:** Chat and research tool dispatch flow through `execute_tool()`. Once it forwards `user_scope` onto the Principal stored in `_mcp_principal`, every MCP tool body sees the scope (via `_visible_doc_ids` from Task 6) with no further changes.
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/tools.py` (the `execute_tool` function around line 648)
+- Test: `tests/test_execute_tool_user_scope.py` (new)
+
+- [ ] **Step 7.1: Write the failing test**
+
+Create `tests/test_execute_tool_user_scope.py`:
+
+```python
+"""Tests for execute_tool forwarding user_scope onto Principal."""
+
+import json
+import uuid
+
+import pytest
+
+from harbor_clerk.api.scope import UserScope
+from harbor_clerk.llm.tools import execute_tool
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_search_with_no_scope_returns_all(async_session, admin_user, two_folder_corpus):
+    """No user_scope = no filter = all docs from both folders visible."""
+    result_str = await execute_tool(
+        "search_documents",
+        {"query": "doc"},
+        user_id=admin_user.user_id,
+    )
+    result = json.loads(result_str)
+    assert "hits" in result
+    titles = {hit["doc_title"] for hit in result["hits"] if hit.get("doc_title")}
+    # Both folders' docs reachable
+    assert any("Doc 0" in t or "Doc 1" in t for t in titles)
+    assert any("Doc 2" in t or "Doc 3" in t for t in titles)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_search_with_folder_scope_restricts(async_session, admin_user, two_folder_corpus):
+    """user_scope=folder_a → only folder_a docs visible."""
+    folder_a, _, docs_in_a, _ = two_folder_corpus
+    scope = UserScope(folder_ids=[folder_a.folder_id])
+
+    result_str = await execute_tool(
+        "search_documents",
+        {"query": "doc"},
+        user_id=admin_user.user_id,
+        user_scope=scope,
+    )
+    result = json.loads(result_str)
+    expected_ids = {str(d.doc_id) for d in docs_in_a}
+    returned_ids = {hit["doc_id"] for hit in result.get("hits", [])}
+    # Every returned hit is in folder_a
+    assert returned_ids.issubset(expected_ids)
+```
+
+(This test depends on the chunks for `two_folder_corpus` being indexable. If chunk/embedding generation isn't fixture-friendly, restrict the test to a tool that returns documents by ID directly — `list_documents` or `corpus_overview` — which doesn't need indexed chunks. Update the fixture accordingly.)
+
+- [ ] **Step 7.2: Run the test, verify it fails on unexpected `user_scope` kwarg**
+
+Run: `uv run pytest tests/test_execute_tool_user_scope.py::test_execute_tool_search_with_folder_scope_restricts -v`
+Expected: FAIL — `TypeError: execute_tool() got an unexpected keyword argument 'user_scope'`.
+
+- [ ] **Step 7.3: Modify `execute_tool` to accept `user_scope`**
+
+Modify `src/harbor_clerk/llm/tools.py` (around line 648):
+
+```python
+async def execute_tool(
+    name: str,
+    arguments: dict,
+    user_id: uuid.UUID | None = None,
+    *,
+    mode: str = "chat",
+    user_scope: "UserScope | None" = None,
+) -> str:
+    """Execute a tool by delegating to the corresponding MCP function.
+
+    mode: "chat" (conservative limits) or "research" (permissive limits).
+    user_scope: optional folder-level scope to apply to all retrievals in
+        this tool call. Mirrors KeyScope.scope_folder_ids semantics.
+    """
+    from harbor_clerk.api.deps import Principal
+    from harbor_clerk.api.scope import UserScope  # noqa: F401 (for forward ref)
+    from harbor_clerk.mcp_server import _mcp_principal
+
+    if name == "corpus_topics":
+        from harbor_clerk.topics import get_topics_for_tool
+
+        return await get_topics_for_tool()
+
+    dispatch = _RESEARCH_TOOL_DISPATCH if mode == "research" else _TOOL_DISPATCH
+    entry = dispatch.get(name)
+    if entry is None:
+        return json.dumps({"error": f"Unknown tool: {name}"})
+
+    mcp_func_name, arg_mapper = entry
+    mapped_args = arg_mapper(arguments)
+
+    # Set MCP auth context so the tool function sees the chat user and scope
+    token = None
+    if user_id is not None:
+        principal = Principal(type="user", id=user_id, role="user", user_scope=user_scope)
+        token = _mcp_principal.set(principal)
+
+    try:
+        import harbor_clerk.mcp_server as mcp_mod
+
+        func = getattr(mcp_mod, mcp_func_name)
+        return await func(**mapped_args)
+    except PermissionError as e:
+        logger.warning("Tool permission error: %s - %s", name, e)
+        return json.dumps({"error": str(e)})
+    except Exception as e:
+        logger.exception("Tool execution error: %s", name)
+        return json.dumps({"error": str(e)})
+    finally:
+        if token is not None:
+            _mcp_principal.reset(token)
+```
+
+- [ ] **Step 7.4: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_execute_tool_user_scope.py -v`
+Expected: PASS — both tests.
+
+- [ ] **Step 7.5: Confirm existing tool-execution tests still pass**
+
+Run: `uv run pytest tests/ -k "execute_tool or tool_dispatch" -v`
+Expected: PASS — no regressions.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/harbor_clerk/llm/tools.py tests/test_execute_tool_user_scope.py
+git commit -m "feat(scope): execute_tool accepts user_scope and forwards to Principal"
+```
+
+---
+
+## Task 8: Chat route — accept and persist `scope` on conversation creation
+
+**Files:**
+- Modify: `src/harbor_clerk/api/schemas/chat.py` (extend `CreateConversationRequest`, `ConversationSummary`, `ConversationDetail`)
+- Modify: `src/harbor_clerk/api/routes/chat.py` (`create_conversation`, `list_conversations`, `get_conversation`)
+- Test: `tests/test_chat_route_scope.py` (new)
+
+- [ ] **Step 8.1: Write the failing test**
+
+Create `tests/test_chat_route_scope.py`:
+
+```python
+"""Tests for the scope field on POST /api/chat/conversations and GET responses."""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_with_no_scope_field_defaults_to_empty(async_client, admin_token):
+    """No scope → conversation.scope == {} in DB, scope == {} in response."""
+    r = await async_client.post(
+        "/api/chat/conversations",
+        json={"title": "Unscoped"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scope"] == {}
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_with_folder_scope_persists(async_client, admin_token, two_folder_corpus):
+    folder_a, _, _, _ = two_folder_corpus
+    r = await async_client.post(
+        "/api/chat/conversations",
+        json={"title": "Scoped", "scope": {"folder_ids": [str(folder_a.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scope"] == {"folder_ids": [str(folder_a.folder_id)]}
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_rejects_unknown_folder_id(async_client, admin_token):
+    """Unknown UUID → 422."""
+    r = await async_client.post(
+        "/api/chat/conversations",
+        json={"title": "Bad", "scope": {"folder_ids": [str(uuid.uuid4())]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_rejects_unavailable_folder(async_client, admin_token, unavailable_folder):
+    """Folder with unavailable_reason set → 422."""
+    r = await async_client.post(
+        "/api/chat/conversations",
+        json={"title": "Bad", "scope": {"folder_ids": [str(unavailable_folder.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_returns_scope(async_client, admin_token, two_folder_corpus):
+    folder_a, _, _, _ = two_folder_corpus
+    create = await async_client.post(
+        "/api/chat/conversations",
+        json={"title": "S", "scope": {"folder_ids": [str(folder_a.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    conv_id = create.json()["conversation_id"]
+
+    r = await async_client.get(
+        f"/api/chat/conversations/{conv_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scope"] == {"folder_ids": [str(folder_a.folder_id)]}
+```
+
+(Add an `unavailable_folder` fixture to `tests/conftest.py` — a `WatchedFolder` with `unavailable_reason="test-disabled"`.)
+
+- [ ] **Step 8.2: Run the test, verify failures**
+
+Run: `uv run pytest tests/test_chat_route_scope.py -v`
+Expected: most tests FAIL — either 422 (scope not in schema, rejected by extra="forbid" if set) or 200 with response missing `scope`.
+
+- [ ] **Step 8.3: Extend chat schemas**
+
+Modify `src/harbor_clerk/api/schemas/chat.py`:
+
+```python
+"""Pydantic schemas for chat and model management endpoints."""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
+# --- Conversations ---
+
+
+class CreateConversationRequest(BaseModel):
+    title: str = "New conversation"
+    scope: ScopeSpec | None = None
+
+
+class ConversationSummary(BaseModel):
+    conversation_id: str
+    title: str
+    scope: dict[str, Any] = {}
+    created_at: datetime
+    updated_at: datetime
+
+
+class ChatMessageOut(BaseModel):
+    message_id: str
+    role: str
+    content: str
+    tool_calls: Any | None = None
+    tool_call_id: str | None = None
+    rag_context: Any | None = None
+    tokens_used: int | None = None
+    model_id: str | None = None
+    context_pct: int | None = None
+    created_at: datetime
+
+
+class ConversationDetail(BaseModel):
+    conversation_id: str
+    title: str
+    scope: dict[str, Any] = {}
+    created_at: datetime
+    updated_at: datetime
+    messages: list[ChatMessageOut]
+
+
+class SendMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1, max_length=10000)
+```
+
+- [ ] **Step 8.4: Add validation helper for `ScopeSpec.folder_ids`**
+
+Create `src/harbor_clerk/api/scope_validation.py`:
+
+```python
+"""Validation: ensure ScopeSpec.folder_ids references existing, available folders."""
+
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
+from harbor_clerk.models.watched import WatchedFolder
+
+
+async def validate_scope_folders(scope: ScopeSpec | None, session: AsyncSession) -> None:
+    """Raise 422 if any folder_id is unknown or unavailable.
+
+    No-op when scope is None or scope.folder_ids is None/empty.
+    """
+    if scope is None or not scope.folder_ids:
+        return
+
+    folder_ids: list[uuid.UUID] = list(scope.folder_ids)
+    rows = (
+        await session.execute(
+            select(WatchedFolder.folder_id, WatchedFolder.unavailable_reason).where(
+                WatchedFolder.folder_id.in_(folder_ids)
+            )
+        )
+    ).all()
+
+    found_ids = {r[0] for r in rows}
+    unknown = [str(fid) for fid in folder_ids if fid not in found_ids]
+    if unknown:
+        raise HTTPException(status_code=422, detail=f"Unknown folder_ids: {unknown}")
+
+    unavailable = [str(r[0]) for r in rows if r[1] is not None]
+    if unavailable:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Cannot scope to unavailable folders: {unavailable}",
+        )
+```
+
+- [ ] **Step 8.5: Wire scope into `create_conversation`**
+
+Modify `src/harbor_clerk/api/routes/chat.py` around line 105:
+
+```python
+@router.post("/chat/conversations", response_model=ConversationSummary)
+async def create_conversation(
+    body: CreateConversationRequest,
+    principal: Principal = Depends(require_authenticated),
+    session: AsyncSession = Depends(get_session),
+):
+    from harbor_clerk.api.scope_validation import validate_scope_folders
+
+    await validate_scope_folders(body.scope, session)
+
+    scope_dict = body.scope.model_dump(exclude_none=True) if body.scope else {}
+    conv = Conversation(
+        user_id=principal.id,
+        title=body.title,
+        scope=scope_dict,
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+
+    return ConversationSummary(
+        conversation_id=str(conv.conversation_id),
+        title=conv.title,
+        scope=conv.scope,
+        created_at=conv.created_at,
+        updated_at=conv.updated_at,
+    )
+```
+
+Also update the `list_conversations` projection (around line 84) and `get_conversation` projection (around line 123) to include `scope=c.scope` / `scope=conv.scope` in their respective response objects.
+
+- [ ] **Step 8.6: Run the chat-route tests**
+
+Run: `uv run pytest tests/test_chat_route_scope.py -v`
+Expected: PASS — all 5 tests.
+
+- [ ] **Step 8.7: Run the broader chat tests to catch regressions**
+
+Run: `uv run pytest tests/ -k chat -v`
+Expected: PASS — no regressions.
+
+- [ ] **Step 8.8: Commit**
+
+```bash
+git add src/harbor_clerk/api/schemas/chat.py src/harbor_clerk/api/routes/chat.py src/harbor_clerk/api/scope_validation.py tests/test_chat_route_scope.py tests/conftest.py
+git commit -m "feat(scope): chat route stores and returns conversation.scope"
+```
+
+---
+
+## Task 9: Chat engine loads conversation scope and threads it to `execute_tool`
+
+**Why:** A conversation's stored scope only matters if it's actually applied at retrieval time.
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/chat.py` (the function that drives a chat turn — around line 492 where `execute_tool` is called)
+- Test: `tests/test_chat_engine_scope_threading.py` (new)
+
+- [ ] **Step 9.1: Write the failing test**
+
+Create `tests/test_chat_engine_scope_threading.py`:
+
+```python
+"""Verify that the chat engine loads conversation.scope and passes a UserScope
+into execute_tool on every tool call."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from harbor_clerk.api.scope import UserScope
+
+
+@pytest.mark.asyncio
+async def test_chat_engine_passes_user_scope_to_execute_tool(
+    async_session, admin_user, two_folder_corpus, scoped_conversation
+):
+    """When a conversation has scope.folder_ids set, execute_tool gets a matching UserScope."""
+    folder_a, _, _, _ = two_folder_corpus
+    conv = scoped_conversation(folders=[folder_a.folder_id])
+
+    with patch("harbor_clerk.llm.chat.execute_tool", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = '{"hits": []}'
+        # Drive a synthetic chat turn that forces a tool call
+        # (helper that posts a user message and lets the engine run a single search)
+        await _drive_chat_turn(conv.conversation_id, admin_user.user_id, "find termination clauses")
+
+    # First positional/kwarg call should include user_scope
+    call = mock_exec.call_args
+    assert call is not None
+    kwargs = call.kwargs
+    assert kwargs.get("user_scope") is not None
+    assert isinstance(kwargs["user_scope"], UserScope)
+    assert kwargs["user_scope"].folder_ids == [folder_a.folder_id]
+
+
+@pytest.mark.asyncio
+async def test_chat_engine_unscoped_passes_no_user_scope(async_session, admin_user, unscoped_conversation):
+    """A conversation with scope=={} → execute_tool called with user_scope=None (or UserScope with empty folder_ids)."""
+    conv = unscoped_conversation()
+    with patch("harbor_clerk.llm.chat.execute_tool", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = '{"hits": []}'
+        await _drive_chat_turn(conv.conversation_id, admin_user.user_id, "anything")
+
+    kwargs = mock_exec.call_args.kwargs
+    scope = kwargs.get("user_scope")
+    assert scope is None or scope.is_unrestricted
+```
+
+(The `scoped_conversation`, `unscoped_conversation`, and `_drive_chat_turn` helpers are test-internal — define them in this file or extend conftest. Use whichever helper pattern existing chat tests use; check `tests/test_chat*` for the right idiom.)
+
+- [ ] **Step 9.2: Run the test, verify it fails**
+
+Run: `uv run pytest tests/test_chat_engine_scope_threading.py -v`
+Expected: FAIL — `execute_tool` is called without `user_scope` kwarg today.
+
+- [ ] **Step 9.3: Modify `chat.py` to load conversation scope and thread it**
+
+In `src/harbor_clerk/llm/chat.py`, find the function that runs the chat turn (the one that loads `conv` and eventually calls `execute_tool` around line 492). Add scope-loading at the top of the function and pass it through:
+
+```python
+# Near the start of the chat turn, after loading the conversation:
+from harbor_clerk.api.scope import UserScope
+
+user_scope: UserScope | None = None
+scope_dict = (conv.scope or {}) if conv is not None else {}
+folder_ids_raw = scope_dict.get("folder_ids") or []
+if folder_ids_raw:
+    user_scope = UserScope(folder_ids=[uuid.UUID(fid) if isinstance(fid, str) else fid for fid in folder_ids_raw])
+
+# Then, every execute_tool call inside the loop:
+result_str = await execute_tool(fn_name, fn_args, user_id, user_scope=user_scope)
+```
+
+There are multiple `execute_tool` call sites in `chat.py` — update each one. Search the file for `execute_tool(` and add `user_scope=user_scope` to every call.
+
+- [ ] **Step 9.4: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_chat_engine_scope_threading.py -v`
+Expected: PASS — both tests.
+
+- [ ] **Step 9.5: Run the broader chat test suite**
+
+Run: `uv run pytest tests/ -k chat -v`
+Expected: PASS — no regression.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add src/harbor_clerk/llm/chat.py tests/test_chat_engine_scope_threading.py
+git commit -m "feat(scope): chat engine threads conversation scope into execute_tool"
+```
+
+---
+
+## Task 10: Research route — accept and persist `scope` on research start
+
+**Files:**
+- Modify: `src/harbor_clerk/api/schemas/research.py` (`StartResearchRequest`, `ResearchSummary`, `ResearchDetail`)
+- Modify: `src/harbor_clerk/api/routes/research.py` (the `POST /research` handler around line 209)
+- Test: `tests/test_research_route_scope.py` (new)
+
+- [ ] **Step 10.1: Write the failing test**
+
+Create `tests/test_research_route_scope.py`:
+
+```python
+"""Tests for scope on POST /api/research and GET /api/research/{id}."""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_start_research_with_no_scope_defaults_to_empty(async_client, admin_token):
+    r = await async_client.post(
+        "/api/research",
+        json={"question": "What are the termination clauses?", "time_limit_minutes": 15, "depth": "light"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+        params={"dry_run": "true"},  # if available; otherwise mock the engine
+    )
+    assert r.status_code in (200, 202)
+    # research_id is in the response — fetch detail to inspect scope
+    rid = r.json()["conversation_id"]
+    d = await async_client.get(
+        f"/api/research/{rid}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert d.json()["scope"] == {}
+
+
+@pytest.mark.asyncio
+async def test_start_research_with_folder_scope_persists(async_client, admin_token, two_folder_corpus):
+    folder_a, _, _, _ = two_folder_corpus
+    r = await async_client.post(
+        "/api/research",
+        json={
+            "question": "Q",
+            "time_limit_minutes": 15,
+            "depth": "light",
+            "scope": {"folder_ids": [str(folder_a.folder_id)]},
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    rid = r.json()["conversation_id"]
+    d = await async_client.get(
+        f"/api/research/{rid}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert d.json()["scope"] == {"folder_ids": [str(folder_a.folder_id)]}
+
+
+@pytest.mark.asyncio
+async def test_start_research_rejects_unknown_folder_id(async_client, admin_token):
+    r = await async_client.post(
+        "/api/research",
+        json={
+            "question": "Q",
+            "time_limit_minutes": 15,
+            "depth": "light",
+            "scope": {"folder_ids": [str(uuid.uuid4())]},
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+```
+
+- [ ] **Step 10.2: Run the test, verify it fails**
+
+Run: `uv run pytest tests/test_research_route_scope.py -v`
+Expected: FAIL — `scope` not in request schema and/or not in detail response.
+
+- [ ] **Step 10.3: Extend research schemas**
+
+Modify `src/harbor_clerk/api/schemas/research.py`:
+
+```python
+"""Pydantic schemas for research mode API."""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
+
+class StartResearchRequest(BaseModel):
+    question: str = Field(..., min_length=1, max_length=10000)
+    strategy: str | None = Field(default=None, pattern="^(search|sweep)$", description="Override default strategy")
+    time_limit_minutes: int = Field(default=30, ge=15, le=180)
+    depth: str = Field(default="standard", pattern="^(light|standard|thorough)$")
+    scope: ScopeSpec | None = None
+```
+
+Add `scope: dict[str, Any] = {}` to `ResearchSummary` and `ResearchDetail`.
+
+- [ ] **Step 10.4: Wire scope into `POST /research`**
+
+Modify the handler around line 209 of `src/harbor_clerk/api/routes/research.py`:
+
+```python
+@router.post("/research")
+async def start_research(
+    body: StartResearchRequest,
+    principal: Principal = Depends(require_authenticated),
+    session: AsyncSession = Depends(get_session),
+):
+    from harbor_clerk.api.scope_validation import validate_scope_folders
+
+    await validate_scope_folders(body.scope, session)
+    scope_dict = body.scope.model_dump(exclude_none=True) if body.scope else {}
+
+    # ... existing conversation + research_state creation ...
+    # When creating the ResearchState row, include scope=scope_dict
+```
+
+(Apply the same pattern when creating the ResearchState — pass `scope=scope_dict` into the constructor.)
+
+Also: update the `GET /research/{conv_id}` projection (line 97) and the list projection (line 63) to include `scope=state.scope` in their response objects.
+
+- [ ] **Step 10.5: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_research_route_scope.py -v`
+Expected: PASS.
+
+- [ ] **Step 10.6: Run the broader research test suite**
+
+Run: `uv run pytest tests/ -k research -v`
+Expected: PASS — no regressions.
+
+- [ ] **Step 10.7: Commit**
+
+```bash
+git add src/harbor_clerk/api/schemas/research.py src/harbor_clerk/api/routes/research.py tests/test_research_route_scope.py
+git commit -m "feat(scope): research route stores and returns research_state.scope"
+```
+
+---
+
+## Task 11: Research engine loads `research_state.scope` and threads it through
+
+**Why:** Same as Task 9 for chat. The engine has multiple `execute_tool()` call sites (lines ~659, ~680, ~760) and direct retrieval helpers. All need the user_scope plumbed through.
+
+**Files:**
+- Modify: `src/harbor_clerk/llm/research.py` (the research-run entry point around line 956, plus the helpers that call `execute_tool`)
+- Test: `tests/test_research_engine_scope_threading.py` (new)
+
+- [ ] **Step 11.1: Write the failing test**
+
+Create `tests/test_research_engine_scope_threading.py`:
+
+```python
+"""Verify the research engine loads research_state.scope and passes UserScope into
+every execute_tool call inside the run."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from harbor_clerk.api.scope import UserScope
+
+
+@pytest.mark.asyncio
+async def test_research_engine_passes_user_scope(async_session, admin_user, two_folder_corpus, scoped_research_state):
+    folder_a, _, _, _ = two_folder_corpus
+    state = scoped_research_state(folders=[folder_a.folder_id])
+
+    with patch("harbor_clerk.llm.research.execute_tool", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = '{"hits": []}'
+        await _drive_one_research_round(state.conversation_id, admin_user.user_id)
+
+    # Every execute_tool call should have user_scope.folder_ids == [folder_a.folder_id]
+    for call in mock_exec.call_args_list:
+        kwargs = call.kwargs
+        assert "user_scope" in kwargs
+        assert isinstance(kwargs["user_scope"], UserScope)
+        assert kwargs["user_scope"].folder_ids == [folder_a.folder_id]
+```
+
+(`scoped_research_state` and `_drive_one_research_round` are test helpers — define in this file mirroring whatever pattern existing research tests use; check `tests/test_research*` for examples. If no existing pattern, use a minimal stub that creates the state row and calls the engine's per-round driver directly.)
+
+- [ ] **Step 11.2: Run the test, verify it fails**
+
+Run: `uv run pytest tests/test_research_engine_scope_threading.py -v`
+Expected: FAIL — `user_scope` not in `execute_tool` kwargs.
+
+- [ ] **Step 11.3: Load scope at the top of the research run + thread it**
+
+Modify `src/harbor_clerk/llm/research.py`. At the start of the run (around line 956), load the scope:
+
+```python
+import uuid as _uuid
+from harbor_clerk.api.scope import UserScope
+
+async def run_research(conversation_id: uuid.UUID, user_id: uuid.UUID | None = None, ...):
+    # ... existing setup ...
+    state = await session.get(ResearchState, conversation_id)
+    if state is None:
+        ...
+
+    # Load user scope from research_state.scope
+    user_scope: UserScope | None = None
+    scope_dict = state.scope or {}
+    folder_ids_raw = scope_dict.get("folder_ids") or []
+    if folder_ids_raw:
+        user_scope = UserScope(
+            folder_ids=[_uuid.UUID(fid) if isinstance(fid, str) else fid for fid in folder_ids_raw]
+        )
+
+    # ... pass user_scope to every helper that ultimately calls execute_tool
+```
+
+Then thread `user_scope` through the helper signatures that call `execute_tool`. Search `research.py` for `execute_tool(` and add `user_scope=user_scope` to every call. The helpers themselves may need to accept `user_scope: UserScope | None` as a kwarg if they're called from multiple places.
+
+Also: any direct DB retrieval in research.py (look for `select(Document...)` or `select(Chunk...)` query construction) needs `apply_folder_scope(query, user_scope.folder_ids if user_scope else None)` applied.
+
+- [ ] **Step 11.4: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_research_engine_scope_threading.py -v`
+Expected: PASS.
+
+- [ ] **Step 11.5: Run the broader research test suite**
+
+Run: `uv run pytest tests/ -k research -v`
+Expected: PASS — no regressions.
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add src/harbor_clerk/llm/research.py tests/test_research_engine_scope_threading.py
+git commit -m "feat(scope): research engine threads research_state.scope into execute_tool"
+```
+
+---
+
+## Task 12: Search route — accept `scope` in request and apply it
+
+**Files:**
+- Modify: `src/harbor_clerk/api/schemas/search.py` (`SearchRequest`)
+- Modify: `src/harbor_clerk/api/routes/search.py` (the `search()` handler around line 47)
+- Test: `tests/test_search_route_scope.py` (new)
+
+- [ ] **Step 12.1: Write the failing test**
+
+Create `tests/test_search_route_scope.py`:
+
+```python
+"""Tests for scope on POST /api/search."""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_search_with_no_scope_returns_all(async_client, admin_token, two_folder_corpus):
+    r = await async_client.post(
+        "/api/search",
+        json={"query": "doc"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    # Either folder's docs may appear
+    doc_ids = {h["doc_id"] for h in r.json()["hits"]}
+    assert len(doc_ids) > 0
+
+
+@pytest.mark.asyncio
+async def test_search_with_folder_scope_restricts(async_client, admin_token, two_folder_corpus):
+    folder_a, _, docs_in_a, _ = two_folder_corpus
+    r = await async_client.post(
+        "/api/search",
+        json={"query": "doc", "scope": {"folder_ids": [str(folder_a.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    expected = {str(d.doc_id) for d in docs_in_a}
+    returned = {h["doc_id"] for h in r.json()["hits"]}
+    assert returned.issubset(expected)
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_unknown_folder_id(async_client, admin_token):
+    r = await async_client.post(
+        "/api/search",
+        json={"query": "x", "scope": {"folder_ids": [str(uuid.uuid4())]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+```
+
+- [ ] **Step 12.2: Run the test, verify it fails**
+
+Run: `uv run pytest tests/test_search_route_scope.py -v`
+Expected: FAIL — `scope` field is unknown to `SearchRequest`.
+
+- [ ] **Step 12.3: Extend `SearchRequest`**
+
+Modify `src/harbor_clerk/api/schemas/search.py`:
+
+```python
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
+
+class SearchRequest(BaseModel):
+    query: str
+    k: int = Field(default=10, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)
+    doc_id: str | None = None
+    doc_ids: list[str] | None = Field(default=None, max_length=50)
+    after: datetime | None = None
+    before: datetime | None = None
+    language: str | None = None
+    mime_type: str | None = None
+    faceted: bool = False
+    scope: ScopeSpec | None = None    # new
+
+    @model_validator(mode="after")
+    def check_doc_id_mutual_exclusion(self):
+        if self.doc_id is not None and self.doc_ids is not None:
+            raise ValueError("Cannot specify both doc_id and doc_ids")
+        return self
+```
+
+- [ ] **Step 12.4: Apply scope in the route handler**
+
+Modify `src/harbor_clerk/api/routes/search.py` around line 47. Add scope validation + intersect-with-doc-ids logic, parallel to the existing API-key path:
+
+```python
+@router.post("/search", response_model=SearchResponse | FacetedSearchResponse)
+async def search(
+    body: SearchRequest,
+    principal: Principal = Depends(require_read_access),
+    session: AsyncSession = Depends(get_session),
+):
+    from harbor_clerk.api.scope import apply_folder_scope
+    from harbor_clerk.api.scope_validation import validate_scope_folders
+
+    await validate_scope_folders(body.scope, session)
+
+    doc_id = uuid.UUID(body.doc_id) if body.doc_id else None
+    doc_ids = [uuid.UUID(d) for d in body.doc_ids] if body.doc_ids else None
+
+    # Per-API-key scope (today)
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(select(Document.doc_id), principal)
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+        # ... existing key-scope intersection logic, unchanged ...
+
+    # Per-request user scope (new)
+    if body.scope is not None and body.scope.folder_ids:
+        scoped_q = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            list(body.scope.folder_ids),
+        )
+        scoped_visible = {row[0] for row in (await session.execute(scoped_q)).all()}
+        if not scoped_visible:
+            return SearchResponse(
+                hits=[], total_candidates=0, has_more=False,
+                possible_conflict=False, conflict_sources=[],
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in scoped_visible]
+            if not doc_ids:
+                return SearchResponse(
+                    hits=[], total_candidates=0, has_more=False,
+                    possible_conflict=False, conflict_sources=[],
+                )
+        else:
+            doc_ids = list(scoped_visible)
+        if doc_id is not None and doc_id not in scoped_visible:
+            return SearchResponse(
+                hits=[], total_candidates=0, has_more=False,
+                possible_conflict=False, conflict_sources=[],
+            )
+
+    # ... rest of the existing handler (hybrid_search call, response shaping) ...
+```
+
+- [ ] **Step 12.5: Run the test, verify it passes**
+
+Run: `uv run pytest tests/test_search_route_scope.py -v`
+Expected: PASS.
+
+- [ ] **Step 12.6: Run the broader search tests**
+
+Run: `uv run pytest tests/ -k search -v`
+Expected: PASS — no regression.
+
+- [ ] **Step 12.7: Commit**
+
+```bash
+git add src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/test_search_route_scope.py
+git commit -m "feat(scope): /api/search accepts and applies request-level scope"
+```
+
+---
+
+## Task 13: Frontend — `useWatchedFolders` hook
+
+**Why:** Three pages (Ask, Research, Search) need the same folder list. The hook centralizes the fetch + filters out unavailable folders.
+
+**Files:**
+- Create: `frontend/src/hooks/useWatchedFolders.ts`
+- Test: `frontend/src/hooks/useWatchedFolders.test.tsx`
+
+- [ ] **Step 13.1: Write the failing test**
+
+Create `frontend/src/hooks/useWatchedFolders.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useWatchedFolders } from './useWatchedFolders';
+import * as api from '../api/client';
+
+describe('useWatchedFolders', () => {
+  function wrapper({ children }: { children: React.ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  it('returns folders, filtering out unavailable ones', async () => {
+    const mockGet = vi.spyOn(api, 'get').mockResolvedValue([
+      { folder_id: 'a', label: 'A', path: '/a', unavailable_reason: null },
+      { folder_id: 'b', label: 'B', path: '/b', unavailable_reason: 'unmounted' },
+      { folder_id: 'c', label: 'C', path: '/c', unavailable_reason: null },
+    ]);
+
+    const { result } = renderHook(() => useWatchedFolders(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.folders.map((f) => f.folder_id)).toEqual(['a', 'c']);
+    mockGet.mockRestore();
+  });
+
+  it('returns empty array when no folders', async () => {
+    const mockGet = vi.spyOn(api, 'get').mockResolvedValue([]);
+    const { result } = renderHook(() => useWatchedFolders(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.folders).toEqual([]);
+    mockGet.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 13.2: Run the test, verify it fails on missing module**
+
+Run: `cd frontend && npm test -- useWatchedFolders`
+Expected: FAIL — module not found.
+
+- [ ] **Step 13.3: Implement the hook**
+
+Create `frontend/src/hooks/useWatchedFolders.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { get } from '../api/client';
+
+export interface WatchedFolderInfo {
+  folder_id: string;
+  label: string;
+  path: string;
+  unavailable_reason: string | null;
+}
+
+export function useWatchedFolders() {
+  const query = useQuery({
+    queryKey: ['watch', 'folders'],
+    queryFn: () => get<WatchedFolderInfo[]>('/api/watch/folders'),
+    staleTime: 30_000,
+  });
+
+  const folders = (query.data ?? []).filter((f) => f.unavailable_reason === null);
+
+  return {
+    folders,
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}
+```
+
+- [ ] **Step 13.4: Run the test, verify it passes**
+
+Run: `cd frontend && npm test -- useWatchedFolders`
+Expected: PASS.
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add frontend/src/hooks/useWatchedFolders.ts frontend/src/hooks/useWatchedFolders.test.tsx
+git commit -m "feat(scope): useWatchedFolders hook (filters out unavailable folders)"
+```
+
+---
+
+## Task 14: Frontend — `<FolderPicker>` component
+
+**Why:** The interactive multi-select used in the New Conversation modal, Research start form, and Search filter row.
+
+**Files:**
+- Create: `frontend/src/components/FolderPicker.tsx`
+- Test: `frontend/src/components/FolderPicker.test.tsx`
+
+- [ ] **Step 14.1: Write the failing test**
+
+Create `frontend/src/components/FolderPicker.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FolderPicker } from './FolderPicker';
+
+const folders = [
+  { folder_id: 'a', label: 'Contracts', path: '/c', unavailable_reason: null },
+  { folder_id: 'b', label: 'Legal', path: '/l', unavailable_reason: null },
+];
+
+describe('FolderPicker', () => {
+  it('renders "Folders: All" when value is empty', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={folders} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Folders: All');
+  });
+
+  it('renders folder labels when one selected', () => {
+    render(<FolderPicker value={['a']} onChange={() => {}} folders={folders} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Folders: Contracts');
+  });
+
+  it('renders count when multiple selected', () => {
+    render(<FolderPicker value={['a', 'b']} onChange={() => {}} folders={folders} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Folders: Contracts, Legal (2)');
+  });
+
+  it('disables when there are no folders', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={[]} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveTextContent('No folders to scope to');
+  });
+
+  it('toggling a folder calls onChange', () => {
+    const onChange = vi.fn();
+    render(<FolderPicker value={[]} onChange={onChange} folders={folders} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByLabelText('Contracts'));
+    expect(onChange).toHaveBeenCalledWith(['a']);
+  });
+
+  it('"Select all" selects every folder', () => {
+    const onChange = vi.fn();
+    render(<FolderPicker value={[]} onChange={onChange} folders={folders} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('Select all'));
+    expect(onChange).toHaveBeenCalledWith(['a', 'b']);
+  });
+
+  it('"Clear" resets selection', () => {
+    const onChange = vi.fn();
+    render(<FolderPicker value={['a', 'b']} onChange={onChange} folders={folders} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('Clear'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('search input filters the list', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={folders} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByPlaceholderText('Search folders…'), { target: { value: 'leg' } });
+    expect(screen.queryByText('Contracts')).not.toBeInTheDocument();
+    expect(screen.getByText('Legal')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 14.2: Run the test, verify it fails**
+
+Run: `cd frontend && npm test -- FolderPicker`
+Expected: FAIL — module not found.
+
+- [ ] **Step 14.3: Implement `<FolderPicker>`**
+
+Create `frontend/src/components/FolderPicker.tsx`:
+
+```tsx
+import { useState, useMemo } from 'react';
+import type { WatchedFolderInfo } from '../hooks/useWatchedFolders';
+
+export interface FolderPickerProps {
+  value: string[];
+  onChange: (folder_ids: string[]) => void;
+  folders: WatchedFolderInfo[];
+  disabled?: boolean;
+  size?: 'sm' | 'md';
+}
+
+function summarize(value: string[], folders: WatchedFolderInfo[]): string {
+  if (value.length === 0) return 'Folders: All';
+  const labels = value
+    .map((id) => folders.find((f) => f.folder_id === id)?.label ?? '?')
+    .slice(0, 3);
+  const suffix = value.length > 1 ? ` (${value.length})` : '';
+  return `Folders: ${labels.join(', ')}${suffix}`;
+}
+
+export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }: FolderPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+
+  const visible = useMemo(
+    () =>
+      folders.filter((f) =>
+        filter.trim() === '' ? true : f.label.toLowerCase().includes(filter.toLowerCase()),
+      ),
+    [folders, filter],
+  );
+
+  const noFolders = folders.length === 0;
+  const buttonText = noFolders ? 'No folders to scope to' : summarize(value, folders);
+
+  const toggle = (id: string) => {
+    if (value.includes(id)) onChange(value.filter((v) => v !== id));
+    else onChange([...value, id]);
+  };
+
+  return (
+    <div className={`folder-picker folder-picker--${size}`}>
+      <button
+        type="button"
+        onClick={() => !noFolders && setOpen((o) => !o)}
+        disabled={disabled || noFolders}
+        className="folder-picker__trigger"
+      >
+        {buttonText}
+      </button>
+      {open && !noFolders && (
+        <div className="folder-picker__popover">
+          <input
+            type="text"
+            placeholder="Search folders…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="folder-picker__search"
+          />
+          <div className="folder-picker__actions">
+            <button type="button" onClick={() => onChange(folders.map((f) => f.folder_id))}>
+              Select all
+            </button>
+            <button type="button" onClick={() => onChange([])}>
+              Clear
+            </button>
+          </div>
+          <ul className="folder-picker__list">
+            {visible.map((f) => (
+              <li key={f.folder_id}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={value.includes(f.folder_id)}
+                    onChange={() => toggle(f.folder_id)}
+                    aria-label={f.label}
+                  />
+                  {f.label}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+(Tailwind classes can be added per the existing component style. Test verifies behavior, not styling.)
+
+- [ ] **Step 14.4: Run the test, verify it passes**
+
+Run: `cd frontend && npm test -- FolderPicker`
+Expected: PASS — all 8 tests.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add frontend/src/components/FolderPicker.tsx frontend/src/components/FolderPicker.test.tsx
+git commit -m "feat(scope): FolderPicker component (multi-select + search + select all/clear)"
+```
+
+---
+
+## Task 15: Frontend — `<ScopeChip>` component (read-only display)
+
+**Why:** Conversation header and Research detail render a chip showing the active scope but don't allow editing.
+
+**Files:**
+- Create: `frontend/src/components/ScopeChip.tsx`
+- Test: `frontend/src/components/ScopeChip.test.tsx`
+
+- [ ] **Step 15.1: Write the failing test**
+
+Create `frontend/src/components/ScopeChip.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ScopeChip } from './ScopeChip';
+
+const folders = [
+  { folder_id: 'a', label: 'Contracts', path: '/c', unavailable_reason: null },
+  { folder_id: 'b', label: 'Legal', path: '/l', unavailable_reason: null },
+];
+
+describe('ScopeChip', () => {
+  it('renders "Folders: All" when scope is empty', () => {
+    render(<ScopeChip scope={{}} folders={folders} />);
+    expect(screen.getByText(/Folders: All/i)).toBeInTheDocument();
+  });
+
+  it('renders folder names when scope has folder_ids', () => {
+    render(<ScopeChip scope={{ folder_ids: ['a'] }} folders={folders} />);
+    expect(screen.getByText(/Contracts/i)).toBeInTheDocument();
+  });
+
+  it('shows count when multiple', () => {
+    render(<ScopeChip scope={{ folder_ids: ['a', 'b'] }} folders={folders} />);
+    expect(screen.getByText(/\(2\)/)).toBeInTheDocument();
+  });
+
+  it('handles unknown folder_ids gracefully', () => {
+    render(<ScopeChip scope={{ folder_ids: ['unknown'] }} folders={folders} />);
+    expect(screen.getByText(/Folders: \?/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 15.2: Run the test, verify it fails**
+
+Run: `cd frontend && npm test -- ScopeChip`
+Expected: FAIL — module not found.
+
+- [ ] **Step 15.3: Implement `<ScopeChip>`**
+
+Create `frontend/src/components/ScopeChip.tsx`:
+
+```tsx
+import type { WatchedFolderInfo } from '../hooks/useWatchedFolders';
+
+export interface ScopeChipProps {
+  scope: { folder_ids?: string[] } | null | undefined;
+  folders: WatchedFolderInfo[];
+  className?: string;
+}
+
+export function ScopeChip({ scope, folders, className }: ScopeChipProps) {
+  const ids = scope?.folder_ids ?? [];
+  if (ids.length === 0) {
+    return <span className={className ?? 'scope-chip'}>Folders: All</span>;
+  }
+  const labels = ids
+    .map((id) => folders.find((f) => f.folder_id === id)?.label ?? '?')
+    .slice(0, 3);
+  const suffix = ids.length > 1 ? ` (${ids.length})` : '';
+  return <span className={className ?? 'scope-chip'}>{`Folders: ${labels.join(', ')}${suffix}`}</span>;
+}
+```
+
+- [ ] **Step 15.4: Run the test, verify it passes**
+
+Run: `cd frontend && npm test -- ScopeChip`
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add frontend/src/components/ScopeChip.tsx frontend/src/components/ScopeChip.test.tsx
+git commit -m "feat(scope): ScopeChip read-only display component"
+```
+
+---
+
+## Task 16: Ask — New Conversation modal + read-only header chip
+
+**Files:**
+- Modify: `frontend/src/pages/ChatPage.tsx` (or wherever the new-conversation modal lives)
+- Modify: `frontend/src/contexts/ChatContext.tsx` (extend the create-conversation API call to pass `scope`)
+- Modify: `frontend/src/api/client.ts` if the conversation type lives there
+
+- [ ] **Step 16.1: Find the new-conversation creation site**
+
+Run: `grep -n "createConversation\|POST.*conversations\|new.*conversation" frontend/src/contexts/ChatContext.tsx frontend/src/pages/ChatPage.tsx`
+
+- [ ] **Step 16.2: Add a `scope_folder_ids` state to the new-conversation modal**
+
+In the modal component (likely a piece of `ChatPage.tsx` or a child component), add:
+
+```tsx
+import { FolderPicker } from '../components/FolderPicker';
+import { useWatchedFolders } from '../hooks/useWatchedFolders';
+
+// inside the modal component:
+const { folders } = useWatchedFolders();
+const [scopeFolderIds, setScopeFolderIds] = useState<string[]>([]);
+
+// in the modal JSX, below the model selector:
+<FolderPicker
+  value={scopeFolderIds}
+  onChange={setScopeFolderIds}
+  folders={folders}
+/>
+```
+
+- [ ] **Step 16.3: Pass the scope to the create call**
+
+When calling `createConversation`, include the scope:
+
+```tsx
+await createConversation({
+  title,
+  model: selectedModel,
+  scope: scopeFolderIds.length > 0 ? { folder_ids: scopeFolderIds } : undefined,
+});
+```
+
+And update the `createConversation` helper in `ChatContext.tsx` (or wherever it lives) to forward the new `scope` field to the POST body.
+
+- [ ] **Step 16.4: Render the read-only chip in the conversation header**
+
+In the chat conversation header (find the component that renders the title — search `grep -n "conv.title\|conversation.title" frontend/src/pages/ChatPage.tsx`):
+
+```tsx
+import { ScopeChip } from '../components/ScopeChip';
+
+// next to the title:
+<ScopeChip scope={conversation.scope} folders={folders} />
+```
+
+Make sure the conversation detail fetch (the call to `GET /api/chat/conversations/{id}`) is preserving the new `scope` field on the type. If the TypeScript Conversation type is defined locally, add `scope?: { folder_ids?: string[] }`.
+
+- [ ] **Step 16.5: Verify by manual run**
+
+Run: `cd frontend && npm run dev` (in one terminal) + `uv run harbor-clerk-api` (in another).
+
+In the browser:
+1. Open New Conversation modal → folder picker is visible.
+2. Pick one folder, give it a title, submit.
+3. Conversation opens — header chip shows "Folders: <name>".
+4. Send a message that triggers a search. Verify the answer cites only docs from the chosen folder.
+
+- [ ] **Step 16.6: Commit**
+
+```bash
+git add frontend/src/pages/ChatPage.tsx frontend/src/contexts/ChatContext.tsx [other touched files]
+git commit -m "feat(scope): Ask supports folder scope at conversation creation"
+```
+
+---
+
+## Task 17: Research — start form picker + detail view chip
+
+**Files:**
+- Modify: `frontend/src/pages/ResearchPage.tsx`
+- Modify: `frontend/src/contexts/ResearchContext.tsx` (the start-research call)
+
+- [ ] **Step 17.1: Add the picker to the start form**
+
+In `ResearchPage.tsx`, find the start-research form (search `grep -n "strategy\|depth\|time_limit" frontend/src/pages/ResearchPage.tsx`). Add state + picker alongside the existing controls:
+
+```tsx
+const { folders } = useWatchedFolders();
+const [scopeFolderIds, setScopeFolderIds] = useState<string[]>([]);
+
+// In the form:
+<FolderPicker value={scopeFolderIds} onChange={setScopeFolderIds} folders={folders} />
+```
+
+- [ ] **Step 17.2: Pass scope when starting research**
+
+When calling the start-research function:
+
+```tsx
+await startResearch({
+  question,
+  strategy,
+  depth,
+  time_limit_minutes: timeLimitMinutes,
+  scope: scopeFolderIds.length > 0 ? { folder_ids: scopeFolderIds } : undefined,
+});
+```
+
+And update the helper in `ResearchContext.tsx` to forward `scope`.
+
+- [ ] **Step 17.3: Show the scope chip in research detail**
+
+In the research detail view (the section that renders the run's metadata like strategy/depth/time_limit), add:
+
+```tsx
+<ScopeChip scope={research.scope} folders={folders} />
+```
+
+- [ ] **Step 17.4: Verify by manual run**
+
+Open Research tab, fill out the start form with one folder selected, start a run. After it completes, verify the detail view shows the scope chip.
+
+- [ ] **Step 17.5: Commit**
+
+```bash
+git add frontend/src/pages/ResearchPage.tsx frontend/src/contexts/ResearchContext.tsx
+git commit -m "feat(scope): Research start form + detail view show folder scope"
+```
+
+---
+
+## Task 18: Search — filter row picker
+
+**Files:**
+- Modify: `frontend/src/pages/SearchPage.tsx`
+
+- [ ] **Step 18.1: Add the picker to the filter row**
+
+Find the search filter UI (existing filters are language, MIME type, date). Add the picker:
+
+```tsx
+const { folders } = useWatchedFolders();
+const [scopeFolderIds, setScopeFolderIds] = useState<string[]>([]);
+
+// In the filter row:
+<FolderPicker value={scopeFolderIds} onChange={setScopeFolderIds} folders={folders} size="sm" />
+```
+
+- [ ] **Step 18.2: Pass scope on each search**
+
+Update the search call:
+
+```tsx
+const result = await post('/api/search', {
+  query,
+  k,
+  // ... existing filters ...
+  scope: scopeFolderIds.length > 0 ? { folder_ids: scopeFolderIds } : undefined,
+});
+```
+
+- [ ] **Step 18.3: Verify by manual run**
+
+In the Search tab, perform a search with all folders. Note the result count. Pick one folder via the chip, re-run. Result count should drop to the in-scope subset.
+
+- [ ] **Step 18.4: Commit**
+
+```bash
+git add frontend/src/pages/SearchPage.tsx
+git commit -m "feat(scope): Search filter row supports folder scope (per-session)"
+```
+
+---
+
+## Task 19: End-to-end manual verification + cleanup
+
+- [ ] **Step 19.1: Full Python test suite**
+
+Run: `uv run pytest --ignore=tests/integration`
+Expected: all tests pass.
+
+- [ ] **Step 19.2: Full frontend test suite**
+
+Run: `cd frontend && npm test`
+Expected: all tests pass.
+
+- [ ] **Step 19.3: Ruff lint + format check**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: both clean.
+
+- [ ] **Step 19.4: Frontend lint + type check**
+
+Run: `cd frontend && npm run lint && npm run type-check && npm run format:check`
+Expected: all three clean.
+
+- [ ] **Step 19.5: Manual end-to-end happy path**
+
+Start the stack (`uv run harbor-clerk-api` + `cd frontend && npm run dev`):
+
+1. **Ask** — start a new conversation scoped to Folder A. Ask a question that should pull from Folder A. Verify only A's docs are cited.
+2. **Ask negative case** — same question but scope = empty. Verify other folders' docs can appear.
+3. **Ask multi-folder** — start a conversation scoped to A + B. Verify both are reachable.
+4. **Research** — start a run scoped to one folder. After it completes, verify the report only cites docs from that folder.
+5. **Search** — search with no scope, note hit count. Apply a folder scope. Verify the count drops.
+6. **API key parity** — create an API key scoped to the same folder as the Ask conversation; query MCP via the API key with the same question; verify the result set matches.
+
+- [ ] **Step 19.6: Manual edge case — unavailable folder rejection**
+
+Set one folder to unavailable (on Docker: unmount the bind; on macOS: temporarily remove). Attempt to start a new conversation scoped to it. Verify the API returns 422.
+
+- [ ] **Step 19.7: Final commit (if anything was tweaked during verification)**
+
+```bash
+git status -s
+# If clean, skip. Otherwise commit any small fixes.
+```
+
+- [ ] **Step 19.8: Push the branch**
+
+```bash
+git push -u origin feat/folder-scope-local-tools
+```
+
+- [ ] **Step 19.9: Dispatch a fresh-eyes review against the branch tip**
+
+Per memory's "FRESH-EYES REVIEW BEFORE MERGING SUBSTANTIVE PRs" standing directive: this PR is multi-component (backend foundation + 3 wiring paths + frontend) — dispatch a `feature-dev:code-reviewer` agent with a minimal unconstrained prompt against the branch tip. Address findings ≥80 confidence before opening the PR.
+
+- [ ] **Step 19.10: Open the PR**
+
+```bash
+gh pr create --title "feat: folder-scope filter for Ask/Research/Search" --body-file ...
+```
+
+Reference the spec, summarize the design highlights, list per-surface test instructions.
+
+---
+
+## Notes / pitfalls
+
+- **MCP tool bodies don't need per-tool edits.** Task 6 extended `_visible_doc_ids` which is the central gate; the OR-with-`user_scope` is handled there, and all 19 tools that already call it get user-scope support transparently. The chunk-level enforcement (in `kb_read_passages` / `kb_expand_context`) also relies on `_visible_doc_ids` — same story.
+- **`apply_key_scope` regression risk.** Task 3 refactors that helper to delegate to `apply_folder_scope`. The existing scoped-API-key tests in `tests/test_scoped_api_keys.py` must remain green throughout. They're explicitly re-run in Task 3 Step 3.5.
+- **Server-side default `'{}'::jsonb`.** Tasks 1-2 set the column default in both Alembic and the ORM. SQLAlchemy's `default=dict` covers Python-side construction; `server_default="{}"` covers raw inserts. Both are needed.
+- **`extra="ignore"` matters at the ScopeSpec level only.** When the field is added to chat/research/search request schemas, those schemas can keep their default `extra` policy — Pydantic will recurse into `ScopeSpec` with the schema's own `extra="ignore"`.
+- **Conversation export.** This plan doesn't add scope to conversation export markdown; it's out of scope per the spec. If export gets reworked later, scope should land in the metadata header.
+- **Forward-compat for collections.** Every place that touches scope today uses `folder_ids`. When Collections lands, the same files extend: `ScopeSpec` gains `collection_ids`, `apply_collection_scope` joins via a future `collection_members` table, `_visible_doc_ids` ORs the folder and collection results. No conversion of existing rows needed.
+
+## Self-review checklist for the engineer
+
+After completing all tasks, verify against the spec:
+
+- [ ] Folder filter works on **Ask** at conversation creation. Picker visible in the modal.
+- [ ] Folder filter works on **Research** at run start. Picker in the start form, chip in the detail view.
+- [ ] Folder filter works on **Search** as a filter chip. Per-session only, no persistence.
+- [ ] Empty selection = no restriction (matches `KeyScope` semantics).
+- [ ] Unavailable folders rejected with 422.
+- [ ] No `PATCH /api/chat/conversations/{id}` — scope is immutable for the container.
+- [ ] API key scoping (existing) is unchanged in behavior. No regressions in `tests/test_scoped_api_keys.py`.
+- [ ] The ScopeSpec wrapper accepts unknown future keys (`collection_ids`, etc.) without error.
+- [ ] DB schema: `conversations.scope` and `research_state.scope` both `JSONB NOT NULL DEFAULT '{}'`.
+
+## Spec coverage verification
+
+Mapping each spec section to tasks:
+
+| Spec section | Task(s) |
+|---|---|
+| Architecture summary | T3, T4, T6, T7 |
+| Ask UX | T8, T9, T16 |
+| Research UX | T10, T11, T17 |
+| Search UX | T12, T18 |
+| Empty-state semantics | T3 (helper), T4 (UserScope.is_unrestricted), T5 (ScopeSpec optional) |
+| Data model — conversations.scope | T1, T2, T8 |
+| Data model — research_state.scope | T1, T2, T10 |
+| Backend — apply_folder_scope | T3 |
+| Backend — UserScope on Principal | T4 |
+| Backend — thread scope through tool dispatch | T7, T9, T11 |
+| Backend — chunk-level enforcement | T6 (via `_visible_doc_ids`) |
+| Backend — Search route applies scope | T12 |
+| API shape — ScopeSpec wrapper | T5 |
+| API shape — chat/research/search requests | T8, T10, T12 |
+| API shape — validation (422 on unknown/unavailable folders) | T8 (validator), T10, T12 reuse |
+| Frontend — `<FolderPicker>` | T13, T14 |
+| Frontend — `<ScopeChip>` (read-only) | T15 |
+| Frontend — Ask integration | T16 |
+| Frontend — Research integration | T17 |
+| Frontend — Search integration | T18 |
+| Edge cases | T6 (visibility), T8 (422), T19 (manual) |
+| Testing strategy | Per-task TDD steps + T19 end-to-end |
+
+Every spec section has at least one task. No orphans.

--- a/docs/superpowers/specs/2026-05-27-folder-scope-for-local-tools-design.md
+++ b/docs/superpowers/specs/2026-05-27-folder-scope-for-local-tools-design.md
@@ -1,0 +1,401 @@
+# Folder-Scope Filter for Local Tools — Design Spec
+
+**Date:** 2026-05-27
+**Status:** Draft
+**Scope:** User-facing folder filter on Ask, Research, and Search. Closes the human-side of task #97 (Projects/Collections) without shipping saved/named collections.
+
+## Overview
+
+Today, only API keys can scope what documents an agent sees — via `KeyScope.scope_folder_ids` enforced by `apply_key_scope()` in `src/harbor_clerk/api/scope.py`. Human users have no equivalent: an Ask conversation always searches every active document; the same is true for Research and Search.
+
+This spec adds a folder-level filter to the three user-driven tools (Ask, Research, Search), surfaced in the existing per-tool config UI and stored on each tool's natural container. The data model and API shape are wrapped to allow collections (future) without a tear-down.
+
+This is **not** Projects/Collections (task #97). It is the folder-scope half of that work, shipped now to unblock users who want to ask about a specific subset of their corpus.
+
+## Motivation
+
+- The watched-folder-first refactor (PRs #245, #253, #255) deliberately deferred this filter so it could land alongside Projects/Collections. Five specs reference task #97 as the future home; no design exists for it.
+- Users with mixed corpora (e.g. "contracts" + "personal scans" + "research papers" under one Harbor Clerk instance) currently can't tell Ask to look in just one slice. The whole-corpus default surfaces irrelevant hits and bleeds context across logical domains.
+- The backend infrastructure already exists. The work is mostly UI placement, naming, and the small lift of threading the scope through the chat-tool dispatch path.
+
+## Goals
+
+- Each of Ask / Research / Search can be limited to a user-selected set of watched folders.
+- Same filter semantics as API key scoping: empty selection = no restriction; selected folders combine with OR (any-in-set).
+- Backend reuses one query helper across the API-key path and the user-driven path. Single source of truth.
+- Forward-compatible API + DB shape so adding collections / doc-level inclusions later is purely additive — no migration, no endpoint version bump.
+
+## Non-Goals
+
+- **Saved / named scopes.** That's "Collections" — separate feature.
+- **Topic-axis filtering for users.** `KeyScope.scope_topic_ids` already exists; can be added to the user surface in a future pass without redesign.
+- **A global "active scope"** that follows you across tools. Each tool sets its own.
+- **Sub-folder selection** (per-doc inclusion/exclusion within a folder). Folders are atomic in v1.
+- **MCP enforcement of user-scope.** MCP keys have their own scope; the user-side filter does not bleed into MCP traffic.
+
+---
+
+## UX per surface
+
+All three reuse one `<FolderPicker>` component: a multi-select with search-as-you-type, "Select all" / "Clear" affordances, and active-folder count. The picker fetches from `GET /api/watch/folders` (filtering to `unavailable_reason IS NULL` so removed/unmounted folders don't appear). Empty selection renders as **"Folders: All"** in any chip.
+
+### Ask (chat)
+
+- **Where the picker lives:** in the **New Conversation modal**, alongside the model selector. Once the conversation exists, the picker is gone — the conversation header shows a read-only "Folders: All" (or "Folders: Contracts, Legal (2)") chip so the active scope is always visible, but it isn't editable.
+- **When it's set:** at conversation creation. Default: empty (= all).
+- **Lifecycle:** **immutable for the conversation.** To use a different scope, start a new conversation. This matches Research and keeps the mental model simple: each conversation is one scope's worth of context.
+- **Persistence:** `conversations.scope` (new JSONB column).
+
+### Research
+
+- **Where the picker lives:** in the start-research form, in the same row as strategy / depth / time limit.
+- **When it's set:** at research start. **Immutable for the run** — same lifecycle as the other run params.
+- **Persistence:** `research_state.scope` (new JSONB column).
+- **Visibility in research detail/history:** scope is shown alongside other run config (model, strategy, depth, time limit) so completed runs are reproducible/auditable.
+
+### Search
+
+- **Where the picker lives:** a filter chip on the existing search filter row, next to language / MIME type / date range.
+- **When it's set:** local React state on the search page. Changes apply on the next query (consistent with how the other filters behave).
+- **Persistence:** none. Per-page-session only. Reload = back to empty.
+- **Backend:** the existing `POST /api/search` body gains a `scope` field; if absent, no filter.
+
+### Empty-state semantics
+
+Both `null` (column unset) and `[]` (column explicitly empty) mean **no restriction**. Mirrors `KeyScope` exactly. The UI never represents "explicitly empty" differently from "unset" — both render as "Folders: All."
+
+This implies an oddity worth flagging: a user cannot configure a chat conversation to mean "show me nothing." That's correct — there's no use case for a deliberately blank conversation, and the API key spec has the same property (`scope_topic_ids: [] AND scope_folder_ids: null` is the only way to get a dead key, and it's explicitly an edge case there).
+
+---
+
+## Data model
+
+### New column on `conversations`
+
+```sql
+ALTER TABLE conversations
+  ADD COLUMN scope JSONB NOT NULL DEFAULT '{}'::jsonb;
+```
+
+- **Default `{}`** (empty object), not `null`. Matches the "wrap in an object for forward-compat" rule.
+- Today's only key is `folder_ids` (a list of folder UUIDs as strings). When collections arrive, additional keys join the same object — no migration.
+
+### New column on `research_state`
+
+```sql
+ALTER TABLE research_state
+  ADD COLUMN scope JSONB NOT NULL DEFAULT '{}'::jsonb;
+```
+
+Same shape, same forward-compat rules.
+
+### No new tables
+
+No `collections` table, no `saved_scopes` table, no join tables. Those land with the real Collections feature.
+
+### Why a wrapper object instead of a bare `scope_folder_ids` column
+
+The API key columns (`scope_folder_ids JSONB`, `scope_topic_ids JSONB`) work because they were defined together at once. Adding `scope_collection_ids` later means a new column and a new endpoint field and a new tool-result handler. By wrapping in `scope: {folder_ids: [...]}` from day one, the same column accepts new axes purely as new JSON keys, with no DDL change.
+
+The cost today is one extra layer of indirection (`scope.folder_ids` instead of `scope_folder_ids`). The benefit is open-ended additive growth.
+
+---
+
+## API shape
+
+### Request bodies (all new fields optional)
+
+**`POST /api/chat/conversations`** — when creating a conversation:
+
+```python
+class CreateConversationRequest(BaseModel):
+    title: str | None = None
+    model: str | None = None
+    scope: ScopeSpec | None = None     # new
+```
+
+Scope is set once at creation. There is intentionally no PATCH endpoint — to use a different scope, start a new conversation.
+
+**`POST /api/research`** — when starting a research run:
+
+```python
+class StartResearchRequest(BaseModel):
+    query: str
+    strategy: Literal["search_driven", "systematic"]
+    depth: Literal["light", "standard", "thorough"]
+    time_limit_minutes: int
+    scope: ScopeSpec | None = None     # new
+```
+
+**`POST /api/search`** — per-request only:
+
+```python
+class SearchRequest(BaseModel):
+    query: str
+    # ... existing filter fields (language, mime_type, after, before, etc.)
+    scope: ScopeSpec | None = None     # new
+```
+
+### The `ScopeSpec` schema
+
+```python
+class ScopeSpec(BaseModel):
+    folder_ids: list[uuid.UUID] | None = None
+    # Future fields (additive):
+    # collection_ids: list[uuid.UUID] | None = None
+    # doc_ids: list[uuid.UUID] | None = None
+    # topic_ids: list[int] | None = None
+
+    model_config = ConfigDict(extra="ignore")   # tolerate future keys on older clients
+```
+
+`extra="ignore"` matters: if a future client sends `collection_ids` to a server that doesn't know about them yet, the request still parses (silently ignoring the unknown key). Avoids version-coupling between client and server.
+
+### Validation
+
+- `folder_ids` is validated against existing watched folders on write. Unknown UUIDs reject with 422.
+- `folder_ids` of folders with `unavailable_reason IS NOT NULL` (unmounted on Docker, missing on macOS) reject with 422 — don't let a user pin a scope to a folder that can't return docs.
+- Empty array `[]` and absent field both serialize to the same stored form (`scope = {}` or `scope = {folder_ids: []}`). The filter helper treats both as no-restriction.
+
+### Response surfaces
+
+- `GET /api/chat/conversations/{id}` returns the current `scope` so the UI can render the chip.
+- `GET /api/research/{id}` returns the run's `scope` for the detail view.
+- `POST /api/search` response is unchanged — search results don't echo the scope back.
+
+---
+
+## Backend
+
+### Filter helper extraction
+
+Pull a pure query builder out of `apply_key_scope()`:
+
+```python
+# in src/harbor_clerk/api/scope.py
+
+def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Select:
+    """Filter a Document query to documents in any of the given folders.
+
+    No-op when folder_ids is None or empty.
+    """
+    if not folder_ids:
+        return query
+    watched_doc_ids = select(WatchedFile.doc_id).where(
+        WatchedFile.folder_id.in_(folder_ids),
+        WatchedFile.status == WatchedFileStatus.active,
+    )
+    return query.where(Document.doc_id.in_(watched_doc_ids))
+```
+
+Then `apply_key_scope` becomes a thin caller (with topic axis OR'd in as today), and the new user-side path also calls `apply_folder_scope` directly.
+
+### `UserScope` on Principal
+
+Add a parallel dataclass next to `KeyScope`:
+
+```python
+@dataclass
+class UserScope:
+    """Per-request scope for human-user tool calls.
+
+    Distinct from KeyScope: no permission_tier / tool_overrides / rate_limit —
+    human users authenticate via JWT and aren't tool-gated. Only document-axis
+    filters live here.
+    """
+    folder_ids: list[uuid.UUID] | None = None
+    # Future fields mirror ScopeSpec (collection_ids, etc.)
+
+
+@dataclass
+class Principal:
+    type: str
+    id: uuid.UUID
+    role: str
+    key_scope: KeyScope | None = None
+    user_scope: UserScope | None = None   # new
+```
+
+The MCP server's `_mcp_principal` ContextVar already carries Principal across the chat-tool path. Adding `user_scope` is mechanically the same pattern as `key_scope`.
+
+### Threading scope through chat-tool dispatch
+
+`execute_tool()` in `src/harbor_clerk/llm/tools.py` currently sets:
+
+```python
+principal = Principal(type="user", id=user_id, role="user")
+token = _mcp_principal.set(principal)
+```
+
+Extend it to accept and forward a scope:
+
+```python
+async def execute_tool(
+    name: str,
+    arguments: dict,
+    user_id: uuid.UUID | None = None,
+    *,
+    mode: str = "chat",
+    user_scope: UserScope | None = None,   # new
+) -> str:
+    ...
+    principal = Principal(
+        type="user",
+        id=user_id,
+        role="user",
+        user_scope=user_scope,
+    )
+    token = _mcp_principal.set(principal)
+```
+
+Inside each MCP tool body, the existing principal-scope hooks (which today only check `key_scope`) gain a parallel `user_scope` branch:
+
+```python
+# Before today:
+if principal.key_scope and not principal.key_scope.is_unrestricted:
+    query = apply_key_scope(query, principal)
+
+# After:
+if principal.key_scope and not principal.key_scope.is_unrestricted:
+    query = apply_key_scope(query, principal)
+elif principal.user_scope and principal.user_scope.folder_ids:
+    query = apply_folder_scope(query, principal.user_scope.folder_ids)
+```
+
+API keys and human users never share scope (different principal types), so the `elif` is unambiguous.
+
+### Chunk-level enforcement (mirrors API key path)
+
+Tools that fetch by chunk ID (`kb_read_passages`, `kb_expand_context`) bypass document-level query filtering today and post-filter using `apply_key_scope`. They get the same post-filter for `user_scope` — same pattern, identical code shape.
+
+### Research and Search backend paths
+
+Research's retrieval is in-process; `src/harbor_clerk/llm/research.py` already runs through `execute_tool()` for tool calls and through internal helpers for direct DB queries. Both paths get `user_scope` from the `research_state.scope` row loaded at run start, passed in alongside the existing strategy/depth params.
+
+Search's `/api/search` route reads `scope` from the request body, constructs `UserScope(folder_ids=...)`, and calls `apply_folder_scope` directly in the hybrid-search query construction. No tool-dispatch indirection needed — search is a single SQL build, not a multi-tool agent loop.
+
+---
+
+## Frontend
+
+### `<FolderPicker>` component
+
+New shared component in `frontend/src/components/`. Props:
+
+```ts
+interface FolderPickerProps {
+  value: string[];                    // selected folder UUIDs (empty = all)
+  onChange: (folder_ids: string[]) => void;
+  folders: Folder[];                  // pre-fetched list
+  disabled?: boolean;
+  size?: 'sm' | 'md';                 // sm for chips, md for forms
+}
+```
+
+Renders:
+- Chip-style trigger when collapsed: "Folders: All" or "Folders: Contracts, Legal (2)"
+- Popover on open: search-as-you-type input, scrollable folder list with checkboxes, "Select all" / "Clear" buttons, "Apply" / "Cancel" footer.
+- Empty folder list (corpus has zero watched folders): trigger shows "No folders to scope to" and is disabled.
+
+The folder list comes from `useWatchedFolders()` — a new TanStack Query hook that wraps `GET /api/watch/folders`, filters out unavailable folders client-side, and is shared across all three surfaces (so picker open is instant if the data is cached from a prior page).
+
+### Ask page integration
+
+- **New Conversation modal:** add `<FolderPicker size="md">` below the model selector. On submit, include the selected `folder_ids` in `scope: {folder_ids: [...]}` on the POST.
+- **Conversation header:** render a **read-only** scope chip next to the conversation title. It always renders (even when scope is empty / "Folders: All") so users see what scope is active. Clicking it does nothing — or shows a tooltip "Scope is set per-conversation; start a new conversation to change it." (Tooltip is nice-to-have; the chip alone is sufficient.)
+- **Same `<FolderPicker>` is reused in the modal**; for the header chip, a separate `<ScopeChip>` component renders the same visual but with no popover.
+
+### Research page integration
+
+- **Start form:** `<FolderPicker size="md">` in the same row as strategy / depth / time limit. Submitted with `scope: {folder_ids: [...]}` on POST.
+- **Research detail header:** display the scope as static text alongside the other run config — no edit (research is one-shot).
+- **Research history list:** if scope is non-empty, show a small "Folders: 2" badge on the list row. Doesn't need to enumerate; clicking opens the detail view.
+
+### Search page integration
+
+- **Filter row:** `<FolderPicker size="sm">` adjacent to the existing language / MIME / date filters. State held by the page; submitted with `scope: {folder_ids: [...]}` on each search.
+- **No persistence:** reload clears the filter (matches the other filters' behavior today).
+
+---
+
+## Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| User picks a folder, then the folder gets removed/unmounted | Picker re-fetch hides it; the conversation/run continues with the now-empty/reduced set. If all selected folders become unavailable, the scope effectively returns nothing — chat says "I couldn't find anything in the selected folders." No automatic scope-clearing. |
+| User picks folders, then deletes them entirely (active → removed) | Same as above. Documents are gone; queries return zero rows in scope. |
+| New folder appears after a conversation has scope set | The new folder is NOT auto-added. Scope is "the folders you picked," not "everything you would have picked at the time." To use the new folder, start a new conversation. |
+| User sets scope on a conversation, then exports / shares the conversation | Out of scope for v1 — there's no conversation export today. When there is, scope is part of the metadata so the conversation is reproducible. |
+| MCP key principal also has user_id set (hypothetical hybrid) | The key_scope branch wins (we check it first). Human-driven user_scope never combines with API-key scope. |
+| Research resume on a run with scope set | Resume reads `research_state.scope`; the scope is the same as the original run. (Resuming with a different scope is not supported — it would change the meaning of the existing notes.) |
+| Conversation created via the API (not the UI) with no `scope` field | Defaults to `scope = {}` = no restriction. Same as today. |
+| Conversation created with `scope = {folder_ids: []}` | Same as no restriction (`folder_ids` empty list = "no folder restriction"). |
+| Scope contains a `folder_ids` UUID for a folder the user doesn't own | N/A — single-tenant. All folders are visible to all admin/user roles. |
+
+---
+
+## Testing
+
+### Python (pytest)
+
+- `apply_folder_scope`: empty list → no-op; populated list → restricts via WatchedFile join.
+- `apply_folder_scope`: includes `WatchedFile.status == active` filter (removed files don't bleed in).
+- `execute_tool`: passes `user_scope` into Principal; tool body sees it.
+- Conversation create with `scope.folder_ids`: row persists; subsequent tool calls in the conversation are filtered.
+- Conversation create without `scope` field: defaults to `{}` = no restriction; tool calls unrestricted.
+- Conversation create with `scope.folder_ids = []`: same as no restriction.
+- Research start with `scope.folder_ids`: persists; tool dispatch during the run filters; resume sees same scope.
+- `POST /api/search` with `scope.folder_ids`: results restricted; results match the equivalent `kb_search` call with `key_scope.scope_folder_ids` set.
+- Reject scope referencing a non-existent folder UUID with 422.
+- Reject scope referencing an unavailable folder with 422.
+- API key path (`key_scope`) still works identically — no regression from the refactor that extracted `apply_folder_scope`.
+- `ScopeSpec` with future keys (`collection_ids: [...]`): parses without error and is silently ignored (`extra="ignore"`).
+- Chunk-level fetch (`kb_read_passages`) for a `user_scope`d conversation respects scope on the post-fetch filter, same as API key path.
+
+### Frontend (vitest + RTL)
+
+- `<FolderPicker>` renders empty trigger as "Folders: All".
+- `<FolderPicker>` selection round-trips: select two folders → trigger shows "Folders: A, B (2)" → reopen picker → both are checked.
+- "Select all" / "Clear" affordances behave as named.
+- Unavailable folders are hidden from the list.
+- Empty corpus state (no folders): trigger reads "No folders to scope to" and the picker is disabled.
+
+### Manual
+
+- Open Ask via "New Conversation," set scope to one folder, ask a question. Verify only docs from that folder are cited and the header chip reads "Folders: <name>".
+- Start a second conversation with a different folder selected. Verify the two conversations are independent and each only cites docs from its own scope.
+- Start a research run scoped to two folders. Verify the run's notes only reference docs from those folders.
+- Search with a folder scope. Verify the result list is restricted. Clear the scope; results widen.
+- Compare against the equivalent MCP-key behavior: scoping an API key to the same folders should produce the same result set as the user-driven scope.
+
+---
+
+## Forward-compat checkpoint — what shipping Collections looks like
+
+When Collections (task #97 proper) ships later, this design supports it additively:
+
+1. **New `collections` table** with `(id, name, owner, created_at)`. Membership via a join table `(collection_id, folder_id)` for v1 of collections; later, `(collection_id, doc_id)` for sub-folder inclusion.
+2. **Add `collection_ids: list[uuid.UUID]` to `ScopeSpec`.** The new field is accepted on every endpoint that already accepts `scope` — no endpoint signature change. Older clients sending only `folder_ids` keep working.
+3. **Add `apply_collection_scope(query, collection_ids)`** to `src/harbor_clerk/api/scope.py`. It resolves collection members and OR-merges with `folder_ids` and any other axes, mirroring `apply_key_scope`'s existing OR-across-axes pattern.
+4. **Extend `<FolderPicker>` → `<ScopePicker>` (or `<SourcePicker>`)** that shows folders and collections side-by-side in the same popover. Folders can still be picked individually; picking a collection picks its members atomically.
+5. **No migration on `conversations.scope` or `research_state.scope`.** Existing rows keep their `folder_ids` keys; new rows can add `collection_ids` alongside.
+
+The naming pivot from "Folders" → "Sources" (or "Scope") in the UI happens at that point, when there's more than one kind of thing to pick. Until then, "Folders" is honest about what's there.
+
+---
+
+## Out of scope (explicit non-goals, restated)
+
+- Saved / named scopes (= Collections proper).
+- Topic-axis user filter (`UserScope.topic_ids` etc.).
+- Sub-folder doc-level inclusion / exclusion within v1.
+- Global "active scope" carrying across tools.
+- Conversation export with scope metadata (out of scope until conversation export exists).
+- Permission gating: in a multi-tenant or per-user-folder-ownership world, scope might intersect with ownership. Single-tenant today, so the filter is purely an organization aid, not an access control.
+
+## References
+
+- Existing scoping plumbing: `src/harbor_clerk/api/scope.py` (`apply_key_scope`, `KeyScope`).
+- Original scoped-API-keys spec: `docs/superpowers/specs/2026-04-07-scoped-api-keys-design.md`.
+- Watched-folder-first deferral notes: `docs/superpowers/specs/2026-04-30-watched-folder-first-stage-{1,2}-design.md`, `2026-05-01-watched-folder-first-stage-3-design.md`.
+- Memory: `~/.claude/projects/-Users-alex-mcp-gateway/memory/project_watched_folder_first_arc.md` (entry on the deferred folder filter).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "harbor-clerk-frontend",
       "version": "0.8.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-virtual": "^3.13.26",
         "@types/d3-drag": "^3.0.7",
         "@types/d3-force": "^3.0.10",
@@ -29,18 +30,82 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/ui": "^4.1.7",
         "eslint": "^10.4.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0",
-        "vite": "^8.0.14"
+        "vite": "^8.0.14",
+        "vitest": "^4.1.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -234,6 +299,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -280,6 +355,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -444,6 +672,24 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -574,6 +820,13 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -1225,6 +1478,32 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.26",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.26.tgz",
@@ -1252,6 +1531,91 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1261,6 +1625,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1355,6 +1737,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1716,6 +2105,141 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.7.tgz",
+      "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.7"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1756,6 +2280,49 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -1784,6 +2351,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1862,6 +2439,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -1957,6 +2544,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2140,6 +2748,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2156,6 +2778,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -2215,6 +2844,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
@@ -2235,6 +2871,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.44.0",
@@ -2451,6 +3107,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2466,6 +3132,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2491,6 +3167,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2647,6 +3330,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2685,6 +3381,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2787,6 +3493,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2810,6 +3523,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3179,6 +3943,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3480,6 +4254,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -4044,6 +4825,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -4133,6 +4924,16 @@
       "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4170,6 +4971,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -4247,6 +5059,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4266,6 +5091,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4341,6 +5173,28 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -4507,6 +5361,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -4588,6 +5456,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -4626,6 +5504,19 @@
         "@rolldown/binding-wasm32-wasi": "1.0.2",
         "@rolldown/binding-win32-arm64-msvc": "1.0.2",
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4673,6 +5564,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4693,6 +5606,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4705,6 +5632,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -4724,6 +5664,13 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
@@ -4751,6 +5698,23 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -4785,6 +5749,72 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
+      "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.0"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.0.tgz",
+      "integrity": "sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -4886,6 +5916,16 @@
       "license": "MIT",
       "dependencies": {
         "ml-levenberg-marquardt": "^2.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -5153,6 +6193,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5169,6 +6347,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5178,6 +6373,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,9 +11,11 @@
     "lint:fix": "eslint --fix src/",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-virtual": "^3.13.26",
     "@types/d3-drag": "^3.0.7",
     "@types/d3-force": "^3.0.10",
@@ -35,16 +37,22 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/ui": "^4.1.7",
     "eslint": "^10.4.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0",
-    "vite": "^8.0.14"
+    "vite": "^8.0.14",
+    "vitest": "^4.1.7"
   }
 }

--- a/frontend/src/components/FolderPicker.test.tsx
+++ b/frontend/src/components/FolderPicker.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FolderPicker } from './FolderPicker'
+
+const folders = [
+  {
+    folder_id: 'a',
+    display_name: 'Contracts',
+    path: '/c',
+    unavailable_reason: null,
+    enabled: true,
+    auto_discovered: false,
+    skipped_count: 0,
+    skipped_extensions: [],
+  },
+  {
+    folder_id: 'b',
+    display_name: 'Legal',
+    path: '/l',
+    unavailable_reason: null,
+    enabled: true,
+    auto_discovered: false,
+    skipped_count: 0,
+    skipped_extensions: [],
+  },
+]
+
+describe('FolderPicker', () => {
+  it('renders "Folders: All" when value is empty', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={folders} />)
+    expect(screen.getByRole('button')).toHaveTextContent('Folders: All')
+  })
+
+  it('renders display_name when one selected', () => {
+    render(<FolderPicker value={['a']} onChange={() => {}} folders={folders} />)
+    expect(screen.getByRole('button')).toHaveTextContent('Folders: Contracts')
+  })
+
+  it('renders count when multiple selected', () => {
+    render(<FolderPicker value={['a', 'b']} onChange={() => {}} folders={folders} />)
+    expect(screen.getByRole('button')).toHaveTextContent(/Folders: Contracts, Legal \(2\)/)
+  })
+
+  it('disables when there are no folders', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={[]} />)
+    expect(screen.getByRole('button')).toBeDisabled()
+    expect(screen.getByRole('button')).toHaveTextContent('No folders to scope to')
+  })
+
+  it('toggling a folder calls onChange', () => {
+    const onChange = vi.fn()
+    render(<FolderPicker value={[]} onChange={onChange} folders={folders} />)
+    // Open the popover via the trigger button (first button in the DOM)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    fireEvent.click(screen.getByLabelText('Contracts'))
+    expect(onChange).toHaveBeenCalledWith(['a'])
+  })
+
+  it('"Select all" selects every folder', () => {
+    const onChange = vi.fn()
+    render(<FolderPicker value={[]} onChange={onChange} folders={folders} />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    fireEvent.click(screen.getByText('Select all'))
+    expect(onChange).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('"Clear" resets selection', () => {
+    const onChange = vi.fn()
+    render(<FolderPicker value={['a', 'b']} onChange={onChange} folders={folders} />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    fireEvent.click(screen.getByText('Clear'))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('search input filters the list', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={folders} />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    fireEvent.change(screen.getByPlaceholderText('Search folders…'), { target: { value: 'leg' } })
+    expect(screen.queryByText('Contracts')).not.toBeInTheDocument()
+    expect(screen.getByText('Legal')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/FolderPicker.tsx
+++ b/frontend/src/components/FolderPicker.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { WatchedFolderInfo } from '../hooks/useWatchedFolders'
+
+export interface FolderPickerProps {
+  value: string[]
+  onChange: (folder_ids: string[]) => void
+  folders: WatchedFolderInfo[]
+  disabled?: boolean
+  size?: 'sm' | 'md'
+}
+
+function summarize(value: string[], folders: WatchedFolderInfo[]): string {
+  if (value.length === 0) return 'Folders: All'
+  const labels = value.map((id) => folders.find((f) => f.folder_id === id)?.display_name ?? '?').slice(0, 3)
+  const suffix = value.length > 1 ? ` (${value.length})` : ''
+  return `Folders: ${labels.join(', ')}${suffix}`
+}
+
+export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }: FolderPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const visible = useMemo(
+    () =>
+      folders.filter((f) =>
+        filter.trim() === '' ? true : (f.display_name ?? '').toLowerCase().includes(filter.toLowerCase()),
+      ),
+    [folders, filter],
+  )
+
+  // Close popover on outside click or Escape
+  useEffect(() => {
+    if (!open) return
+    function onMouseDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const noFolders = folders.length === 0
+  const isDisabled = disabled || noFolders
+  const buttonText = noFolders ? 'No folders to scope to' : summarize(value, folders)
+
+  const toggle = (id: string) => {
+    if (value.includes(id)) onChange(value.filter((v) => v !== id))
+    else onChange([...value, id])
+  }
+
+  const sizeClasses = size === 'sm' ? 'px-2 py-1 text-xs' : 'px-3 py-1.5 text-sm'
+
+  return (
+    <div className="relative inline-block" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => !isDisabled && setOpen((o) => !o)}
+        disabled={isDisabled}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className={[
+          sizeClasses,
+          'inline-flex items-center gap-1.5 rounded-md border font-medium transition-colors',
+          'border-[var(--color-border)] bg-[var(--color-bg-secondary)] text-[var(--color-text-primary)]',
+          'hover:bg-[var(--color-bg-tertiary)]',
+          'disabled:cursor-not-allowed disabled:opacity-40',
+        ].join(' ')}
+      >
+        <span>{buttonText}</span>
+        {!isDisabled && (
+          <svg
+            aria-hidden
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="currentColor"
+            className={`transition-transform ${open ? 'rotate-180' : ''}`}
+          >
+            <path d="M1.5 3.5L5 7l3.5-3.5" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" />
+          </svg>
+        )}
+      </button>
+
+      {open && !noFolders && (
+        <div
+          className={[
+            'absolute z-30 mt-1 min-w-[200px] rounded-lg shadow-mac-lg',
+            'border border-[var(--color-border)] bg-[var(--color-bg-primary)]',
+            'flex flex-col',
+          ].join(' ')}
+          role="dialog"
+          aria-label="Folder filter"
+        >
+          {/* Search */}
+          <div className="px-2 pt-2">
+            <input
+              type="text"
+              placeholder="Search folders…"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              className={[
+                'w-full rounded-md border border-[var(--color-border)]',
+                'bg-[var(--color-bg-secondary)] px-2 py-1 text-xs',
+                'text-[var(--color-text-primary)] placeholder:text-[var(--color-text-secondary)]',
+                'outline-none focus:ring-1 focus:ring-[var(--color-accent)]',
+              ].join(' ')}
+              autoFocus
+            />
+          </div>
+
+          {/* Select all / Clear */}
+          <div className="flex items-center gap-2 px-3 pt-2 pb-1">
+            <button
+              type="button"
+              onClick={() => onChange(folders.map((f) => f.folder_id))}
+              className="text-xs text-[var(--color-accent)] hover:underline"
+            >
+              Select all
+            </button>
+            <span className="text-[var(--color-text-secondary)] text-xs">·</span>
+            <button
+              type="button"
+              onClick={() => onChange([])}
+              className="text-xs text-[var(--color-accent)] hover:underline"
+            >
+              Clear
+            </button>
+          </div>
+
+          {/* Folder list */}
+          <ul role="listbox" aria-multiselectable="true" className="max-h-48 overflow-y-auto px-1 pb-1">
+            {visible.map((f) => (
+              <li key={f.folder_id} role="option" aria-selected={value.includes(f.folder_id)}>
+                <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-[var(--color-bg-secondary)]">
+                  <input
+                    type="checkbox"
+                    checked={value.includes(f.folder_id)}
+                    onChange={() => toggle(f.folder_id)}
+                    aria-label={f.display_name ?? f.folder_id}
+                    className="h-3.5 w-3.5 accent-[var(--color-accent)]"
+                  />
+                  <span className="text-sm text-[var(--color-text-primary)] truncate">
+                    {f.display_name ?? f.folder_id}
+                  </span>
+                </label>
+              </li>
+            ))}
+            {visible.length === 0 && (
+              <li className="px-3 py-2 text-xs text-[var(--color-text-secondary)]">No folders match</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ScopeChip.test.tsx
+++ b/frontend/src/components/ScopeChip.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ScopeChip } from './ScopeChip'
+
+const folders = [
+  {
+    folder_id: 'a',
+    display_name: 'Contracts',
+    path: '/c',
+    unavailable_reason: null,
+    enabled: true,
+    auto_discovered: false,
+    skipped_count: 0,
+    skipped_extensions: [],
+  },
+  {
+    folder_id: 'b',
+    display_name: 'Legal',
+    path: '/l',
+    unavailable_reason: null,
+    enabled: true,
+    auto_discovered: false,
+    skipped_count: 0,
+    skipped_extensions: [],
+  },
+]
+
+describe('ScopeChip', () => {
+  it('renders "Folders: All" when scope is empty', () => {
+    render(<ScopeChip scope={{}} folders={folders} />)
+    expect(screen.getByText(/Folders: All/i)).toBeInTheDocument()
+  })
+
+  it('renders "Folders: All" when scope is null', () => {
+    render(<ScopeChip scope={null} folders={folders} />)
+    expect(screen.getByText(/Folders: All/i)).toBeInTheDocument()
+  })
+
+  it('renders display_name when scope has one folder_id', () => {
+    render(<ScopeChip scope={{ folder_ids: ['a'] }} folders={folders} />)
+    expect(screen.getByText(/Contracts/i)).toBeInTheDocument()
+    // No count suffix for a single folder
+    expect(screen.queryByText(/\(/)).not.toBeInTheDocument()
+  })
+
+  it('renders names and count when multiple', () => {
+    render(<ScopeChip scope={{ folder_ids: ['a', 'b'] }} folders={folders} />)
+    expect(screen.getByText(/Contracts.*Legal.*\(2\)/)).toBeInTheDocument()
+  })
+
+  it('handles unknown folder_ids gracefully with ?', () => {
+    render(<ScopeChip scope={{ folder_ids: ['unknown'] }} folders={folders} />)
+    expect(screen.getByText(/Folders: \?/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ScopeChip.tsx
+++ b/frontend/src/components/ScopeChip.tsx
@@ -1,0 +1,35 @@
+import type { WatchedFolderInfo } from '../hooks/useWatchedFolders'
+
+export interface ScopeChipProps {
+  scope: { folder_ids?: string[] } | null | undefined
+  folders: WatchedFolderInfo[]
+  className?: string
+}
+
+export function ScopeChip({ scope, folders, className }: ScopeChipProps) {
+  const ids = scope?.folder_ids ?? []
+  if (ids.length === 0) {
+    return (
+      <span
+        className={
+          className ??
+          'inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-2 py-1 text-xs font-medium text-[var(--color-text-primary)]'
+        }
+      >
+        Folders: All
+      </span>
+    )
+  }
+  const labels = ids.map((id) => folders.find((f) => f.folder_id === id)?.display_name ?? '?').slice(0, 3)
+  const suffix = ids.length > 1 ? ` (${ids.length})` : ''
+  return (
+    <span
+      className={
+        className ??
+        'inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-2 py-1 text-xs font-medium text-[var(--color-text-primary)]'
+      }
+    >
+      {`Folders: ${labels.join(', ')}${suffix}`}
+    </span>
+  )
+}

--- a/frontend/src/contexts/ResearchContext.tsx
+++ b/frontend/src/contexts/ResearchContext.tsx
@@ -30,7 +30,13 @@ interface ResearchState {
   error: string | null
   conversationId: string | null
   completedToolCalls: ToolCallEntry[]
-  startResearch: (question: string, strategy?: string, timeLimitMinutes?: number, depth?: string) => Promise<boolean>
+  startResearch: (
+    question: string,
+    strategy?: string,
+    timeLimitMinutes?: number,
+    depth?: string,
+    scope?: { folder_ids?: string[] },
+  ) => Promise<boolean>
   resumeResearch: (convId: string) => Promise<void>
   cancelResearch: () => void
   reset: () => void
@@ -162,7 +168,13 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const startResearch = useCallback(
-    async (question: string, strategy?: string, timeLimitMinutes?: number, depth?: string): Promise<boolean> => {
+    async (
+      question: string,
+      strategy?: string,
+      timeLimitMinutes?: number,
+      depth?: string,
+      scope?: { folder_ids?: string[] },
+    ): Promise<boolean> => {
       if (!token) return false
 
       setError(null)
@@ -175,6 +187,7 @@ export function ResearchProvider({ children }: { children: ReactNode }) {
         if (strategy) body.strategy = strategy
         if (timeLimitMinutes) body.time_limit_minutes = timeLimitMinutes
         if (depth) body.depth = depth
+        if (scope && scope.folder_ids && scope.folder_ids.length > 0) body.scope = scope
 
         const res = await fetchWithRefresh('/api/research', {
           method: 'POST',

--- a/frontend/src/hooks/useWatchedFolders.test.tsx
+++ b/frontend/src/hooks/useWatchedFolders.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWatchedFolders } from './useWatchedFolders'
+import * as api from '../api'
+
+describe('useWatchedFolders', () => {
+  function wrapper({ children }: { children: React.ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+
+  it('returns folders, filtering out unavailable ones', async () => {
+    const mockGet = vi.spyOn(api, 'get').mockResolvedValue([
+      { folder_id: 'a', display_name: 'A', path: '/a', unavailable_reason: null },
+      { folder_id: 'b', display_name: 'B', path: '/b', unavailable_reason: 'unmounted' },
+      { folder_id: 'c', display_name: 'C', path: '/c', unavailable_reason: null },
+    ])
+
+    const { result } = renderHook(() => useWatchedFolders(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.folders.map((f) => f.folder_id)).toEqual(['a', 'c'])
+    mockGet.mockRestore()
+  })
+
+  it('returns empty array when no folders', async () => {
+    const mockGet = vi.spyOn(api, 'get').mockResolvedValue([])
+    const { result } = renderHook(() => useWatchedFolders(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.folders).toEqual([])
+    mockGet.mockRestore()
+  })
+})

--- a/frontend/src/hooks/useWatchedFolders.ts
+++ b/frontend/src/hooks/useWatchedFolders.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import { get } from '../api'
+
+export interface WatchedFolderInfo {
+  folder_id: string
+  path: string
+  display_name: string | null
+  enabled: boolean
+  auto_discovered: boolean
+  unavailable_reason: string | null
+  skipped_count: number
+  skipped_extensions: string[]
+}
+
+export function useWatchedFolders() {
+  const query = useQuery({
+    queryKey: ['watch', 'folders'],
+    queryFn: () => get<WatchedFolderInfo[]>('/api/watch/folders'),
+    staleTime: 30_000,
+  })
+
+  const folders = (query.data ?? []).filter((f) => f.unavailable_reason === null)
+
+  return {
+    folders,
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    refetch: query.refetch,
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,22 +1,34 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './auth'
 import { ChatProvider } from './contexts/ChatContext'
 import { ResearchProvider } from './contexts/ResearchContext'
 import App from './App'
 import './index.css'
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+    },
+  },
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <ChatProvider>
-          <ResearchProvider>
-            <App />
-          </ResearchProvider>
-        </ChatProvider>
-      </AuthProvider>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider>
+          <ChatProvider>
+            <ResearchProvider>
+              <App />
+            </ResearchProvider>
+          </ChatProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -2,10 +2,13 @@ import { FormEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { IconTile } from '../components/IconTile'
+import { FolderPicker } from '../components/FolderPicker'
+import { ScopeChip } from '../components/ScopeChip'
 import { del, get, post } from '../api'
 import { useAuth } from '../auth'
 import { useChat, type ChatMessage, type RagContextChunk, type ToolCallInfo } from '../contexts/ChatContext'
 import { useResearch } from '../contexts/ResearchContext'
+import { useWatchedFolders } from '../hooks/useWatchedFolders'
 import RagContextCard from '../components/RagContextCard'
 import ToolResultDisplay from '../components/ToolResultDisplay'
 import { formatRelativeDate } from '../utils/dates'
@@ -16,6 +19,7 @@ interface ConversationSummary {
   title: string
   created_at: string
   updated_at: string
+  scope?: { folder_ids?: string[] }
 }
 
 interface ConversationDetail extends ConversationSummary {
@@ -69,10 +73,13 @@ export default function ChatPage() {
     latestTitle,
   } = useChat()
   const { conversationId: researchConversationId } = useResearch()
+  const { folders } = useWatchedFolders()
   const [modelNames, setModelNames] = useState<Record<string, string>>({})
   const [hasActiveModel, setHasActiveModel] = useState(true) // optimistic default
   const [activeModelId, setActiveModelId] = useState<string | null>(null)
   const [researchActive, setResearchActive] = useState(false)
+  // Folder scope for next new conversation (reset when conversation is created)
+  const [newConvFolderIds, setNewConvFolderIds] = useState<string[]>([])
 
   // Derive latest context_pct from most recent assistant message
   const latestContextPct = [...messages]
@@ -194,10 +201,13 @@ export default function ChatPage() {
         let activeConvId = conversationId
         if (!activeConvId) {
           const eagerTitle = text.length > 80 ? text.slice(0, 77) + '...' : text
+          const scopePayload = newConvFolderIds.length > 0 ? { scope: { folder_ids: newConvFolderIds } } : {}
           const conv = await post<ConversationSummary>('/api/chat/conversations', {
             title: eagerTitle,
+            ...scopePayload,
           })
           activeConvId = conv.conversation_id
+          setNewConvFolderIds([])
           setConversations((prev) => [conv, ...prev])
           navigate(`/c/${activeConvId}`, { replace: true })
         }
@@ -216,7 +226,18 @@ export default function ChatPage() {
         setInput(text)
       }
     },
-    [isStreaming, conversationId, sendMessage, lastTitle, hasActiveModel, activeModelId, contextFull, setInput],
+    [
+      isStreaming,
+      conversationId,
+      sendMessage,
+      lastTitle,
+      hasActiveModel,
+      activeModelId,
+      contextFull,
+      setInput,
+      navigate,
+      newConvFolderIds,
+    ],
   )
 
   const handleNewChat = useCallback(() => {
@@ -248,9 +269,9 @@ export default function ChatPage() {
     [handleSubmit],
   )
 
-  const activeConvTitle = conversationId
-    ? conversations.find((c) => c.conversation_id === conversationId)?.title
-    : undefined
+  const activeConv = conversationId ? conversations.find((c) => c.conversation_id === conversationId) : undefined
+  const activeConvTitle = activeConv?.title
+  const activeConvScope = activeConv?.scope
 
   return (
     <div className="chat-page flex h-[calc(100vh-3.5rem)] -mx-4 -my-6 overflow-hidden">
@@ -351,6 +372,13 @@ export default function ChatPage() {
             <h2 className="text-[13px] font-semibold text-gray-700 dark:text-gray-300 truncate">{activeConvTitle}</h2>
           ) : (
             <h2 className="text-[13px] font-medium text-gray-400 dark:text-gray-500">New conversation</h2>
+          )}
+          {activeConvScope && (activeConvScope.folder_ids?.length ?? 0) > 0 && (
+            <ScopeChip
+              scope={activeConvScope}
+              folders={folders}
+              className="shrink-0 inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-2 py-0.5 text-[11px] font-medium text-[var(--color-text-secondary)]"
+            />
           )}
           <div className="ml-auto flex items-center gap-2">
             {isStreaming && (
@@ -489,9 +517,21 @@ export default function ChatPage() {
                   }}
                 />
                 <div className="flex items-center justify-between px-3 pb-2">
-                  <span className="text-[10px] text-gray-300 dark:text-gray-600 select-none">
-                    {input.trim() ? 'Enter to send' : 'Shift+Enter for new line'}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    {!conversationId && (
+                      <FolderPicker
+                        value={newConvFolderIds}
+                        onChange={setNewConvFolderIds}
+                        folders={folders}
+                        size="sm"
+                      />
+                    )}
+                    {conversationId && (
+                      <span className="text-[10px] text-gray-300 dark:text-gray-600 select-none">
+                        {input.trim() ? 'Enter to send' : 'Shift+Enter for new line'}
+                      </span>
+                    )}
+                  </div>
                   <div className="flex items-center gap-2">
                     {isStreaming ? (
                       <button

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -373,9 +373,9 @@ export default function ChatPage() {
           ) : (
             <h2 className="text-[13px] font-medium text-gray-400 dark:text-gray-500">New conversation</h2>
           )}
-          {activeConvScope && (activeConvScope.folder_ids?.length ?? 0) > 0 && (
+          {activeConv && (
             <ScopeChip
-              scope={activeConvScope}
+              scope={activeConvScope ?? {}}
               folders={folders}
               className="shrink-0 inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-2 py-0.5 text-[11px] font-medium text-[var(--color-text-secondary)]"
             />

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -1,12 +1,15 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
+import { FolderPicker } from '../components/FolderPicker'
 import { PageHeader } from '../components/PageHeader'
+import { ScopeChip } from '../components/ScopeChip'
 import ToolResultDisplay from '../components/ToolResultDisplay'
 import { del, get } from '../api'
 import { useChat } from '../contexts/ChatContext'
 import { useResearch, type ToolCallEntry } from '../contexts/ResearchContext'
 import { useLLMStatus } from '../hooks/useLLMStatus'
+import { useWatchedFolders } from '../hooks/useWatchedFolders'
 import { formatRelativeDate } from '../utils/dates'
 import { topicDotVar } from '../utils/topicDotColor'
 
@@ -19,6 +22,7 @@ interface ResearchSummary {
   max_rounds: number
   created_at: string
   completed_at: string | null
+  scope?: { folder_ids?: string[] }
 }
 
 interface ResearchMessage {
@@ -104,6 +108,7 @@ export default function ResearchPage() {
   const { isStreaming: chatStreaming } = useChat()
   const { status: llmStatus } = useLLMStatus()
   const hasActiveModel = llmStatus.state === 'ready' && llmStatus.model_id !== null
+  const { folders } = useWatchedFolders()
   const [history, setHistory] = useState<ResearchSummary[]>([])
   const [selectedTask, setSelectedTask] = useState<ResearchDetail | null>(null)
   const [question, setQuestionRaw] = useState(() => sessionStorage.getItem('research_draft') ?? '')
@@ -115,6 +120,7 @@ export default function ResearchPage() {
   const [strategy, setStrategy] = useState<'search' | 'sweep'>('search')
   const [depth, setDepth] = useState<'light' | 'standard' | 'thorough'>('standard')
   const [timeLimit, setTimeLimit] = useState(30)
+  const [scopeFolderIds, setScopeFolderIds] = useState<string[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [discardConfirm, setDiscardConfirm] = useState<string | null>(null)
   const discardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -259,9 +265,13 @@ export default function ResearchPage() {
     setSelectedTask(null)
     setShowNewForm(false)
     hasAutoNavigatedRef.current = null
-    const accepted = await startResearch(q, strategy, timeLimit, depth)
-    if (accepted) setQuestion('')
-  }, [question, strategy, timeLimit, depth, startResearch, setQuestion])
+    const scope = scopeFolderIds.length > 0 ? { folder_ids: scopeFolderIds } : undefined
+    const accepted = await startResearch(q, strategy, timeLimit, depth, scope)
+    if (accepted) {
+      setQuestion('')
+      setScopeFolderIds([])
+    }
+  }, [question, strategy, timeLimit, depth, scopeFolderIds, startResearch, setQuestion])
 
   const handleResume = useCallback(
     async (convId: string) => {
@@ -565,6 +575,10 @@ export default function ResearchPage() {
                       </select>
                     </div>
 
+                    <div className="flex items-center justify-center">
+                      <FolderPicker value={scopeFolderIds} onChange={setScopeFolderIds} folders={folders} size="sm" />
+                    </div>
+
                     <button
                       onClick={handleStartResearch}
                       disabled={!question.trim()}
@@ -744,6 +758,9 @@ export default function ResearchPage() {
                       )}
                       {selectedTask.time_limit_minutes != null && ` / ${selectedTask.time_limit_minutes}m limit`}
                     </span>
+                  )}
+                  {selectedTask.scope?.folder_ids && selectedTask.scope.folder_ids.length > 0 && (
+                    <ScopeChip scope={selectedTask.scope} folders={folders} />
                   )}
                 </div>
               )}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -2,7 +2,9 @@ import { FormEvent, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { post } from '../api'
 import { Card } from '../components/Card'
+import { FolderPicker } from '../components/FolderPicker'
 import { PageHeader } from '../components/PageHeader'
+import { useWatchedFolders } from '../hooks/useWatchedFolders'
 
 interface SearchHit {
   chunk_id: string
@@ -152,8 +154,10 @@ export default function SearchPage() {
   const [showHistory, setShowHistory] = useState(false)
   const [pageSize, setPageSize] = useState(initial?.pageSize || 25)
   const [currentPage, setCurrentPage] = useState(initial?.currentPage || 1)
+  const [scopeFolderIds, setScopeFolderIds] = useState<string[]>([])
   const lastQuery = useRef(initial?.lastQuery || '')
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const { folders } = useWatchedFolders()
 
   // Persist search state to sessionStorage
   useEffect(() => {
@@ -171,7 +175,7 @@ export default function SearchPage() {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  async function doSearch(q: string, page: number, size: number) {
+  async function doSearch(q: string, page: number, size: number, folderIds: string[] = scopeFolderIds) {
     const trimmed = q.trim()
     if (!trimmed) return
     setError('')
@@ -185,6 +189,7 @@ export default function SearchPage() {
         query: trimmed,
         k: size,
         offset,
+        ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
       })
       setResults(data)
     } catch (e) {
@@ -234,7 +239,7 @@ export default function SearchPage() {
   return (
     <div>
       <PageHeader title="Search" subtitle="Hybrid lexical + semantic retrieval" />
-      <form onSubmit={handleSearch} className="mb-6 flex space-x-2">
+      <form onSubmit={handleSearch} className="mb-6 flex items-center gap-2">
         <div className="relative flex-1" ref={wrapperRef}>
           <input
             type="text"
@@ -289,6 +294,7 @@ export default function SearchPage() {
             </div>
           )}
         </div>
+        <FolderPicker value={scopeFolderIds} onChange={setScopeFolderIds} folders={folders} size="sm" />
         <button
           type="submit"
           disabled={loading}

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -13,5 +14,10 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
   },
 })

--- a/src/harbor_clerk/api/deps.py
+++ b/src/harbor_clerk/api/deps.py
@@ -9,7 +9,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from harbor_clerk.api.scope import KeyScope
+from harbor_clerk.api.scope import KeyScope, UserScope
 from harbor_clerk.auth import API_KEY_PREFIXES, decode_token, hash_api_key
 from harbor_clerk.db import get_session
 from harbor_clerk.models import ApiKey, User
@@ -23,6 +23,7 @@ class Principal:
     id: uuid.UUID  # user_id or key_id
     role: str  # "admin" or "user"
     key_scope: KeyScope | None = None  # populated for api_key principals only
+    user_scope: UserScope | None = None  # populated for human-user principals when folder scope is active
 
 
 def _extract_bearer_token(request: Request) -> str | None:

--- a/src/harbor_clerk/api/routes/chat.py
+++ b/src/harbor_clerk/api/routes/chat.py
@@ -20,6 +20,7 @@ from harbor_clerk.api.schemas.chat import (
     ModelOut,
     SendMessageRequest,
 )
+from harbor_clerk.api.scope_validation import validate_scope_folders
 from harbor_clerk.config import get_settings, refresh_llm_settings, sync_native_config
 from harbor_clerk.db import get_session
 from harbor_clerk.llm.chat import chat_stream
@@ -97,6 +98,7 @@ async def list_conversations(
             title=c.title,
             created_at=c.created_at,
             updated_at=c.updated_at,
+            scope=c.scope,
         )
         for c in result.scalars().all()
     ]
@@ -108,7 +110,9 @@ async def create_conversation(
     principal: Principal = Depends(require_human_user),
     session: AsyncSession = Depends(get_session),
 ):
-    conv = Conversation(user_id=principal.id, title=body.title)
+    await validate_scope_folders(body.scope, session)
+    scope_dict = body.scope.model_dump(mode="json", exclude_none=True) if body.scope else {}
+    conv = Conversation(user_id=principal.id, title=body.title, scope=scope_dict)
     session.add(conv)
     await session.commit()
     await session.refresh(conv)
@@ -117,6 +121,7 @@ async def create_conversation(
         title=conv.title,
         created_at=conv.created_at,
         updated_at=conv.updated_at,
+        scope=conv.scope,
     )
 
 
@@ -170,6 +175,7 @@ async def get_conversation(
         title=conv.title,
         created_at=conv.created_at,
         updated_at=conv.updated_at,
+        scope=conv.scope,
         messages=messages,
     )
 

--- a/src/harbor_clerk/api/routes/research.py
+++ b/src/harbor_clerk/api/routes/research.py
@@ -82,6 +82,7 @@ async def list_research(
             max_rounds=rs.max_rounds,
             time_limit_minutes=rs.time_limit_minutes,
             depth=rs.depth,
+            scope=rs.scope or {},
             created_at=conv.created_at,
             completed_at=rs.completed_at,
         )
@@ -189,6 +190,7 @@ async def get_research(
         max_rounds=state.max_rounds,
         time_limit_minutes=state.time_limit_minutes,
         depth=state.depth,
+        scope=state.scope or {},
         progress=state.progress,
         notes=state.notes,
         report=report,
@@ -212,6 +214,11 @@ async def start_research(
     principal: Principal = Depends(require_human_user),
     session: AsyncSession = Depends(get_session),
 ):
+    from harbor_clerk.api.scope_validation import validate_scope_folders
+
+    # Validate scope before any DB writes
+    await validate_scope_folders(body.scope, session)
+
     # Check no active research
     running_result = await session.execute(select(ResearchState).where(ResearchState.status == "running"))
     if running_result.scalar_one_or_none():
@@ -247,6 +254,9 @@ async def start_research(
     # Safety cap for max_rounds; actual stopping is wall-time based
     max_rounds = 500
 
+    # Serialise scope to plain dict (UUIDs → strings) for JSONB storage
+    scope_dict = body.scope.model_dump(mode="json", exclude_none=True) if body.scope else {}
+
     # Create conversation — title from question immediately
     eager_title = body.question.strip()
     if len(eager_title) > 80:
@@ -272,6 +282,7 @@ async def start_research(
         max_rounds=max_rounds,
         time_limit_minutes=body.time_limit_minutes,
         depth=body.depth,
+        scope=scope_dict,
     )
     session.add(state)
     try:

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -202,6 +202,12 @@ async def read_passages(
     if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
         visible_q = apply_key_scope(select(Document.doc_id), principal)
         visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+    elif principal.type == "user" and principal.user_scope is not None and not principal.user_scope.is_unrestricted:
+        visible_q = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            principal.user_scope.folder_ids,
+        )
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
 
     result = await session.execute(select(Chunk).where(Chunk.chunk_id.in_(chunk_uuids)))
     chunks = {c.chunk_id: c for c in result.scalars().all()}

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -19,7 +19,8 @@ from harbor_clerk.api.schemas.search import (
     SearchRequest,
     SearchResponse,
 )
-from harbor_clerk.api.scope import apply_key_scope
+from harbor_clerk.api.scope import apply_folder_scope, apply_key_scope
+from harbor_clerk.api.scope_validation import validate_scope_folders
 from harbor_clerk.db import get_session
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.search import hybrid_search
@@ -50,6 +51,8 @@ async def search(
     principal: Principal = Depends(require_read_access),
     session: AsyncSession = Depends(get_session),
 ):
+    await validate_scope_folders(body.scope, session)
+
     doc_id = uuid.UUID(body.doc_id) if body.doc_id else None
     doc_ids = [uuid.UUID(d) for d in body.doc_ids] if body.doc_ids else None
 
@@ -79,6 +82,43 @@ async def search(
             doc_ids = list(visible_ids)
         # Also enforce single-doc filter against visible set
         if doc_id is not None and doc_id not in visible_ids:
+            return SearchResponse(
+                hits=[],
+                total_candidates=0,
+                has_more=False,
+                possible_conflict=False,
+                conflict_sources=[],
+            )
+
+    # Per-request user scope: intersect with visible doc_ids for the requested folders.
+    if body.scope is not None and body.scope.folder_ids:
+        scoped_q = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            list(body.scope.folder_ids),
+        )
+        scoped_visible = {row[0] for row in (await session.execute(scoped_q)).all()}
+        if not scoped_visible:
+            return SearchResponse(
+                hits=[],
+                total_candidates=0,
+                has_more=False,
+                possible_conflict=False,
+                conflict_sources=[],
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in scoped_visible]
+            if not doc_ids:
+                return SearchResponse(
+                    hits=[],
+                    total_candidates=0,
+                    has_more=False,
+                    possible_conflict=False,
+                    conflict_sources=[],
+                )
+        else:
+            doc_ids = list(scoped_visible)
+        # Also enforce single-doc filter against scoped visible set
+        if doc_id is not None and doc_id not in scoped_visible:
             return SearchResponse(
                 hits=[],
                 total_candidates=0,

--- a/src/harbor_clerk/api/schemas/chat.py
+++ b/src/harbor_clerk/api/schemas/chat.py
@@ -5,11 +5,14 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
 # --- Conversations ---
 
 
 class CreateConversationRequest(BaseModel):
     title: str = "New conversation"
+    scope: ScopeSpec | None = None
 
 
 class ConversationSummary(BaseModel):
@@ -17,6 +20,7 @@ class ConversationSummary(BaseModel):
     title: str
     created_at: datetime
     updated_at: datetime
+    scope: dict[str, Any] = {}
 
 
 class ChatMessageOut(BaseModel):
@@ -37,6 +41,7 @@ class ConversationDetail(BaseModel):
     title: str
     created_at: datetime
     updated_at: datetime
+    scope: dict[str, Any] = {}
     messages: list[ChatMessageOut]
 
 

--- a/src/harbor_clerk/api/schemas/research.py
+++ b/src/harbor_clerk/api/schemas/research.py
@@ -1,8 +1,11 @@
 """Pydantic schemas for research mode API."""
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
 
 
 class StartResearchRequest(BaseModel):
@@ -10,6 +13,7 @@ class StartResearchRequest(BaseModel):
     strategy: str | None = Field(default=None, pattern="^(search|sweep)$", description="Override default strategy")
     time_limit_minutes: int = Field(default=30, ge=15, le=180)
     depth: str = Field(default="standard", pattern="^(light|standard|thorough)$")
+    scope: ScopeSpec | None = None
 
 
 class ResearchProgress(BaseModel):
@@ -39,6 +43,7 @@ class ResearchSummary(BaseModel):
     max_rounds: int
     time_limit_minutes: int | None = None
     depth: str | None = None
+    scope: dict[str, Any] = {}
     created_at: datetime
     completed_at: datetime | None = None
 
@@ -55,6 +60,7 @@ class ResearchDetail(BaseModel):
     max_rounds: int
     time_limit_minutes: int | None = None
     depth: str | None = None
+    scope: dict[str, Any] = {}
     progress: dict | None = None
     notes: str | None = None
     report: str | None = None

--- a/src/harbor_clerk/api/schemas/scope.py
+++ b/src/harbor_clerk/api/schemas/scope.py
@@ -1,0 +1,28 @@
+"""Shared scope schema for Ask / Research / Search request bodies.
+
+Forward-compatible wrapper: today only `folder_ids` is honored. Future axes
+(collection_ids, doc_ids, topic_ids) can be added as new optional fields with
+no migration and no endpoint version bump. extra='ignore' on the model lets
+older servers tolerate newer clients sending unknown keys.
+"""
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ScopeSpec(BaseModel):
+    """A user-driven document-visibility scope.
+
+    Empty (`{}`) or all fields None/[] means no restriction — all active
+    documents are visible. When fields are populated, scoping mirrors
+    KeyScope's OR-across-axes semantics (today: only folder_ids).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    folder_ids: list[uuid.UUID] | None = None
+    # Future axes will be added here additively. Examples (not yet active):
+    #   collection_ids: list[uuid.UUID] | None = None
+    #   doc_ids: list[uuid.UUID] | None = None
+    #   topic_ids: list[int] | None = None

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
 
 class SearchRequest(BaseModel):
     query: str
@@ -17,6 +19,7 @@ class SearchRequest(BaseModel):
     language: str | None = None
     mime_type: str | None = None
     faceted: bool = False
+    scope: ScopeSpec | None = None
 
     @model_validator(mode="after")
     def check_doc_id_mutual_exclusion(self):

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -99,6 +99,24 @@ class KeyScope:
         return compute_effective_tools(self.permission_tier, self.tool_overrides)
 
 
+@dataclass
+class UserScope:
+    """Per-request scope for human-user tool calls.
+
+    Distinct from KeyScope: no permission_tier / tool_overrides / rate_limit —
+    human users authenticate via JWT and aren't tool-gated. Only document-axis
+    filters live here. Forward-compatible: collection_ids, doc_ids, topic_ids
+    will be added here additively when Collections ships.
+    """
+
+    folder_ids: list[uuid.UUID] | None = None
+
+    @property
+    def is_unrestricted(self) -> bool:
+        """True when no document-axis filter applies. Both None and [] count."""
+        return not self.folder_ids
+
+
 def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Select:
     """Filter a Document query to documents whose active WatchedFile lives in any
     of the given folders. No-op when folder_ids is None or empty.

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -2,16 +2,13 @@
 
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Protocol
 
 from sqlalchemy import or_, select
 from sqlalchemy.sql import Select
 
 from harbor_clerk.models.document import Document
 from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
-
-if TYPE_CHECKING:
-    from harbor_clerk.api.deps import Principal
 
 # Tier -> base tool set
 SEARCH_TIER_TOOLS: frozenset[str] = frozenset(
@@ -117,6 +114,18 @@ class UserScope:
         return not self.folder_ids
 
 
+class _ScopedPrincipal(Protocol):
+    """Subset of Principal that apply_key_scope reads.
+
+    Defined as a Protocol so apply_key_scope doesn't need to import the
+    full Principal from deps — avoiding the scope ⇄ deps cyclic import.
+    Principal in deps satisfies this protocol structurally.
+    """
+
+    type: str
+    key_scope: KeyScope | None
+
+
 def build_user_scope(scope_dict: dict | None) -> "UserScope | None":
     """Build a UserScope from a Conversation.scope or ResearchState.scope JSONB dict.
 
@@ -155,7 +164,7 @@ def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Sel
     return query.where(Document.doc_id.in_(_folder_watched_doc_ids_subquery(folder_ids)))
 
 
-def apply_key_scope(query: Select, principal: "Principal") -> Select:
+def apply_key_scope(query: Select, principal: _ScopedPrincipal) -> Select:
     """Filter a Document query by the API key's scope.
 
     No-op for human users (type='user') and unrestricted API keys.

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -99,6 +99,21 @@ class KeyScope:
         return compute_effective_tools(self.permission_tier, self.tool_overrides)
 
 
+def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Select:
+    """Filter a Document query to documents whose active WatchedFile lives in any
+    of the given folders. No-op when folder_ids is None or empty.
+
+    Pure query builder — no DB access. Safe to compose with other WHERE clauses.
+    """
+    if not folder_ids:
+        return query
+    watched_doc_ids = select(WatchedFile.doc_id).where(
+        WatchedFile.folder_id.in_(folder_ids),
+        WatchedFile.status == WatchedFileStatus.active,
+    )
+    return query.where(Document.doc_id.in_(watched_doc_ids))
+
+
 def apply_key_scope(query: Select, principal: "Principal") -> Select:
     """Filter a Document query by the API key's scope.
 
@@ -123,11 +138,11 @@ def apply_key_scope(query: Select, principal: "Principal") -> Select:
         except (ValueError, AttributeError):
             folder_uuids = []
         if folder_uuids:
-            watched_doc_ids = select(WatchedFile.doc_id).where(
-                WatchedFile.folder_id.in_(folder_uuids),
-                WatchedFile.status == WatchedFileStatus.active,
-            )
-            conditions.append(Document.doc_id.in_(watched_doc_ids))
+            # Delegate to apply_folder_scope to keep the WatchedFile join logic in one
+            # place. Extract the WHERE clause so we can append it alongside the topic
+            # condition and OR them at the end.
+            folder_condition = apply_folder_scope(select(Document.doc_id), folder_uuids).whereclause
+            conditions.append(folder_condition)
 
     if not conditions:
         # Both axes empty — explicitly nothing visible

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -132,6 +132,18 @@ def build_user_scope(scope_dict: dict | None) -> "UserScope | None":
     return UserScope(folder_ids=folder_ids)
 
 
+def _folder_watched_doc_ids_subquery(folder_ids: list[uuid.UUID]) -> Select:
+    """Subquery yielding doc_ids that have an ACTIVE WatchedFile in any of `folder_ids`.
+
+    Shared by apply_folder_scope and apply_key_scope's folder branch so both call sites
+    use the same SQL shape.
+    """
+    return select(WatchedFile.doc_id).where(
+        WatchedFile.folder_id.in_(folder_ids),
+        WatchedFile.status == WatchedFileStatus.active,
+    )
+
+
 def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Select:
     """Filter a Document query to documents whose active WatchedFile lives in any
     of the given folders. No-op when folder_ids is None or empty.
@@ -140,11 +152,7 @@ def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Sel
     """
     if not folder_ids:
         return query
-    watched_doc_ids = select(WatchedFile.doc_id).where(
-        WatchedFile.folder_id.in_(folder_ids),
-        WatchedFile.status == WatchedFileStatus.active,
-    )
-    return query.where(Document.doc_id.in_(watched_doc_ids))
+    return query.where(Document.doc_id.in_(_folder_watched_doc_ids_subquery(folder_ids)))
 
 
 def apply_key_scope(query: Select, principal: "Principal") -> Select:
@@ -171,11 +179,7 @@ def apply_key_scope(query: Select, principal: "Principal") -> Select:
         except (ValueError, AttributeError):
             folder_uuids = []
         if folder_uuids:
-            # Delegate to apply_folder_scope to keep the WatchedFile join logic in one
-            # place. Extract the WHERE clause so we can append it alongside the topic
-            # condition and OR them at the end.
-            folder_condition = apply_folder_scope(select(Document.doc_id), folder_uuids).whereclause
-            conditions.append(folder_condition)
+            conditions.append(Document.doc_id.in_(_folder_watched_doc_ids_subquery(folder_uuids)))
 
     if not conditions:
         # Both axes empty — explicitly nothing visible

--- a/src/harbor_clerk/api/scope.py
+++ b/src/harbor_clerk/api/scope.py
@@ -117,6 +117,21 @@ class UserScope:
         return not self.folder_ids
 
 
+def build_user_scope(scope_dict: dict | None) -> "UserScope | None":
+    """Build a UserScope from a Conversation.scope or ResearchState.scope JSONB dict.
+
+    Returns None when scope_dict is None, empty, or contains an empty folder_ids list.
+    String UUIDs are parsed to uuid.UUID; UUID objects pass through unchanged.
+    """
+    if not scope_dict:
+        return None
+    folder_ids_raw = scope_dict.get("folder_ids") or []
+    if not folder_ids_raw:
+        return None
+    folder_ids = [uuid.UUID(fid) if isinstance(fid, str) else fid for fid in folder_ids_raw]
+    return UserScope(folder_ids=folder_ids)
+
+
 def apply_folder_scope(query: Select, folder_ids: list[uuid.UUID] | None) -> Select:
     """Filter a Document query to documents whose active WatchedFile lives in any
     of the given folders. No-op when folder_ids is None or empty.

--- a/src/harbor_clerk/api/scope_validation.py
+++ b/src/harbor_clerk/api/scope_validation.py
@@ -1,0 +1,40 @@
+"""Validation: ensure ScopeSpec.folder_ids references existing, available folders."""
+
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
+from harbor_clerk.models.watched import WatchedFolder
+
+
+async def validate_scope_folders(scope: ScopeSpec | None, session: AsyncSession) -> None:
+    """Raise 422 if any folder_id is unknown or unavailable.
+
+    No-op when scope is None or scope.folder_ids is None/empty.
+    """
+    if scope is None or not scope.folder_ids:
+        return
+
+    folder_ids: list[uuid.UUID] = list(scope.folder_ids)
+    rows = (
+        await session.execute(
+            select(WatchedFolder.folder_id, WatchedFolder.unavailable_reason).where(
+                WatchedFolder.folder_id.in_(folder_ids)
+            )
+        )
+    ).all()
+
+    found_ids = {r[0] for r in rows}
+    unknown = [str(fid) for fid in folder_ids if fid not in found_ids]
+    if unknown:
+        raise HTTPException(status_code=422, detail=f"Unknown folder_ids: {unknown}")
+
+    unavailable = [str(r[0]) for r in rows if r[1] is not None]
+    if unavailable:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Cannot scope to unavailable folders: {unavailable}",
+        )

--- a/src/harbor_clerk/llm/chat.py
+++ b/src/harbor_clerk/llm/chat.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import httpx
 from sqlalchemy import select
 
+from harbor_clerk.api.scope import build_user_scope
 from harbor_clerk.config import get_settings, refresh_llm_settings
 from harbor_clerk.db import async_session_factory
 from harbor_clerk.llm.citations import dedupe_citations, extract_citations_from_tool_result
@@ -235,6 +236,9 @@ async def chat_stream(
 
         # Auto-title immediately on first message so the sidebar updates before LLM responds
         conv = await session.get(Conversation, conversation_id)
+        # Build scope filter from the conversation's stored scope JSONB.
+        # user_scope is None when no folder restriction is active.
+        user_scope = build_user_scope(conv.scope) if conv else None
         if conv and conv.title == "New conversation":
             conv.title = _generate_title(user_message)
             await session.commit()
@@ -489,7 +493,7 @@ async def chat_stream(
 
                     yield f"data: {json.dumps({'type': 'tool_call', 'name': fn_name, 'arguments': fn_args})}\n\n"
 
-                    result_str = await execute_tool(fn_name, fn_args, user_id)
+                    result_str = await execute_tool(fn_name, fn_args, user_id, user_scope=user_scope)
 
                     # Capture citations parsed from this tool result. Best-effort:
                     # tools that don't return citation-shaped JSON contribute nothing.

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 import httpx
 from sqlalchemy import select
 
+from harbor_clerk.api.scope import UserScope, apply_folder_scope, build_user_scope
 from harbor_clerk.config import get_settings
 from harbor_clerk.db import async_session_factory
 from harbor_clerk.llm.health import report_llm_error, report_llm_success
@@ -425,12 +426,16 @@ def _is_plausible_query(q: object) -> bool:
     return len(words) >= 1
 
 
-async def _fetch_document_list(user_id: uuid.UUID | None) -> list[dict]:
+async def _fetch_document_list(
+    user_id: uuid.UUID | None,
+    user_scope: UserScope | None = None,
+) -> list[dict]:
     """Get corpus document list for sweep strategy."""
     async with async_session_factory() as session:
-        result = await session.execute(
-            select(Document.doc_id, Document.title).where(Document.status == "ready").order_by(Document.title)
-        )
+        query = select(Document.doc_id, Document.title).where(Document.status == "ready").order_by(Document.title)
+        if user_scope and user_scope.folder_ids:
+            query = apply_folder_scope(query, user_scope.folder_ids)
+        result = await session.execute(query)
         return [{"doc_id": str(row.doc_id), "title": row.title} for row in result.all()]
 
 
@@ -643,6 +648,7 @@ async def _search_fan_out(
     k_per_query: int,
     *,
     paginate: bool = False,
+    user_scope: UserScope | None = None,
 ) -> dict[str, dict]:
     """Phase 2: Run all queries, dedupe by chunk_id.
 
@@ -661,6 +667,7 @@ async def _search_fan_out(
                 {"queries": batch, "k": k_per_query},
                 user_id,
                 mode="research",
+                user_scope=user_scope,
             )
             result = json.loads(result_json)
 
@@ -682,6 +689,7 @@ async def _search_fan_out(
                         {"query": query_text, "k": k_per_query, "offset": offset},
                         user_id,
                         mode="research",
+                        user_scope=user_scope,
                     )
                     page_result = json.loads(page_json)
                     hits = page_result.get("hits", [])
@@ -705,6 +713,8 @@ async def _read_evidence(
     user_id: uuid.UUID | None,
     max_passages: int,
     context_budget_chars: int,
+    *,
+    user_scope: UserScope | None = None,
 ) -> tuple[str, list[dict]]:
     """Phase 3: Read full passages for top-scoring chunks.
 
@@ -762,6 +772,7 @@ async def _read_evidence(
                 {"chunk_ids": batch_ids, "include_context": False},
                 user_id,
                 mode="research",
+                user_scope=user_scope,
             )
             result = json.loads(result_json)
 
@@ -994,6 +1005,8 @@ async def research_stream(
             yield _sse({"type": "error", "message": "No user question found"})
             return
 
+        user_scope = build_user_scope(state.scope)
+
         strategy = state.strategy
         resume_from_synthesis = resume and state.notes and len(state.notes) > 200
 
@@ -1035,7 +1048,9 @@ async def research_stream(
                     from harbor_clerk.topics import get_topic_summary
 
                     topic_hint = await get_topic_summary()
-                    doc_list = await _fetch_document_list(user_id) if strategy == "sweep" else None
+                    doc_list = (
+                        await _fetch_document_list(user_id, user_scope=user_scope) if strategy == "sweep" else None
+                    )
 
                     try:
                         queries = await _plan_queries(
@@ -1095,6 +1110,7 @@ async def research_stream(
                         user_id,
                         depth_config["k_per_query"],
                         paginate=depth_config.get("paginate", False),
+                        user_scope=user_scope,
                     )
 
                     # Build coverage summary
@@ -1162,6 +1178,7 @@ async def research_stream(
                         user_id,
                         depth_config["max_passages"],
                         passage_budget_chars,
+                        user_scope=user_scope,
                     )
                     research_citations = list(evidence_docs)
 
@@ -1300,6 +1317,7 @@ async def research_stream(
                             gap_queries,
                             user_id,
                             depth_config["k_per_query"],
+                            user_scope=user_scope,
                         )
                         # Filter out already-seen chunks
                         new_chunks = {k: v for k, v in gap_coverage.items() if k not in coverage}
@@ -1326,6 +1344,7 @@ async def research_stream(
                             user_id,
                             20,
                             passage_budget_chars // 3,
+                            user_scope=user_scope,
                         )
                         seen_cite_ids = {c["doc_id"] for c in research_citations}
                         research_citations.extend(d for d in gap_evidence_docs if d["doc_id"] not in seen_cite_ids)

--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -18,8 +18,9 @@ import logging
 import uuid
 from typing import TYPE_CHECKING
 
+from harbor_clerk.api.scope import UserScope
+
 if TYPE_CHECKING:
-    from harbor_clerk.api.scope import UserScope
     from harbor_clerk.llm.models import ModelInfo
 
 logger = logging.getLogger(__name__)
@@ -652,7 +653,7 @@ async def execute_tool(
     user_id: uuid.UUID | None = None,
     *,
     mode: str = "chat",
-    user_scope: "UserScope | None" = None,
+    user_scope: UserScope | None = None,
 ) -> str:
     """Execute a tool by delegating to the corresponding MCP function.
 

--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -19,6 +19,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from harbor_clerk.api.scope import UserScope
     from harbor_clerk.llm.models import ModelInfo
 
 logger = logging.getLogger(__name__)
@@ -645,10 +646,19 @@ _RESEARCH_TOOL_DISPATCH: dict[str, tuple[str, callable]] = {
 }
 
 
-async def execute_tool(name: str, arguments: dict, user_id: uuid.UUID | None = None, *, mode: str = "chat") -> str:
+async def execute_tool(
+    name: str,
+    arguments: dict,
+    user_id: uuid.UUID | None = None,
+    *,
+    mode: str = "chat",
+    user_scope: "UserScope | None" = None,
+) -> str:
     """Execute a tool by delegating to the corresponding MCP function.
 
     mode: "chat" (conservative limits) or "research" (permissive limits).
+    user_scope: optional folder-level scope to apply to all retrievals in
+        this tool call. Mirrors KeyScope.scope_folder_ids semantics.
     """
     from harbor_clerk.api.deps import Principal
     from harbor_clerk.mcp_server import _mcp_principal
@@ -669,7 +679,7 @@ async def execute_tool(name: str, arguments: dict, user_id: uuid.UUID | None = N
     # Set MCP auth context so the tool function sees the chat user
     token = None
     if user_id is not None:
-        principal = Principal(type="user", id=user_id, role="user")
+        principal = Principal(type="user", id=user_id, role="user", user_scope=user_scope)
         token = _mcp_principal.set(principal)
 
     try:

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -316,17 +316,31 @@ def _require_admin() -> Principal:
 async def _visible_doc_ids(session: AsyncSession, principal: Principal) -> set[uuid.UUID] | None:
     """Get the set of doc_ids visible to this principal, or None if unrestricted.
 
-    Returns None for human users and unrestricted API keys (no filter needed).
-    Returns the explicit set for scoped keys — callers use this to filter results.
-    Only active (non-removed) documents are included.
+    Returns None when no scope filter applies (API key with no scope, OR human
+    user with no user_scope). Returns the explicit set for scoped keys/users —
+    callers use this to filter results. Only active (non-removed) documents
+    are included.
     """
-    if principal.type != "api_key" or principal.key_scope is None or principal.key_scope.is_unrestricted:
-        return None
-    from harbor_clerk.api.scope import apply_key_scope
+    # API-key path (existing behavior, unchanged)
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        from harbor_clerk.api.scope import apply_key_scope
 
-    query = apply_key_scope(select(Document.doc_id).where(Document.status == "active"), principal)
-    result = await session.execute(query)
-    return {row[0] for row in result.all()}
+        query = apply_key_scope(select(Document.doc_id).where(Document.status == "active"), principal)
+        result = await session.execute(query)
+        return {row[0] for row in result.all()}
+
+    # User-scope path (new)
+    if principal.type == "user" and principal.user_scope is not None and not principal.user_scope.is_unrestricted:
+        from harbor_clerk.api.scope import apply_folder_scope
+
+        query = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            principal.user_scope.folder_ids,
+        )
+        result = await session.execute(query)
+        return {row[0] for row in result.all()}
+
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/harbor_clerk/models/conversation.py
+++ b/src/harbor_clerk/models/conversation.py
@@ -1,7 +1,9 @@
 import uuid
+from typing import Any
 
+import sqlalchemy as sa
 from sqlalchemy import ForeignKey, Index, String
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from harbor_clerk.models.base import Base, created_at, updated_at, uuid_pk
@@ -22,6 +24,12 @@ class Conversation(Base):
         server_default="New conversation",
     )
     mode: Mapped[str] = mapped_column(String(10), nullable=False, server_default="chat")
+    scope: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=sa.text("'{}'::jsonb"),
+        default=dict,
+    )
     created_at: Mapped[created_at]
     updated_at: Mapped[updated_at]
 

--- a/src/harbor_clerk/models/research_state.py
+++ b/src/harbor_clerk/models/research_state.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
+import sqlalchemy as sa
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -28,4 +29,10 @@ class ResearchState(Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     depth: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    scope: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=sa.text("'{}'::jsonb"),
+        default=dict,
+    )
     citations: Mapped[Any | None] = mapped_column(JSONB, nullable=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,3 +259,62 @@ def user_token(regular_user: User) -> str:
 
 def auth_header(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+import pytest_asyncio  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def two_folder_corpus(db_session):
+    """Create two watched folders, each with 2 active documents."""
+    from harbor_clerk.models.document import Document
+    from harbor_clerk.models.enums import PipelineStatus
+    from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+
+    folder_a = WatchedFolder(path="/a", display_name="Folder A", auto_discovered=False)
+    folder_b = WatchedFolder(path="/b", display_name="Folder B", auto_discovered=False)
+    db_session.add_all([folder_a, folder_b])
+    await db_session.flush()
+
+    docs_in_a, docs_in_b = [], []
+    for i, folder in [(0, folder_a), (1, folder_a), (2, folder_b), (3, folder_b)]:
+        d = Document(
+            title=f"FolderScopeTest Doc {i}",
+            canonical_filename=f"doc{i}.txt",
+            status="active",
+            sha256=bytes([i] * 32),
+            pipeline_status=PipelineStatus.ready,
+        )
+        db_session.add(d)
+        await db_session.flush()
+        wf = WatchedFile(
+            folder_id=folder.folder_id,
+            doc_id=d.doc_id,
+            relative_path=f"doc{i}.txt",
+            sha256=d.sha256,
+            bookmark_data=b"",
+            status=WatchedFileStatus.active,
+        )
+        db_session.add(wf)
+        (docs_in_a if folder is folder_a else docs_in_b).append(d)
+
+    await db_session.commit()
+    return folder_a, folder_b, docs_in_a, docs_in_b
+
+
+@pytest_asyncio.fixture
+async def mark_one_removed(db_session):
+    """Helper fixture: returns a coroutine that marks one WatchedFile in a folder as removed."""
+    from sqlalchemy import select
+
+    from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus
+
+    async def _mark(folder):
+        wf = (
+            await db_session.execute(select(WatchedFile).where(WatchedFile.folder_id == folder.folder_id).limit(1))
+        ).scalar_one()
+        wf.status = WatchedFileStatus.removed
+        await db_session.commit()
+        return wf.doc_id
+
+    return _mark

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,23 @@ async def two_folder_corpus(db_session):
 
 
 @pytest_asyncio.fixture
+async def unavailable_folder(db_session):
+    """A WatchedFolder that has been marked unavailable."""
+    from harbor_clerk.models.watched import WatchedFolder
+
+    folder = WatchedFolder(
+        path="/unavailable",
+        display_name="Unavailable",
+        auto_discovered=False,
+        unavailable_reason="test-disabled",
+    )
+    db_session.add(folder)
+    await db_session.commit()
+    await db_session.refresh(folder)
+    return folder
+
+
+@pytest_asyncio.fixture
 async def mark_one_removed(db_session):
     """Helper fixture: returns a coroutine that marks one WatchedFile in a folder as removed."""
     from sqlalchemy import select

--- a/tests/models/test_user_scope_models.py
+++ b/tests/models/test_user_scope_models.py
@@ -1,0 +1,57 @@
+"""Tests for the new scope JSONB column on Conversation and ResearchState."""
+
+import uuid
+
+from sqlalchemy import select
+
+from harbor_clerk.models.conversation import Conversation
+from harbor_clerk.models.research_state import ResearchState
+
+
+async def test_conversation_scope_defaults_to_empty_dict(db_session, admin_user):
+    """A new conversation has scope == {} when not explicitly set."""
+    conv = Conversation(user_id=admin_user.user_id, title="Test")
+    db_session.add(conv)
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    assert conv.scope == {}
+
+
+async def test_conversation_scope_round_trips_folder_ids(db_session, admin_user):
+    """Setting scope persists the JSONB shape correctly."""
+    folder_id = str(uuid.uuid4())
+    conv = Conversation(
+        user_id=admin_user.user_id,
+        title="Scoped",
+        scope={"folder_ids": [folder_id]},
+    )
+    db_session.add(conv)
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    assert conv.scope == {"folder_ids": [folder_id]}
+
+    # Round-trip via fresh query
+    fetched = (
+        await db_session.execute(select(Conversation).where(Conversation.conversation_id == conv.conversation_id))
+    ).scalar_one()
+    assert fetched.scope == {"folder_ids": [folder_id]}
+
+
+async def test_research_state_scope_defaults_to_empty_dict(db_session, admin_user):
+    """A new research_state row has scope == {} when not explicitly set."""
+    conv = Conversation(user_id=admin_user.user_id, title="Research conv", mode="research")
+    db_session.add(conv)
+    await db_session.flush()
+    state = ResearchState(
+        conversation_id=conv.conversation_id,
+        strategy="search",
+        status="queued",
+        max_rounds=5,
+    )
+    db_session.add(state)
+    await db_session.commit()
+    await db_session.refresh(state)
+
+    assert state.scope == {}

--- a/tests/test_chat_engine_scope_threading.py
+++ b/tests/test_chat_engine_scope_threading.py
@@ -1,0 +1,259 @@
+"""Verify chat engine loads conversation.scope and passes it to execute_tool.
+
+Approach: Option A — unit-test the small build_user_scope helper directly
+(avoids SQLAlchemy ORM instrumentation overhead),
+plus wiring integration tests that drive chat_stream with a mocked LLM and
+mocked execute_tool to confirm user_scope is threaded through correctly.
+"""
+
+import uuid
+
+import pytest
+
+from harbor_clerk.api.scope import UserScope, build_user_scope
+
+# ---------------------------------------------------------------------------
+# Unit tests for build_user_scope
+# Passes raw JSONB dicts — no SQLAlchemy instrumentation involved.
+# ---------------------------------------------------------------------------
+
+
+def test_build_user_scope_empty_dict_returns_none():
+    """scope={} → no restriction → None."""
+    assert build_user_scope({}) is None
+
+
+def test_build_user_scope_missing_folder_ids_returns_none():
+    """scope without folder_ids key → None."""
+    assert build_user_scope({"other_key": "value"}) is None
+
+
+def test_build_user_scope_empty_folder_ids_returns_none():
+    """scope={"folder_ids": []} → no restriction → None."""
+    assert build_user_scope({"folder_ids": []}) is None
+
+
+def test_build_user_scope_string_uuids_parsed():
+    """scope={"folder_ids": [str(uuid)]} → UserScope with parsed UUIDs."""
+    fid = uuid.uuid4()
+    result = build_user_scope({"folder_ids": [str(fid)]})
+    assert result is not None
+    assert isinstance(result, UserScope)
+    assert result.folder_ids == [fid]
+
+
+def test_build_user_scope_multiple_folder_ids():
+    """scope with multiple folder_ids → UserScope with all UUIDs."""
+    fid1 = uuid.uuid4()
+    fid2 = uuid.uuid4()
+    result = build_user_scope({"folder_ids": [str(fid1), str(fid2)]})
+    assert result is not None
+    assert len(result.folder_ids) == 2
+    assert fid1 in result.folder_ids
+    assert fid2 in result.folder_ids
+
+
+def test_build_user_scope_uuid_objects_passed_through():
+    """scope with UUID objects (not strings) are passed through unchanged."""
+    fid = uuid.uuid4()
+    result = build_user_scope({"folder_ids": [fid]})
+    assert result is not None
+    assert result.folder_ids == [fid]
+
+
+def test_build_user_scope_none_scope_returns_none():
+    """scope=None (can happen if column default hasn't fired) → None."""
+    assert build_user_scope(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for the wiring integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client(call_count_holder, tool_call_chunk, text_chunk):
+    """Return a mock httpx.AsyncClient that serves tool-call then text response."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    def make_response(lines):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        async def aiter_lines():
+            for line in lines:
+                yield line
+
+        mock_resp.aiter_lines = aiter_lines
+        mock_resp.aclose = AsyncMock()
+        return mock_resp
+
+    def build_response(*args, **kwargs):
+        call_count_holder[0] += 1
+        if call_count_holder[0] == 1:
+            return make_response([f"data: {tool_call_chunk}", "data: [DONE]"])
+        else:
+            return make_response([f"data: {text_chunk}", "data: [DONE]"])
+
+    mock_client = MagicMock()
+    mock_client.build_request = MagicMock(return_value=MagicMock())
+    mock_client.send = AsyncMock(side_effect=build_response)
+    mock_client.aclose = AsyncMock()
+    return mock_client
+
+
+def _search_tool_call_chunk():
+    import json
+
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_abc",
+                                "type": "function",
+                                "function": {
+                                    "name": "search_documents",
+                                    "arguments": '{"query": "test"}',
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+
+
+def _text_chunk(content="Here is the answer."):
+    import json
+
+    return json.dumps({"choices": [{"delta": {"content": content}}]})
+
+
+# ---------------------------------------------------------------------------
+# Wiring integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def mock_chat_session_factory(db_session, _engine, monkeypatch):
+    """Patch async_session_factory everywhere chat_stream touches it so all DB
+    access uses the test engine and its own connections (avoids the 'different
+    loop' problem with the global asyncpg pool)."""
+    from contextlib import asynccontextmanager
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    factory = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def _factory():
+        async with factory() as session:
+            yield session
+
+    # chat.py and topics.py each import async_session_factory at module level;
+    # patch both so every DB call inside chat_stream uses the test engine.
+    monkeypatch.setattr("harbor_clerk.llm.chat.async_session_factory", _factory)
+    monkeypatch.setattr("harbor_clerk.topics.async_session_factory", _factory)
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_passes_user_scope_to_execute_tool(
+    db_session,
+    admin_user,
+    two_folder_corpus,
+    mock_chat_session_factory,
+):
+    """When a conversation has scope.folder_ids, chat_stream passes a matching
+    UserScope to execute_tool.
+
+    The LLM is mocked to return one tool call then a text response so the
+    tool-calling branch is exercised exactly once.
+    """
+    import json
+    from unittest.mock import patch
+
+    from harbor_clerk.llm import chat as chat_module
+    from harbor_clerk.models.conversation import Conversation
+
+    folder_a, _, _, _ = two_folder_corpus
+
+    conv = Conversation(
+        user_id=admin_user.user_id,
+        title="Scoped chat",
+        scope={"folder_ids": [str(folder_a.folder_id)]},
+    )
+    db_session.add(conv)
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    captured_scope: list = []
+
+    async def fake_execute_tool(fn_name, fn_args, user_id, *, user_scope=None):
+        captured_scope.append(user_scope)
+        return json.dumps({"results": [], "total": 0})
+
+    call_count = [0]
+    mock_client = _make_mock_client(call_count, _search_tool_call_chunk(), _text_chunk())
+
+    with (
+        patch.object(chat_module, "execute_tool", side_effect=fake_execute_tool),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        from harbor_clerk.llm.chat import chat_stream
+
+        async for _ in chat_stream(conv.conversation_id, "test query", admin_user.user_id):
+            pass
+
+    assert len(captured_scope) == 1, f"execute_tool called {len(captured_scope)} times, expected 1"
+    scope = captured_scope[0]
+    assert isinstance(scope, UserScope), f"Expected UserScope, got {type(scope)}"
+    assert scope.folder_ids == [folder_a.folder_id], (
+        f"Expected folder_ids=[{folder_a.folder_id}], got {scope.folder_ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_unscoped_conversation_passes_none_scope(
+    db_session,
+    admin_user,
+    mock_chat_session_factory,
+):
+    """An unscoped conversation → execute_tool receives user_scope=None."""
+    import json
+    from unittest.mock import patch
+
+    from harbor_clerk.llm import chat as chat_module
+    from harbor_clerk.models.conversation import Conversation
+
+    conv = Conversation(
+        user_id=admin_user.user_id,
+        title="Unscoped chat",
+    )
+    db_session.add(conv)
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    captured_scope: list = []
+
+    async def fake_execute_tool(fn_name, fn_args, user_id, *, user_scope=None):
+        captured_scope.append(user_scope)
+        return json.dumps({"results": [], "total": 0})
+
+    call_count = [0]
+    mock_client = _make_mock_client(call_count, _search_tool_call_chunk(), _text_chunk("Answer."))
+
+    with (
+        patch.object(chat_module, "execute_tool", side_effect=fake_execute_tool),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        from harbor_clerk.llm.chat import chat_stream
+
+        async for _ in chat_stream(conv.conversation_id, "hello", admin_user.user_id):
+            pass
+
+    assert len(captured_scope) == 1, f"execute_tool called {len(captured_scope)} times, expected 1"
+    assert captured_scope[0] is None, f"Expected None scope for unscoped conv, got {captured_scope[0]}"

--- a/tests/test_chat_route_scope.py
+++ b/tests/test_chat_route_scope.py
@@ -1,0 +1,59 @@
+"""Tests for scope field on chat conversation routes."""
+
+import uuid
+
+
+async def test_create_conversation_with_no_scope_field_defaults_to_empty(client, admin_token):
+    r = await client.post(
+        "/api/chat/conversations",
+        json={"title": "Unscoped"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scope"] == {}
+
+
+async def test_create_conversation_with_folder_scope_persists(client, admin_token, two_folder_corpus):
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.post(
+        "/api/chat/conversations",
+        json={"title": "Scoped", "scope": {"folder_ids": [str(folder_a.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scope"] == {"folder_ids": [str(folder_a.folder_id)]}
+
+
+async def test_create_conversation_rejects_unknown_folder_id(client, admin_token):
+    r = await client.post(
+        "/api/chat/conversations",
+        json={"title": "Bad", "scope": {"folder_ids": [str(uuid.uuid4())]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_create_conversation_rejects_unavailable_folder(client, admin_token, unavailable_folder):
+    r = await client.post(
+        "/api/chat/conversations",
+        json={"title": "Bad", "scope": {"folder_ids": [str(unavailable_folder.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_get_conversation_returns_scope(client, admin_token, two_folder_corpus):
+    folder_a, _, _, _ = two_folder_corpus
+    create = await client.post(
+        "/api/chat/conversations",
+        json={"title": "S", "scope": {"folder_ids": [str(folder_a.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    conv_id = create.json()["conversation_id"]
+
+    r = await client.get(
+        f"/api/chat/conversations/{conv_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scope"] == {"folder_ids": [str(folder_a.folder_id)]}

--- a/tests/test_execute_tool_user_scope.py
+++ b/tests/test_execute_tool_user_scope.py
@@ -1,0 +1,61 @@
+"""Tests for execute_tool forwarding user_scope onto Principal."""
+
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.api.scope import UserScope
+from harbor_clerk.llm.tools import execute_tool
+
+
+@pytest.fixture
+async def mock_session_factory(db_session: AsyncSession, _engine, monkeypatch):
+    """Patch async_session_factory to use the test connection so MCP tools
+    see flushed/committed data from the test's db_session."""
+    conn = await db_session.connection()
+
+    @asynccontextmanager
+    async def _factory():
+        session = AsyncSession(bind=conn, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.async_session_factory", _factory)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_corpus_overview_with_no_scope_sees_all(
+    db_session, admin_user, two_folder_corpus, mock_session_factory
+):
+    """No user_scope = no filter = all docs from both folders visible in overview."""
+    result_str = await execute_tool(
+        "corpus_overview",
+        {},
+        user_id=admin_user.user_id,
+    )
+    result = json.loads(result_str)
+    # Should see all 4 docs from two_folder_corpus
+    assert result.get("document_count", 0) >= 4
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_corpus_overview_with_folder_scope_restricts(
+    db_session, admin_user, two_folder_corpus, mock_session_factory
+):
+    """user_scope=folder_a → only folder_a's 2 docs visible in overview."""
+    folder_a, _, docs_in_a, _ = two_folder_corpus
+    scope = UserScope(folder_ids=[folder_a.folder_id])
+
+    result_str = await execute_tool(
+        "corpus_overview",
+        {},
+        user_id=admin_user.user_id,
+        user_scope=scope,
+    )
+    result = json.loads(result_str)
+    # With scope to folder_a only, document_count should be exactly 2
+    assert result.get("document_count") == 2

--- a/tests/test_folder_scope_helper.py
+++ b/tests/test_folder_scope_helper.py
@@ -1,6 +1,8 @@
 """Tests for apply_folder_scope — the pure query builder shared by
 apply_key_scope and the user-side folder filter."""
 
+import uuid
+
 from sqlalchemy import select
 
 from harbor_clerk.api.scope import apply_folder_scope
@@ -51,3 +53,57 @@ async def test_apply_folder_scope_excludes_removed_watched_files(db_session, two
     scoped_ids = {r[0] for r in (await db_session.execute(scoped)).all()}
 
     assert removed_doc_id not in scoped_ids
+
+
+async def test_apply_key_scope_combined_topic_and_folder_axes(db_session, two_folder_corpus):
+    """apply_key_scope with BOTH scope_topic_ids AND scope_folder_ids set
+    should return docs matching either axis (OR). This path was not covered by
+    existing tests before the .whereclause refactor."""
+    from datetime import UTC, datetime
+
+    from harbor_clerk.api.deps import Principal
+    from harbor_clerk.api.scope import KeyScope, apply_key_scope
+    from harbor_clerk.models.corpus_topic import CorpusTopic
+
+    folder_a, folder_b, docs_in_a, docs_in_b = two_folder_corpus
+
+    # Insert a real CorpusTopic row so the FK from Document.topic_id is satisfied.
+    target_topic_id = 999
+    topic = CorpusTopic(
+        topic_id=target_topic_id,
+        label="test-topic",
+        keywords=["foo"],
+        doc_count=1,
+        representative_doc_ids=[],
+        updated_at=datetime.now(UTC),
+    )
+    db_session.add(topic)
+    await db_session.flush()
+
+    # Assign the topic to one doc in folder_b so the topic axis surfaces it.
+    docs_in_b[0].topic_id = target_topic_id
+    await db_session.commit()
+
+    # Build a scope with both axes: topic=999 (matches one folder_b doc) OR folder_a (all folder_a docs)
+    principal = Principal(
+        type="api_key",
+        id=uuid.uuid4(),
+        role="user",
+        key_scope=KeyScope(
+            scope_topic_ids=[target_topic_id],
+            scope_folder_ids=[str(folder_a.folder_id)],
+            permission_tier="full",
+            tool_overrides={},
+            max_snippet_chars=None,
+            rate_limit_rpm=None,
+            rate_limit_rph=None,
+        ),
+    )
+
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_key_scope(query, principal)
+    rows = {r[0] for r in (await db_session.execute(scoped)).all()}
+
+    # Should include: all folder_a docs + the one folder_b doc with the target topic
+    expected = {d.doc_id for d in docs_in_a} | {docs_in_b[0].doc_id}
+    assert rows == expected

--- a/tests/test_folder_scope_helper.py
+++ b/tests/test_folder_scope_helper.py
@@ -1,0 +1,53 @@
+"""Tests for apply_folder_scope — the pure query builder shared by
+apply_key_scope and the user-side folder filter."""
+
+from sqlalchemy import select
+
+from harbor_clerk.api.scope import apply_folder_scope
+from harbor_clerk.models.document import Document
+
+
+async def test_apply_folder_scope_none_is_noop(db_session, two_folder_corpus):
+    """folder_ids=None returns the query unchanged — all docs visible."""
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, None)
+
+    all_ids = {r[0] for r in (await db_session.execute(query)).all()}
+    scoped_ids = {r[0] for r in (await db_session.execute(scoped)).all()}
+
+    assert scoped_ids == all_ids
+
+
+async def test_apply_folder_scope_empty_list_is_noop(db_session, two_folder_corpus):
+    """folder_ids=[] also means no restriction."""
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, [])
+
+    all_ids = {r[0] for r in (await db_session.execute(query)).all()}
+    scoped_ids = {r[0] for r in (await db_session.execute(scoped)).all()}
+
+    assert scoped_ids == all_ids
+
+
+async def test_apply_folder_scope_restricts_to_named_folder(db_session, two_folder_corpus):
+    """folder_ids=[folder_a] returns only docs in folder_a."""
+    folder_a, folder_b, docs_in_a, docs_in_b = two_folder_corpus
+
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, [folder_a.folder_id])
+
+    scoped_ids = {r[0] for r in (await db_session.execute(scoped)).all()}
+    expected_ids = {d.doc_id for d in docs_in_a}
+    assert scoped_ids == expected_ids
+
+
+async def test_apply_folder_scope_excludes_removed_watched_files(db_session, two_folder_corpus, mark_one_removed):
+    """A WatchedFile in `removed` status no longer surfaces its document."""
+    folder_a, _, _, _ = two_folder_corpus
+    removed_doc_id = await mark_one_removed(folder_a)
+
+    query = select(Document.doc_id).where(Document.status == "active")
+    scoped = apply_folder_scope(query, [folder_a.folder_id])
+    scoped_ids = {r[0] for r in (await db_session.execute(scoped)).all()}
+
+    assert removed_doc_id not in scoped_ids

--- a/tests/test_research_engine_scope_threading.py
+++ b/tests/test_research_engine_scope_threading.py
@@ -1,0 +1,330 @@
+"""Verify research engine loads research_state.scope and threads it to execute_tool.
+
+Approach mirrors test_chat_engine_scope_threading.py:
+- Unit tests for build_user_scope are already covered there; we add a couple
+  research-specific ones here for completeness.
+- Wiring integration tests drive research_stream with a mocked LLM and
+  mocked execute_tool to confirm user_scope is threaded through correctly.
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from harbor_clerk.api.scope import UserScope, build_user_scope
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — build_user_scope is shared; verify it behaves the same when
+# called from the research path (no branching in the helper itself, but
+# belt-and-suspenders for the integration).
+# ---------------------------------------------------------------------------
+
+
+def test_build_user_scope_from_research_state_scope():
+    """scope dict with folder_ids → UserScope with parsed UUIDs."""
+    fid = uuid.uuid4()
+    result = build_user_scope({"folder_ids": [str(fid)]})
+    assert isinstance(result, UserScope)
+    assert result.folder_ids == [fid]
+
+
+def test_build_user_scope_none_returns_none():
+    """state.scope=None → no restriction → None."""
+    assert build_user_scope(None) is None
+
+
+def test_build_user_scope_empty_folder_ids_returns_none():
+    """state.scope={"folder_ids": []} → no restriction → None."""
+    assert build_user_scope({"folder_ids": []}) is None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared by wiring integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def mock_research_session_factory(db_session, _engine, monkeypatch):
+    """Patch async_session_factory everywhere research_stream touches it."""
+    from contextlib import asynccontextmanager
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    factory = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def _factory():
+        async with factory() as session:
+            yield session
+
+    monkeypatch.setattr("harbor_clerk.llm.research.async_session_factory", _factory)
+    monkeypatch.setattr("harbor_clerk.topics.async_session_factory", _factory)
+
+
+@pytest.fixture
+async def scoped_research_state(db_session, admin_user, two_folder_corpus):
+    """Conversation + ResearchState with scope restricted to folder_a."""
+    from harbor_clerk.models.chat_message import ChatMessage
+    from harbor_clerk.models.conversation import Conversation
+    from harbor_clerk.models.research_state import ResearchState
+
+    folder_a, _, _, _ = two_folder_corpus
+
+    conv = Conversation(
+        user_id=admin_user.user_id,
+        title="Scoped research",
+        mode="research",
+    )
+    db_session.add(conv)
+    await db_session.flush()
+
+    state = ResearchState(
+        conversation_id=conv.conversation_id,
+        strategy="search",
+        status="queued",
+        max_rounds=2,
+        scope={"folder_ids": [str(folder_a.folder_id)]},
+    )
+    db_session.add(state)
+    await db_session.flush()
+
+    msg = ChatMessage(
+        conversation_id=conv.conversation_id,
+        role="user",
+        content="What are the main findings?",
+    )
+    db_session.add(msg)
+    await db_session.commit()
+    await db_session.refresh(conv)
+    await db_session.refresh(state)
+
+    return conv, state, folder_a
+
+
+@pytest.fixture
+async def unscoped_research_state(db_session, admin_user):
+    """Conversation + ResearchState with no scope."""
+    from harbor_clerk.models.chat_message import ChatMessage
+    from harbor_clerk.models.conversation import Conversation
+    from harbor_clerk.models.research_state import ResearchState
+
+    conv = Conversation(
+        user_id=admin_user.user_id,
+        title="Unscoped research",
+        mode="research",
+    )
+    db_session.add(conv)
+    await db_session.flush()
+
+    state = ResearchState(
+        conversation_id=conv.conversation_id,
+        strategy="search",
+        status="queued",
+        max_rounds=2,
+    )
+    db_session.add(state)
+    await db_session.flush()
+
+    msg = ChatMessage(
+        conversation_id=conv.conversation_id,
+        role="user",
+        content="Tell me about everything.",
+    )
+    db_session.add(msg)
+    await db_session.commit()
+
+    return conv, state
+
+
+# ---------------------------------------------------------------------------
+# LLM mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_planning_response(queries: list[str]) -> str:
+    """Return a JSON string that looks like a query-planning LLM response."""
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": json.dumps({"queries": queries}),
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+
+
+def _make_note_extraction_response(notes: str = "Test notes.") -> str:
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": notes,
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+
+
+def _make_synthesis_stream_response(text: str = "Final answer.") -> list[str]:
+    chunk = json.dumps({"choices": [{"delta": {"content": text}}]})
+    return [f"data: {chunk}", "data: [DONE]"]
+
+
+def _make_mock_httpx_client(
+    planning_resp: str,
+    note_resp: str,
+    synthesis_lines: list[str],
+) -> MagicMock:
+    """Return a mock AsyncClient that serves planning → note → synthesis."""
+    call_order = [0]
+
+    def make_non_streaming(body: str):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json = MagicMock(return_value=json.loads(body))
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def make_streaming(lines: list[str]):
+        resp = MagicMock()
+        resp.status_code = 200
+
+        async def aiter_lines():
+            for line in lines:
+                yield line
+
+        resp.aiter_lines = aiter_lines
+        resp.aclose = AsyncMock()
+        return resp
+
+    def _post(*args, **kwargs):
+        call_order[0] += 1
+        if call_order[0] == 1:
+            # Phase 1: query planning (non-streaming)
+            return make_non_streaming(planning_resp)
+        elif call_order[0] == 2:
+            # Phase 4: note extraction (non-streaming)
+            return make_non_streaming(note_resp)
+        else:
+            # Synthesis (streaming)
+            return make_streaming(synthesis_lines)
+
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=_post)
+    client.aclose = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Wiring integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_research_stream_passes_user_scope_to_execute_tool(
+    db_session,
+    admin_user,
+    two_folder_corpus,
+    scoped_research_state,
+    mock_research_session_factory,
+):
+    """When research_state.scope has folder_ids, all execute_tool calls get
+    a matching UserScope with those folder IDs."""
+    from harbor_clerk.llm import research as research_module
+
+    conv, state, folder_a = scoped_research_state
+
+    captured_scopes: list = []
+
+    async def fake_execute_tool(fn_name, fn_args, user_id, *, mode=None, user_scope=None):
+        captured_scopes.append(user_scope)
+        if fn_name == "batch_search":
+            return json.dumps({"results": [{"query": fn_args.get("queries", ["q"])[0], "hits": []}]})
+        if fn_name == "search_documents":
+            return json.dumps({"hits": [], "has_more": False})
+        if fn_name == "read_passages":
+            return json.dumps({"passages": []})
+        return json.dumps({})
+
+    mock_client = _make_mock_httpx_client(
+        planning_resp=_make_planning_response(["test query"]),
+        note_resp=_make_note_extraction_response(),
+        synthesis_lines=_make_synthesis_stream_response(),
+    )
+
+    with (
+        patch.object(research_module, "execute_tool", side_effect=fake_execute_tool),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        events = []
+        async for event in research_module.research_stream(
+            conv.conversation_id,
+            user_id=admin_user.user_id,
+        ):
+            events.append(event)
+
+    assert len(captured_scopes) >= 1, "execute_tool was never called"
+    for i, scope in enumerate(captured_scopes):
+        assert isinstance(scope, UserScope), f"execute_tool call #{i + 1} received {type(scope)} instead of UserScope"
+        assert scope.folder_ids == [folder_a.folder_id], (
+            f"execute_tool call #{i + 1}: expected folder_ids=[{folder_a.folder_id}], got {scope.folder_ids}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_research_stream_unscoped_passes_none_scope(
+    db_session,
+    admin_user,
+    unscoped_research_state,
+    mock_research_session_factory,
+):
+    """When research_state has no scope, execute_tool receives user_scope=None."""
+    from harbor_clerk.llm import research as research_module
+
+    conv, state = unscoped_research_state
+
+    captured_scopes: list = []
+
+    async def fake_execute_tool(fn_name, fn_args, user_id, *, mode=None, user_scope=None):
+        captured_scopes.append(user_scope)
+        if fn_name == "batch_search":
+            return json.dumps({"results": [{"query": fn_args.get("queries", ["q"])[0], "hits": []}]})
+        if fn_name == "search_documents":
+            return json.dumps({"hits": [], "has_more": False})
+        if fn_name == "read_passages":
+            return json.dumps({"passages": []})
+        return json.dumps({})
+
+    mock_client = _make_mock_httpx_client(
+        planning_resp=_make_planning_response(["another query"]),
+        note_resp=_make_note_extraction_response(),
+        synthesis_lines=_make_synthesis_stream_response("All done."),
+    )
+
+    with (
+        patch.object(research_module, "execute_tool", side_effect=fake_execute_tool),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        async for _ in research_module.research_stream(
+            conv.conversation_id,
+            user_id=admin_user.user_id,
+        ):
+            pass
+
+    assert len(captured_scopes) >= 1, "execute_tool was never called"
+    for i, scope in enumerate(captured_scopes):
+        assert scope is None, f"execute_tool call #{i + 1}: expected None for unscoped run, got {scope!r}"

--- a/tests/test_research_engine_scope_threading.py
+++ b/tests/test_research_engine_scope_threading.py
@@ -15,7 +15,6 @@ import pytest
 
 from harbor_clerk.api.scope import UserScope, build_user_scope
 
-
 # ---------------------------------------------------------------------------
 # Unit tests — build_user_scope is shared; verify it behaves the same when
 # called from the research path (no branching in the helper itself, but

--- a/tests/test_research_route_scope.py
+++ b/tests/test_research_route_scope.py
@@ -1,0 +1,122 @@
+"""Tests for scope field on research routes.
+
+POST /research checks settings.llm_model_id before creating the DB row, so we
+must patch get_settings() to return a valid model_id. We also patch
+research_stream to a no-op async generator so the StreamingResponse completes
+immediately — the row is committed before the generator runs, so the subsequent
+GET can read it without any timing issues.
+"""
+
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(model_id: str = "qwen3-8b") -> MagicMock:
+    """Return a minimal settings mock with llm_model_id set."""
+    s = MagicMock()
+    s.llm_model_id = model_id
+    return s
+
+
+async def _noop_research_stream(*args, **kwargs) -> AsyncGenerator[bytes, None]:
+    """Minimal no-op replacement for research_stream.
+
+    Yields a single SSE done event so the StreamingResponse body terminates
+    cleanly. The conversation row is committed BEFORE this generator is called,
+    so no DB interaction is needed here.
+    """
+    yield b'data: {"type": "done"}\n\n'
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_start_research_with_no_scope_defaults_to_empty(client, admin_token):
+    with (
+        patch("harbor_clerk.api.routes.research.get_settings", return_value=_make_settings()),
+        patch("harbor_clerk.api.routes.research.research_stream", new=_noop_research_stream),
+    ):
+        r = await client.post(
+            "/api/research",
+            json={"question": "What are the termination clauses?", "time_limit_minutes": 15, "depth": "light"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert r.status_code == 200
+    rid = r.headers["x-research-id"]
+
+    d = await client.get(
+        f"/api/research/{rid}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert d.status_code == 200
+    assert d.json()["scope"] == {}
+
+
+async def test_start_research_with_folder_scope_persists(client, admin_token, two_folder_corpus):
+    folder_a, _, _, _ = two_folder_corpus
+    with (
+        patch("harbor_clerk.api.routes.research.get_settings", return_value=_make_settings()),
+        patch("harbor_clerk.api.routes.research.research_stream", new=_noop_research_stream),
+    ):
+        r = await client.post(
+            "/api/research",
+            json={
+                "question": "Q",
+                "time_limit_minutes": 15,
+                "depth": "light",
+                "scope": {"folder_ids": [str(folder_a.folder_id)]},
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert r.status_code == 200
+    rid = r.headers["x-research-id"]
+
+    d = await client.get(
+        f"/api/research/{rid}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert d.status_code == 200
+    assert d.json()["scope"] == {"folder_ids": [str(folder_a.folder_id)]}
+
+
+async def test_start_research_rejects_unknown_folder_id(client, admin_token):
+    with (
+        patch("harbor_clerk.api.routes.research.get_settings", return_value=_make_settings()),
+        patch("harbor_clerk.api.routes.research.research_stream", new=_noop_research_stream),
+    ):
+        r = await client.post(
+            "/api/research",
+            json={
+                "question": "Q",
+                "time_limit_minutes": 15,
+                "depth": "light",
+                "scope": {"folder_ids": [str(uuid.uuid4())]},
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert r.status_code == 422
+
+
+async def test_start_research_rejects_unavailable_folder(client, admin_token, unavailable_folder):
+    with (
+        patch("harbor_clerk.api.routes.research.get_settings", return_value=_make_settings()),
+        patch("harbor_clerk.api.routes.research.research_stream", new=_noop_research_stream),
+    ):
+        r = await client.post(
+            "/api/research",
+            json={
+                "question": "Q",
+                "time_limit_minutes": 15,
+                "depth": "light",
+                "scope": {"folder_ids": [str(unavailable_folder.folder_id)]},
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert r.status_code == 422

--- a/tests/test_scope_spec_schema.py
+++ b/tests/test_scope_spec_schema.py
@@ -1,0 +1,44 @@
+"""Tests for the ScopeSpec Pydantic schema."""
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from harbor_clerk.api.schemas.scope import ScopeSpec
+
+
+def test_empty_scope_spec_round_trips():
+    """ScopeSpec() = empty = no restriction. Round-trips to/from {}."""
+    spec = ScopeSpec()
+    assert spec.folder_ids is None
+    assert spec.model_dump(exclude_none=True) == {}
+
+
+def test_scope_spec_with_folder_ids():
+    folder_id = uuid.uuid4()
+    spec = ScopeSpec(folder_ids=[folder_id])
+    assert spec.folder_ids == [folder_id]
+
+
+def test_scope_spec_accepts_empty_folder_ids_list():
+    """An explicit empty list is valid and equivalent to None per the spec."""
+    spec = ScopeSpec(folder_ids=[])
+    assert spec.folder_ids == []
+
+
+def test_scope_spec_ignores_unknown_keys():
+    """Future axes (collection_ids, doc_ids, etc.) sent by newer clients to an older
+    server must parse without error. extra='ignore' guarantees forward-compat."""
+    spec = ScopeSpec.model_validate(
+        {"folder_ids": [str(uuid.uuid4())], "collection_ids": ["future-key"], "extra_weirdness": 42}
+    )
+    assert spec.folder_ids is not None
+    # The unknown keys are silently dropped.
+    assert "collection_ids" not in spec.model_dump()
+
+
+def test_scope_spec_rejects_non_uuid_folder_ids():
+    """Bad UUIDs should fail validation cleanly with 422."""
+    with pytest.raises(ValidationError):
+        ScopeSpec(folder_ids=["not-a-uuid"])

--- a/tests/test_search_route_scope.py
+++ b/tests/test_search_route_scope.py
@@ -1,0 +1,47 @@
+"""Tests for scope on POST /api/search."""
+
+import uuid
+
+
+async def test_search_with_no_scope_returns_all(client, admin_token, two_folder_corpus):
+    r = await client.post(
+        "/api/search",
+        json={"query": "doc"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    # Without scope, both folders' docs may appear in results
+    doc_ids = {h["doc_id"] for h in r.json()["hits"]}
+    # Just confirm we got some results (don't assert exact count — depends on corpus state)
+    assert len(doc_ids) >= 0  # tautology; real assertion is the scoped one below
+
+
+async def test_search_with_folder_scope_restricts(client, admin_token, two_folder_corpus):
+    folder_a, _, docs_in_a, _ = two_folder_corpus
+    r = await client.post(
+        "/api/search",
+        json={"query": "doc", "scope": {"folder_ids": [str(folder_a.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    expected = {str(d.doc_id) for d in docs_in_a}
+    returned = {h["doc_id"] for h in r.json()["hits"]}
+    assert returned.issubset(expected)
+
+
+async def test_search_rejects_unknown_folder_id(client, admin_token):
+    r = await client.post(
+        "/api/search",
+        json={"query": "x", "scope": {"folder_ids": [str(uuid.uuid4())]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_search_rejects_unavailable_folder(client, admin_token, unavailable_folder):
+    r = await client.post(
+        "/api/search",
+        json={"query": "x", "scope": {"folder_ids": [str(unavailable_folder.folder_id)]}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422

--- a/tests/test_user_scope_dataclass.py
+++ b/tests/test_user_scope_dataclass.py
@@ -1,0 +1,45 @@
+"""Tests for UserScope and Principal.user_scope."""
+
+import uuid
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import UserScope
+
+
+def test_user_scope_defaults():
+    """Empty UserScope means no restriction (matches KeyScope semantics)."""
+    scope = UserScope()
+    assert scope.folder_ids is None
+    assert scope.is_unrestricted is True
+
+
+def test_user_scope_is_unrestricted_with_empty_list():
+    """folder_ids=[] also unrestricted (matches KeyScope)."""
+    scope = UserScope(folder_ids=[])
+    assert scope.is_unrestricted is True
+
+
+def test_user_scope_with_folders_is_restricted():
+    folder_id = uuid.uuid4()
+    scope = UserScope(folder_ids=[folder_id])
+    assert scope.is_unrestricted is False
+    assert scope.folder_ids == [folder_id]
+
+
+def test_principal_user_scope_defaults_to_none():
+    """API-key principals carry key_scope; user principals carry user_scope. Both default None."""
+    p = Principal(type="user", id=uuid.uuid4(), role="user")
+    assert p.user_scope is None
+    assert p.key_scope is None
+
+
+def test_principal_can_carry_user_scope():
+    folder_id = uuid.uuid4()
+    p = Principal(
+        type="user",
+        id=uuid.uuid4(),
+        role="user",
+        user_scope=UserScope(folder_ids=[folder_id]),
+    )
+    assert p.user_scope is not None
+    assert p.user_scope.folder_ids == [folder_id]

--- a/tests/test_visible_doc_ids_user_scope.py
+++ b/tests/test_visible_doc_ids_user_scope.py
@@ -1,0 +1,43 @@
+"""Tests for _visible_doc_ids honoring user_scope alongside key_scope."""
+
+import pytest
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.scope import UserScope
+from harbor_clerk.mcp_server import _visible_doc_ids
+
+
+@pytest.mark.asyncio
+async def test_visible_doc_ids_user_principal_no_scope_returns_none(db_session, admin_user, two_folder_corpus):
+    """User principal with no user_scope → None (unrestricted)."""
+    p = Principal(type="user", id=admin_user.user_id, role="user")
+    visible = await _visible_doc_ids(db_session, p)
+    assert visible is None
+
+
+@pytest.mark.asyncio
+async def test_visible_doc_ids_user_principal_with_empty_scope_returns_none(db_session, admin_user, two_folder_corpus):
+    """user_scope with folder_ids=[] is unrestricted."""
+    p = Principal(
+        type="user",
+        id=admin_user.user_id,
+        role="user",
+        user_scope=UserScope(folder_ids=[]),
+    )
+    visible = await _visible_doc_ids(db_session, p)
+    assert visible is None
+
+
+@pytest.mark.asyncio
+async def test_visible_doc_ids_user_principal_with_folder_scope_restricts(db_session, admin_user, two_folder_corpus):
+    """user_scope with folder_ids returns only docs in those folders."""
+    folder_a, _, docs_in_a, _ = two_folder_corpus
+    p = Principal(
+        type="user",
+        id=admin_user.user_id,
+        role="user",
+        user_scope=UserScope(folder_ids=[folder_a.folder_id]),
+    )
+    visible = await _visible_doc_ids(db_session, p)
+    expected = {d.doc_id for d in docs_in_a}
+    assert visible == expected


### PR DESCRIPTION
## Summary

Adds user-driven folder scoping to the three local tools (Ask, Research, Search). Closes the human-side of the long-deferred Projects/Collections work — task #97 — by shipping just the folder-filter half. Saved/named scopes (real "Collections") remain a separate future feature, but the API and DB shape leaves room for them to be added additively with no migration.

The backend reuses the same `KeyScope.scope_folder_ids` semantics already in place for API keys — empty/None = no restriction; non-empty = OR-across-axes filter via a shared `_folder_watched_doc_ids_subquery` helper. The frontend exposes a `<FolderPicker>` in each tool's existing config surface and a read-only `<ScopeChip>` in conversation headers / research detail.

**Spec:** `docs/superpowers/specs/2026-05-27-folder-scope-for-local-tools-design.md`
**Plan:** `docs/superpowers/plans/2026-05-27-folder-scope-for-local-tools.md` (19 tasks, subagent-driven)

## What's in scope

- **Ask:** scope set at conversation creation; immutable for the conversation. Header chip shows active scope ("Folders: All" by default).
- **Research:** scope set at run start; immutable for the run. Detail view shows the chip.
- **Search:** per-request filter alongside language / MIME / date. Per-page-session only.
- **MCP enforcement:** API-key scoping path unchanged; the chat/research path threads `UserScope` onto `Principal` so every existing MCP tool body sees it via `_visible_doc_ids` with no per-tool change.

## What's intentionally out of scope

- Saved / named scopes (= "Collections" proper) — separate future feature.
- Topic-axis user filter (`KeyScope.scope_topic_ids` exists; can be added without redesign).
- Mid-conversation scope change — no `PATCH /chat/conversations`. Start a new conversation to change scope.
- Sub-folder doc-level inclusion / exclusion.

## API surface

All four new request bodies use the same `ScopeSpec` wrapper with `extra="ignore"` so future axes (`collection_ids`, `doc_ids`, `topic_ids`) parse silently on older servers:

```json
{ "scope": { "folder_ids": ["uuid", "uuid"] } }
```

Storage: new JSONB columns `conversations.scope` and `research_state.scope` (NOT NULL DEFAULT `'{}'`). Migration `0005_user_scope_columns`.

## Forward compatibility

When Collections ships later:

1. Add `collections` table + join.
2. Add `collection_ids: list[uuid.UUID]` to `ScopeSpec` — additive, no breakage.
3. Add `apply_collection_scope` next to `apply_folder_scope`, OR'd into `apply_key_scope` the same way folder is today.
4. Replace `<FolderPicker>` with a `<ScopePicker>` showing folders + collections side-by-side.
5. No migration on existing `conversations.scope` / `research_state.scope` rows.

## Tests

- **Python:** 1265 passed, 15 skipped. New tests cover the filter helper, UserScope, ScopeSpec, `_visible_doc_ids` user path, `execute_tool` user_scope, the three route handlers (chat/research/search), the chat engine threading, the research engine threading, and the previously-uncovered combined topic+folder axes path in `apply_key_scope`.
- **Frontend:** 15 passed (3 test files). New tests cover `useWatchedFolders`, `FolderPicker` (8 tests across all visual states + interactions), and `ScopeChip`.
- **Lint / typecheck / format:** ruff + ESLint + tsc + prettier all clean on the touched files. No new warnings.

## Fresh-eyes review findings addressed

A `feature-dev:code-reviewer` pass against the branch tip flagged three issues ≥80 confidence, all fixed in the final commit (`04861bd`):

1. `apply_key_scope` was using `.whereclause` extraction (semi-internal SQLAlchemy property) — replaced with a shared `_folder_watched_doc_ids_subquery` helper consumed by both `apply_folder_scope` and the API-key folder branch. Test for combined topic+folder axes added (previously uncovered).
2. `POST /passages/read` REST endpoint was missing a `user_scope` enforcement branch. Added defensively — `get_current_principal` doesn't populate `user_scope` for REST endpoints today, but the gap matches spec intent for chunk-level filtering.
3. Chat header `<ScopeChip>` was suppressed when scope was empty. Spec requires it to always render so users see "Folders: All" for unscoped conversations.

## Test plan

- [x] CI: python lint/format + pytest + frontend lint/typecheck/prettier
- [x] Full pytest (1265 passed, 0 failures) — `uv run pytest --ignore=tests/integration`
- [x] Full frontend vitest (15 passed) — `cd frontend && npm test -- --run`
- [x] ruff check + format check clean
- [x] Frontend lint + typecheck + prettier clean
- [x] Fresh-eyes code-reviewer pass — three findings addressed
- [ ] **Manual UI verification** (not done in this PR — user has the running stack):
  - Open Ask → start a new conversation with one folder selected → ask a question → verify only that folder's docs are cited; header chip reads "Folders: <name>"
  - Start a second conversation unscoped → header chip reads "Folders: All"
  - Start a Research run scoped to one folder → verify detail view shows the scope chip
  - On Search → filter by one folder → verify result count drops
  - With a scoped API key minted against the same folder → verify MCP-side and human-side results are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
