### PR TITLE
fix(api-keys): one time-range selector drives the whole activity dashboard

### DIFF
--- a/frontend/src/pages/ApiKeyDashboardPage.tsx
+++ b/frontend/src/pages/ApiKeyDashboardPage.tsx
@@ -55,9 +55,7 @@ interface RequestPage {
 
 /* ---------- constants ---------- */
 
-const REQUEST_RANGES = ['1h', '6h', '12h', '24h', '7d', '30d'] as const
-const ERROR_RANGES = ['1h', '24h', '7d'] as const
-const DENIAL_RANGES = ['1h', '24h', '7d'] as const
+const RANGES = ['1h', '6h', '12h', '24h', '7d', '30d'] as const
 const PAGE_SIZES = [25, 50, 100, 200] as const
 
 /* ---------- helpers ---------- */
@@ -94,11 +92,9 @@ export default function ApiKeyDashboardPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
-  // card dropdown selections
-  const [reqRange, setReqRange] = useState<string>('24h')
-  const [errRange, setErrRange] = useState<string>('7d')
-  const [denRange, setDenRange] = useState<string>('7d')
-  const [rlRange, setRlRange] = useState<string>('7d')
+  // Single time-range selector drives every count card and the tool-breakdown
+  // chart. The 30-day timeline and the request log have their own controls.
+  const [range, setRange] = useState<string>('24h')
 
   // request log filters + pagination
   const [logPage, setLogPage] = useState(1)
@@ -197,7 +193,7 @@ export default function ApiKeyDashboardPage() {
     )
   }
 
-  const hasData = usage && (usage.requests['24h'] > 0 || usage.requests['30d'] > 0 || timeline.length > 0)
+  const hasData = usage && (usage.requests[range] > 0 || usage.requests['30d'] > 0 || timeline.length > 0)
 
   // Collect unique endpoints from top_tools across all ranges for filter dropdown
   const allEndpoints = usage
@@ -280,87 +276,50 @@ export default function ApiKeyDashboardPage() {
 
       {usage && (
         <>
+          {/* Unified time range — drives every count card and the tool-breakdown chart */}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-semibold text-(--color-text-primary)">Activity</h2>
+            <label className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+              Time range
+              <select
+                value={range}
+                onChange={(e) => setRange(e.target.value)}
+                className="rounded border-0 bg-(--color-bg-secondary) px-2 py-1 text-xs"
+              >
+                {RANGES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
           {/* Summary cards */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
             {/* Requests card */}
             <Card className="p-4">
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Requests</span>
-                <select
-                  value={reqRange}
-                  onChange={(e) => setReqRange(e.target.value)}
-                  className="rounded border-0 bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs"
-                >
-                  {REQUEST_RANGES.map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <p className="mt-2 text-2xl font-bold">{usage.requests[reqRange] ?? 0}</p>
+              <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Requests</span>
+              <p className="mt-2 text-2xl font-bold">{usage.requests[range] ?? 0}</p>
             </Card>
 
             {/* Errors card */}
-            <Card className={`p-4 ${(usage.errors[errRange] ?? 0) > 0 ? 'bg-red-50 dark:bg-red-900/10' : ''}`}>
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Errors</span>
-                <select
-                  value={errRange}
-                  onChange={(e) => setErrRange(e.target.value)}
-                  className="rounded border-0 bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs"
-                >
-                  {ERROR_RANGES.map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <p className="mt-2 text-2xl font-bold text-red-600 dark:text-red-400">{usage.errors[errRange] ?? 0}</p>
+            <Card className={`p-4 ${(usage.errors[range] ?? 0) > 0 ? 'bg-red-50 dark:bg-red-900/10' : ''}`}>
+              <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Errors</span>
+              <p className="mt-2 text-2xl font-bold text-red-600 dark:text-red-400">{usage.errors[range] ?? 0}</p>
             </Card>
 
             {/* Denials card */}
-            <Card className={`p-4 ${(usage.denials[denRange] ?? 0) > 0 ? 'bg-amber-50 dark:bg-amber-900/10' : ''}`}>
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Denials</span>
-                <select
-                  value={denRange}
-                  onChange={(e) => setDenRange(e.target.value)}
-                  className="rounded border-0 bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs"
-                >
-                  {DENIAL_RANGES.map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <p className="mt-2 text-2xl font-bold text-amber-600 dark:text-amber-400">
-                {usage.denials[denRange] ?? 0}
-              </p>
+            <Card className={`p-4 ${(usage.denials[range] ?? 0) > 0 ? 'bg-amber-50 dark:bg-amber-900/10' : ''}`}>
+              <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Denials</span>
+              <p className="mt-2 text-2xl font-bold text-amber-600 dark:text-amber-400">{usage.denials[range] ?? 0}</p>
             </Card>
 
             {/* Rate Limited card */}
-            <Card
-              className={`p-4 ${(usage.rate_limited[rlRange] ?? 0) > 0 ? 'bg-orange-50 dark:bg-orange-900/20' : ''}`}
-            >
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Rate Limited</span>
-                <select
-                  value={rlRange}
-                  onChange={(e) => setRlRange(e.target.value)}
-                  className="rounded border-0 bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs"
-                >
-                  {DENIAL_RANGES.map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            <Card className={`p-4 ${(usage.rate_limited[range] ?? 0) > 0 ? 'bg-orange-50 dark:bg-orange-900/20' : ''}`}>
+              <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Rate Limited</span>
               <p className="mt-2 text-2xl font-bold text-orange-600 dark:text-orange-400">
-                {usage.rate_limited[rlRange] ?? 0}
+                {usage.rate_limited[range] ?? 0}
               </p>
             </Card>
 
@@ -395,25 +354,12 @@ export default function ApiKeyDashboardPage() {
               )}
             </Card>
 
-            {/* Tool breakdown */}
+            {/* Tool breakdown — uses the unified time range from the Activity header above */}
             <Card className="p-4">
-              <div className="mb-3 flex items-center justify-between">
-                <h2 className="text-sm font-semibold">Tool breakdown</h2>
-                <select
-                  value={reqRange}
-                  onChange={(e) => setReqRange(e.target.value)}
-                  className="rounded border-0 bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs"
-                >
-                  {REQUEST_RANGES.map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              {(usage.top_tools[reqRange] ?? []).length > 0 ? (
+              <h2 className="mb-3 text-sm font-semibold">Tool breakdown</h2>
+              {(usage.top_tools[range] ?? []).length > 0 ? (
                 <ResponsiveContainer width="100%" height={240}>
-                  <BarChart data={usage.top_tools[reqRange]} layout="vertical">
+                  <BarChart data={usage.top_tools[range]} layout="vertical">
                     <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
                     <YAxis dataKey="endpoint" type="category" width={140} tick={{ fontSize: 11 }} />
                     <Tooltip />

--- a/src/harbor_clerk/api/routes/api_keys.py
+++ b/src/harbor_clerk/api/routes/api_keys.py
@@ -265,35 +265,33 @@ async def get_key_usage(
     ts = ApiRequestLog.created_at
     st = ApiRequestLog.status
 
-    # Single query: all request/error/denial counts + last_used via FILTER (WHERE ...)
-    request_buckets = {"1h": 1, "6h": 6, "12h": 12, "24h": 24, "7d": 168, "30d": 720}
-    error_buckets = {"1h": 1, "24h": 24, "7d": 168}
+    # Single query: all request/error/denial counts + last_used via FILTER (WHERE ...).
+    # All metrics share the same bucket set so a single time-range selector on the
+    # frontend can drive every panel coherently.
+    buckets = {"1h": 1, "6h": 6, "12h": 12, "24h": 24, "7d": 168, "30d": 720}
 
     columns = [func.max(ts).label("last_used")]
     labels = ["last_used"]
-    for label, hours in request_buckets.items():
+    for label, hours in buckets.items():
         cutoff = now - timedelta(hours=hours)
         columns.append(func.count(ApiRequestLog.request_id).filter(ts >= cutoff).label(f"req_{label}"))
-        labels.append(f"req_{label}")
-    for label, hours in error_buckets.items():
-        cutoff = now - timedelta(hours=hours)
         columns.append(func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "error").label(f"err_{label}"))
         columns.append(func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "denied").label(f"den_{label}"))
         columns.append(
             func.count(ApiRequestLog.request_id).filter(ts >= cutoff, st == "rate_limited").label(f"rl_{label}")
         )
-        labels.extend([f"err_{label}", f"den_{label}", f"rl_{label}"])
+        labels.extend([f"req_{label}", f"err_{label}", f"den_{label}", f"rl_{label}"])
 
     row = (await session.execute(select(*columns).where(ApiRequestLog.api_key_id == key_id))).one()
 
-    requests = {label: getattr(row, f"req_{label}") for label in request_buckets}
-    errors = {label: getattr(row, f"err_{label}") for label in error_buckets}
-    denials = {label: getattr(row, f"den_{label}") for label in error_buckets}
-    rate_limited = {label: getattr(row, f"rl_{label}") for label in error_buckets}
+    requests = {label: getattr(row, f"req_{label}") for label in buckets}
+    errors = {label: getattr(row, f"err_{label}") for label in buckets}
+    denials = {label: getattr(row, f"den_{label}") for label in buckets}
+    rate_limited = {label: getattr(row, f"rl_{label}") for label in buckets}
 
     # Top tools: single query with FILTER per bucket, sort/limit in Python
     tool_columns = [ApiRequestLog.endpoint]
-    for label, hours in request_buckets.items():
+    for label, hours in buckets.items():
         cutoff = now - timedelta(hours=hours)
         tool_columns.append(func.count(ApiRequestLog.request_id).filter(ts >= cutoff).label(f"cnt_{label}"))
     tool_rows = (
@@ -305,7 +303,7 @@ async def get_key_usage(
     ).all()
 
     top_tools: dict[str, list[dict[str, object]]] = {}
-    for label in request_buckets:
+    for label in buckets:
         col = f"cnt_{label}"
         ranked = sorted(
             [(r.endpoint, getattr(r, col)) for r in tool_rows if getattr(r, col) > 0],

--- a/tests/test_api_request_log_endpoints.py
+++ b/tests/test_api_request_log_endpoints.py
@@ -23,6 +23,11 @@ async def test_usage_summary_empty(client, admin_token):
     resp = await client.get(f"/api/api-keys/{key_id}/usage", headers=auth_header(admin_token))
     assert resp.status_code == 200
     data = resp.json()
+    # All four metric maps share the same bucket set so a single unified time-range
+    # selector on the frontend can drive every panel.
+    expected_buckets = {"1h", "6h", "12h", "24h", "7d", "30d"}
+    for metric in ("requests", "errors", "denials", "rate_limited", "top_tools"):
+        assert set(data[metric].keys()) == expected_buckets, f"{metric} missing buckets"
     assert data["requests"]["1h"] == 0
     assert data["requests"]["30d"] == 0
     assert data["errors"]["7d"] == 0


### PR DESCRIPTION
## Summary

- Five independent dropdowns on the API Key dashboard (one per count card + one on the tool-breakdown chart) made it impossible to read the activity panels as a coherent "what happened in the last X" snapshot. The cards also used non-equal range sets (requests = 6 buckets, errors/denials/rate_limited = 3 buckets), so picking matching ranges across them required juggling.
- Collapse to a single "Time range" selector in an Activity header above the cards. Backend now computes errors / denials / rate_limited for the same 6 buckets as requests (single query, 9 extra `COUNT(...) FILTER` aggregates).
- Removed `ERROR_RANGES` / `DENIAL_RANGES` constants and the four per-card range states on the frontend; all panels driven by one `range` state.

## Out of scope

- The 30-day Requests-over-time chart and the Request log (which has its own endpoint/status/date filters) are unaffected — they have their own controls and weren't part of the unification ask.

## Test plan

- [ ] CI runs `tests/test_api_request_log_endpoints.py::test_usage_summary_empty` on Python 3.14+ — extended to assert every metric (requests, errors, denials, rate_limited, top_tools) exposes the unified bucket set `{1h, 6h, 12h, 24h, 7d, 30d}`.
- [ ] **Manual UI check needed after rebuild:** local menubar HC is on pre-PR code; I could not run a live browser pass. After merge + rebuild, verify (a) one selector above the cards, (b) all four count cards + tool breakdown update together when range changes, (c) Last Used + 30d timeline + Request log are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
