### PR TITLE
fix(observatory): pipeline view shows Apple Intelligence when AFM is the summarize backend

### DIFF
--- a/frontend/src/components/stats/PipelineDiagram.tsx
+++ b/frontend/src/components/stats/PipelineDiagram.tsx
@@ -201,7 +201,14 @@ function SummarizeCircle({ queued, running }: { queued: number; running: number 
 
 function SummarizeCard({ queued, running, summarizing }: SummarizeCardProps) {
   const { status } = useLLMStatusContext()
-  const model = modelLabel(status.state, status.model_name, status.model_id)
+  // The summarize stage has its own backend resolution (AFM / LLM / extractive)
+  // that's independent of the loaded llama-server model. Prefer the dedicated
+  // `summarize` sub-status from the backend; fall back to the top-level llama
+  // fields only if the field is absent (older builds).
+  const summarize = status.summarize
+  const model = summarize
+    ? modelLabel(summarize.state, summarize.name, summarize.backend)
+    : modelLabel(status.state, status.model_name, status.model_id)
 
   // Running first (most-advanced map step on top), then queued in FIFO.
   // Backend already orders by created_at; we resort here just for the

--- a/frontend/src/hooks/useLLMStatus.ts
+++ b/frontend/src/hooks/useLLMStatus.ts
@@ -3,10 +3,20 @@ import { useAuth } from '../auth'
 
 export type LLMState = 'deactivated' | 'loading' | 'ready' | 'unknown'
 
+// Per-stage summarize backend. Decoupled from the llama-server fields above
+// because the summarize stage can run against AFM (Apple Intelligence) — or
+// fall back to extractive — independently of the active llama-server model.
+export interface SummarizeBackend {
+  backend: string // 'apple-intelligence' | <llm_model_id> | 'extractive'
+  name: string | null
+  state: LLMState
+}
+
 export interface LLMStatus {
   state: LLMState
   model_id: string | null
   model_name: string | null
+  summarize?: SummarizeBackend
 }
 
 const IDLE_INTERVAL_MS = 8000 // poll every 8s when nothing seems to be transitioning

--- a/src/harbor_clerk/api/routes/chat.py
+++ b/src/harbor_clerk/api/routes/chat.py
@@ -393,7 +393,7 @@ async def deactivate_model(
 async def llm_status(
     _principal: Principal = Depends(require_user),
 ):
-    """Lightweight probe of llama-server's health.
+    """Lightweight probe of llama-server's health + the summarize backend.
 
     Returns one of three states the UI uses to drive a "model is
     loading" banner across the model-switch transition:
@@ -409,6 +409,16 @@ async def llm_status(
     Probe is bounded to 2s so this endpoint stays fast even when
     llama-server is wedged. The frontend polls it every second or
     two during a model switch.
+
+    Also reports the **summarize** backend separately. The summarize
+    pipeline stage can be configured (via the "Always use Apple
+    Intelligence for summaries" toggle) to bypass the local LLM and
+    use AFM directly — so the Observatory's per-stage label needs to
+    reflect AFM, not the unrelated llama-server model that happens to
+    be loaded. Three possible backends:
+      - `apple-intelligence`: AFM is configured + available
+      - `<llm_model_id>`: the active llama-server model
+      - `extractive`: heuristic fallback (no LLM, no AFM)
     """
     # See list_available_models — refresh to catch menubar-side writes
     # to config.json that bypass this process.
@@ -418,33 +428,48 @@ async def llm_status(
     info = get_model(model_id) if model_id else None
     model_name = info.name if info else None
 
+    # Llama-server state (existing logic, hoisted out so we can reuse it
+    # for the summarize sub-status when the LLM is the summarize backend).
     if not model_id:
-        return {"state": "deactivated", "model_id": None, "model_name": None}
+        state = "deactivated"
+    else:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                r = await client.get(f"{settings.llama_server_url}/health")
+                state = "ready" if r.status_code == 200 else "loading"
+        except (httpx.ConnectError, httpx.TimeoutException):
+            state = "loading"
 
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            r = await client.get(f"{settings.llama_server_url}/health")
-            if r.status_code == 200:
-                return {
-                    "state": "ready",
-                    "model_id": model_id,
-                    "model_name": model_name,
-                }
-            # Non-200 — model still coming up (llama-server returns
-            # 503 during model load) or in some other transient state.
-            return {
-                "state": "loading",
-                "model_id": model_id,
-                "model_name": model_name,
+    # Summarize backend resolution mirrors the precedence in
+    # `harbor_clerk.llm.summarize.generate_summary`:
+    #   force_afm=true → AFM (or extractive if AFM unavailable)
+    #   else LLM model active → LLM
+    #   else → AFM (or extractive)
+    from harbor_clerk.llm.summarize import _find_apple_summarize_binary
+
+    afm_available = _find_apple_summarize_binary() is not None
+    if settings.summary_force_apple_intelligence:
+        if afm_available:
+            summarize = {"backend": "apple-intelligence", "name": "Apple Intelligence", "state": "ready"}
+        else:
+            summarize = {
+                "backend": "extractive",
+                "name": "Extractive (Apple Intelligence unavailable)",
+                "state": "ready",
             }
-    except (httpx.ConnectError, httpx.TimeoutException):
-        # Connection refused (server stopped or restarting) or didn't
-        # answer within 2s (loading weights, mmap'ing the gguf, etc.).
-        return {
-            "state": "loading",
-            "model_id": model_id,
-            "model_name": model_name,
-        }
+    elif model_id:
+        summarize = {"backend": model_id, "name": model_name, "state": state}
+    elif afm_available:
+        summarize = {"backend": "apple-intelligence", "name": "Apple Intelligence", "state": "ready"}
+    else:
+        summarize = {"backend": "extractive", "name": "Extractive", "state": "ready"}
+
+    return {
+        "state": state,
+        "model_id": model_id,
+        "model_name": model_name,
+        "summarize": summarize,
+    }
 
 
 @router.put("/chat/models/yarn", status_code=200)

--- a/tests/api/test_chat_models_status.py
+++ b/tests/api/test_chat_models_status.py
@@ -71,9 +71,34 @@ def _succeed_llama_probe():
         yield
 
 
+@pytest.fixture
+def _force_afm(monkeypatch):
+    """Toggle settings.summary_force_apple_intelligence for one test."""
+
+    def _set(enabled: bool):
+        settings = get_settings()
+        monkeypatch.setattr(settings, "summary_force_apple_intelligence", enabled)
+
+    return _set
+
+
+@pytest.fixture
+def _afm_binary(monkeypatch):
+    """Stub _find_apple_summarize_binary to control AFM availability per test."""
+
+    def _set(available: bool):
+        monkeypatch.setattr(
+            "harbor_clerk.llm.summarize._find_apple_summarize_binary",
+            lambda: "/fake/apple-summarize" if available else None,
+        )
+
+    return _set
+
+
 async def test_status_returns_model_name_for_known_model(
-    client, admin_user, admin_token, _set_llm_model_id, _fail_llama_probe
+    client, admin_user, admin_token, _set_llm_model_id, _fail_llama_probe, _afm_binary
 ):
+    _afm_binary(False)
     _set_llm_model_id("qwen3-8b")
     resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
 
@@ -82,9 +107,14 @@ async def test_status_returns_model_name_for_known_model(
     assert body["state"] == "loading"
     assert body["model_id"] == "qwen3-8b"
     assert body["model_name"] == "Qwen3 8B"
+    # LLM is the configured summarize backend; mirrors the llama-server state.
+    assert body["summarize"] == {"backend": "qwen3-8b", "name": "Qwen3 8B", "state": "loading"}
 
 
-async def test_status_returns_null_model_name_when_deactivated(client, admin_user, admin_token, _set_llm_model_id):
+async def test_status_returns_null_model_name_when_deactivated(
+    client, admin_user, admin_token, _set_llm_model_id, _afm_binary
+):
+    _afm_binary(False)
     _set_llm_model_id(None)
     resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
 
@@ -93,11 +123,15 @@ async def test_status_returns_null_model_name_when_deactivated(client, admin_use
     assert body["state"] == "deactivated"
     assert body["model_id"] is None
     assert body["model_name"] is None
+    # No LLM + no AFM → extractive is the (degraded) summarize backend.
+    assert body["summarize"]["backend"] == "extractive"
+    assert body["summarize"]["state"] == "ready"
 
 
 async def test_status_returns_null_model_name_for_unknown_model_id(
-    client, admin_user, admin_token, _set_llm_model_id, _fail_llama_probe
+    client, admin_user, admin_token, _set_llm_model_id, _fail_llama_probe, _afm_binary
 ):
+    _afm_binary(False)
     _set_llm_model_id("not-a-real-model-id")
     resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
 
@@ -109,8 +143,9 @@ async def test_status_returns_null_model_name_for_unknown_model_id(
 
 
 async def test_status_returns_ready_with_model_name_when_llama_healthy(
-    client, admin_user, admin_token, _set_llm_model_id, _succeed_llama_probe
+    client, admin_user, admin_token, _set_llm_model_id, _succeed_llama_probe, _afm_binary
 ):
+    _afm_binary(False)
     _set_llm_model_id("qwen3-8b")
     resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
 
@@ -119,3 +154,50 @@ async def test_status_returns_ready_with_model_name_when_llama_healthy(
     assert body["state"] == "ready"
     assert body["model_id"] == "qwen3-8b"
     assert body["model_name"] == "Qwen3 8B"
+    assert body["summarize"] == {"backend": "qwen3-8b", "name": "Qwen3 8B", "state": "ready"}
+
+
+async def test_summarize_backend_is_afm_when_force_afm_and_binary_available(
+    client, admin_user, admin_token, _set_llm_model_id, _succeed_llama_probe, _force_afm, _afm_binary
+):
+    """When force-AFM is on and the binary is found, summarize reports AFM regardless of the LLM state."""
+    _set_llm_model_id("qwen3-8b")
+    _force_afm(True)
+    _afm_binary(True)
+    resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
+
+    body = resp.json()
+    # LLM probe still drives the top-level state (other stages still use the LLM).
+    assert body["state"] == "ready"
+    assert body["model_id"] == "qwen3-8b"
+    # Summarize stage is AFM-backed.
+    assert body["summarize"] == {"backend": "apple-intelligence", "name": "Apple Intelligence", "state": "ready"}
+
+
+async def test_summarize_backend_falls_back_to_extractive_when_force_afm_but_binary_missing(
+    client, admin_user, admin_token, _set_llm_model_id, _force_afm, _afm_binary
+):
+    """force-AFM on + binary missing → extractive label (matches generate_summary's runtime behavior)."""
+    _set_llm_model_id(None)
+    _force_afm(True)
+    _afm_binary(False)
+    resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
+
+    body = resp.json()
+    assert body["summarize"]["backend"] == "extractive"
+    assert "unavailable" in body["summarize"]["name"].lower()
+
+
+async def test_summarize_backend_is_afm_when_no_llm_but_binary_available(
+    client, admin_user, admin_token, _set_llm_model_id, _force_afm, _afm_binary
+):
+    """No LLM configured + AFM available → AFM is the (default-fallback) summarize backend."""
+    _set_llm_model_id(None)
+    _force_afm(False)
+    _afm_binary(True)
+    resp = await client.get("/api/chat/models/status", headers=auth_header(admin_token))
+
+    body = resp.json()
+    assert body["state"] == "deactivated"
+    assert body["summarize"]["backend"] == "apple-intelligence"
+    assert body["summarize"]["state"] == "ready"


### PR DESCRIPTION
## Summary

- Observatory's pipeline SummarizeCard read its model label from `useLLMStatus().model_name`, which only reflects the active llama-server model. When the user enabled "Always use Apple Intelligence for summaries" (`summary_force_apple_intelligence`), the summarize stage actually bypassed the local LLM and ran against AFM — but the card kept showing the llama-server model (e.g., "Model · Gemma 4 26B"), misleading the operator.
- `/api/chat/models/status` now exposes a `summarize` sub-object that mirrors the per-stage backend resolution in `llm/summarize.py:generate_summary`. SummarizeCard reads it instead of the global llama fields.

## Backend resolution

Mirrors the precedence inside `generate_summary` so the label can't drift from runtime behavior:

| Condition | `summarize.backend` | `summarize.name` | `summarize.state` |
|---|---|---|---|
| `summary_force_apple_intelligence=true` AND AFM binary present | `apple-intelligence` | `Apple Intelligence` | `ready` |
| `summary_force_apple_intelligence=true` AND AFM binary missing | `extractive` | `Extractive (Apple Intelligence unavailable)` | `ready` |
| LLM model active (force-AFM off) | `<llm_model_id>` | `<llm_name>` | mirrors llama-server `state` |
| No LLM, AFM available | `apple-intelligence` | `Apple Intelligence` | `ready` |
| No LLM, no AFM | `extractive` | `Extractive` | `ready` |

The top-level `state` / `model_id` / `model_name` fields are unchanged — other consumers (chat / model picker) still see the llama-server state.

## Frontend

`useLLMStatus` adds an optional `summarize?: SummarizeBackend` field on `LLMStatus`. `SummarizeCard` prefers `status.summarize` when present, falling back to the top-level llama fields if absent (older backend builds). Other pipeline cards (extract/ocr/chunk/entities/embed) don't use LLMs and are unaffected.

## Test plan

- [x] 7 tests in `tests/api/test_chat_models_status.py` (4 existing + 3 new): asserts `summarize` is populated correctly for LLM-active, force-AFM-with-binary, force-AFM-without-binary, and no-LLM-with-AFM. Full API suite (58 tests) passes.
- [x] Backend ruff + format clean. Frontend lint (0 errors), prettier, tsc all pass.
- [ ] **Manual UI check after rebuild:** with `summary_force_apple_intelligence=true` (Models page toggle), confirm the pipeline view's summarize card reads "Model · Apple Intelligence" instead of the llama-server model name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
