### PR TITLE
fix(macos): move PG data dir aside instead of removing it on version mismatch

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -46,7 +46,11 @@ final class PostgresService: ManagedService {
         if fm.fileExists(atPath: pgVersionFile.path) {
             let stored = (try? String(contentsOf: pgVersionFile, encoding: .utf8))?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            if stored != expectedMajor {
+            // Guard against `expectedMajor` being empty — `bundledPgMajorVersion()`
+            // returns "" on any failure to probe `postgres --version`. Without
+            // this, a transient bundled-binary error would treat a healthy
+            // data dir as mismatched and move it aside unnecessarily.
+            if !expectedMajor.isEmpty && stored != expectedMajor {
                 Log.logger("postgresql").warning(
                     "Data directory version mismatch: found \(stored ?? "?", privacy: .public), expected \(expectedMajor, privacy: .public). Moving aside before initializing a fresh cluster."
                 )

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -48,9 +48,26 @@ final class PostgresService: ManagedService {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if stored != expectedMajor {
                 Log.logger("postgresql").warning(
-                    "Data directory version mismatch: found \(stored ?? "?", privacy: .public), expected \(expectedMajor, privacy: .public). Reinitializing."
+                    "Data directory version mismatch: found \(stored ?? "?", privacy: .public), expected \(expectedMajor, privacy: .public). Moving aside before initializing a fresh cluster."
                 )
-                try? fm.removeItem(at: dataDir)
+                // Move the existing data dir aside instead of `removeItem` —
+                // a user restoring an older-PG backup or running a worktree
+                // build with stale bundled PG would otherwise lose every
+                // user / document / chat history with no recovery path.
+                // Throwing on failure is intentional: refusing to start beats
+                // silent data loss.
+                let backup: URL
+                do {
+                    backup = try Self.moveDataDirAside(dataDir: dataDir, storedVersion: stored)
+                } catch {
+                    Log.logger("postgresql").error(
+                        "Could not move data directory aside: \(error.localizedDescription, privacy: .public). Refusing to start to avoid data loss."
+                    )
+                    throw error
+                }
+                Log.logger("postgresql").warning(
+                    "Previous PostgreSQL data preserved at: \(backup.path, privacy: .public) — delete it manually once you've confirmed nothing was lost."
+                )
                 needsInit = true
             }
         } else {
@@ -279,6 +296,55 @@ final class PostgresService: ManagedService {
             return .remove(pid)
         }
         return .keep
+    }
+
+    /// Move the existing data directory aside to a timestamped sibling, returning
+    /// the backup URL on success. Data-safety guard for the PG major-version
+    /// mismatch path — without it, a user restoring an older-PG backup (or
+    /// running a worktree build with stale bundled PG) silently loses every
+    /// user / document / chat history when start() calls removeItem.
+    ///
+    /// The destination name encodes the source PG version and a UTC timestamp
+    /// (`postgres-data-pg16-backup-20260528-120000`) so an operator can tell
+    /// which cluster the backup belongs to and what time the move happened.
+    /// Same-second collisions (rare — implies two restarts in the same second)
+    /// get a numeric suffix; >100 collisions throws to surface the bug.
+    ///
+    /// Throws on move failure. Callers should let the error propagate —
+    /// refusing to start beats silent data loss. Extracted as static for
+    /// testability against tempdirs.
+    nonisolated static func moveDataDirAside(
+        dataDir: URL,
+        storedVersion: String?,
+        now: Date = Date(),
+        fileManager: FileManager = .default,
+    ) throws -> URL {
+        let parent = dataDir.deletingLastPathComponent()
+        let base = dataDir.lastPathComponent
+        let pgTag = storedVersion.flatMap { $0.isEmpty ? nil : "pg\($0)" } ?? "pg-unknown"
+        let stampFmt = DateFormatter()
+        stampFmt.locale = Locale(identifier: "en_US_POSIX")
+        stampFmt.timeZone = TimeZone(identifier: "UTC")
+        stampFmt.dateFormat = "yyyyMMdd-HHmmss"
+        let stamp = stampFmt.string(from: now)
+
+        var candidate = parent.appendingPathComponent("\(base)-\(pgTag)-backup-\(stamp)")
+        var attempt = 1
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = parent.appendingPathComponent("\(base)-\(pgTag)-backup-\(stamp)-\(attempt)")
+            attempt += 1
+            if attempt > 100 {
+                throw NSError(
+                    domain: "com.harborclerk.postgres",
+                    code: -1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Too many backup-directory collisions at \(candidate.path)",
+                    ],
+                )
+            }
+        }
+        try fileManager.moveItem(at: dataDir, to: candidate)
+        return candidate
     }
 
     private func pgEnvironment() -> [String: String] {

--- a/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
@@ -65,6 +65,113 @@ final class ServiceConfigTests: XCTestCase {
         XCTAssertEqual(action, .removeUnparseable)
     }
 
+    // MARK: - PG Data Dir Safety Move
+
+    /// Helper: create a fresh fake data dir in a tempdir, return (parent, dataDir).
+    private func makeFakeDataDir(withPGVersion stored: String?) throws -> (parent: URL, dataDir: URL) {
+        let parent = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pg-safety-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: parent) }
+        let dataDir = parent.appendingPathComponent("postgres-data", isDirectory: true)
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        if let stored {
+            try stored.write(
+                to: dataDir.appendingPathComponent("PG_VERSION"),
+                atomically: true,
+                encoding: .utf8,
+            )
+        }
+        // Drop a sentinel file so we can prove the move preserved contents.
+        try Data("hello".utf8).write(to: dataDir.appendingPathComponent("sentinel.txt"))
+        return (parent, dataDir)
+    }
+
+    func testMoveDataDirAsideRenamesToTimestampedSibling() throws {
+        let (parent, dataDir) = try makeFakeDataDir(withPGVersion: "16")
+        let now = Date(timeIntervalSince1970: 1_716_864_000)  // 2026-05-28 00:00:00 UTC
+
+        let backup = try PostgresService.moveDataDirAside(
+            dataDir: dataDir,
+            storedVersion: "16",
+            now: now,
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dataDir.path),
+            "Original data dir should be gone after the move",
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: backup.path),
+            "Backup dir should exist after the move",
+        )
+        XCTAssertEqual(backup.deletingLastPathComponent(), parent, "Backup must be a sibling, not nested")
+        XCTAssertEqual(backup.lastPathComponent, "postgres-data-pg16-backup-20260528-000000")
+        // Sentinel survived → it's a real rename, not a copy-and-truncate
+        let sentinel = try String(contentsOf: backup.appendingPathComponent("sentinel.txt"), encoding: .utf8)
+        XCTAssertEqual(sentinel, "hello")
+    }
+
+    func testMoveDataDirAsideHandlesUnknownStoredVersion() throws {
+        let (_, dataDir) = try makeFakeDataDir(withPGVersion: nil)
+        let now = Date(timeIntervalSince1970: 1_716_864_000)
+
+        let backup = try PostgresService.moveDataDirAside(
+            dataDir: dataDir,
+            storedVersion: nil,
+            now: now,
+        )
+        XCTAssertEqual(backup.lastPathComponent, "postgres-data-pg-unknown-backup-20260528-000000")
+
+        // Empty-string stored version (defensive — `String(contentsOf:)` could
+        // theoretically yield this if PG_VERSION existed but was empty) takes
+        // the same branch as nil.
+        let (_, dataDir2) = try makeFakeDataDir(withPGVersion: nil)
+        let backup2 = try PostgresService.moveDataDirAside(
+            dataDir: dataDir2,
+            storedVersion: "",
+            now: now,
+        )
+        XCTAssertTrue(backup2.lastPathComponent.contains("pg-unknown"))
+    }
+
+    func testMoveDataDirAsideHandlesSameSecondCollision() throws {
+        let (parent, dataDir) = try makeFakeDataDir(withPGVersion: "16")
+        let now = Date(timeIntervalSince1970: 1_716_864_000)
+
+        // Pre-create the naive candidate destination so the helper has to
+        // pick a suffixed name. This is the "two restarts within the same
+        // second after a crash" edge case.
+        let pre = parent.appendingPathComponent("postgres-data-pg16-backup-20260528-000000")
+        try FileManager.default.createDirectory(at: pre, withIntermediateDirectories: true)
+
+        let backup = try PostgresService.moveDataDirAside(
+            dataDir: dataDir,
+            storedVersion: "16",
+            now: now,
+        )
+
+        XCTAssertEqual(
+            backup.lastPathComponent,
+            "postgres-data-pg16-backup-20260528-000000-1",
+            "First collision should append -1, not overwrite the existing backup",
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pre.path), "Existing backup must remain untouched")
+    }
+
+    func testMoveDataDirAsideThrowsWhenSourceMissing() throws {
+        let parent = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pg-safety-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: parent) }
+        let missing = parent.appendingPathComponent("postgres-data", isDirectory: true)
+
+        XCTAssertThrowsError(
+            try PostgresService.moveDataDirAside(dataDir: missing, storedVersion: "16"),
+            "Move should throw when the source dir does not exist; refusing to start is safer than silent data loss",
+        )
+    }
+
     // MARK: - Log Formatting
 
     func testLogFormatForCopy() {

--- a/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
@@ -89,7 +89,7 @@ final class ServiceConfigTests: XCTestCase {
 
     func testMoveDataDirAsideRenamesToTimestampedSibling() throws {
         let (parent, dataDir) = try makeFakeDataDir(withPGVersion: "16")
-        let now = Date(timeIntervalSince1970: 1_716_864_000)  // 2026-05-28 00:00:00 UTC
+        let now = Date(timeIntervalSince1970: 1_779_926_400)  // 2026-05-28 00:00:00 UTC
 
         let backup = try PostgresService.moveDataDirAside(
             dataDir: dataDir,
@@ -114,7 +114,7 @@ final class ServiceConfigTests: XCTestCase {
 
     func testMoveDataDirAsideHandlesUnknownStoredVersion() throws {
         let (_, dataDir) = try makeFakeDataDir(withPGVersion: nil)
-        let now = Date(timeIntervalSince1970: 1_716_864_000)
+        let now = Date(timeIntervalSince1970: 1_779_926_400)
 
         let backup = try PostgresService.moveDataDirAside(
             dataDir: dataDir,
@@ -137,7 +137,7 @@ final class ServiceConfigTests: XCTestCase {
 
     func testMoveDataDirAsideHandlesSameSecondCollision() throws {
         let (parent, dataDir) = try makeFakeDataDir(withPGVersion: "16")
-        let now = Date(timeIntervalSince1970: 1_716_864_000)
+        let now = Date(timeIntervalSince1970: 1_779_926_400)
 
         // Pre-create the naive candidate destination so the helper has to
         // pick a suffixed name. This is the "two restarts within the same


### PR DESCRIPTION
## Summary

`PostgresService.start()` detected a PG major-version mismatch on the data directory (e.g. a user-restored PG 16 backup under bundled PG 18) and ran `try? fm.removeItem(at: dataDir)` — silently destroying every user, document, and chat history with no prompt and no recovery path. Reproduced live during PR-A smoke testing (see `pr_followups.md` § Data safety).

Replace the `removeItem` with a rename to a timestamped sibling: `postgres-data-pg16-backup-20260528-120000`. Cheap (single rename within the same APFS volume — atomic), reversible (operator can rename back), and the backup path is surfaced prominently in the log so the user can find it. Same-second collision after a quick-restart cycle gets a numeric suffix.

**Throw on move failure rather than fall through to the destructive path** — refusing to start beats silent data loss. The error propagates up `start()` and surfaces via the normal "service errored" UI affordance.

## Belt-and-suspenders

Also guards against the related "probe failure" scenario: `bundledPgMajorVersion()` returns `""` if `postgres --version` fails for any transient reason. Pre-this-PR, `"" != stored` would trigger the destructive `removeItem` on a healthy data dir. Post-this-PR, it would still trigger the move-aside + throw — safer than before, but still an unnecessary rename. Added `!expectedMajor.isEmpty` to the guard so a probe failure is now a complete no-op for the data directory.

## Tests

Four new XCTest cases in `ServiceConfigTests.swift` covering:
- Happy path — rename succeeds, sentinel file survives the move
- Unknown / empty `storedVersion` → falls back to `pg-unknown` tag
- Same-second collision — naive candidate already exists, helper picks suffixed name, original backup is not overwritten
- Source missing → throws (refusing to start is safer than silent data loss)

Logic extracted as `PostgresService.moveDataDirAside(dataDir:storedVersion:now:fileManager:)`, a `nonisolated static` following the same pattern as `stalePidAction` — fully testable against tempdirs.

## Fresh-eyes review

Dispatched against `51fde31` before opening this PR per the standing directive. Reviewer caught two issues, both fixed in the follow-up commit `ce94e1d`:
1. Wrong Unix epoch in three test constants (`1_716_864_000` = 2024-05-28, not 2026-05-28 as the comment claimed) — would have caused three assertion failures on CI. Bumped to `1_779_926_400`.
2. Pre-existing `bundledPgMajorVersion() → ""` would trigger the destructive branch unnecessarily — added the `!expectedMajor.isEmpty` guard above.

## Test plan

- [x] `xcodebuild build-for-testing -scheme HarborClerkServer -destination 'platform=macOS'` → **TEST BUILD SUCCEEDED**.
- [ ] Tests did NOT run locally — `xcodebuild test` consistently hits *"The test runner hung before establishing connection"* on this machine (macOS 26.4 / current Xcode) for ALL test classes, not just the new ones. Pre-existing infrastructure issue, unrelated to this change. The compile passes; logic is reviewed and matches the existing `stalePidAction` pattern that's already passing on developer machines.
- [ ] **Manual verification before merge:** ideally run `xcodebuild test-without-building -scheme HarborClerkServer -destination 'platform=macOS' -only-testing:HarborClerkServerTests/ServiceConfigTests` from Xcode (rather than CLI) on a machine where the test runner works, OR confirm via a deliberate version-mismatch reproduction (start the app against a `postgres-data` directory containing `PG_VERSION = "16"` while bundled PG is 18; verify the original dir is renamed to `postgres-data-pg16-backup-<stamp>` rather than wiped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
