### PR TITLE
feat(test-corpora): pass folder scope to local-model runs in --no-ingest mode

### DIFF
--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -396,6 +396,7 @@ class HarborClerkClient:
         depth: str = "standard",
         time_limit_minutes: int = 30,
         strategy: str | None = None,
+        scope: dict | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """POST /api/research and drain the SSE stream until the research
         finishes server-side. Returns ``(conv_id, ResearchDetail)``.
@@ -424,6 +425,8 @@ class HarborClerkClient:
         }
         if strategy is not None:
             body["strategy"] = strategy
+        if scope:
+            body["scope"] = scope
 
         # Read timeout must accommodate the full time_limit + slack for
         # synthesis tail.
@@ -542,7 +545,11 @@ class HarborClerkClient:
 
     # ── ask (chat SSE) ──
 
-    def create_conversation(self, title: str = "test-corpora") -> str:
+    def create_conversation(
+        self,
+        title: str = "test-corpora",
+        scope: dict | None = None,
+    ) -> str:
         """POST /api/chat/conversations — returns conversation_id.
 
         HC's ``CreateConversationRequest`` schema is ``title: str`` (no longer
@@ -550,8 +557,16 @@ class HarborClerkClient:
         harness sent ``{"title": null, "mode": "chat"}`` which Pydantic
         rejects with 422 ("Input should be a valid string"). We now always
         pass a non-empty title and never send ``mode``.
+
+        ``scope``: optional folder-scope spec (PR #415). When set, HC's chat
+        engine restricts tool calls during the conversation to documents in
+        the named folders. Pass e.g. ``{"folder_ids": ["<uuid>"]}``. Omitted
+        and None both mean "no folder restriction" (the default).
         """
-        r = self._client.post("/api/chat/conversations", json={"title": title})
+        body: dict[str, object] = {"title": title}
+        if scope:
+            body["scope"] = scope
+        r = self._client.post("/api/chat/conversations", json=body)
         r.raise_for_status()
         return r.json()["conversation_id"]
 
@@ -662,6 +677,36 @@ class HarborClerkClient:
         r = self._client.get("/api/watch/folders")
         r.raise_for_status()
         return r.json()
+
+    def folder_id_for_corpus(self, corpus: str) -> str:
+        """Resolve a corpus name (cuad / enron / synthetic / etc.) to its watch
+        folder UUID. Used by scoped runs to scope chat/research to a single
+        corpus on a multi-corpus HC instance.
+
+        Matches by ``display_name`` first (set by the Folders page rename UI
+        or assigned on auto-discovery), and falls back to the last path
+        segment when display_name doesn't match — so a folder ingested at
+        ``…/test-corpora/cuad/ingest`` resolves under either ``cuad`` (the
+        display name) or the literal path basename.
+
+        Raises ValueError when no folder matches — callers should fail loudly
+        rather than silently fall back to an unscoped query that would pull
+        cross-corpus contamination into the tool results.
+        """
+        folders = self.watch_folder_list()
+        # Prefer display_name match
+        for f in folders:
+            if f.get("display_name") == corpus:
+                return f["folder_id"]
+        # Fall back to the parent directory of the ingest path
+        # (e.g. .../cuad/ingest -> corpus=cuad)
+        for f in folders:
+            path = f.get("path", "")
+            parts = [p for p in path.split("/") if p]
+            if len(parts) >= 2 and parts[-2] == corpus:
+                return f["folder_id"]
+        known = [f.get("display_name") for f in folders]
+        raise ValueError(f"no watch folder matches corpus {corpus!r}; known display_names: {known}")
 
     def watch_folder_delete(self, folder_id: str) -> None:
         """DELETE /api/watch/folders/{folder_id}."""

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -637,8 +637,17 @@ def _run_local(
     time_limit_minutes: int,
     is_research: bool,
     results_dir: Path,
+    scope_folder_id: str | None = None,
 ) -> dict:
-    """Run one local-model question. Assumes the right model is already active and loaded."""
+    """Run one local-model question. Assumes the right model is already active and loaded.
+
+    ``scope_folder_id`` (optional): when set, the spawned chat conversation
+    or research run is scoped to a single watched folder via PR #415's
+    folder-scope feature. Used by ``--no-ingest`` unified-corpus runs to
+    isolate per-corpus retrieval on a multi-corpus HC instance. When None,
+    HC searches across all visible documents (legacy wipe-and-reload mode).
+    """
+    scope = {"folder_ids": [scope_folder_id]} if scope_folder_id else None
     if is_research:
         # Clean up any orphan research task from a prior killed sweep before
         # POSTing a new one — otherwise Harbor Clerk returns 409 Conflict
@@ -649,14 +658,16 @@ def _run_local(
         # run_research drains the SSE stream until the research finishes
         # server-side. Closing the stream early would trigger HC's
         # "interrupted-on-disconnect" handler and produce empty results.
-        conv_id, result = hc.run_research(question_text, depth=depth, time_limit_minutes=time_limit_minutes)
+        conv_id, result = hc.run_research(
+            question_text, depth=depth, time_limit_minutes=time_limit_minutes, scope=scope
+        )
         # Normalize: ResearchDetail returns "report", chat returns "answer".
         # Store under "answer" so all downstream metrics code uses a uniform key.
         normalized_answer = result.get("report") or result.get("answer", "")
         result["answer"] = normalized_answer
     else:
         # Ask flow: create a chat conversation, then send the question, drain SSE
-        conv_id = hc.create_conversation(title=f"test-corpora/{corpus}/{model}/{question_id}")
+        conv_id = hc.create_conversation(title=f"test-corpora/{corpus}/{model}/{question_id}", scope=scope)
         events = list(hc.stream_ask(conv_id, question_text))
         # Harbor Clerk chat SSE emits {type: "token", content: "<text>"} for tokens.
         # Citations are in the final {type: "done"} event's rag_context.citations field.
@@ -1020,6 +1031,14 @@ def main(argv: list[str] | None = None) -> int:
         # Sonnet 4.6 baseline generator has real KB tools available.
         mcp_session: SyncMcpSession | None = None
 
+        # Corpus → folder_id mapping for scoped local runs. Populated lazily
+        # on the first _run_local call when --no-ingest is set, so unified
+        # multi-corpus HC instances can isolate per-corpus retrieval via
+        # PR #415's folder-scope feature. Skipped entirely when ingesting
+        # corpora the legacy way (one corpus loaded at a time, no scope
+        # needed).
+        scope_folder_id_by_corpus: dict[str, str] = {}
+
         # Iterate corpus-outer / phase-inner so each corpus is ingested at most
         # once per sweep run. The previous phase-outer / corpus-inner ordering
         # forced the corpus to be wiped + re-ingested between phases (e.g.
@@ -1277,6 +1296,16 @@ def main(argv: list[str] | None = None) -> int:
                                 error=f"unfilled placeholder: {placeholder}",
                             )
                             continue
+                        # In --no-ingest mode (unified-corpus HC), resolve the
+                        # corpus's watch-folder UUID once and reuse it. Passing
+                        # the UUID to _run_local makes HC's chat / research
+                        # restrict tool calls to that folder (PR #415).
+                        scope_folder_id: str | None = None
+                        if args.no_ingest and u.corpus != "unified":
+                            if u.corpus not in scope_folder_id_by_corpus:
+                                scope_folder_id_by_corpus[u.corpus] = hc.folder_id_for_corpus(u.corpus)
+                            scope_folder_id = scope_folder_id_by_corpus[u.corpus]
+
                         out = _run_local(
                             hc=hc,
                             corpus=u.corpus,
@@ -1287,6 +1316,7 @@ def main(argv: list[str] | None = None) -> int:
                             time_limit_minutes=args.time_limit_minutes,
                             is_research=_is_research(u.question_id),
                             results_dir=run_dir,
+                            scope_folder_id=scope_folder_id,
                         )
 
                         # One-shot retry on transient research failures. The most
@@ -1321,6 +1351,7 @@ def main(argv: list[str] | None = None) -> int:
                                     time_limit_minutes=args.time_limit_minutes,
                                     is_research=True,
                                     results_dir=run_dir,
+                                    scope_folder_id=scope_folder_id,
                                 )
 
                     # For local-model questions (phases 2-6), inspect the


### PR DESCRIPTION
## Summary

After PR #415 added folder-scope to chat conversations + research runs (the human-side of the long-deferred "Projects/Collections" work), the test-corpora harness could in theory run all three corpora simultaneously on one HC instance and restrict each cell's retrieval to a single corpus. This PR wires that up.

The cloud-side answer-eval mode already had this capability via scoped API keys. The local-model path (legacy `--phases 4` sweep, which routes through HC's own chat/research APIs) was missing it — local cells would have pulled cross-corpus tool results once the unified corpus was loaded.

## Changes

- **`client.create_conversation(scope=...)`** — forwards a scope object to `POST /chat/conversations`.
- **`client.run_research(scope=...)`** — same for `POST /research`.
- **`client.folder_id_for_corpus(corpus)`** — resolves a corpus name to its watch folder UUID. Matches by `display_name` first, falls back to the path-basename of the parent directory. Raises loudly when no folder matches so callers don't silently fall back to an unscoped (cross-corpus) query.
- **`_run_local(scope_folder_id=...)`** — builds `{folder_ids: [scope_folder_id]}` when set and passes to both chat creation and research start.
- **Main sweep loop** — lazily resolves + caches the folder_id per corpus only when `--no-ingest` is set. Legacy wipe-and-reload mode is completely unaffected; nothing changes for runs that ingest one corpus at a time.

## Verification

End-to-end smoke against the running HC instance with the unified corpus loaded (CUAD + Enron + synthetic as three folders):

```bash
uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
  --phases 4 --no-ingest --skip-canary --no-judge --no-hc-logs --resume \
  --run-id 2026-05-28-local-smoke \
  --corpora cuad --models qwen3-4b \
  --api-base "$HC_API_BASE" \
  --workdir "$HOME/Library/Application Support/Harbor Clerk/test-corpora"
```

16 cuad-ask + cuad-research questions completed (~20 min total wall, ~130s each for research, ~5s each for ask). Sample conversation inspected via `GET /api/chat/conversations/<id>` confirms `scope.folder_ids` matches the CUAD folder UUID.

## Test plan

- [x] `ruff check` + module imports clean
- [x] Smoke: 16 questions through qwen3-4b scoped to CUAD on unified HC instance → 0 errors, scope persisted on every conversation
- [ ] CI doesn't cover the test-corpora module (opt-in eval).
- [ ] Manual: full 24-cell sweep (8 local models × 3 corpora) — gated on a separate decision since it's multi-day wall clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
