### PR TITLE
fix(test-corpora): use max_completion_tokens for OpenAI provider

### DIFF
--- a/scripts/test_corpora/runner/providers/openai_provider.py
+++ b/scripts/test_corpora/runner/providers/openai_provider.py
@@ -157,7 +157,11 @@ class OpenAIProvider:
         while True:
             kwargs: dict[str, Any] = {
                 "model": self._model,
-                "max_tokens": 8000,
+                # max_completion_tokens replaced max_tokens in OpenAI's API
+                # starting with the o1 / gpt-5 families. It's accepted by
+                # older models too (gpt-4o, gpt-4-turbo) for back-compat, so
+                # we use the new name universally.
+                "max_completion_tokens": 8000,
                 "messages": messages,
             }
             if tools:


### PR DESCRIPTION
## Summary

The test-corpora harness's OpenAI provider passed `max_tokens` on every chat-completions request. OpenAI's newer models (gpt-5, gpt-5.x, o1, o3) reject this:

```
openai.BadRequestError: Error code: 400 - {'error': {
  'message': "Unsupported parameter: 'max_tokens' is not supported with this model.
   Use 'max_completion_tokens' instead.",
  'param': 'max_tokens',
  'code': 'unsupported_parameter'
}}
```

Surfaced while running a smoke cell of `gpt-5.5 × CUAD` via `--mode answer-eval` against the new unified-corpus + scoped-key setup.

`max_completion_tokens` is the modern name (introduced with the o1 family) and is also accepted by older models (`gpt-4o`, `gpt-4-turbo`, etc.) for backward compatibility, so the switch is safe across the board — no model-name branching needed.

## Files changed

- `scripts/test_corpora/runner/providers/openai_provider.py:160` — `"max_tokens": 8000` → `"max_completion_tokens": 8000` with a comment explaining the migration.

## Test plan

- [x] Re-ran the `gpt-5.5 × CUAD` smoke after the fix — 15/15 questions captured, judge produced verdicts, aggregate report generated (correctness 4.40, groundedness 3.73, completeness 4.27).
- [ ] CI: the test-corpora module isn't part of the main CI tree; this fix only affects opt-in eval runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
