### PR TITLE
fix(folders): show "Processing" pill while ingest jobs are in flight

### DIFF
--- a/frontend/src/hooks/useFolderProgress.ts
+++ b/frontend/src/hooks/useFolderProgress.ts
@@ -6,6 +6,7 @@ export interface FolderProgressEvent {
   total_files: number
   completed_files: number
   scan_status: 'scanning' | 'idle'
+  ingest_status: 'processing' | 'idle'
 }
 
 type Listener = (event: FolderProgressEvent) => void

--- a/frontend/src/pages/FoldersPage.tsx
+++ b/frontend/src/pages/FoldersPage.tsx
@@ -31,6 +31,7 @@ interface ProgressInfo {
   completed_files: number
   by_stage: Record<string, StageCounts>
   scan_status: 'scanning' | 'idle'
+  ingest_status: 'processing' | 'idle'
   last_scan_at: string | null
 }
 
@@ -48,11 +49,12 @@ function errorMessage(e: unknown, fallback: string): string {
   return fallback
 }
 
-// Precedence: a disabled folder shouldn't show "scanning" even if a stale scan is in flight.
+// Precedence: a disabled folder shouldn't show "scanning" or "processing" even
+// if a stale scan is in flight or jobs are still draining.
 function mapFolderStatusToPillState(f: FolderInfo, p?: ProgressInfo): PillState {
   if (f.unavailable_reason) return 'error'
   if (!f.enabled) return 'idle'
-  if (p?.scan_status === 'scanning') return 'running'
+  if (p?.scan_status === 'scanning' || p?.ingest_status === 'processing') return 'running'
   return 'active'
 }
 
@@ -61,6 +63,7 @@ function mapFolderStatusLabel(f: FolderInfo, p?: ProgressInfo): string {
   if (f.unavailable_reason) return 'unavailable'
   if (!f.enabled) return 'disabled'
   if (p?.scan_status === 'scanning') return 'scanning'
+  if (p?.ingest_status === 'processing') return 'processing'
   return 'idle'
 }
 
@@ -163,6 +166,7 @@ export default function FoldersPage() {
           total_files: event.total_files,
           completed_files: event.completed_files,
           scan_status: event.scan_status,
+          ingest_status: event.ingest_status,
         },
       }
     })

--- a/src/harbor_clerk/api/routes/watch.py
+++ b/src/harbor_clerk/api/routes/watch.py
@@ -184,11 +184,13 @@ async def _folder_progress_event_generator(session_factory=None):
     """
     if session_factory is None:
         session_factory = async_session_factory
-    prev: dict[str, tuple[int, int, str]] = {}
+    prev: dict[str, tuple[int, int, str, str]] = {}
     try:
         while True:
             async with session_factory() as sess:
-                # Per-folder counts: total active files + finalize-done jobs
+                # Per-folder counts: total active files + finalize-done jobs +
+                # in-flight (queued OR running) jobs across any stage. The
+                # in_flight count drives the "processing" pill on the frontend.
                 stmt = (
                     select(
                         WatchedFolder.folder_id,
@@ -202,6 +204,9 @@ async def _folder_progress_event_generator(session_factory=None):
                             IngestionJob.status == JobStatus.done,
                         )
                         .label("done"),
+                        func.count(IngestionJob.job_id)
+                        .filter(IngestionJob.status.in_((JobStatus.queued, JobStatus.running)))
+                        .label("in_flight"),
                     )
                     .outerjoin(WatchedFile, WatchedFile.folder_id == WatchedFolder.folder_id)
                     .outerjoin(IngestionJob, IngestionJob.doc_id == WatchedFile.doc_id)
@@ -209,9 +214,10 @@ async def _folder_progress_event_generator(session_factory=None):
                 )
                 rows = (await sess.execute(stmt)).all()
 
-            for fid, last_scan, total, done in rows:
+            for fid, last_scan, total, done, in_flight in rows:
                 scan_status = "scanning" if last_scan is None else "idle"
-                snap = (total or 0, done or 0, scan_status)
+                ingest_status = "processing" if (in_flight or 0) > 0 else "idle"
+                snap = (total or 0, done or 0, scan_status, ingest_status)
                 fid_str = str(fid)
                 if prev.get(fid_str) != snap:
                     prev[fid_str] = snap
@@ -223,6 +229,7 @@ async def _folder_progress_event_generator(session_factory=None):
                                 "total_files": snap[0],
                                 "completed_files": snap[1],
                                 "scan_status": snap[2],
+                                "ingest_status": snap[3],
                             }
                         )
                         + "\n\n"
@@ -303,12 +310,17 @@ async def get_folder_progress(
             by_stage[stage.value][status_map[status]] = count
 
     completed = by_stage[JobStage.finalize.value]["done"]
+    # A folder is "processing" while any stage has work queued or running for one
+    # of its files; otherwise "idle". scan_status (the filesystem walk) is
+    # independent of this — both can be true at once on a first-add.
+    in_flight = sum(counts["pending"] + counts["running"] for counts in by_stage.values())
 
     return {
         "total_files": total or 0,
         "completed_files": completed,
         "by_stage": by_stage,
         "scan_status": "scanning" if folder.last_scan_at is None else "idle",
+        "ingest_status": "processing" if in_flight > 0 else "idle",
         "last_scan_at": folder.last_scan_at.isoformat() if folder.last_scan_at else None,
     }
 

--- a/tests/test_api_watch.py
+++ b/tests/test_api_watch.py
@@ -114,6 +114,8 @@ async def test_folder_progress_aggregates(client, admin_token, db_session):
     assert body["by_stage"]["ocr"]["error"] == 1
     assert body["by_stage"]["chunk"]["pending"] == 1
     assert body["scan_status"] == "scanning"  # last_scan_at is null
+    # File A has ocr.running + chunk.queued — in-flight count > 0 → processing.
+    assert body["ingest_status"] == "processing"
 
 
 async def test_folder_progress_404_for_unknown(client, admin_token):
@@ -139,6 +141,45 @@ async def test_folder_progress_empty_folder(client, admin_token, db_session):
     # All 7 stages × 4 states should still be present, all zero
     for stage in ("extract", "ocr", "chunk", "entities", "embed", "summarize", "finalize"):
         assert body["by_stage"][stage] == {"pending": 0, "running": 0, "done": 0, "error": 0}
+    # No jobs means nothing in flight.
+    assert body["ingest_status"] == "idle"
+
+
+async def test_folder_progress_ingest_status_idle_when_only_done_or_error(client, admin_token, db_session):
+    """Folder with finished + errored jobs only (no pending/running) reports idle."""
+    folder = WatchedFolder(path="/tmp/done", display_name="done", bookmark_data=None)
+    db_session.add(folder)
+    await db_session.flush()
+    sha = b"d" * 32
+    doc = Document(title="d", status="active", sha256=sha, pipeline_status=PipelineStatus.queued)
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(
+        WatchedFile(
+            folder_id=folder.folder_id,
+            relative_path="d",
+            bookmark_data=b"",
+            sha256=sha,
+            doc_id=doc.doc_id,
+            status=WatchedFileStatus.active,
+        )
+    )
+    db_session.add_all(
+        [
+            IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.done),
+            IngestionJob(doc_id=doc.doc_id, stage=JobStage.ocr, status=JobStatus.error),
+            IngestionJob(doc_id=doc.doc_id, stage=JobStage.finalize, status=JobStatus.done),
+        ]
+    )
+    await db_session.flush()
+
+    resp = await client.get(
+        f"/api/watch/folders/{folder.folder_id}/progress",
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ingest_status"] == "idle"
 
 
 async def test_folder_progress_scan_status_idle(client, admin_token, db_session):
@@ -368,6 +409,7 @@ async def test_folder_progress_stream_emits_initial_snapshot(_engine, db_session
         assert "total_files" in payload
         assert "completed_files" in payload
         assert payload["scan_status"] in ("scanning", "idle")
+        assert payload["ingest_status"] in ("processing", "idle")
     finally:
         # Cleanup the seeded folder so it doesn't leak across tests
         from sqlalchemy import delete as sa_delete


### PR DESCRIPTION
## Summary

- The Folders page status pill only reflected `scan_status` (filesystem walk: scanning vs idle), so a folder full of pending or running extract/ocr/chunk/embed/summarize jobs would still read as **Idle**. Drop a corpus into a folder, the indicator settles to "idle" almost immediately, hiding the fact that the actual ingest pipeline is still grinding.
- Backend exposes a new `ingest_status` field on `GET /api/watch/folders/{id}/progress` and on each SSE delta from `/api/watch/folders/stream`. Value is `"processing"` whenever any IngestionJob row for one of this folder's documents is in `queued` or `running` state, otherwise `"idle"`.
- Frontend (FoldersPage + useFolderProgress) reads the field from both the initial GET and the SSE stream. The status pill now shows `running` when scanning OR processing; the label distinguishes them.

## Precedence (unchanged from existing UX)

`unavailable` → `disabled` → `scanning` → `processing` → `idle`. A disabled folder still suppresses both scanning and processing — jobs may continue to drain in the background, but the folder is "out of scope" from the user's perspective.

## Test plan

- [x] `tests/test_api_watch.py` (21 tests, all pass locally on Py 3.12): `test_folder_progress_aggregates` now asserts `ingest_status == "processing"` for the in-flight fixture; new `test_folder_progress_ingest_status_idle_when_only_done_or_error` covers the done+error case; `test_folder_progress_empty_folder` and `test_folder_progress_stream_emits_initial_snapshot` extended to assert the new field.
- [x] Backend ruff check + format clean. Frontend lint (0 errors, pre-existing warnings only), prettier, tsc all pass.
- [ ] **Manual UI check needed after rebuild:** local menubar HC is on pre-PR code; after merge + rebuild, drop a few files into a watched folder and confirm the pill shows "processing" until the last finalize job lands, then flips to "idle".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
