### PR TITLE
chore: npm audit fix + Swift String(contentsOf:) deprecation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -70,7 +70,7 @@ final class PostgresService: ManagedService {
         // agent.ensureInstalled) handles the lingering instance.
         let pidFile = dataDir.appendingPathComponent("postmaster.pid")
         if fm.fileExists(atPath: pidFile.path) {
-            let action = Self.stalePidAction(pidFileContents: try? String(contentsOf: pidFile))
+            let action = Self.stalePidAction(pidFileContents: try? String(contentsOf: pidFile, encoding: .utf8))
             switch action {
             case .remove(let pid):
                 try? fm.removeItem(at: pidFile)


### PR DESCRIPTION
## Summary

Two small hygiene fixes surfaced by a fresh `npm audit` and a `make clean && make all` run on `main`:

1. **`brace-expansion` moderate CVE** (GHSA-jxxr-4gwj-5jf2) — DoS via maliciously crafted brace patterns. Pulled in transitively by `eslint → minimatch → brace-expansion`. Patched via `npm audit fix` (3-line `package-lock.json` bump). Dev-dependency only — never shipped in the production bundle — but worth keeping the audit table clean.

2. **`String(contentsOf:)` deprecation in `PostgresService.swift`** — macOS 15 deprecated the implicit-encoding form. Adds `encoding: .utf8` per Apple's guidance. `postmaster.pid` is ASCII so the decoding is safe and matches the previous implicit behavior. Quiets the one Swift warning emitted during a clean macOS app rebuild.

## Verification

- `cd frontend && npm audit` → `found 0 vulnerabilities`
- `cd macos && make clean && make all` → `** BUILD SUCCEEDED **` (3.2G server app, 2.1M client app); the prior Swift deprecation warning is gone.

## Why two commits, one PR

Both are one-line touches; bundling them avoids two trivial PRs. The history keeps them separate so a future bisect can attribute changes cleanly.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] Full `make clean && make all` on macOS — no new warnings introduced; previous Swift deprecation gone
- [ ] CI: python + frontend + container-scan + dependency-audit + codeql

🤖 Generated with [Claude Code](https://claude.com/claude-code)
