### PR TITLE
fix(macos): audit data dir state pre-init + refuse to silently reinit on suspect dir

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -57,6 +57,20 @@ final class PostgresService: ManagedService {
             needsInit = true
 
         case .pgVersionPresent(let stored):
+            // PG_VERSION exists but unreadable (permission glitch, full disk,
+            // NFS hiccup) → `auditDataDirBeforeInit` reports the file as
+            // present but with `nil` contents. Without this guard, `nil !=
+            // expectedMajor` would fire the move-aside path and reinitialize
+            // a potentially-valid cluster — same shape as the original
+            // wipe bug. Refuse instead; operator should investigate.
+            guard let stored else {
+                let message =
+                    "PG_VERSION at \(dataDir.path)/PG_VERSION exists but could not be read. " +
+                    "Refusing to start — check filesystem permissions and disk space; " +
+                    "do NOT delete the data directory manually before recovery."
+                Log.logger("postgresql").error("\(message, privacy: .public)")
+                throw ServiceError.startFailed(name, message)
+            }
             // Existing version-mismatch + move-aside path (PR #426). Guard
             // against `expectedMajor` being empty — `bundledPgMajorVersion()`
             // returns "" on any failure to probe `postgres --version`; without
@@ -64,7 +78,7 @@ final class PostgresService: ManagedService {
             // data dir as mismatched.
             if !expectedMajor.isEmpty && stored != expectedMajor {
                 Log.logger("postgresql").warning(
-                    "Data directory version mismatch: found \(stored ?? "?", privacy: .public), expected \(expectedMajor, privacy: .public). Moving aside before initializing a fresh cluster."
+                    "Data directory version mismatch: found \(stored, privacy: .public), expected \(expectedMajor, privacy: .public). Moving aside before initializing a fresh cluster."
                 )
                 let backup: URL
                 do {

--- a/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/PostgresService.swift
@@ -36,30 +36,36 @@ final class PostgresService: ManagedService {
 
     func start() async throws {
         let fm = FileManager.default
-        let pgVersionFile = dataDir.appendingPathComponent("PG_VERSION")
 
         // Determine bundled PG major version (e.g. "18" from "postgres (PostgreSQL) 18.3")
         let expectedMajor = await bundledPgMajorVersion()
 
-        // Check if data directory needs (re-)initialization
+        // Audit the data directory before any potentially-destructive action.
+        // Always log so a recurrence of the undiagnosed 2026-05-14 user-table
+        // wipe (described in pr_followups.md § Data safety) has forensic data
+        // on what state the directory was in pre-init, instead of disappearing
+        // into the noise like the original incident did.
+        let audit = Self.auditDataDirBeforeInit(dataDir: dataDir)
+        Log.logger("postgresql").info(
+            "Data dir audit at start: \(String(describing: audit), privacy: .public)"
+        )
+
         var needsInit = false
-        if fm.fileExists(atPath: pgVersionFile.path) {
-            let stored = (try? String(contentsOf: pgVersionFile, encoding: .utf8))?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            // Guard against `expectedMajor` being empty — `bundledPgMajorVersion()`
-            // returns "" on any failure to probe `postgres --version`. Without
+        switch audit {
+        case .missing, .empty:
+            // No data present — proceed to initdb (the normal first-launch path).
+            needsInit = true
+
+        case .pgVersionPresent(let stored):
+            // Existing version-mismatch + move-aside path (PR #426). Guard
+            // against `expectedMajor` being empty — `bundledPgMajorVersion()`
+            // returns "" on any failure to probe `postgres --version`; without
             // this, a transient bundled-binary error would treat a healthy
-            // data dir as mismatched and move it aside unnecessarily.
+            // data dir as mismatched.
             if !expectedMajor.isEmpty && stored != expectedMajor {
                 Log.logger("postgresql").warning(
                     "Data directory version mismatch: found \(stored ?? "?", privacy: .public), expected \(expectedMajor, privacy: .public). Moving aside before initializing a fresh cluster."
                 )
-                // Move the existing data dir aside instead of `removeItem` —
-                // a user restoring an older-PG backup or running a worktree
-                // build with stale bundled PG would otherwise lose every
-                // user / document / chat history with no recovery path.
-                // Throwing on failure is intentional: refusing to start beats
-                // silent data loss.
                 let backup: URL
                 do {
                     backup = try Self.moveDataDirAside(dataDir: dataDir, storedVersion: stored)
@@ -74,8 +80,19 @@ final class PostgresService: ManagedService {
                 )
                 needsInit = true
             }
-        } else {
-            needsInit = true
+
+        case .corruptOrForeign(let fileCount, let sampleNames):
+            // Tripwire for the undiagnosed-wipe path: PG_VERSION is gone but
+            // the data dir contains files. `initdb` would refuse anyway, but
+            // its "initdb failed with N" hides the real condition. Surface
+            // the actual state and refuse — recovery should be manual so the
+            // operator can inspect what's left of the cluster.
+            let message =
+                "Data directory at \(dataDir.path) is non-empty (\(fileCount) files; sample: " +
+                "\(sampleNames.joined(separator: ", "))) but PG_VERSION is missing. " +
+                "Refusing to initialize a fresh cluster over potentially-populated state — investigate manually."
+            Log.logger("postgresql").error("\(message, privacy: .public)")
+            throw ServiceError.startFailed(name, message)
         }
 
         if needsInit {
@@ -301,6 +318,66 @@ final class PostgresService: ManagedService {
         }
         return .keep
     }
+
+    // MARK: - Data Dir Pre-Init Audit
+
+    /// Classification of the data directory's state at the moment `start()`
+    /// is about to consider initdb. Drives both forensic logging and the
+    /// `corruptOrForeign` tripwire — the audit is the only entry point that
+    /// can refuse to start without a version-mismatch having fired first.
+    enum DataDirState: Equatable {
+        /// dataDir does not exist on disk. First-launch or post-wipe.
+        case missing
+        /// dataDir exists, is a directory, but is completely empty.
+        case empty
+        /// PG_VERSION present at top level. Inner string is the trimmed
+        /// contents (or nil if the file existed but couldn't be read).
+        case pgVersionPresent(String?)
+        /// PG_VERSION missing but the directory contains other files. Suspect
+        /// state — refuse to initdb on top. `fileCount` is the entire entry
+        /// count; `sampleNames` is up to 8 entry basenames, sorted, for log
+        /// triage (e.g. `["base", "global", "pg_wal"]` is unmistakably a
+        /// real cluster missing its version sentinel).
+        case corruptOrForeign(fileCount: Int, sampleNames: [String])
+    }
+
+    /// Classify the data directory's pre-init state. Forensic + safety guard
+    /// for the undiagnosed 2026-05-14 user-table wipe scenario: if PG_VERSION
+    /// is missing but the directory contains files, something has interfered
+    /// with the cluster — `initdb` would refuse anyway, but the resulting
+    /// "initdb failed with N" error hides the actual condition. By auditing
+    /// first we (a) always log what was on disk pre-init (the forensic data
+    /// the original incident report asked for), and (b) refuse with a
+    /// specific error message instead of the opaque `initdb` failure.
+    ///
+    /// Extracted as static for testability against tempdirs.
+    nonisolated static func auditDataDirBeforeInit(
+        dataDir: URL,
+        fileManager: FileManager = .default,
+    ) -> DataDirState {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: dataDir.path, isDirectory: &isDir), isDir.boolValue else {
+            return .missing
+        }
+        let pgVersionPath = dataDir.appendingPathComponent("PG_VERSION").path
+        if fileManager.fileExists(atPath: pgVersionPath) {
+            let contents = (try? String(contentsOfFile: pgVersionPath, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return .pgVersionPresent(contents)
+        }
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: dataDir,
+            includingPropertiesForKeys: nil,
+            options: [],
+        )) ?? []
+        if entries.isEmpty {
+            return .empty
+        }
+        let sample = entries.prefix(8).map { $0.lastPathComponent }.sorted()
+        return .corruptOrForeign(fileCount: entries.count, sampleNames: sample)
+    }
+
+    // MARK: - Version-Mismatch Safety Move
 
     /// Move the existing data directory aside to a timestamped sibling, returning
     /// the backup URL on success. Data-safety guard for the PG major-version

--- a/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
@@ -217,6 +217,26 @@ final class ServiceConfigTests: XCTestCase {
         )
     }
 
+    func testAuditDataDirReportsPGVersionPresentNilWhenContentsUnreadable() throws {
+        // Simulate "PG_VERSION exists but unreadable" by making the path a
+        // directory instead of a regular file. `fileExists(atPath:)` returns
+        // true, but `String(contentsOfFile:)` fails (EISDIR) and the audit
+        // surfaces `.pgVersionPresent(nil)`. The `start()` switch arm refuses
+        // to start in this case (rather than treating `nil != expectedMajor`
+        // as mismatch and moving aside a potentially-valid cluster).
+        let (_, dataDir) = try makeAuditScaffold()
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: dataDir.appendingPathComponent("PG_VERSION", isDirectory: true),
+            withIntermediateDirectories: true,
+        )
+
+        XCTAssertEqual(
+            PostgresService.auditDataDirBeforeInit(dataDir: dataDir),
+            .pgVersionPresent(nil),
+        )
+    }
+
     func testAuditDataDirReportsCorruptWhenPGVersionMissingButFilesPresent() throws {
         // The tripwire case: real cluster subdirs present (base/, global/,
         // pg_wal/, pg_xact/) but PG_VERSION is gone. Pre-this-PR the bare

--- a/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/ServiceConfigTests.swift
@@ -172,6 +172,96 @@ final class ServiceConfigTests: XCTestCase {
         )
     }
 
+    // MARK: - Data Dir Pre-Init Audit
+
+    /// Helper: create a fresh `parent` dir in a tempdir, add a teardown block,
+    /// and return the parent + the not-yet-created `dataDir` URL inside it.
+    /// Callers seed `dataDir` to whatever state they want for the test.
+    private func makeAuditScaffold() throws -> (parent: URL, dataDir: URL) {
+        let parent = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("pg-audit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: parent) }
+        return (parent, parent.appendingPathComponent("postgres-data", isDirectory: true))
+    }
+
+    func testAuditDataDirReportsMissingWhenDirAbsent() throws {
+        let (_, dataDir) = try makeAuditScaffold()
+        // Note: dataDir not created — exercise the missing path.
+        XCTAssertEqual(PostgresService.auditDataDirBeforeInit(dataDir: dataDir), .missing)
+    }
+
+    func testAuditDataDirReportsMissingWhenPathIsAFile() throws {
+        // A regular file at `dataDir.path` is not a usable data directory.
+        let (parent, _) = try makeAuditScaffold()
+        let dataDir = parent.appendingPathComponent("postgres-data")
+        try Data().write(to: dataDir)
+        XCTAssertEqual(PostgresService.auditDataDirBeforeInit(dataDir: dataDir), .missing)
+    }
+
+    func testAuditDataDirReportsEmptyWhenDirHasNoFiles() throws {
+        let (_, dataDir) = try makeAuditScaffold()
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        XCTAssertEqual(PostgresService.auditDataDirBeforeInit(dataDir: dataDir), .empty)
+    }
+
+    func testAuditDataDirReportsPGVersionPresentWithTrimmedContents() throws {
+        let (_, dataDir) = try makeAuditScaffold()
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        // Real PG_VERSION files end with a newline; the audit must trim it.
+        try "18\n".write(to: dataDir.appendingPathComponent("PG_VERSION"), atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            PostgresService.auditDataDirBeforeInit(dataDir: dataDir),
+            .pgVersionPresent("18"),
+        )
+    }
+
+    func testAuditDataDirReportsCorruptWhenPGVersionMissingButFilesPresent() throws {
+        // The tripwire case: real cluster subdirs present (base/, global/,
+        // pg_wal/, pg_xact/) but PG_VERSION is gone. Pre-this-PR the bare
+        // `fileExists(PG_VERSION)` check would treat this as a fresh launch
+        // and call initdb; `initdb` would refuse, but the user only sees
+        // "initdb failed with N". The audit surfaces the real state.
+        let (_, dataDir) = try makeAuditScaffold()
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        for name in ["base", "global", "pg_wal", "pg_xact"] {
+            try FileManager.default.createDirectory(
+                at: dataDir.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: true,
+            )
+        }
+
+        let result = PostgresService.auditDataDirBeforeInit(dataDir: dataDir)
+        guard case .corruptOrForeign(let fileCount, let sampleNames) = result else {
+            return XCTFail("Expected .corruptOrForeign, got \(result)")
+        }
+        XCTAssertEqual(fileCount, 4)
+        XCTAssertEqual(sampleNames, ["base", "global", "pg_wal", "pg_xact"])
+    }
+
+    func testAuditDataDirSampleNamesCapAt8() throws {
+        let (_, dataDir) = try makeAuditScaffold()
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        // 12 entries; the sample is capped at 8 and returned sorted ascending.
+        let names = ["a01", "b02", "c03", "d04", "e05", "f06", "g07", "h08", "i09", "j10", "k11", "l12"]
+        for name in names {
+            try Data().write(to: dataDir.appendingPathComponent(name))
+        }
+
+        let result = PostgresService.auditDataDirBeforeInit(dataDir: dataDir)
+        guard case .corruptOrForeign(let fileCount, let sampleNames) = result else {
+            return XCTFail("Expected .corruptOrForeign, got \(result)")
+        }
+        XCTAssertEqual(fileCount, 12)
+        // FileManager.contentsOfDirectory's order is undefined per Apple's
+        // docs (depends on filesystem semantics) so we assert only that we
+        // get exactly 8 entries from the seeded set, sorted ascending.
+        XCTAssertEqual(sampleNames.count, 8)
+        XCTAssertTrue(Set(sampleNames).isSubset(of: Set(names)))
+        XCTAssertEqual(sampleNames, sampleNames.sorted())
+    }
+
     // MARK: - Log Formatting
 
     func testLogFormatForCopy() {


### PR DESCRIPTION
> **Stacks on [#426](https://github.com/r0shi/harborclerk/pull/426).** Diff against `main` includes #426's safety-move; diff against `fix/postgres-data-dir-safety-move` is just this PR's contribution (audit + tripwire). Rebase target becomes `main` once #426 lands.

## Summary

Closes the second Critical item in `pr_followups.md` § Data safety — the **undiagnosed** 2026-05-14 user-table wipe with no "Reinitializing" log entry. The wipe's root cause isn't recoverable without a live reproducer (the user declined forensics at the time), but the start path can grow a tripwire so a recurrence leaves the diagnostic gold the original incident report asked for.

## What I audited

| Hypothesis | Outcome |
|---|---|
| Test suite ran with `DATABASE_URL` pointed at production `lka` | **Guarded** — PR #146 (2026-04-10) refuses pytest against any DB not matching `_test` suffix. Predates the 2026-05-14 incident. |
| An Alembic migration drops or truncates `users` | **Clean** — no `DROP TABLE users` / `TRUNCATE` / `DELETE FROM users` in any `alembic/versions/*.py`. Only `document_links` has a `drop_table` and only on downgrade. |
| App-side code path deletes users | **Audited** — only the admin endpoint deletes users, and it's audit-logged + admin-gated. |
| `initdb` runs on a populated dir somehow | **Self-protected** — `initdb` refuses, but the resulting `ServiceError("initdb failed with N")` hides the actual condition (dir is non-empty AND PG_VERSION is missing). |

Without a live reproducer the cause is genuinely unrecoverable, so this PR ships defenses instead of a one-line fix.

## What this PR does

1. **`PostgresService.DataDirState` enum** — classifies the data dir's pre-init state into `missing` / `empty` / `pgVersionPresent(String?)` / `corruptOrForeign(fileCount:sampleNames:)`.

2. **`nonisolated static auditDataDirBeforeInit(dataDir:fileManager:)`** — produces the classification. Same pattern as the existing `stalePidAction` and `moveDataDirAside` statics (testable against tempdirs).

3. **`start()` always logs the audit result at `info, privacy: .public`** — so a recurrence always leaves forensic data in the unified log (the diagnostic gold the original incident report asked for: file count, PG_VERSION state, sample of entry names).

4. **`.corruptOrForeign` arm throws `ServiceError.startFailed`** with the file count + sample names. Refuses to silently reinit over a populated dir. PR #426's version-mismatch safety-move becomes a sub-step of the `.pgVersionPresent` arm — same behavior, cleaner routing.

5. **Fresh-eyes review fix (`5923d5d`):** `pgVersionPresent(nil)` (PG_VERSION exists but unreadable — permission glitch, full disk, NFS) previously fell through to "mismatch" because `nil != expectedMajor`. Now refuses to start with a clear error rather than treating a transient read failure as version mismatch.

## Tests

7 new XCTest cases in `ServiceConfigTests.swift`:
- `testAuditDataDirReportsMissingWhenDirAbsent`
- `testAuditDataDirReportsMissingWhenPathIsAFile`
- `testAuditDataDirReportsEmptyWhenDirHasNoFiles`
- `testAuditDataDirReportsPGVersionPresentWithTrimmedContents` (real PG_VERSION files end in `\n`; trim must strip it)
- `testAuditDataDirReportsPGVersionPresentNilWhenContentsUnreadable` (added in the review-fix commit; uses a directory-as-PG_VERSION trick to deterministically produce the nil-contents case)
- `testAuditDataDirReportsCorruptWhenPGVersionMissingButFilesPresent` (the tripwire — seeds `base/global/pg_wal/pg_xact` then asserts `.corruptOrForeign` with the sample)
- `testAuditDataDirSampleNamesCapAt8` (>8 entries → sample is 8, sorted, subset of the seeded set)

## Test plan

- [x] `xcodebuild build-for-testing -scheme HarborClerkServer -destination 'platform=macOS'` → **TEST BUILD SUCCEEDED**.
- [ ] Tests did NOT run locally — `xcodebuild test` hits *"The test runner hung before establishing connection"* on macOS 26.4 / current Xcode for ALL test classes (same flake flagged in #426). Compile passes; logic mirrors the already-passing `moveDataDirAside` pattern.
- [ ] **Manual verification before merge:** ideally run from Xcode UI rather than CLI. Or do a deliberate reproduction:
  - Stop HC. Move `~/Library/Application Support/Harbor Clerk/postgres-data/PG_VERSION` aside. Start HC → should refuse with a `.corruptOrForeign` error in the log (NOT silent reinit).
  - Restore PG_VERSION. Start HC → normal startup.

## Fresh-eyes review

Dispatched against `13e7489` before opening this PR. The reviewer found one issue at confidence 88 (the `pgVersionPresent(nil)` false-positive path) — fixed in `5923d5d`. Other questions (log-injection risk, teardown-block UUID safety, `prefix(8)` ordering claims) were verified safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
