### PR TITLE
fix(observatory): scrollable topic list in Document Clusters

### DIFF
--- a/frontend/src/components/stats/TopicKeywords.tsx
+++ b/frontend/src/components/stats/TopicKeywords.tsx
@@ -15,7 +15,7 @@ export default function TopicKeywords({ topics }: { topics: TopicCluster[] }) {
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-[36rem] overflow-y-auto pr-1">
       {topics.map((topic) => (
         <div key={topic.cluster_id} className="rounded-lg bg-(--color-bg-secondary) p-3">
           <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary

- The topic-cluster grid in Observatory → Document Clusters was rendering one card per topic with no scroll constraint, so on larger corpora the list pushed every panel below it off the page.
- Cap the grid at \`max-h-[36rem]\` (~576px, ~5 rows in 3-col layout = 15 cards visible) with \`overflow-y-auto\` so the rest of the dashboard stays reachable. \`pr-1\` keeps the scrollbar from overlapping the rightmost card.

## Test plan

- [ ] Observatory → Document Clusters renders the topic list with an internal scrollbar when there are more topics than fit
- [ ] List still expands responsively (1 col / 2 col / 3 col across breakpoints)
- [ ] The "No topics" empty state is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)