### PR TITLE
fix(scope): folder picker positioning + label disambiguation + rename

### DIFF
--- a/docs/superpowers/plans/2026-05-27-folder-picker-display-fixes.md
+++ b/docs/superpowers/plans/2026-05-27-folder-picker-display-fixes.md
@@ -1,0 +1,1094 @@
+# Folder Picker Display Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two display issues in PR #415's folder picker — popover overflow at viewport bottom and indistinguishable labels for folders sharing a basename — via a positioning bugfix, label auto-disambiguation, hover tooltips, and an operator-editable folder alias.
+
+**Architecture:** Four mostly-independent pieces in one PR. A new shared `disambiguateLabels()` utility computes unique display labels from a folder list and is consumed by both `FolderPicker` and `ScopeChip`. The picker measures viewport space on open and flips the popover upward when needed. Folder rows and chips render the disambiguated label and carry a `title=fullPath` tooltip. The Folders tab gains an inline pencil-edit affordance that calls the existing `PATCH /api/watch/folders/{id}` route, which is extended to accept `display_name`. No schema migration.
+
+**Tech Stack:** FastAPI + Pydantic v2 (backend), React 19 + TanStack Query (frontend), vitest + RTL (frontend tests), pytest (backend tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-27-folder-picker-display-fixes-design.md`
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Confirm branch state**
+
+Run: `git rev-parse --abbrev-ref HEAD && git log --oneline -1`
+Expected: branch `feat/folder-picker-display-fixes`, HEAD is `9e68dcf docs(spec): folder picker display fixes — positioning + disambiguation + alias`.
+
+- [ ] **Step 0.2: Confirm clean working tree**
+
+Run: `git status -s`
+Expected: empty (or only the pre-existing untracked CLI-experiment spec file in `docs/superpowers/specs/`).
+
+---
+
+## Task 1: Extend `FolderPatch` + `patch_folder` to accept `display_name`
+
+**Why:** The Folders-tab rename UI in Task 6 needs an API to write to. The existing PATCH route only accepts `enabled` and `last_event_id`. Add `display_name` with empty-string-reverts-to-default semantics and a length cap.
+
+**Files:**
+- Modify: `src/harbor_clerk/api/routes/watch.py:45` (FolderPatch class) and `src/harbor_clerk/api/routes/watch.py:387` (patch_folder handler body)
+- Test: `tests/test_api_watch.py` (existing file — add tests there to follow project convention)
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Add to `tests/test_api_watch.py`:
+
+```python
+async def test_patch_folder_sets_display_name(client, admin_token, two_folder_corpus):
+    """PATCH with display_name='My Folder' updates the row and returns 200."""
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "Receipts"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == "Receipts"
+
+
+async def test_patch_folder_empty_display_name_reverts_to_basename(
+    client, admin_token, two_folder_corpus
+):
+    """PATCH with display_name='' (or whitespace) writes Path(folder.path).name."""
+    from pathlib import Path
+
+    folder_a, _, _, _ = two_folder_corpus
+
+    # First alias to something custom, then clear it
+    await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "Custom"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": ""},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == Path(folder_a.path).name
+
+
+async def test_patch_folder_whitespace_display_name_reverts_to_basename(
+    client, admin_token, two_folder_corpus
+):
+    """PATCH with display_name='   ' is treated as empty → reverts."""
+    from pathlib import Path
+
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "   "},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == Path(folder_a.path).name
+
+
+async def test_patch_folder_too_long_display_name_returns_422(
+    client, admin_token, two_folder_corpus
+):
+    """display_name longer than 200 chars → 422."""
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "x" * 201},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_patch_folder_omitted_display_name_leaves_field_unchanged(
+    client, admin_token, two_folder_corpus
+):
+    """A PATCH that doesn't include display_name must not alter it."""
+    folder_a, _, _, _ = two_folder_corpus
+
+    # Set a custom alias first
+    await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "Sentinel"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    # Now PATCH only enabled
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"enabled": True},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == "Sentinel"
+```
+
+The `client`, `admin_token`, and `two_folder_corpus` fixtures are already in `tests/conftest.py` from PR #415's work — verify they exist before running.
+
+- [ ] **Step 1.2: Run the tests, verify they fail**
+
+Run: `uv run pytest tests/test_api_watch.py -v -k patch_folder`
+Expected: 5 FAILs — the existing PATCH doesn't accept `display_name`, so requests with that field either succeed without writing the field (display_name returned remains the default) or get rejected, depending on whether Pydantic's extras policy on FolderPatch ignores or forbids unknowns. Either way, the assertions fail.
+
+- [ ] **Step 1.3: Extend `FolderPatch` schema**
+
+Modify `src/harbor_clerk/api/routes/watch.py:45-47` (add the new field):
+
+```python
+class FolderPatch(BaseModel):
+    enabled: bool | None = None
+    last_event_id: int | None = None
+    display_name: str | None = None
+```
+
+- [ ] **Step 1.4: Extend `patch_folder` handler**
+
+Modify `src/harbor_clerk/api/routes/watch.py` (the `patch_folder` function around line 387). After the `last_event_id` block and before the `enabled_changed_to` notification block, add:
+
+```python
+    if body.display_name is not None:
+        from pathlib import Path
+
+        new_name = body.display_name.strip()
+        if not new_name:
+            new_name = Path(folder.path).name
+        if len(new_name) > 200:
+            raise HTTPException(status_code=422, detail="display_name exceeds 200 chars")
+        folder.display_name = new_name
+```
+
+The final shape of the function body (relevant section):
+
+```python
+    enabled_changed_to: bool | None = None
+    if body.enabled is not None and body.enabled != folder.enabled:
+        folder.enabled = body.enabled
+        enabled_changed_to = body.enabled
+    if body.last_event_id is not None:
+        folder.last_event_id = body.last_event_id
+    if body.display_name is not None:
+        from pathlib import Path
+
+        new_name = body.display_name.strip()
+        if not new_name:
+            new_name = Path(folder.path).name
+        if len(new_name) > 200:
+            raise HTTPException(status_code=422, detail="display_name exceeds 200 chars")
+        folder.display_name = new_name
+
+    if enabled_changed_to is not None:
+        action = "enabled" if enabled_changed_to else "disabled"
+        await notify_folder_change_async(session, folder.folder_id, action=action)
+
+    await session.commit()
+    return {"status": "updated"}
+```
+
+- [ ] **Step 1.5: Run the tests, verify they pass**
+
+Run: `uv run pytest tests/test_api_watch.py -v -k patch_folder`
+Expected: 5 PASS.
+
+- [ ] **Step 1.6: Regression on the broader watch suite**
+
+Run: `uv run pytest tests/test_api_watch.py -v`
+Expected: all pass — no other watch behavior changed.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add src/harbor_clerk/api/routes/watch.py tests/test_api_watch.py
+git commit -m "feat(watch): PATCH /folders/{id} accepts display_name with revert-to-basename semantics"
+```
+
+---
+
+## Task 2: `disambiguateLabels()` utility — new shared pure function
+
+**Why:** Both `FolderPicker` and `ScopeChip` need to render unique labels for folders. Centralizing this in one tested, React-free utility is cleaner than duplicating it twice.
+
+**Files:**
+- Create: `frontend/src/components/folderLabels.ts`
+- Test: `frontend/src/components/folderLabels.test.ts`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `frontend/src/components/folderLabels.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { disambiguateLabels, type FolderLike } from './folderLabels'
+
+function f(folder_id: string, path: string, display_name: string | null = null): FolderLike {
+  return { folder_id, path, display_name }
+}
+
+describe('disambiguateLabels', () => {
+  it('uses display_name as-is when no collisions', () => {
+    const folders = [
+      f('1', '/work/contracts', 'Contracts'),
+      f('2', '/work/legal', 'Legal'),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('Contracts')
+    expect(labels.get('2')).toBe('Legal')
+  })
+
+  it('walks up one path segment when two labels collide', () => {
+    const folders = [
+      f('1', '/work/cuad/ingest', 'ingest'),
+      f('2', '/work/qwen3-20b/cuad/ingest', 'ingest'),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('cuad/ingest')
+    expect(labels.get('2')).toBe('qwen3-20b/cuad/ingest')
+  })
+
+  it('extends as many segments as needed for three+ folders sharing a basename', () => {
+    const folders = [
+      f('1', '/work/cuad/ingest', 'ingest'),
+      f('2', '/work/qwen3-20b/cuad/ingest', 'ingest'),
+      f('3', '/work/gpt-oss-20b/cuad/ingest', 'ingest'),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('cuad/ingest')
+    expect(labels.get('2')).toBe('qwen3-20b/cuad/ingest')
+    expect(labels.get('3')).toBe('gpt-oss-20b/cuad/ingest')
+  })
+
+  it('mixes unique and colliding correctly', () => {
+    const folders = [
+      f('1', '/work/contracts', 'Contracts'),    // unique
+      f('2', '/work/cuad/ingest', 'ingest'),     // colliding group
+      f('3', '/work/qwen3-20b/cuad/ingest', 'ingest'),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('Contracts')
+    expect(labels.get('2')).toBe('cuad/ingest')
+    expect(labels.get('3')).toBe('qwen3-20b/cuad/ingest')
+  })
+
+  it('falls back to path basename when display_name is null', () => {
+    const folders = [
+      f('1', '/work/contracts', null),
+      f('2', '/work/legal', null),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('contracts')
+    expect(labels.get('2')).toBe('legal')
+  })
+
+  it('falls back to UUID suffix when two folders have identical paths (degenerate)', () => {
+    const folders = [
+      f('aaaaaaaa-1111-2222-3333-444444444444', '/work/dup', 'dup'),
+      f('bbbbbbbb-5555-6666-7777-888888888888', '/work/dup', 'dup'),
+    ]
+    const labels = disambiguateLabels(folders)
+    // Each label must be unique and end with a UUID suffix
+    const a = labels.get('aaaaaaaa-1111-2222-3333-444444444444')
+    const b = labels.get('bbbbbbbb-5555-6666-7777-888888888888')
+    expect(a).not.toBe(b)
+    expect(a).toContain('dup')
+    expect(b).toContain('dup')
+  })
+})
+```
+
+- [ ] **Step 2.2: Run the tests, verify they fail with module-not-found**
+
+Run: `cd frontend && npm test -- folderLabels --run`
+Expected: FAIL — `Failed to load url ./folderLabels` (module does not exist yet).
+
+- [ ] **Step 2.3: Implement the utility**
+
+Create `frontend/src/components/folderLabels.ts`:
+
+```ts
+export interface FolderLike {
+  folder_id: string
+  path: string
+  display_name: string | null
+}
+
+function basename(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts[parts.length - 1] ?? path
+}
+
+function pathSegments(path: string): string[] {
+  return path.split('/').filter(Boolean)
+}
+
+function candidate(folder: FolderLike): string {
+  if (folder.display_name && folder.display_name.trim() !== '') {
+    return folder.display_name
+  }
+  return basename(folder.path)
+}
+
+/**
+ * Build a unique display label for each folder.
+ *
+ * Default label is `display_name` (or path basename when display_name is null/empty).
+ * When two or more folders share the same default label, prepend just enough of
+ * the parent path to each so that all labels in the colliding group are unique
+ * (file-manager / VS Code tab pattern).
+ *
+ * In the degenerate case where two folders have identical paths, falls back to
+ * appending the last 6 characters of the folder UUID.
+ */
+export function disambiguateLabels(folders: FolderLike[]): Map<string, string> {
+  const labels = new Map<string, string>()
+
+  // Group by candidate label
+  const groups = new Map<string, FolderLike[]>()
+  for (const folder of folders) {
+    const key = candidate(folder)
+    const existing = groups.get(key) ?? []
+    existing.push(folder)
+    groups.set(key, existing)
+  }
+
+  for (const [key, group] of groups) {
+    if (group.length === 1) {
+      labels.set(group[0].folder_id, key)
+      continue
+    }
+
+    // Disambiguate by extending each folder's path one segment at a time
+    // until all labels in the group are unique.
+    const groupLabels = new Map<string, string>() // folder_id -> current label
+    for (const f of group) {
+      groupLabels.set(f.folder_id, key)
+    }
+
+    let depth = 2 // start with parent/basename
+    const maxDepth = Math.max(...group.map((f) => pathSegments(f.path).length))
+
+    while (depth <= maxDepth) {
+      // Recompute each group member's label at the current depth
+      const tentative = new Map<string, string>()
+      for (const f of group) {
+        const segs = pathSegments(f.path)
+        const tail = segs.slice(-depth).join('/')
+        // If candidate was a custom alias (not the basename), keep the alias
+        // as the leaf and prepend path segments above the basename.
+        // Implementation: when display_name overrides basename, replace the
+        // last segment of the slice with the alias.
+        const cand = candidate(f)
+        const segsForLabel =
+          cand === basename(f.path)
+            ? segs.slice(-depth)
+            : [...segs.slice(-depth, -1), cand]
+        tentative.set(f.folder_id, segsForLabel.join('/'))
+      }
+      // Check for uniqueness within the group
+      const seen = new Set<string>()
+      let allUnique = true
+      for (const label of tentative.values()) {
+        if (seen.has(label)) {
+          allUnique = false
+          break
+        }
+        seen.add(label)
+      }
+      if (allUnique) {
+        for (const [fid, label] of tentative) {
+          groupLabels.set(fid, label)
+        }
+        break
+      }
+      depth += 1
+    }
+
+    // If we reached maxDepth and still have collisions (e.g., identical paths),
+    // fall back to UUID suffix on the duplicates.
+    const finalSeen = new Map<string, string[]>()
+    for (const [fid, label] of groupLabels) {
+      const ids = finalSeen.get(label) ?? []
+      ids.push(fid)
+      finalSeen.set(label, ids)
+    }
+    for (const [label, ids] of finalSeen) {
+      if (ids.length > 1) {
+        for (const fid of ids) {
+          groupLabels.set(fid, `${label} (${fid.slice(-6)})`)
+        }
+      }
+    }
+
+    for (const [fid, label] of groupLabels) {
+      labels.set(fid, label)
+    }
+  }
+
+  return labels
+}
+```
+
+- [ ] **Step 2.4: Run the tests, verify they pass**
+
+Run: `cd frontend && npm test -- folderLabels --run`
+Expected: 6 PASS.
+
+- [ ] **Step 2.5: Ruff/lint check**
+
+Run: `cd frontend && npm run lint && npm run type-check`
+Expected: clean — no new errors.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add frontend/src/components/folderLabels.ts frontend/src/components/folderLabels.test.ts
+git commit -m "feat(scope): disambiguateLabels utility — shared by FolderPicker and ScopeChip"
+```
+
+---
+
+## Task 3: `FolderPicker` — popover auto-flip on viewport overflow
+
+**Why:** Popover gets clipped at the bottom of the viewport in the Ask chat input row. Detect proximity to viewport bottom and open upward when there's more room above.
+
+**Files:**
+- Modify: `frontend/src/components/FolderPicker.tsx`
+
+- [ ] **Step 3.1: Read the current FolderPicker structure**
+
+Open `frontend/src/components/FolderPicker.tsx`. Identify:
+- The trigger button (the `<button>` showing "Folders: All" / current selection).
+- The popover container (the `<div>` rendered when `open` is true).
+- The current direction classes (likely `top-full mt-1` or similar).
+
+- [ ] **Step 3.2: Add a useRef for the trigger and useState for direction**
+
+In the component body (near the existing `useState` calls), add:
+
+```tsx
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+
+// inside the component:
+const triggerRef = useRef<HTMLButtonElement>(null)
+const [popDirection, setPopDirection] = useState<'down' | 'up'>('down')
+```
+
+- [ ] **Step 3.3: Add the layout-effect that measures and chooses direction**
+
+After the existing useEffect / useState hooks, add:
+
+```tsx
+useLayoutEffect(() => {
+  if (!open || !triggerRef.current) return
+  const rect = triggerRef.current.getBoundingClientRect()
+  const popoverMaxHeight = 360 // matches the max-h cap on the popover div
+  const margin = 8
+  const spaceBelow = window.innerHeight - rect.bottom - margin
+  const spaceAbove = rect.top - margin
+  setPopDirection(
+    spaceBelow >= popoverMaxHeight || spaceBelow >= spaceAbove ? 'down' : 'up',
+  )
+}, [open])
+```
+
+- [ ] **Step 3.4: Attach the ref to the trigger button**
+
+Find the trigger `<button>` element (the one with text content `summarize(value, folders)`) and add `ref={triggerRef}` to it.
+
+- [ ] **Step 3.5: Swap popover positioning classes based on direction**
+
+Find the popover container div (the one rendered conditionally inside `{open && (...)}`). It currently has classes like `absolute top-full ... mt-1 ...`. Swap to conditional positioning:
+
+```tsx
+<div
+  className={`absolute z-30 ${
+    popDirection === 'up' ? 'bottom-full mb-1' : 'top-full mt-1'
+  } left-0 min-w-[260px] max-h-[360px] overflow-hidden rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] shadow-lg`}
+  role="listbox"
+  aria-multiselectable
+>
+  ...
+</div>
+```
+
+Keep all other props (role, aria-multiselectable, etc.) as they currently are. The key change is `bottom-full mb-1` vs `top-full mt-1` and the explicit `max-h-[360px]`.
+
+- [ ] **Step 3.6: Verify the existing FolderPicker tests still pass**
+
+Run: `cd frontend && npm test -- FolderPicker --run`
+Expected: all 8 existing tests still pass. JSDOM's `getBoundingClientRect` returns zeros, so `popDirection` will resolve to its default `'down'` in tests — the existing assertions remain valid.
+
+- [ ] **Step 3.7: Lint + typecheck**
+
+Run: `cd frontend && npm run lint && npm run type-check`
+Expected: clean.
+
+- [ ] **Step 3.8: Manual verification**
+
+Start the dev server and Harbor Clerk API:
+```bash
+cd frontend && npm run dev
+# in another terminal:
+uv run harbor-clerk-api
+```
+
+In the browser:
+1. Open the Ask page (`/`) with the window at default height. Open the folder picker via the "Folders: All" chip. Confirm the popover opens DOWNWARD and the folder list is visible/scrollable.
+2. Shrink the browser window vertically so the chat input is at the very bottom of the viewport. Open the picker. Confirm the popover now flips UPWARD and remains fully visible.
+3. Open the Research page. The folder picker is mid-page; popover should open downward.
+4. Open the Search page. Folder picker is near the top; popover should open downward.
+
+If any of those don't work, fix and re-verify before committing.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add frontend/src/components/FolderPicker.tsx
+git commit -m "fix(scope): FolderPicker popover flips upward when viewport bottom is near"
+```
+
+---
+
+## Task 4: `FolderPicker` — consume `disambiguateLabels` + add tooltips
+
+**Why:** Replace the inline `display_name ?? folder_id` rendering in `FolderPicker` rows and the `summarize()` trigger label with the new utility's output. Add `title=fullPath` on each row.
+
+**Files:**
+- Modify: `frontend/src/components/FolderPicker.tsx`
+- Test: `frontend/src/components/FolderPicker.test.tsx` (add tests, keep existing)
+
+- [ ] **Step 4.1: Write the failing tests**
+
+Append to `frontend/src/components/FolderPicker.test.tsx`:
+
+```ts
+it('disambiguates labels when two folders share display_name', () => {
+  const colliding = [
+    {
+      folder_id: 'a',
+      path: '/work/cuad/ingest',
+      display_name: 'ingest',
+      unavailable_reason: null,
+      enabled: true,
+      auto_discovered: false,
+      skipped_count: 0,
+      skipped_extensions: [],
+    },
+    {
+      folder_id: 'b',
+      path: '/work/qwen3-20b/cuad/ingest',
+      display_name: 'ingest',
+      unavailable_reason: null,
+      enabled: true,
+      auto_discovered: false,
+      skipped_count: 0,
+      skipped_extensions: [],
+    },
+  ]
+  render(<FolderPicker value={[]} onChange={() => {}} folders={colliding} />)
+  fireEvent.click(screen.getAllByRole('button')[0])
+  expect(screen.getByText('cuad/ingest')).toBeInTheDocument()
+  expect(screen.getByText('qwen3-20b/cuad/ingest')).toBeInTheDocument()
+})
+
+it('renders a title attribute with the full path on each row', () => {
+  render(<FolderPicker value={[]} onChange={() => {}} folders={folders} />)
+  fireEvent.click(screen.getAllByRole('button')[0])
+  // folders[0] is /c (test fixture at top of file)
+  const row = screen.getByText('Contracts').closest('label')
+  expect(row).toHaveAttribute('title', '/c')
+})
+
+it('uses disambiguated labels in the trigger button summary', () => {
+  const colliding = [
+    {
+      folder_id: 'a',
+      path: '/work/cuad/ingest',
+      display_name: 'ingest',
+      unavailable_reason: null,
+      enabled: true,
+      auto_discovered: false,
+      skipped_count: 0,
+      skipped_extensions: [],
+    },
+    {
+      folder_id: 'b',
+      path: '/work/qwen3-20b/cuad/ingest',
+      display_name: 'ingest',
+      unavailable_reason: null,
+      enabled: true,
+      auto_discovered: false,
+      skipped_count: 0,
+      skipped_extensions: [],
+    },
+  ]
+  render(<FolderPicker value={['a', 'b']} onChange={() => {}} folders={colliding} />)
+  expect(screen.getByRole('button')).toHaveTextContent(
+    'Folders: cuad/ingest, qwen3-20b/cuad/ingest (2)',
+  )
+})
+```
+
+- [ ] **Step 4.2: Run the tests, verify they fail**
+
+Run: `cd frontend && npm test -- FolderPicker --run`
+Expected: 3 new FAILs (one renders raw "ingest" twice, one finds no title, one shows duplicate "ingest" in summary).
+
+- [ ] **Step 4.3: Wire the utility into FolderPicker**
+
+In `frontend/src/components/FolderPicker.tsx`:
+
+Add the import near the top:
+
+```tsx
+import { disambiguateLabels } from './folderLabels'
+```
+
+Inside the component, after the existing destructured state, compute the label map:
+
+```tsx
+const labelMap = useMemo(() => disambiguateLabels(folders), [folders])
+```
+
+Replace the `summarize` function to take the labelMap:
+
+```tsx
+function summarize(
+  value: string[],
+  folders: WatchedFolderInfo[],
+  labelMap: Map<string, string>,
+): string {
+  if (value.length === 0) return 'Folders: All'
+  const labels = value
+    .map((id) => labelMap.get(id) ?? folders.find((f) => f.folder_id === id)?.display_name ?? '?')
+    .slice(0, 3)
+  const suffix = value.length > 1 ? ` (${value.length})` : ''
+  return `Folders: ${labels.join(', ')}${suffix}`
+}
+```
+
+Update the call site of `summarize`:
+
+```tsx
+const buttonText = noFolders ? 'No folders to scope to' : summarize(value, folders, labelMap)
+```
+
+Find the row rendering loop. Each row's label currently renders `{f.display_name ?? f.folder_id}` and `aria-label={f.display_name ?? f.folder_id}`. Replace with the labelMap:
+
+```tsx
+<label
+  className="..."
+  title={f.path}
+>
+  <input
+    type="checkbox"
+    checked={value.includes(f.folder_id)}
+    onChange={() => toggle(f.folder_id)}
+    aria-label={labelMap.get(f.folder_id) ?? f.folder_id}
+  />
+  <span className="text-sm text-[var(--color-text-primary)] truncate">
+    {labelMap.get(f.folder_id) ?? f.folder_id}
+  </span>
+</label>
+```
+
+Also update the search-filter predicate to match the disambiguated label (so users can type a fragment of `cuad/ingest` and find it):
+
+```tsx
+const visible = useMemo(
+  () =>
+    folders.filter((f) => {
+      if (filter.trim() === '') return true
+      const label = labelMap.get(f.folder_id) ?? f.display_name ?? ''
+      return label.toLowerCase().includes(filter.toLowerCase())
+    }),
+  [folders, filter, labelMap],
+)
+```
+
+- [ ] **Step 4.4: Run the tests, verify they pass**
+
+Run: `cd frontend && npm test -- FolderPicker --run`
+Expected: 11 PASS (8 original + 3 new).
+
+- [ ] **Step 4.5: Lint + typecheck**
+
+Run: `cd frontend && npm run lint && npm run type-check`
+Expected: clean.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add frontend/src/components/FolderPicker.tsx frontend/src/components/FolderPicker.test.tsx
+git commit -m "feat(scope): FolderPicker uses disambiguateLabels + full-path tooltips"
+```
+
+---
+
+## Task 5: `ScopeChip` — consume `disambiguateLabels` + tooltip
+
+**Why:** The read-only chip in conversation/research headers shows the active scope. Must use the same disambiguation as the picker so the rendered labels stay consistent.
+
+**Files:**
+- Modify: `frontend/src/components/ScopeChip.tsx`
+- Test: `frontend/src/components/ScopeChip.test.tsx`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Append to `frontend/src/components/ScopeChip.test.tsx`:
+
+```ts
+it('disambiguates colliding display_names', () => {
+  const colliding = [
+    { folder_id: 'a', path: '/work/cuad/ingest', display_name: 'ingest',
+      unavailable_reason: null, enabled: true, auto_discovered: false,
+      skipped_count: 0, skipped_extensions: [] },
+    { folder_id: 'b', path: '/work/qwen3-20b/cuad/ingest', display_name: 'ingest',
+      unavailable_reason: null, enabled: true, auto_discovered: false,
+      skipped_count: 0, skipped_extensions: [] },
+  ]
+  render(<ScopeChip scope={{ folder_ids: ['a', 'b'] }} folders={colliding} />)
+  expect(screen.getByText(/cuad\/ingest.*qwen3-20b\/cuad\/ingest/)).toBeInTheDocument()
+})
+
+it('sets a title attribute with full paths, one per line', () => {
+  render(<ScopeChip scope={{ folder_ids: ['a'] }} folders={folders} />)
+  const chip = screen.getByText(/Contracts/)
+  expect(chip.getAttribute('title')).toContain('/c')
+})
+```
+
+- [ ] **Step 5.2: Run the tests, verify they fail**
+
+Run: `cd frontend && npm test -- ScopeChip --run`
+Expected: 2 FAILs.
+
+- [ ] **Step 5.3: Wire the utility into ScopeChip**
+
+Modify `frontend/src/components/ScopeChip.tsx`:
+
+```tsx
+import type { WatchedFolderInfo } from '../hooks/useWatchedFolders'
+import { disambiguateLabels } from './folderLabels'
+
+export interface ScopeChipProps {
+  scope: { folder_ids?: string[] } | null | undefined
+  folders: WatchedFolderInfo[]
+  className?: string
+}
+
+export function ScopeChip({ scope, folders, className }: ScopeChipProps) {
+  const ids = scope?.folder_ids ?? []
+  if (ids.length === 0) {
+    return <span className={className ?? 'scope-chip'}>Folders: All</span>
+  }
+  const labelMap = disambiguateLabels(folders)
+  const labels = ids.map((id) => labelMap.get(id) ?? '?').slice(0, 3)
+  const suffix = ids.length > 1 ? ` (${ids.length})` : ''
+  const fullPaths = ids
+    .map((id) => folders.find((f) => f.folder_id === id)?.path)
+    .filter((p): p is string => p != null)
+    .join('\n')
+  return (
+    <span className={className ?? 'scope-chip'} title={fullPaths}>
+      {`Folders: ${labels.join(', ')}${suffix}`}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 5.4: Run the tests, verify they pass**
+
+Run: `cd frontend && npm test -- ScopeChip --run`
+Expected: 6 PASS (4 existing + 2 new).
+
+- [ ] **Step 5.5: Lint + typecheck**
+
+Run: `cd frontend && npm run lint && npm run type-check`
+Expected: clean.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add frontend/src/components/ScopeChip.tsx frontend/src/components/ScopeChip.test.tsx
+git commit -m "feat(scope): ScopeChip uses disambiguateLabels + full-path tooltip"
+```
+
+---
+
+## Task 6: `FoldersPage` — inline rename affordance
+
+**Why:** Operators need to alias a folder. Inline pencil-edit on the existing Folders tab is the lowest-friction UX and reuses the PATCH route from Task 1.
+
+**Files:**
+- Modify: `frontend/src/pages/FoldersPage.tsx`
+
+This task does not add new tests (the spec explicitly says manual verification is sufficient for the rename UI). Existing FoldersPage tests, if any, should not regress.
+
+- [ ] **Step 6.1: Read FoldersPage and identify the folder-row rendering site**
+
+Open `frontend/src/pages/FoldersPage.tsx`. Search for the JSX that renders each watched folder row (likely a `.map((folder) => <div ...>` or similar). Note:
+- Where the folder's display name renders
+- Where the path is shown (or if it's only in a tooltip currently)
+- How API calls are made (look for existing `patch`, `post`, or `put` helpers — `frontend/src/api.ts` likely exposes a `patch()` function)
+- How the folders list is fetched and refreshed (TanStack Query cache key — likely `['watch', 'folders']`)
+
+- [ ] **Step 6.2: Add rename state to the page**
+
+At the top of the FoldersPage component, add:
+
+```tsx
+const [editingId, setEditingId] = useState<string | null>(null)
+const [draftName, setDraftName] = useState('')
+const [renameError, setRenameError] = useState<string | null>(null)
+const queryClient = useQueryClient()
+```
+
+Add the import:
+
+```tsx
+import { useQueryClient } from '@tanstack/react-query'
+```
+
+- [ ] **Step 6.3: Add the rename handler**
+
+Add a `saveAlias` function near the other handlers in the component:
+
+```tsx
+async function saveAlias(folderId: string, alias: string) {
+  setRenameError(null)
+  try {
+    await patch(`/api/watch/folders/${folderId}`, { display_name: alias })
+    setEditingId(null)
+    setDraftName('')
+    queryClient.invalidateQueries({ queryKey: ['watch', 'folders'] })
+  } catch (err) {
+    setRenameError(err instanceof Error ? err.message : 'Rename failed')
+  }
+}
+```
+
+Import the `patch` helper from `frontend/src/api.ts` (verify the export name — it should be alongside `get` and `post`). If the project uses `request` or a different pattern, adapt to match.
+
+- [ ] **Step 6.4: Replace the folder-name display with edit-or-display**
+
+Find the JSX block that renders the folder name in each row. Replace it with:
+
+```tsx
+<div className="folder-row__identity">
+  {editingId === folder.folder_id ? (
+    <div className="flex items-center gap-2">
+      <input
+        autoFocus
+        value={draftName}
+        onChange={(e) => setDraftName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') saveAlias(folder.folder_id, draftName)
+          if (e.key === 'Escape') {
+            setEditingId(null)
+            setDraftName('')
+            setRenameError(null)
+          }
+        }}
+        onBlur={() => saveAlias(folder.folder_id, draftName)}
+        maxLength={200}
+        className="rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2 py-1 text-sm"
+      />
+      {renameError ? (
+        <span className="text-xs text-red-400">{renameError}</span>
+      ) : null}
+    </div>
+  ) : (
+    <div className="flex items-center gap-2">
+      <span className="font-medium" title={folder.path}>
+        {folder.display_name ?? folder.path.split('/').filter(Boolean).pop() ?? folder.folder_id}
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          setDraftName(folder.display_name ?? '')
+          setEditingId(folder.folder_id)
+          setRenameError(null)
+        }}
+        aria-label={`Rename ${folder.display_name ?? folder.folder_id}`}
+        className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+      >
+        ✎
+      </button>
+    </div>
+  )}
+  <div className="text-xs text-[var(--color-text-secondary)] truncate" title={folder.path}>
+    {folder.path}
+  </div>
+</div>
+```
+
+The secondary line showing `folder.path` is the read-only path display from the spec. Style it muted so it doesn't compete with the alias.
+
+- [ ] **Step 6.5: Sanity check via grep**
+
+Confirm no other place in `FoldersPage.tsx` renders the same folder name without your new edit affordance. If there's a separate folder-detail view or any other rendering site, leave it alone — this task is the list view only.
+
+```bash
+grep -n "display_name" frontend/src/pages/FoldersPage.tsx
+```
+
+You should see the new usages plus whatever was there before. Don't add the pencil to other surfaces (e.g., breadcrumbs, page headers) in this task.
+
+- [ ] **Step 6.6: Lint + typecheck**
+
+Run: `cd frontend && npm run lint && npm run type-check`
+Expected: clean.
+
+- [ ] **Step 6.7: Manual verification**
+
+Start dev stack:
+```bash
+cd frontend && npm run dev
+# in another terminal:
+uv run harbor-clerk-api
+```
+
+In the browser:
+1. Open `/folders`. Each folder row should show its name + a pencil icon + the path beneath.
+2. Click a pencil. The name converts to an input pre-filled with the current name.
+3. Type a new name. Press Enter. Confirm the row re-renders with the new name; the picker on `/` shows the new name too (cache invalidation worked).
+4. Click the pencil again. Clear the field entirely. Press Enter. Confirm the row shows the path basename (revert).
+5. Click the pencil. Type 201 characters. Press Enter. Confirm an error appears next to the field and the row keeps the original name.
+6. Click the pencil. Press Escape. Confirm the edit is cancelled with no API call (verify in network tab).
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add frontend/src/pages/FoldersPage.tsx
+git commit -m "feat(folders): inline pencil-edit rename for folder display_name"
+```
+
+---
+
+## Task 7: Wrap-up — full verification, fresh-eyes review, PR
+
+- [ ] **Step 7.1: Full Python test suite**
+
+Run: `uv run pytest --ignore=tests/integration`
+Expected: all pass — no regression from the watch-route changes.
+
+- [ ] **Step 7.2: Full frontend test suite**
+
+Run: `cd frontend && npm test -- --run`
+Expected: all pass.
+
+- [ ] **Step 7.3: Lint + format + type-check (both stacks)**
+
+Run:
+```bash
+uv run ruff check . && uv run ruff format --check .
+cd frontend && npm run lint && npm run type-check && npm run format:check
+```
+Expected: every check clean.
+
+- [ ] **Step 7.4: Manual happy path on a real corpus**
+
+(If possible — needs the actual macOS dev stack or Docker stack running with > 1 watched folder.)
+
+1. **Confirm popover fix:** Open Ask. Folder picker opens with list visible. Shrink window so chat input sits at viewport bottom; picker flips upward and remains usable.
+2. **Confirm disambiguation:** Create at least two watched folders that share a basename (e.g., on macOS Server, watch two parent directories that each have an `ingest` subfolder). Confirm the picker shows them as `parent1/ingest` and `parent2/ingest`, not two identical `ingest` rows.
+3. **Confirm rename:** Go to `/folders`. Rename one of the colliding folders to `Receipts`. Return to Ask. Open the picker. The renamed folder appears as `Receipts`; the other remains disambiguated.
+4. **Confirm tooltip:** Hover any picker row. Native browser tooltip shows the full filesystem path.
+5. **Confirm chip in conversation header:** Start a new conversation scoped to the renamed folder. Header chip reads `Folders: Receipts`. Hover the chip; tooltip shows the path.
+
+- [ ] **Step 7.5: Dispatch a fresh-eyes review**
+
+Per the standing directive on substantive PRs, dispatch a `feature-dev:code-reviewer` agent against the branch tip with a minimal, unconstrained prompt. Address findings ≥80 confidence before opening the PR.
+
+The PR touches: 1 backend schema/route, 1 new TS utility + tests, 3 React components, 1 page. Multi-component scope — review is warranted.
+
+- [ ] **Step 7.6: Push the branch**
+
+```bash
+git push -u origin feat/folder-picker-display-fixes
+```
+
+- [ ] **Step 7.7: Open the PR**
+
+```bash
+gh pr create --title "fix(scope): folder picker positioning + label disambiguation + rename" --body-file ...
+```
+
+PR body should:
+- Reference the spec at `docs/superpowers/specs/2026-05-27-folder-picker-display-fixes-design.md`
+- Summarize the four pieces (positioning, disambig, tooltip, alias)
+- Test plan: list the 5 manual checks from Step 7.4 plus the automated CI suite
+- Note the fresh-eyes review findings (if any) and how they were addressed
+
+---
+
+## Notes / pitfalls
+
+- **`disambiguateLabels` algorithm:** the inner loop walks segments from rightmost to leftmost. For two folders with shared tail prefixes (`a/x` and `b/a/x`), the depth-2 attempt would yield `a/x` and `a/x` (still colliding), so the loop advances to depth 3: `a/x` (only 2 segments available) and `b/a/x`. The implementation should not crash on `slice(-3)` when there are only 2 segments — `slice` handles short arrays gracefully. The reference implementation in Task 2 has been written to do this.
+
+- **Test fixture shape drift:** `WatchedFolderInfo` has these required fields per `useWatchedFolders.ts`: `folder_id`, `display_name`, `path`, `unavailable_reason`, `enabled`, `auto_discovered`, `skipped_count`, `skipped_extensions`. New test fixtures must include all of them or TypeScript will complain. The plan's test snippets include them; reuse the pattern.
+
+- **TanStack Query cache key:** the existing fetch in `useWatchedFolders` uses `['watch', 'folders']`. Invalidate with that exact key after the PATCH in Task 6. Verify by reading `useWatchedFolders.ts` first.
+
+- **The `summarize` truncation:** the rendered button text only shows the first 3 folder names plus a count suffix. With long disambiguated names (`qwen3-20b/cuad/ingest`) the button can grow wide. We're not adding ellipsis here — the existing CSS truncation (`truncate` class) on the trigger button will handle it. If a future polish pass wants smarter truncation, it can come later.
+
+- **No portal / no floating-ui dep:** Task 3 deliberately uses raw DOM measurement and a class swap. Adding `@floating-ui/react` would be ~10kb gz for behavior we get for free with one `useLayoutEffect`.
+
+- **The "Select all" / "Clear" buttons inside the popover:** Task 3's structural change to the popover container doesn't alter these. They live inside the popover, which now has `max-h-[360px] overflow-hidden`. The inner `<ul>` keeps its own `overflow-y-auto`. The actions bar (Select all / Clear) sits above the scrollable list and remains pinned.
+
+- **Pre-existing ESLint warnings:** the project has ~14 pre-existing react-hooks/react-refresh warnings on unrelated files. Lint runs should report no NEW warnings on any file we touch.
+
+## Self-review checklist for the engineer
+
+- [ ] PATCH `/api/watch/folders/{id}` accepts `display_name` and produces 422 over 200 chars
+- [ ] Empty/whitespace `display_name` reverts to `Path(path).name` server-side
+- [ ] Omitting `display_name` from a PATCH body leaves the field unchanged
+- [ ] `disambiguateLabels` handles: no-collision, single-collision, multi-collision, mixed, null display_name, degenerate identical paths
+- [ ] FolderPicker popover flips upward when there's not enough room below
+- [ ] FolderPicker rows show disambiguated labels + `title=fullPath`
+- [ ] FolderPicker trigger button summarizes with disambiguated labels
+- [ ] FolderPicker search filter matches against the rendered (disambiguated) label
+- [ ] ScopeChip shows disambiguated labels + `title=fullPaths` (newline-separated when multiple)
+- [ ] FoldersPage row has pencil-edit affordance + path display below the name
+- [ ] Pencil-edit Enter saves, Escape cancels, blur saves
+- [ ] After rename, the picker on other pages updates without manual refresh (cache invalidation)
+- [ ] No regressions in the existing FolderPicker (8) / ScopeChip (4) / useWatchedFolders (2) test counts
+
+## Spec coverage mapping
+
+| Spec piece | Task(s) |
+|---|---|
+| Piece 1 — popover positioning | Task 3 |
+| Piece 2 — label disambiguation | Task 2, Task 4, Task 5 |
+| Piece 3 — tooltips | Task 4, Task 5 |
+| Piece 4 — editable alias backend | Task 1 |
+| Piece 4 — editable alias frontend (FoldersPage) | Task 6 |
+| Edge cases (length cap, empty alias, etc.) | Task 1 tests |
+| Edge cases (collision, mixed, degenerate) | Task 2 tests |
+| Manual verification | Task 7 |
+
+Every spec section has at least one task. No orphans.

--- a/docs/superpowers/specs/2026-05-27-folder-picker-display-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-27-folder-picker-display-fixes-design.md
@@ -1,0 +1,283 @@
+# Folder Picker Display Fixes — Design Spec
+
+**Date:** 2026-05-27
+**Status:** Draft
+**Scope:** Two related UX fixes to the folder picker shipped in PR #415 (feat: folder-scope filter for Ask/Research/Search).
+
+## Overview
+
+PR #415 introduced a folder filter for Ask/Research/Search. Two display issues surfaced in real use:
+
+1. **Popover overflow.** When the picker sits at the bottom of the viewport (the Ask page's input footer), opening the popover downward extends off-screen — the folder list isn't reachable.
+2. **Identical labels.** Watched folders are labeled by their path basename (`Path(path).name`). Corpora that follow a `<model>/<dataset>/ingest` layout (e.g. test-corpora runs) produce multiple folders all displayed as "ingest", indistinguishable in the picker.
+
+This spec addresses both with a bundle: a positioning bugfix, automatic label disambiguation when basenames collide, hover tooltips with the full path, and an operator-editable alias on the Folders tab.
+
+## Goals
+
+- The picker popover never overflows the viewport; folders are always reachable.
+- Folders with colliding `display_name` values are visually distinguished without operator action.
+- Operators can give any folder a custom name on the Folders tab.
+- The same disambiguation logic is reused by `FolderPicker` rows and `ScopeChip` (the read-only chip in conversation headers / research detail).
+- Backward compatibility: existing watched folders, conversations, and research runs work without migration.
+
+## Non-Goals
+
+- Tree-style rendering (`▼ work/ ⋯ ingest`) — not necessary, the flat-with-disambig pattern is sufficient.
+- Drag/drop reordering or grouping of folders.
+- Color-coding or icons per folder.
+- Search by full path inside the picker (today's search filters on the rendered label only, which now contains enough of the path to make typing fragments useful anyway).
+- Renaming folders via the MCP API or CLI — alias is a UI-driven operator feature.
+- Cross-device sync of aliases (single-tenant; alias is a server-side DB column).
+
+---
+
+## Piece 1 — Popover positioning (bugfix)
+
+**Problem.** `FolderPicker.tsx` renders its popover with `absolute top-full`. When the trigger sits within `popoverHeight + margin` pixels of the viewport bottom (the Ask chat input footer is exactly this case), the popover extends below the visible area. The component's parent has `overflow-hidden` on the chat-input wrapper, clipping the popover further. The folder list rows are unreachable.
+
+**Fix.** On open, measure the trigger's `getBoundingClientRect()` and the viewport height; choose the popover direction based on available space.
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement>(null);
+const [direction, setDirection] = useState<'down' | 'up'>('down');
+
+useLayoutEffect(() => {
+  if (!open || !triggerRef.current) return;
+  const rect = triggerRef.current.getBoundingClientRect();
+  const popoverMaxHeight = 360; // matches the max-h cap below
+  const margin = 8;
+  const spaceBelow = window.innerHeight - rect.bottom - margin;
+  const spaceAbove = rect.top - margin;
+  setDirection(
+    spaceBelow >= popoverMaxHeight || spaceBelow >= spaceAbove ? 'down' : 'up'
+  );
+}, [open]);
+```
+
+**Class binding.**
+
+```tsx
+<div
+  className={
+    direction === 'up'
+      ? 'absolute bottom-full mb-1 ...'   // open upward
+      : 'absolute top-full mt-1 ...'      // open downward (today's behavior)
+  }
+  style={{ maxHeight: 360 }}
+  ...
+>
+  ...
+</div>
+```
+
+The popover list itself remains scrollable internally (`max-h-48 overflow-y-auto` on the `<ul>` stays the same). Capping the outer popover at 360px and choosing direction by available space handles every viewport position without needing a portal/floating-ui dependency.
+
+**Tests.** The existing `FolderPicker.test.tsx` doesn't measure layout, so no positioning test is added at the unit level. Manual verification: open Ask at full window height, open the picker — list visible; resize the window so the input is at the very bottom — picker now flips upward and is fully visible.
+
+---
+
+## Piece 2 — Label disambiguation
+
+**Problem.** `WatchedFolder.display_name` defaults to `Path(path).name`. Multiple folders sharing a basename (`ingest`) render identically in both `FolderPicker` and `ScopeChip`.
+
+**Fix.** A new pure function `disambiguateLabels(folders): Map<folder_id, string>` builds a unique label per folder. Both components consume it.
+
+**Algorithm:**
+
+1. For each folder, candidate label is `display_name` (the user-controlled string; `null` falls back to `Path(path).name`).
+2. Group folders by candidate label.
+3. For groups of size 1: the candidate is the final label.
+4. For groups of size > 1: for each folder in the group, extend the label by prepending its parent directory segment. Repeat until each folder in the group has a unique extended label.
+5. Folders outside any colliding group keep their candidate label.
+
+Path traversal uses `path.split('/').filter(Boolean)` from the rightmost segment back. If two paths share a tail prefix (e.g., `a/cuad/ingest` and `b/a/cuad/ingest`), the algorithm walks farther up until the prefixes diverge. In the extreme degenerate case where two paths are identical at every depth (shouldn't happen — paths are filesystem-unique), the algorithm falls back to appending the folder UUID's last 6 chars.
+
+**Implementation location:** `frontend/src/components/folderLabels.ts` (new file). Single export, fully unit-testable, no React imports.
+
+**Consumers:**
+- `FolderPicker.tsx`: replaces the inline `summarize()` and the inline `f.display_name ?? f.folder_id` in row rendering.
+- `ScopeChip.tsx`: replaces its inline `display_name ?? '?'` mapping.
+
+**Tests** (in `folderLabels.test.ts`):
+
+- No collisions → labels match display_name exactly.
+- Two folders both named "ingest" with parents `cuad` and `qwen3-20b/cuad` → `cuad/ingest` and `qwen3-20b/cuad/ingest`.
+- Three folders all named "ingest" with parents `cuad`, `qwen3-20b/cuad`, `gpt-oss-20b/cuad` → unique prefixes for each.
+- Mix of unique and colliding: unique ones keep simple labels, colliding group disambiguates.
+- Empty/null `display_name` falls back to `Path(path).name`.
+- Degenerate: two folders with identical paths → falls back to UUID suffix.
+
+---
+
+## Piece 3 — Tooltips with full path
+
+**Implementation.** Native browser `title` attribute on every picker row and on the chip span:
+
+```tsx
+// FolderPicker.tsx row:
+<label className="..." title={f.path}>
+  <input type="checkbox" ... aria-label={labelMap.get(f.folder_id)} />
+  {labelMap.get(f.folder_id)}
+</label>
+
+// ScopeChip.tsx:
+<span className={...} title={folder_ids.map(id => folders.find(...)?.path).filter(Boolean).join('\n')}>
+  Folders: {/* disambiguated names */}
+</span>
+```
+
+The chip's title shows one path per line for the selected folders (when multiple). No JS tooltip library — the native browser one is fine for low-information disclosure like this.
+
+---
+
+## Piece 4 — Editable alias on the Folders tab
+
+### Backend
+
+**Extend `FolderPatch`** in `src/harbor_clerk/api/schemas/watch.py` (or wherever it's defined) to include `display_name: str | None = None`. Add validation:
+
+- Strip whitespace.
+- Length 1–200 (matching `conversations.title` convention).
+- An empty/whitespace-only string is treated as "revert to default" — the handler writes `Path(folder.path).name`.
+
+**Handler change** in `src/harbor_clerk/api/routes/watch.py:387` (`patch_folder`):
+
+```python
+if body.display_name is not None:
+    new_name = body.display_name.strip()
+    if not new_name:
+        # Empty alias → revert to default (path basename)
+        new_name = Path(folder.path).name
+    if len(new_name) > 200:
+        raise HTTPException(status_code=422, detail="display_name exceeds 200 chars")
+    folder.display_name = new_name
+```
+
+(`None` continues to mean "field absent in patch" — no change.)
+
+### Frontend
+
+**`FoldersPage.tsx`** — find the row rendering for each folder. Add a small pencil icon adjacent to the displayed name; clicking it converts the cell to a controlled text input.
+
+```tsx
+const [editingId, setEditingId] = useState<string | null>(null);
+const [draft, setDraft] = useState('');
+
+// In each row:
+{editingId === folder.folder_id ? (
+  <input
+    autoFocus
+    value={draft}
+    onChange={(e) => setDraft(e.target.value)}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter') saveAlias(folder, draft);
+      if (e.key === 'Escape') setEditingId(null);
+    }}
+    onBlur={() => saveAlias(folder, draft)}
+  />
+) : (
+  <>
+    <span title={folder.path}>{folder.display_name}</span>
+    <button onClick={() => { setDraft(folder.display_name ?? ''); setEditingId(folder.folder_id); }}>
+      <PencilIcon />
+    </button>
+  </>
+)}
+```
+
+`saveAlias` calls `PATCH /api/watch/folders/{folder_id}` with `{display_name: draft}` and on success invalidates the `['watch', 'folders']` query (via TanStack's `queryClient.invalidateQueries`).
+
+**Path display on the row.** Add the full path as secondary text below the folder name (matching the spec's preview):
+
+```
+[CUAD test set ✎]
+  ~/work/cuad/ingest                ← muted, smaller font
+```
+
+This way the operator can always see what the alias points at without hover. (The pencil-edit interaction handles renames; the path text is read-only.)
+
+### Refresh
+
+The TanStack Query cache key for the folders list is `['watch', 'folders']`. After a successful PATCH, invalidate that key. The picker, chip, and Folders page all subscribe to the same cache so they refresh consistently. Conversations and research runs already store `folder_ids` (UUIDs), not labels, so a rename has zero impact on their stored scope — it only changes what's rendered.
+
+---
+
+## Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| User aliases two folders to the same name ("Receipts" both) | Both get the alias as their candidate; `disambiguateLabels` treats them as a collision and prepends path segments, yielding `parent/Receipts` for each. |
+| User clears the alias (submits empty) | Handler writes `Path(folder.path).name`. Folder reverts to the default basename. Auto-disambig still kicks in if that basename collides. |
+| User aliases to a string longer than 200 chars | 422 from the API. Frontend shows the error inline and keeps the input open. |
+| User aliases to a single character | Allowed. Length 1–200 is the only constraint. |
+| Folder is unavailable (`unavailable_reason IS NOT NULL`) and user tries to rename | Allowed. Rename is metadata; doesn't depend on filesystem accessibility. The folder is hidden from the picker anyway (filtered by `useWatchedFolders` on `unavailable_reason === null`). |
+| Aliased folder is then deleted | Standard delete path; the alias goes with the row. |
+| New folder auto-discovered after Docker mount | Receives `display_name = Path(path).name` as today. If it collides, `disambiguateLabels` handles it without operator action. Operator can alias later. |
+| Two folders have the same path (shouldn't happen) | Degenerate; the algorithm appends the folder UUID's last 6 chars to make labels unique. |
+| `useWatchedFolders` is still loading when the picker opens | `folders` is `[]`; the picker shows "No folders to scope to" until the fetch completes. Existing behavior; unchanged. |
+
+---
+
+## Testing
+
+### Frontend unit
+
+- `folderLabels.test.ts` covers the 6 algorithm cases above.
+- `FolderPicker.test.tsx` gains 1 test: when given two folders with identical `display_name`, the rendered row labels are the disambiguated forms (not the bare collision).
+- `ScopeChip.test.tsx` gains 1 test: same disambiguation behavior in the chip.
+- `FolderPicker.test.tsx` gains 1 test for the `title` attribute carrying the full path.
+
+### Frontend integration (Folders tab)
+
+- Existing FoldersPage tests (if any) gain a test for the inline pencil-edit interaction:
+  - Click pencil → input appears with current name.
+  - Type new name → Enter → calls PATCH with the new name.
+  - Empty string + Enter → PATCH succeeds; folder name reverts to path basename.
+  - Escape → closes the edit, no PATCH.
+- If FoldersPage has no test file yet, this task does not add one — the alias UI is small enough that manual verification is fine. (A future test would also exercise the loading/error states.)
+
+### Backend
+
+- `tests/test_watch_routes.py` (or wherever PATCH `/folders/{id}` is tested today) gains 3 tests:
+  - PATCH with `display_name="My Folder"` updates the row and 200s.
+  - PATCH with `display_name=""` writes `Path(path).name` (revert).
+  - PATCH with `display_name="x" * 201` → 422.
+
+### Positioning (manual)
+
+- Open Ask at full window height, click the chip → popover opens downward, list visible.
+- Shrink the window until the chat input is near the bottom → popover flips upward.
+- Same on Research start form (mid-page) and Search filter row (top of page) — popover opens downward in both because there's more room below.
+
+---
+
+## Migration
+
+No schema change. `WatchedFolder.display_name` is already `Mapped[str | None]` with no default — the column accepts both user aliases and the existing `Path(path).name` default. The PATCH endpoint already exists; only the request schema and handler body change.
+
+---
+
+## Out of scope (explicit)
+
+- Slash-aware path display in tooltips (showing `~/work/cuad/ingest` rather than full absolute path) — could be a polish pass later. For now we show the raw `path` field as the backend stores it.
+- Bulk rename / find-and-replace across many folders.
+- Per-conversation folder name overrides ("for THIS conversation, call this folder 'Contracts'") — out of scope; folders have one canonical alias.
+- Reordering folders. The picker list is alphabetical by candidate label.
+- Showing the alias on the Documents page document list (where folder is sometimes referenced). Defer until users ask for it.
+
+---
+
+## Forward compat
+
+If we later add a `path_display` column (e.g. for showing the home-relative form `~/foo`) or a `color` column or icons, none of this work blocks it. `disambiguateLabels` is keyed off `display_name + path` only; it doesn't care about new columns.
+
+If we ever ship a per-conversation folder pinning feature (the speculative "label this folder 'Active' for the duration of this conversation"), it would live on the Conversation, not on the WatchedFolder. The shared `disambiguateLabels` algorithm continues to work for the global aliases.
+
+## References
+
+- PR #415 — the folder-scope feature that introduced the picker
+- `WatchedFolder.display_name` model field: `src/harbor_clerk/models/watched.py:28`
+- Current PATCH handler: `src/harbor_clerk/api/routes/watch.py:386`
+- Existing FolderPicker: `frontend/src/components/FolderPicker.tsx`
+- Existing ScopeChip: `frontend/src/components/ScopeChip.tsx`

--- a/frontend/src/components/FolderPicker.test.tsx
+++ b/frontend/src/components/FolderPicker.test.tsx
@@ -79,4 +79,67 @@ describe('FolderPicker', () => {
     expect(screen.queryByText('Contracts')).not.toBeInTheDocument()
     expect(screen.getByText('Legal')).toBeInTheDocument()
   })
+
+  it('disambiguates labels when two folders share display_name', () => {
+    const colliding = [
+      {
+        folder_id: 'a',
+        path: '/work/cuad/ingest',
+        display_name: 'ingest',
+        unavailable_reason: null,
+        enabled: true,
+        auto_discovered: false,
+        skipped_count: 0,
+        skipped_extensions: [],
+      },
+      {
+        folder_id: 'b',
+        path: '/work/qwen3-20b/cuad/ingest',
+        display_name: 'ingest',
+        unavailable_reason: null,
+        enabled: true,
+        auto_discovered: false,
+        skipped_count: 0,
+        skipped_extensions: [],
+      },
+    ]
+    render(<FolderPicker value={[]} onChange={() => {}} folders={colliding} />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    expect(screen.getByText('cuad/ingest')).toBeInTheDocument()
+    expect(screen.getByText('qwen3-20b/cuad/ingest')).toBeInTheDocument()
+  })
+
+  it('renders a title attribute with the full path on each row', () => {
+    render(<FolderPicker value={[]} onChange={() => {}} folders={folders} />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    const row = screen.getByText('Contracts').closest('label')
+    expect(row).toHaveAttribute('title', '/c')
+  })
+
+  it('uses disambiguated labels in the trigger button summary', () => {
+    const colliding = [
+      {
+        folder_id: 'a',
+        path: '/work/cuad/ingest',
+        display_name: 'ingest',
+        unavailable_reason: null,
+        enabled: true,
+        auto_discovered: false,
+        skipped_count: 0,
+        skipped_extensions: [],
+      },
+      {
+        folder_id: 'b',
+        path: '/work/qwen3-20b/cuad/ingest',
+        display_name: 'ingest',
+        unavailable_reason: null,
+        enabled: true,
+        auto_discovered: false,
+        skipped_count: 0,
+        skipped_extensions: [],
+      },
+    ]
+    render(<FolderPicker value={['a', 'b']} onChange={() => {}} folders={colliding} />)
+    expect(screen.getByRole('button')).toHaveTextContent('Folders: cuad/ingest, qwen3-20b/cuad/ingest (2)')
+  })
 })

--- a/frontend/src/components/FolderPicker.tsx
+++ b/frontend/src/components/FolderPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { WatchedFolderInfo } from '../hooks/useWatchedFolders'
+import { disambiguateLabels } from './folderLabels'
 
 export interface FolderPickerProps {
   value: string[]
@@ -9,9 +10,11 @@ export interface FolderPickerProps {
   size?: 'sm' | 'md'
 }
 
-function summarize(value: string[], folders: WatchedFolderInfo[]): string {
+function summarize(value: string[], folders: WatchedFolderInfo[], labelMap: Map<string, string>): string {
   if (value.length === 0) return 'Folders: All'
-  const labels = value.map((id) => folders.find((f) => f.folder_id === id)?.display_name ?? '?').slice(0, 3)
+  const labels = value
+    .map((id) => labelMap.get(id) ?? folders.find((f) => f.folder_id === id)?.display_name ?? '?')
+    .slice(0, 3)
   const suffix = value.length > 1 ? ` (${value.length})` : ''
   return `Folders: ${labels.join(', ')}${suffix}`
 }
@@ -23,12 +26,16 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
   const triggerRef = useRef<HTMLButtonElement>(null)
   const [popDirection, setPopDirection] = useState<'down' | 'up'>('down')
 
+  const labelMap = useMemo(() => disambiguateLabels(folders), [folders])
+
   const visible = useMemo(
     () =>
-      folders.filter((f) =>
-        filter.trim() === '' ? true : (f.display_name ?? '').toLowerCase().includes(filter.toLowerCase()),
-      ),
-    [folders, filter],
+      folders.filter((f) => {
+        if (filter.trim() === '') return true
+        const label = labelMap.get(f.folder_id) ?? f.display_name ?? ''
+        return label.toLowerCase().includes(filter.toLowerCase())
+      }),
+    [folders, filter, labelMap],
   )
 
   // Close popover on outside click or Escape
@@ -62,7 +69,7 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
 
   const noFolders = folders.length === 0
   const isDisabled = disabled || noFolders
-  const buttonText = noFolders ? 'No folders to scope to' : summarize(value, folders)
+  const buttonText = noFolders ? 'No folders to scope to' : summarize(value, folders, labelMap)
 
   const toggle = (id: string) => {
     if (value.includes(id)) onChange(value.filter((v) => v !== id))
@@ -154,16 +161,19 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
           <ul role="listbox" aria-multiselectable="true" className="max-h-48 overflow-y-auto px-1 pb-1">
             {visible.map((f) => (
               <li key={f.folder_id} role="option" aria-selected={value.includes(f.folder_id)}>
-                <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-[var(--color-bg-secondary)]">
+                <label
+                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-[var(--color-bg-secondary)]"
+                  title={f.path}
+                >
                   <input
                     type="checkbox"
                     checked={value.includes(f.folder_id)}
                     onChange={() => toggle(f.folder_id)}
-                    aria-label={f.display_name ?? f.folder_id}
+                    aria-label={labelMap.get(f.folder_id) ?? f.folder_id}
                     className="h-3.5 w-3.5 accent-[var(--color-accent)]"
                   />
                   <span className="text-sm text-[var(--color-text-primary)] truncate">
-                    {f.display_name ?? f.folder_id}
+                    {labelMap.get(f.folder_id) ?? f.folder_id}
                   </span>
                 </label>
               </li>

--- a/frontend/src/components/FolderPicker.tsx
+++ b/frontend/src/components/FolderPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { WatchedFolderInfo } from '../hooks/useWatchedFolders'
 
 export interface FolderPickerProps {
@@ -20,6 +20,8 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
   const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const [popDirection, setPopDirection] = useState<'down' | 'up'>('down')
 
   const visible = useMemo(
     () =>
@@ -48,6 +50,16 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
     }
   }, [open])
 
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return
+    const rect = triggerRef.current.getBoundingClientRect()
+    const popoverMaxHeight = 360 // matches the max-h cap on the popover div
+    const margin = 8
+    const spaceBelow = window.innerHeight - rect.bottom - margin
+    const spaceAbove = rect.top - margin
+    setPopDirection(spaceBelow >= popoverMaxHeight || spaceBelow >= spaceAbove ? 'down' : 'up')
+  }, [open])
+
   const noFolders = folders.length === 0
   const isDisabled = disabled || noFolders
   const buttonText = noFolders ? 'No folders to scope to' : summarize(value, folders)
@@ -62,6 +74,7 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
   return (
     <div className="relative inline-block" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => !isDisabled && setOpen((o) => !o)}
         disabled={isDisabled}
@@ -93,7 +106,8 @@ export function FolderPicker({ value, onChange, folders, disabled, size = 'md' }
       {open && !noFolders && (
         <div
           className={[
-            'absolute z-30 mt-1 min-w-[200px] rounded-lg shadow-mac-lg',
+            'absolute z-30 min-w-[200px] max-h-[360px] rounded-lg shadow-mac-lg overflow-hidden',
+            popDirection === 'up' ? 'bottom-full mb-1' : 'top-full mt-1',
             'border border-[var(--color-border)] bg-[var(--color-bg-primary)]',
             'flex flex-col',
           ].join(' ')}

--- a/frontend/src/components/ScopeChip.test.tsx
+++ b/frontend/src/components/ScopeChip.test.tsx
@@ -52,4 +52,37 @@ describe('ScopeChip', () => {
     render(<ScopeChip scope={{ folder_ids: ['unknown'] }} folders={folders} />)
     expect(screen.getByText(/Folders: \?/i)).toBeInTheDocument()
   })
+
+  it('disambiguates colliding display_names', () => {
+    const colliding = [
+      {
+        folder_id: 'a',
+        path: '/work/cuad/ingest',
+        display_name: 'ingest',
+        unavailable_reason: null,
+        enabled: true,
+        auto_discovered: false,
+        skipped_count: 0,
+        skipped_extensions: [],
+      },
+      {
+        folder_id: 'b',
+        path: '/work/qwen3-20b/cuad/ingest',
+        display_name: 'ingest',
+        unavailable_reason: null,
+        enabled: true,
+        auto_discovered: false,
+        skipped_count: 0,
+        skipped_extensions: [],
+      },
+    ]
+    render(<ScopeChip scope={{ folder_ids: ['a', 'b'] }} folders={colliding} />)
+    expect(screen.getByText(/cuad\/ingest.*qwen3-20b\/cuad\/ingest/)).toBeInTheDocument()
+  })
+
+  it('sets a title attribute with full paths', () => {
+    render(<ScopeChip scope={{ folder_ids: ['a'] }} folders={folders} />)
+    const chip = screen.getByText(/Contracts/)
+    expect(chip.getAttribute('title')).toContain('/c')
+  })
 })

--- a/frontend/src/components/ScopeChip.tsx
+++ b/frontend/src/components/ScopeChip.tsx
@@ -1,4 +1,5 @@
 import type { WatchedFolderInfo } from '../hooks/useWatchedFolders'
+import { disambiguateLabels } from './folderLabels'
 
 export interface ScopeChipProps {
   scope: { folder_ids?: string[] } | null | undefined
@@ -20,14 +21,20 @@ export function ScopeChip({ scope, folders, className }: ScopeChipProps) {
       </span>
     )
   }
-  const labels = ids.map((id) => folders.find((f) => f.folder_id === id)?.display_name ?? '?').slice(0, 3)
+  const labelMap = disambiguateLabels(folders)
+  const labels = ids.map((id) => labelMap.get(id) ?? '?').slice(0, 3)
   const suffix = ids.length > 1 ? ` (${ids.length})` : ''
+  const fullPaths = ids
+    .map((id) => folders.find((f) => f.folder_id === id)?.path)
+    .filter((p): p is string => p != null)
+    .join('\n')
   return (
     <span
       className={
         className ??
         'inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-2 py-1 text-xs font-medium text-[var(--color-text-primary)]'
       }
+      title={fullPaths}
     >
       {`Folders: ${labels.join(', ')}${suffix}`}
     </span>

--- a/frontend/src/components/folderLabels.test.ts
+++ b/frontend/src/components/folderLabels.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { disambiguateLabels, type FolderLike } from './folderLabels'
+
+function f(folder_id: string, path: string, display_name: string | null = null): FolderLike {
+  return { folder_id, path, display_name }
+}
+
+describe('disambiguateLabels', () => {
+  it('uses display_name as-is when no collisions', () => {
+    const folders = [f('1', '/work/contracts', 'Contracts'), f('2', '/work/legal', 'Legal')]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('Contracts')
+    expect(labels.get('2')).toBe('Legal')
+  })
+
+  it('walks up one path segment when two labels collide', () => {
+    const folders = [f('1', '/work/cuad/ingest', 'ingest'), f('2', '/work/qwen3-20b/cuad/ingest', 'ingest')]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('cuad/ingest')
+    expect(labels.get('2')).toBe('qwen3-20b/cuad/ingest')
+  })
+
+  it('extends as many segments as needed for three+ folders sharing a basename', () => {
+    const folders = [
+      f('1', '/work/cuad/ingest', 'ingest'),
+      f('2', '/work/qwen3-20b/cuad/ingest', 'ingest'),
+      f('3', '/work/gpt-oss-20b/cuad/ingest', 'ingest'),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('cuad/ingest')
+    expect(labels.get('2')).toBe('qwen3-20b/cuad/ingest')
+    expect(labels.get('3')).toBe('gpt-oss-20b/cuad/ingest')
+  })
+
+  it('mixes unique and colliding correctly', () => {
+    const folders = [
+      f('1', '/work/contracts', 'Contracts'),
+      f('2', '/work/cuad/ingest', 'ingest'),
+      f('3', '/work/qwen3-20b/cuad/ingest', 'ingest'),
+    ]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('Contracts')
+    expect(labels.get('2')).toBe('cuad/ingest')
+    expect(labels.get('3')).toBe('qwen3-20b/cuad/ingest')
+  })
+
+  it('falls back to path basename when display_name is null', () => {
+    const folders = [f('1', '/work/contracts', null), f('2', '/work/legal', null)]
+    const labels = disambiguateLabels(folders)
+    expect(labels.get('1')).toBe('contracts')
+    expect(labels.get('2')).toBe('legal')
+  })
+
+  it('falls back to UUID suffix when two folders have identical paths (degenerate)', () => {
+    const folders = [
+      f('aaaaaaaa-1111-2222-3333-444444444444', '/work/dup', 'dup'),
+      f('bbbbbbbb-5555-6666-7777-888888888888', '/work/dup', 'dup'),
+    ]
+    const labels = disambiguateLabels(folders)
+    const a = labels.get('aaaaaaaa-1111-2222-3333-444444444444')
+    const b = labels.get('bbbbbbbb-5555-6666-7777-888888888888')
+    expect(a).not.toBe(b)
+    expect(a).toContain('dup')
+    expect(b).toContain('dup')
+  })
+})

--- a/frontend/src/components/folderLabels.ts
+++ b/frontend/src/components/folderLabels.ts
@@ -97,12 +97,11 @@ export function disambiguateLabels(folders: FolderLike[]): Map<string, string> {
       siblingLabelsAtD.set(f.folder_id, labelAt(f, resolvedDepth))
     }
 
-    // Phase 2: assign labels greedily, processing folders with longer paths
-    // first (they need more segments to distinguish themselves). Each folder
-    // gets the shortest depth (≥ 2) whose label doesn't match any
-    // already-assigned label. Shorter-path folders benefit because the longer
-    // siblings have already "claimed" their deeper labels, leaving the shorter
-    // suffixes free.
+    // Phase 2: assign labels greedily, processing shorter paths first.
+    // Shorter paths claim the minimal (depth-2) suffix first; longer paths
+    // get pushed to deeper depths only when the shorter suffixes are already
+    // taken. The full resolvedDepth label is always available as a fallback
+    // since Phase 1 guarantees it's unique within the group.
     const groupLabels = new Map<string, string>()
     const assigned = new Set<string>() // labels already locked in
 

--- a/frontend/src/components/folderLabels.ts
+++ b/frontend/src/components/folderLabels.ts
@@ -1,0 +1,147 @@
+export interface FolderLike {
+  folder_id: string
+  path: string
+  display_name: string | null
+}
+
+function basename(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts[parts.length - 1] ?? path
+}
+
+function pathSegments(path: string): string[] {
+  return path.split('/').filter(Boolean)
+}
+
+function candidate(folder: FolderLike): string {
+  if (folder.display_name && folder.display_name.trim() !== '') {
+    return folder.display_name
+  }
+  return basename(folder.path)
+}
+
+/**
+ * Build a unique display label for each folder.
+ *
+ * Default label is `display_name` (or path basename when display_name is null/empty).
+ * When two or more folders share the same default label, prepend just enough of
+ * the parent path to each so that all labels in the colliding group are unique
+ * (file-manager / VS Code tab pattern).
+ *
+ * In the degenerate case where two folders have identical paths, falls back to
+ * appending the last 6 characters of the folder UUID.
+ */
+export function disambiguateLabels(folders: FolderLike[]): Map<string, string> {
+  const labels = new Map<string, string>()
+
+  // Group by candidate label
+  const groups = new Map<string, FolderLike[]>()
+  for (const folder of folders) {
+    const key = candidate(folder)
+    const existing = groups.get(key) ?? []
+    existing.push(folder)
+    groups.set(key, existing)
+  }
+
+  for (const [key, group] of groups) {
+    if (group.length === 1) {
+      labels.set(group[0].folder_id, key)
+      continue
+    }
+
+    // Disambiguate in two phases:
+    //
+    // Phase 1 — find the minimum uniform depth D at which every folder in the
+    // group has a distinct label. This is the smallest D where no two folders
+    // share the same last-D path segments.
+    //
+    // Phase 2 — trim: for each folder independently, find the smallest depth
+    // d (1 ≤ d ≤ D) such that labelAt(f, d) does not appear in the set of
+    // sibling labels computed at the full depth D. Shorter paths naturally
+    // end up with fewer segments because their early suffixes are already unique
+    // against the longer-path siblings' depth-D labels.
+    const maxDepth = Math.max(...group.map((f) => pathSegments(f.path).length))
+
+    function labelAt(f: FolderLike, depth: number): string {
+      const segs = pathSegments(f.path)
+      const cand = candidate(f)
+      // If candidate is a custom alias (differs from basename), keep it as
+      // the leaf and prepend path segments above the actual basename.
+      const segsForLabel = cand === basename(f.path) ? segs.slice(-depth) : [...segs.slice(-depth, -1), cand]
+      return segsForLabel.join('/')
+    }
+
+    // Phase 1: find minimum uniform depth where all labels are distinct.
+    let resolvedDepth = 1
+    for (let d = 1; d <= maxDepth; d++) {
+      const seen = new Set<string>()
+      let allUnique = true
+      for (const f of group) {
+        const lbl = labelAt(f, d)
+        if (seen.has(lbl)) {
+          allUnique = false
+          break
+        }
+        seen.add(lbl)
+      }
+      if (allUnique) {
+        resolvedDepth = d
+        break
+      }
+      resolvedDepth = d // keep advancing even if not unique (fallback)
+    }
+
+    // The sibling labels at the resolved depth — used as the comparison set.
+    const siblingLabelsAtD = new Map<string, string>()
+    for (const f of group) {
+      siblingLabelsAtD.set(f.folder_id, labelAt(f, resolvedDepth))
+    }
+
+    // Phase 2: assign labels greedily, processing folders with longer paths
+    // first (they need more segments to distinguish themselves). Each folder
+    // gets the shortest depth (≥ 2) whose label doesn't match any
+    // already-assigned label. Shorter-path folders benefit because the longer
+    // siblings have already "claimed" their deeper labels, leaving the shorter
+    // suffixes free.
+    const groupLabels = new Map<string, string>()
+    const assigned = new Set<string>() // labels already locked in
+
+    // Sort shorter paths first: they get priority on shorter suffixes.
+    const sorted = [...group].sort((a, b) => pathSegments(a.path).length - pathSegments(b.path).length)
+
+    for (const f of sorted) {
+      let chosen = siblingLabelsAtD.get(f.folder_id)!
+      // Try from depth 2 upward; take the first depth whose label isn't taken.
+      for (let d = 2; d <= resolvedDepth; d++) {
+        const lbl = labelAt(f, d)
+        if (!assigned.has(lbl)) {
+          chosen = lbl
+          break
+        }
+      }
+      groupLabels.set(f.folder_id, chosen)
+      assigned.add(chosen)
+    }
+
+    // If still collisions (e.g., identical paths), fall back to UUID suffix.
+    const finalSeen = new Map<string, string[]>()
+    for (const [fid, label] of groupLabels) {
+      const ids = finalSeen.get(label) ?? []
+      ids.push(fid)
+      finalSeen.set(label, ids)
+    }
+    for (const [label, ids] of finalSeen) {
+      if (ids.length > 1) {
+        for (const fid of ids) {
+          groupLabels.set(fid, `${label} (${fid.slice(-6)})`)
+        }
+      }
+    }
+
+    for (const [fid, label] of groupLabels) {
+      labels.set(fid, label)
+    }
+  }
+
+  return labels
+}

--- a/frontend/src/pages/FoldersPage.tsx
+++ b/frontend/src/pages/FoldersPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { del, get, patch, post, ApiError } from '../api'
 import { useAuth } from '../auth'
 import { useFolderProgress } from '../hooks/useFolderProgress'
@@ -110,6 +111,11 @@ export default function FoldersPage() {
   // the Delete button look broken. The state tracks which folder is
   // armed for delete; first click sets it, second confirms.
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  // Inline rename state
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draftName, setDraftName] = useState('')
+  const [renameError, setRenameError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
 
   async function reload() {
     try {
@@ -211,6 +217,19 @@ export default function FoldersPage() {
     }
   }
 
+  async function saveAlias(folderId: string, alias: string) {
+    setRenameError(null)
+    try {
+      await patch(`/api/watch/folders/${folderId}`, { display_name: alias })
+      setEditingId(null)
+      setDraftName('')
+      reload()
+      queryClient.invalidateQueries({ queryKey: ['watch', 'folders'] })
+    } catch (err) {
+      setRenameError(err instanceof Error ? err.message : 'Rename failed')
+    }
+  }
+
   if (!system) return <div className="text-sm text-(--color-text-secondary)">Loading…</div>
 
   const addButton = system.picker === 'native' ? <AddFolderButton onClick={handleAdd} /> : null
@@ -260,10 +279,25 @@ export default function FoldersPage() {
                 isExpanded={isExpanded}
                 deleteDisabled={deleteDisabled}
                 pendingDelete={pendingDelete}
+                isEditing={editingId === f.folder_id}
+                draftName={draftName}
+                renameError={renameError}
                 onToggleExpand={() => setExpanded(isExpanded ? null : f.folder_id)}
                 onToggleEnabled={() => handleToggle(f)}
                 onDelete={() => handleDeleteClick(f.folder_id)}
                 onCancelDelete={() => setPendingDeleteId(null)}
+                onStartEdit={() => {
+                  setDraftName(f.display_name ?? '')
+                  setEditingId(f.folder_id)
+                  setRenameError(null)
+                }}
+                onDraftChange={(v) => setDraftName(v)}
+                onSaveAlias={() => saveAlias(f.folder_id, draftName)}
+                onCancelEdit={() => {
+                  setEditingId(null)
+                  setDraftName('')
+                  setRenameError(null)
+                }}
               />
             )
           })}
@@ -284,10 +318,17 @@ interface FolderRowProps {
   isExpanded: boolean
   deleteDisabled: boolean
   pendingDelete: boolean
+  isEditing: boolean
+  draftName: string
+  renameError: string | null
   onToggleExpand: () => void
   onToggleEnabled: () => void
   onDelete: () => void
   onCancelDelete: () => void
+  onStartEdit: () => void
+  onDraftChange: (value: string) => void
+  onSaveAlias: () => void
+  onCancelEdit: () => void
 }
 
 function FolderRow({
@@ -296,17 +337,71 @@ function FolderRow({
   isExpanded,
   deleteDisabled,
   pendingDelete,
+  isEditing,
+  draftName,
+  renameError,
   onToggleExpand,
   onToggleEnabled,
   onDelete,
   onCancelDelete,
+  onStartEdit,
+  onDraftChange,
+  onSaveAlias,
+  onCancelEdit,
 }: FolderRowProps) {
+  // Escape keydown sets this flag so the subsequent blur event (fired by the
+  // browser when focus leaves the input) doesn't trigger a spurious save with
+  // an empty draftName. Enter doesn't need it — React doesn't fire blur on
+  // unmount the same way.
+  const ignoreBlurRef = useRef(false)
+
   return (
     <Card className="mb-2" interactive>
       <div className="flex cursor-pointer items-center gap-3 px-3.5 py-3" onClick={onToggleExpand}>
         <IconTile size={30}>📁</IconTile>
         <div className="min-w-0 flex-1">
-          <div className="truncate font-medium text-(--color-text-primary)">{f.display_name || f.path}</div>
+          <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            {isEditing ? (
+              <>
+                <input
+                  autoFocus
+                  value={draftName}
+                  onChange={(e) => onDraftChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') onSaveAlias()
+                    if (e.key === 'Escape') {
+                      ignoreBlurRef.current = true
+                      onCancelEdit()
+                    }
+                  }}
+                  onBlur={() => {
+                    if (ignoreBlurRef.current) {
+                      ignoreBlurRef.current = false
+                      return
+                    }
+                    onSaveAlias()
+                  }}
+                  maxLength={200}
+                  className="rounded border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-2 py-1 text-sm font-medium"
+                />
+                {renameError ? <span className="text-xs text-red-400">{renameError}</span> : null}
+              </>
+            ) : (
+              <>
+                <span className="font-medium text-(--color-text-primary)" title={f.path}>
+                  {f.display_name ?? f.path.split('/').filter(Boolean).pop() ?? f.folder_id}
+                </span>
+                <button
+                  type="button"
+                  onClick={onStartEdit}
+                  aria-label={`Rename ${f.display_name ?? f.folder_id}`}
+                  className="text-(--color-text-secondary) hover:text-(--color-text-primary)"
+                >
+                  ✎
+                </button>
+              </>
+            )}
+          </div>
           <div className="flex items-center gap-2 text-[11px] text-(--color-text-secondary)">
             <span className="truncate font-mono">{f.path}</span>
             {f.auto_discovered && (

--- a/src/harbor_clerk/api/routes/watch.py
+++ b/src/harbor_clerk/api/routes/watch.py
@@ -45,6 +45,7 @@ class FolderCreate(BaseModel):
 class FolderPatch(BaseModel):
     enabled: bool | None = None
     last_event_id: int | None = None
+    display_name: str | None = None
 
 
 class IngestRequest(BaseModel):
@@ -403,6 +404,13 @@ async def patch_folder(
         enabled_changed_to = body.enabled
     if body.last_event_id is not None:
         folder.last_event_id = body.last_event_id
+    if body.display_name is not None:
+        new_name = body.display_name.strip()
+        if not new_name:
+            new_name = Path(folder.path).name
+        if len(new_name) > 200:
+            raise HTTPException(status_code=422, detail="display_name exceeds 200 chars")
+        folder.display_name = new_name
 
     if enabled_changed_to is not None:
         action = "enabled" if enabled_changed_to else "disabled"

--- a/tests/test_api_watch.py
+++ b/tests/test_api_watch.py
@@ -448,3 +448,109 @@ async def test_folder_serializer_skip_fields_defaults(client, admin_token, db_se
     row = by_path["/tmp/test-skip-defaults-api"]
     assert row["skipped_count"] == 0
     assert row["skipped_extensions"] == []
+
+
+# ---------------------------------------------------------------------------
+# PATCH /folders/{id} — display_name
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_folder_sets_display_name(client, admin_token, two_folder_corpus):
+    """PATCH with display_name='Receipts' updates the row and returns 200."""
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "Receipts"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == "Receipts"
+
+
+async def test_patch_folder_empty_display_name_reverts_to_basename(client, admin_token, two_folder_corpus):
+    """PATCH with display_name='' (or whitespace) writes Path(folder.path).name."""
+    from pathlib import Path
+
+    folder_a, _, _, _ = two_folder_corpus
+
+    # First alias to something custom, then clear it
+    await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "Custom"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": ""},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == Path(folder_a.path).name
+
+
+async def test_patch_folder_whitespace_display_name_reverts_to_basename(client, admin_token, two_folder_corpus):
+    """PATCH with display_name='   ' is treated as empty → reverts."""
+    from pathlib import Path
+
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "   "},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == Path(folder_a.path).name
+
+
+async def test_patch_folder_too_long_display_name_returns_422(client, admin_token, two_folder_corpus):
+    """display_name longer than 200 chars → 422."""
+    folder_a, _, _, _ = two_folder_corpus
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "x" * 201},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_patch_folder_omitted_display_name_leaves_field_unchanged(client, admin_token, two_folder_corpus):
+    """A PATCH that doesn't include display_name must not alter it."""
+    folder_a, _, _, _ = two_folder_corpus
+
+    # Set a custom alias first
+    await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"display_name": "Sentinel"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    # Now PATCH only enabled
+    r = await client.patch(
+        f"/api/watch/folders/{folder_a.folder_id}",
+        json={"enabled": True},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+    list_r = await client.get(
+        "/api/watch/folders",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    folder_row = next(f for f in list_r.json() if f["folder_id"] == str(folder_a.folder_id))
+    assert folder_row["display_name"] == "Sentinel"


### PR DESCRIPTION
## Summary

Fixes two display issues in the folder picker shipped in PR #415:

1. **Popover overflow at viewport bottom.** When the picker sits in the chat input footer at the bottom of the Ask page, the popover extends off-screen and the folder list is unreachable.
2. **Identical labels.** Watched folders labeled by their path basename (`Path(path).name`) — common with test-corpora `<model>/<dataset>/ingest` layouts — render as three indistinguishable "ingest" rows.

Four pieces in one PR:

- **Popover auto-flip:** `FolderPicker` measures trigger position with `useLayoutEffect` on open and flips the popover upward when there's more room above. No flicker (layout effect runs before paint). All three usage sites (Ask / Research / Search) benefit.
- **Auto-disambiguation:** new shared utility `disambiguateLabels(folders)` walks up each colliding folder's path until labels are unique (`cuad/ingest` vs `qwen3-20b/cuad/ingest`). Both `FolderPicker` rows and `ScopeChip` consume it. The picker's search filter also matches against the disambiguated label.
- **Tooltips:** `title={folder.path}` on picker rows; `title` with `\n`-joined paths on the multi-folder chip. Native browser tooltips, no library.
- **Editable alias:** Folders tab gains an inline pencil-edit per row. Click pencil → input pre-filled with current name. Enter/blur saves via `PATCH /api/watch/folders/{id}` (extended to accept `display_name`). Escape cancels safely (ignoreBlurRef pattern prevents the blur-after-Escape race). Empty input reverts to `Path(path).name` server-side. 200-char limit enforced on both sides.

No schema migration — `WatchedFolder.display_name` was already `Mapped[str | None]`. Existing PATCH route extended; aliases survive folder reordering / removal because scoped queries use `folder_id` UUIDs, not labels.

## Files changed

| File | Change |
|---|---|
| `src/harbor_clerk/api/routes/watch.py` | `FolderPatch` accepts `display_name`; handler strips → empty-revert → 422 over 200 chars → write |
| `tests/test_api_watch.py` | 5 new PATCH tests (set, empty-revert, whitespace-revert, 422, omitted-unchanged) |
| `frontend/src/components/folderLabels.ts` | NEW: `disambiguateLabels()` pure utility |
| `frontend/src/components/folderLabels.test.ts` | NEW: 6 unit tests (no-collision, two-collision, three-collision, mixed, null display_name, degenerate identical paths) |
| `frontend/src/components/FolderPicker.tsx` | `useLayoutEffect` popover auto-flip; consumes `labelMap`; `title={f.path}` on rows; search filter uses labelMap |
| `frontend/src/components/FolderPicker.test.tsx` | 3 new tests (disambig rows, title attr, disambig summary) |
| `frontend/src/components/ScopeChip.tsx` | consumes `labelMap`; `title` with `\n`-joined paths |
| `frontend/src/components/ScopeChip.test.tsx` | 2 new tests (disambig chip, title attr) |
| `frontend/src/pages/FoldersPage.tsx` | Inline pencil-edit rename + path display per row; `ignoreBlurRef` for Escape safety; both `reload()` + TanStack cache invalidation |

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-27-folder-picker-display-fixes-design.md`
- Plan: `docs/superpowers/plans/2026-05-27-folder-picker-display-fixes.md`

## Tests

- **Python:** 1277 passed, 15 skipped (5 new PATCH tests added to the 25-test `test_api_watch.py` suite).
- **Frontend:** 26 passed (6 new `folderLabels` + 3 new `FolderPicker` + 2 new `ScopeChip`).
- **Lint / typecheck / format:** ruff + ESLint + tsc + prettier clean. No new warnings.

## Fresh-eyes review

A `feature-dev:code-reviewer` pass against the branch tip flagged one Important finding — addressed in commit `95d6f27`:

- **Stale block comment in `disambiguateLabels` Phase 2:** the comment described the previous longer-paths-first design but the code sorts shorter-first. Comment rewritten to accurately describe the implemented shorter-first ordering. No functional change.

(The reviewer's first pass had to be re-dispatched because the working tree had been transiently checked out on a different branch by a parallel session — known shared-worktree hazard. The second pass with explicit `git show feat/folder-picker-display-fixes:<path>` instructions found the stale-comment issue.)

## Test plan

- [x] Python: `uv run pytest --ignore=tests/integration` — 1277 passed
- [x] Frontend: `cd frontend && npm test -- --run` — 26 passed
- [x] ruff check + format check clean
- [x] ESLint + tsc + prettier clean
- [x] Fresh-eyes code review — finding addressed
- [ ] **Manual UI verification** (left to reviewer with the running stack):
  - Open Ask at full window height → folder picker opens downward, list visible
  - Shrink window so chat input is at viewport bottom → picker flips upward
  - Create / watch a folder layout with multiple `ingest` basenames → picker shows `cuad/ingest`, `qwen3-20b/cuad/ingest` etc., not three identical rows
  - Hover any picker row → tooltip shows full path
  - Open `/folders`, click a pencil → input appears; type new name + Enter → row updates, picker on `/` reflects the rename
  - Click pencil, press Escape → no PATCH fires (verify via network tab)
  - Click pencil, type 201 chars + Enter → inline error appears, name unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
