### PR TITLE
fix(watcher): parse .eml at ingest + extract-stage backfill for legacy rows

### DIFF
--- a/src/harbor_clerk/watcher/events.py
+++ b/src/harbor_clerk/watcher/events.py
@@ -233,10 +233,13 @@ def _apply_email_fields(doc: Document, parsed: EmailParseResult) -> None:
     """Copy parsed-email metadata onto an existing Document row.
 
     Mirrors `mail/ingest.py::create_email_document` for the watched-folder
-    ingest path. Only the email_* columns + title + created_at/updated_at;
-    we don't touch sha256, source_path, mime_type, etc. The IMAP path also
-    sets email_label_path (Gmail label name); watched-folder ingest has
-    folder_id on the WatchedFile row for that role, so email_label_path
+    ingest path. Sets the email_* columns + title + created_at; we don't
+    touch sha256, source_path, mime_type, or updated_at. `updated_at` is
+    intentionally left to the caller — on a reprocess (in-place .eml edit)
+    it would be wrong to slide updated_at backwards to the email's send
+    date when the record was just touched now. The IMAP path also sets
+    `email_label_path` (Gmail label name); watched-folder ingest has
+    `folder_id` on the WatchedFile row for that role, so email_label_path
     stays NULL here.
     """
     doc.title = parsed.subject
@@ -250,10 +253,11 @@ def _apply_email_fields(doc: Document, parsed: EmailParseResult) -> None:
     doc.email_date_sent = parsed.date_sent
     # Match IMAP-path semantics: created_at = email send date, so the
     # Documents page sorts emails by when they were sent, not when they
-    # were dropped into the watched folder.
+    # were dropped into the watched folder. Stays semantically correct
+    # on reprocess too — `created_at` describes the email content, and
+    # the new bytes' Date header is what we want.
     if parsed.date_sent is not None:
         doc.created_at = parsed.date_sent
-        doc.updated_at = parsed.date_sent
 
 
 def _create_doc_and_enqueue(session: Session, event: FileEvent, sha: bytes) -> None:
@@ -284,6 +288,12 @@ def _create_doc_and_enqueue(session: Session, event: FileEvent, sha: bytes) -> N
         parsed = _try_parse_eml(event.absolute_path)
         if parsed is not None:
             _apply_email_fields(doc, parsed)
+            # Pin updated_at = date_sent at first-create only (matches IMAP
+            # `create_email_document`). `_apply_email_fields` deliberately
+            # doesn't touch updated_at because the reprocess caller would
+            # otherwise slide updated_at backwards on every in-place edit.
+            if parsed.date_sent is not None:
+                doc.updated_at = parsed.date_sent
 
     session.add(doc)
     session.flush()

--- a/src/harbor_clerk/watcher/events.py
+++ b/src/harbor_clerk/watcher/events.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from harbor_clerk.file_types import ALLOWED_EXTENSIONS, guess_mime_type, is_excalidraw
+from harbor_clerk.mail.parser import EmailParseResult, parse_eml
 from harbor_clerk.models.chunk import Chunk
 from harbor_clerk.models.document import Document
 from harbor_clerk.models.document_heading import DocumentHeading
@@ -197,6 +198,14 @@ def _reprocess_doc(session: Session, doc_id: uuid.UUID, sha: bytes, source_path:
     doc.source_path = source_path
     doc.pipeline_status = PipelineStatus.queued
     doc.error = None
+    # For .eml: re-parse so the email_* columns (subject, from, to, date,
+    # etc.) reflect the new bytes. Otherwise an in-place edit that, say,
+    # corrects a misspelled subject would leave the old subject in the DB.
+    # Best-effort — parse failure leaves the existing values intact.
+    if (doc.mime_type or guess_mime_type(source_path)) == "message/rfc822":
+        parsed = _try_parse_eml(source_path)
+        if parsed is not None:
+            _apply_email_fields(doc, parsed)
     # Delete child rows explicitly (FKs have CASCADE but we do it here for
     # clarity and to avoid relying on DB-level CASCADE for application state).
     session.query(Chunk).filter_by(doc_id=doc_id).delete()
@@ -207,8 +216,50 @@ def _reprocess_doc(session: Session, doc_id: uuid.UUID, sha: bytes, source_path:
     session.add(IngestionJob(doc_id=doc_id, stage=JobStage.extract, status=JobStatus.queued))
 
 
+def _try_parse_eml(absolute_path: str) -> EmailParseResult | None:
+    """Best-effort `.eml` parse from disk. Returns None on any read or parse
+    failure — the caller falls through to a generic Document with email_*
+    columns NULL. `.eml` files are typically small; the extra read here on
+    top of the SHA-streaming read is page-cache-cheap in practice."""
+    try:
+        with open(absolute_path, "rb") as fh:
+            return parse_eml(fh.read())
+    except Exception as exc:
+        logger.warning("watcher: parse_eml failed for %s: %s", absolute_path, exc)
+        return None
+
+
+def _apply_email_fields(doc: Document, parsed: EmailParseResult) -> None:
+    """Copy parsed-email metadata onto an existing Document row.
+
+    Mirrors `mail/ingest.py::create_email_document` for the watched-folder
+    ingest path. Only the email_* columns + title + created_at/updated_at;
+    we don't touch sha256, source_path, mime_type, etc. The IMAP path also
+    sets email_label_path (Gmail label name); watched-folder ingest has
+    folder_id on the WatchedFile row for that role, so email_label_path
+    stays NULL here.
+    """
+    doc.title = parsed.subject
+    doc.email_message_id = parsed.message_id
+    doc.email_thread_id = parsed.thread_id
+    doc.email_from_address = parsed.from_address
+    doc.email_from_name = parsed.from_name
+    doc.email_subject = parsed.subject
+    doc.email_to_addresses = parsed.to_addresses or None
+    doc.email_cc_addresses = parsed.cc_addresses or None
+    doc.email_date_sent = parsed.date_sent
+    # Match IMAP-path semantics: created_at = email send date, so the
+    # Documents page sorts emails by when they were sent, not when they
+    # were dropped into the watched folder.
+    if parsed.date_sent is not None:
+        doc.created_at = parsed.date_sent
+        doc.updated_at = parsed.date_sent
+
+
 def _create_doc_and_enqueue(session: Session, event: FileEvent, sha: bytes) -> None:
     filename = Path(event.absolute_path).name
+    mime = guess_mime_type(filename)
+
     # mime_type was historically left NULL on the watched-folder path (the
     # primary ingest path post Stage-2 watched-folder-first refactor), which
     # broke the Observatory's file-type breakdown. The extract stage already
@@ -220,9 +271,20 @@ def _create_doc_and_enqueue(session: Session, event: FileEvent, sha: bytes) -> N
         status="active",
         sha256=sha,
         source_path=event.absolute_path,
-        mime_type=guess_mime_type(filename),
+        mime_type=mime,
         pipeline_status=PipelineStatus.queued,
     )
+
+    # For .eml files: parse RFC 5322 headers at ingest so PR #414's preamble
+    # injection and the `email.*` metadata_filter namespace actually fire on
+    # watched-folder docs (not just IMAP-synced ones). The previous version
+    # left email_* NULL, which silently disabled both features for every
+    # .eml ever loaded via a watched folder.
+    if mime == "message/rfc822":
+        parsed = _try_parse_eml(event.absolute_path)
+        if parsed is not None:
+            _apply_email_fields(doc, parsed)
+
     session.add(doc)
     session.flush()
     session.add(

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -297,12 +297,46 @@ def run_extract(doc_id: uuid.UUID) -> None:
             # Unknown type — try Tika
             pages = _extract_via_tika(data, mime or "application/octet-stream")
 
+        # Backfill the email_* columns from the raw bytes if this is an .eml
+        # and the ingest path didn't populate them (pre-this-PR watched-folder
+        # ingests left them NULL). Running `kb_reprocess` on those docs will
+        # land here and populate the columns in the same extract pass, so the
+        # preamble-injection block below also fires on the same run. This is
+        # the operator's backfill path for the existing 10k+ watched-folder
+        # .eml docs that pre-date the watcher fix in this PR.
+        if (mime == "message/rfc822" or obj_key.endswith(".eml")) and doc.email_message_id is None:
+            from harbor_clerk.mail.parser import parse_eml
+
+            try:
+                parsed = parse_eml(data)
+            except Exception as exc:
+                logger.warning("extract: parse_eml backfill failed for %s: %s", doc_id, exc)
+            else:
+                doc.email_message_id = parsed.message_id
+                doc.email_thread_id = parsed.thread_id
+                doc.email_from_address = parsed.from_address
+                doc.email_from_name = parsed.from_name
+                doc.email_subject = parsed.subject
+                doc.email_to_addresses = parsed.to_addresses or None
+                doc.email_cc_addresses = parsed.cc_addresses or None
+                doc.email_date_sent = parsed.date_sent
+                # Mirror the watcher's title-and-date semantics. Only adopt
+                # parsed.subject when the existing title looks generic (== the
+                # filename stem) so we don't clobber an operator-edited title.
+                stem = Path(doc.source_path or doc.canonical_filename or "").stem
+                if doc.title == stem and parsed.subject:
+                    doc.title = parsed.subject
+                if parsed.date_sent is not None:
+                    doc.created_at = parsed.date_sent
+                    doc.updated_at = parsed.date_sent
+
         # Email preamble injection: for .eml documents, prepend a key:value
         # header block (From / To / Cc / Subject / Date) to the first page
         # so that those fields are searchable as plain text in chunks.
         # The Document.email_* columns are already populated by the ingest
-        # stage; we build the preamble from them here rather than re-parsing
-        # the raw bytes. Only page 0 (index 0 in the pages list) is modified.
+        # stage (or the backfill block immediately above for legacy rows);
+        # we build the preamble from them here rather than re-parsing the
+        # raw bytes. Only page 0 (index 0 in the pages list) is modified.
         #
         # Guard: attachment Documents also carry email_message_id (it links
         # them back to the parent email). They must NOT get the preamble —

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -323,8 +323,12 @@ def run_extract(doc_id: uuid.UUID) -> None:
                 # Mirror the watcher's title-and-date semantics. Only adopt
                 # parsed.subject when the existing title looks generic (== the
                 # filename stem) so we don't clobber an operator-edited title.
+                # `stem` truthiness check: if both source_path and
+                # canonical_filename are NULL/empty (pathological legacy doc),
+                # `Path("").stem` is "" — without the truthy guard we'd then
+                # clobber any doc whose title happens to also be empty.
                 stem = Path(doc.source_path or doc.canonical_filename or "").stem
-                if doc.title == stem and parsed.subject:
+                if stem and doc.title == stem and parsed.subject:
                     doc.title = parsed.subject
                 if parsed.date_sent is not None:
                     doc.created_at = parsed.date_sent

--- a/tests/watcher/test_events.py
+++ b/tests/watcher/test_events.py
@@ -60,6 +60,134 @@ def test_new_file_creates_document_and_extract_job(sync_session, folder, tmp_pat
     assert job.status == JobStatus.queued
 
 
+_SAMPLE_EML = (
+    b'From: "Alice" <alice@example.com>\r\n'
+    b"To: bob@example.com\r\n"
+    b"Cc: carol@example.com, dave@example.com\r\n"
+    b"Subject: Project status update\r\n"
+    b"Message-ID: <eml-fixture-001@example.com>\r\n"
+    b"Date: Wed, 28 May 2026 12:00:00 +0000\r\n"
+    b"\r\n"
+    b"Body of the email here.\r\n"
+)
+
+
+def test_new_eml_file_populates_email_metadata_columns(sync_session, folder, tmp_path):
+    """For .eml ingest, the watcher must populate email_* columns by calling
+    parse_eml on the bytes. Pre-this-PR these were NULL on every watched-folder
+    .eml, leaving PR #414's preamble injection + email.* metadata_filter
+    dormant on the entire Enron-style corpus."""
+    f = tmp_path / "msg.eml"
+    f.write_bytes(_SAMPLE_EML)
+    handle_event(
+        sync_session,
+        FileEvent(EventKind.created, folder.folder_id, "msg.eml", str(f)),
+    )
+    sync_session.commit()
+
+    doc = sync_session.query(Document).one()
+    assert doc.mime_type == "message/rfc822"
+    assert doc.email_message_id == "<eml-fixture-001@example.com>"
+    assert doc.email_from_address == "alice@example.com"
+    assert doc.email_from_name == "Alice"
+    assert doc.email_subject == "Project status update"
+    assert doc.email_to_addresses == ["bob@example.com"]
+    assert doc.email_cc_addresses == ["carol@example.com", "dave@example.com"]
+    assert doc.email_date_sent is not None
+    # Match IMAP-path semantics: title = subject, not filename.stem.
+    assert doc.title == "Project status update"
+    # created_at = date_sent so Documents page sorts by send date.
+    assert doc.created_at == doc.email_date_sent
+
+
+def test_new_eml_file_with_unparseable_content_falls_through(sync_session, folder, tmp_path):
+    """A malformed .eml shouldn't crash ingest — the doc is created with
+    email_* NULL and the standard extract job is still enqueued."""
+    f = tmp_path / "broken.eml"
+    # `parse_eml` is best-effort and tolerates most malformed content; force a
+    # parse failure by making the file non-readable as RFC 5322. The Python
+    # `email` module is famously forgiving, so the surest way to exercise the
+    # except branch is a unicode-decode error inside the parser path. We
+    # achieve that obliquely by writing a header line that triggers the
+    # downstream `decode_header` to choke. Empty bytes round-trip cleanly
+    # through `message_from_bytes` returning an empty Message — that exercises
+    # the "no headers" fallback (synthetic message_id) and so does NOT hit
+    # the except branch. To exercise the except, we monkeypatch parse_eml.
+    f.write_bytes(b"this is not really an email\r\n\r\n")
+    import harbor_clerk.watcher.events as ev
+
+    original = ev.parse_eml
+
+    def _exploding_parse(_data: bytes):
+        raise RuntimeError("simulated parser failure")
+
+    ev.parse_eml = _exploding_parse
+    try:
+        handle_event(
+            sync_session,
+            FileEvent(EventKind.created, folder.folder_id, "broken.eml", str(f)),
+        )
+        sync_session.commit()
+    finally:
+        ev.parse_eml = original
+
+    doc = sync_session.query(Document).one()
+    assert doc.mime_type == "message/rfc822"
+    assert doc.email_message_id is None  # fell through cleanly
+    # Filename-stem title (parsing failed → no subject)
+    assert doc.title == "broken"
+    # Extract job still enqueued — ingest is best-effort about email metadata
+    # but never blocks the pipeline.
+    assert sync_session.query(IngestionJob).count() == 1
+
+
+def test_new_non_eml_file_leaves_email_metadata_null(sync_session, folder, tmp_path):
+    """Sanity guard: parse_eml only runs for .eml. A PDF must NOT accidentally
+    populate email_* columns."""
+    f = tmp_path / "report.pdf"
+    f.write_bytes(b"%PDF-1.4\nfake pdf body")
+    handle_event(sync_session, FileEvent(EventKind.created, folder.folder_id, "report.pdf", str(f)))
+    sync_session.commit()
+
+    doc = sync_session.query(Document).one()
+    assert doc.email_message_id is None
+    assert doc.email_subject is None
+    assert doc.title == "report"  # filename stem
+
+
+def test_modify_eml_refreshes_email_metadata(sync_session, folder, tmp_path):
+    """In-place .eml edit (SHA change) must re-parse so email_* reflects the
+    new contents instead of the old."""
+    f = tmp_path / "msg.eml"
+    f.write_bytes(_SAMPLE_EML)
+    handle_event(sync_session, FileEvent(EventKind.created, folder.folder_id, "msg.eml", str(f)))
+    sync_session.commit()
+
+    doc_id = sync_session.query(Document).one().doc_id
+
+    # Replace with a fresh email — different subject + sender.
+    updated = (
+        b"From: bob@example.com\r\n"
+        b"To: alice@example.com\r\n"
+        b"Subject: RE: Project status update\r\n"
+        b"Message-ID: <eml-fixture-002@example.com>\r\n"
+        b"Date: Thu, 29 May 2026 09:00:00 +0000\r\n"
+        b"\r\n"
+        b"Thanks for the update.\r\n"
+    )
+    f.write_bytes(updated)
+    handle_event(sync_session, FileEvent(EventKind.modified, folder.folder_id, "msg.eml", str(f)))
+    sync_session.commit()
+
+    # Same doc_id, refreshed email_* columns.
+    doc = sync_session.query(Document).one()
+    assert doc.doc_id == doc_id
+    assert doc.email_message_id == "<eml-fixture-002@example.com>"
+    assert doc.email_subject == "RE: Project status update"
+    assert doc.email_from_address == "bob@example.com"
+    assert doc.title == "RE: Project status update"
+
+
 def test_modify_same_sha_is_noop(sync_session, folder, tmp_path):
     """Branch 1: existing+active+same SHA → no-op (no new job, no state change)."""
     f = tmp_path / "doc.pdf"

--- a/tests/watcher/test_events.py
+++ b/tests/watcher/test_events.py
@@ -96,8 +96,10 @@ def test_new_eml_file_populates_email_metadata_columns(sync_session, folder, tmp
     assert doc.email_date_sent is not None
     # Match IMAP-path semantics: title = subject, not filename.stem.
     assert doc.title == "Project status update"
-    # created_at = date_sent so Documents page sorts by send date.
+    # created_at = date_sent so Documents page sorts by send date. updated_at
+    # tracks created_at at first-ingest (matches IMAP `create_email_document`).
     assert doc.created_at == doc.email_date_sent
+    assert doc.updated_at == doc.email_date_sent
 
 
 def test_new_eml_file_with_unparseable_content_falls_through(sync_session, folder, tmp_path):
@@ -186,6 +188,22 @@ def test_modify_eml_refreshes_email_metadata(sync_session, folder, tmp_path):
     assert doc.email_subject == "RE: Project status update"
     assert doc.email_from_address == "bob@example.com"
     assert doc.title == "RE: Project status update"
+    # `created_at` refreshes from the new Date header (it's a property of the
+    # email content). `updated_at` MUST NOT slide backwards to date_sent on
+    # reprocess — `_apply_email_fields` intentionally doesn't touch it, only
+    # `_create_doc_and_enqueue` does for first-ingest. The reprocess path
+    # otherwise has the same first-set value updated_at held before the modify,
+    # which is the correct "record was meaningfully touched at first-ingest
+    # time" answer for the IMAP-parity model.
+    assert doc.created_at == doc.email_date_sent  # = 2026-05-29 from new Date header
+    # The first-ingest set updated_at to the OLD date_sent (2026-05-28); the
+    # reprocess must NOT have slid it to the NEW date_sent (2026-05-29). The
+    # `<` assertion catches both the original bug (would have been ==) and any
+    # future change that incorrectly clobbers updated_at on reprocess.
+    assert doc.updated_at < doc.email_date_sent, (
+        f"updated_at ({doc.updated_at}) should NOT slide forward to the new date_sent "
+        f"({doc.email_date_sent}) on reprocess"
+    )
 
 
 def test_modify_same_sha_is_noop(sync_session, folder, tmp_path):

--- a/tests/worker/test_extract_metadata_persistence.py
+++ b/tests/worker/test_extract_metadata_persistence.py
@@ -110,3 +110,127 @@ async def test_extract_stage_clears_stale_metadata_when_extractors_return_empty(
     # The whole metadata dict should be empty (or at most contain whatever
     # Tika /meta returned, which for text/plain in this hermetic env is None).
     assert metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_extract_stage_backfills_email_columns_on_legacy_eml(db_session, tmp_path: Path):
+    """Backfill path: an .eml doc that was ingested before the watcher fix
+    (email_message_id is NULL) gets its email_* columns populated when extract
+    runs. This is how `kb_reprocess` lights up the existing 10k+ watched-folder
+    .eml docs that pre-date the watcher-side fix in this PR — operators don't
+    need a separate backfill script.
+
+    Tika is mocked so the test is hermetic (the test environment may not have
+    a Tika container running)."""
+    from unittest.mock import patch
+
+    from harbor_clerk.worker.stages import extract
+
+    eml_bytes = (
+        b'From: "Alice" <alice@example.com>\r\n'
+        b"To: bob@example.com\r\n"
+        b"Subject: Legacy email backfill test\r\n"
+        b"Message-ID: <legacy-backfill-001@example.com>\r\n"
+        b"Date: Wed, 28 May 2026 12:00:00 +0000\r\n"
+        b"\r\n"
+        b"Body content.\r\n"
+    )
+    source = tmp_path / "legacy.eml"
+    source.write_bytes(eml_bytes)
+
+    doc = Document(
+        title="legacy",  # filename stem — pre-this-PR behavior
+        canonical_filename="legacy.eml",
+        status="active",
+        sha256=hashlib.sha256(source.read_bytes()).digest(),
+        pipeline_status=PipelineStatus.queued,
+        mime_type="message/rfc822",
+        source_path=str(source),
+        # NOTE: all email_* columns deliberately NULL — simulating pre-PR ingest.
+        email_message_id=None,
+        email_subject=None,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.queued))
+    await db_session.commit()
+    doc_id = doc.doc_id
+
+    # Mock Tika — real extraction of an .eml would return some pages; we
+    # don't need realism here, just SOMETHING for the preamble-injection
+    # block to consume so we can verify it fires too.
+    with patch.object(extract, "_extract_via_tika", return_value=[(1, "Body content.")]):
+        from harbor_clerk.worker.stages.extract import run_extract
+
+        run_extract(doc_id)
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one()
+    finally:
+        sync_session.close()
+
+    # email_* columns populated from the raw bytes via parse_eml.
+    assert refreshed.email_message_id == "<legacy-backfill-001@example.com>"
+    assert refreshed.email_subject == "Legacy email backfill test"
+    assert refreshed.email_from_address == "alice@example.com"
+    assert refreshed.email_to_addresses == ["bob@example.com"]
+    assert refreshed.email_date_sent is not None
+    # Title adopts parsed.subject only when the previous title looked like
+    # the filename stem (guard against clobbering an operator edit).
+    assert refreshed.title == "Legacy email backfill test"
+    # created_at slides to the email's send date — matches IMAP-path + new
+    # watcher-path semantics so all email rows sort uniformly.
+    assert refreshed.created_at == refreshed.email_date_sent
+
+
+@pytest.mark.asyncio
+async def test_extract_stage_does_not_clobber_existing_email_columns(db_session, tmp_path: Path):
+    """If email_message_id is already populated (e.g. IMAP-ingested doc, or
+    watcher fix already ran), the backfill block must be a no-op — we don't
+    want to overwrite IMAP-side data (e.g. email_label_path) with the
+    parse_eml-derived view, and re-parsing on every extract would be wasteful."""
+    from unittest.mock import patch
+
+    from harbor_clerk.worker.stages import extract
+
+    eml_bytes = (
+        b"From: alice@example.com\r\nSubject: Already populated\r\nMessage-ID: <new-id@example.com>\r\n\r\nBody.\r\n"
+    )
+    source = tmp_path / "imap.eml"
+    source.write_bytes(eml_bytes)
+
+    doc = Document(
+        title="IMAP set this",
+        canonical_filename="imap.eml",
+        status="active",
+        sha256=hashlib.sha256(source.read_bytes()).digest(),
+        pipeline_status=PipelineStatus.queued,
+        mime_type="message/rfc822",
+        source_path=str(source),
+        email_message_id="<existing-imap-id@example.com>",  # ALREADY SET
+        email_subject="IMAP set this subject",
+        email_label_path="INBOX/Work",  # IMAP-only field
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.queued))
+    await db_session.commit()
+    doc_id = doc.doc_id
+
+    with patch.object(extract, "_extract_via_tika", return_value=[(1, "Body.")]):
+        from harbor_clerk.worker.stages.extract import run_extract
+
+        run_extract(doc_id)
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc_id)).scalar_one()
+    finally:
+        sync_session.close()
+
+    # No clobbering — pre-existing values preserved.
+    assert refreshed.email_message_id == "<existing-imap-id@example.com>"
+    assert refreshed.email_subject == "IMAP set this subject"
+    assert refreshed.email_label_path == "INBOX/Work"
+    assert refreshed.title == "IMAP set this"


### PR DESCRIPTION
## Summary

PR #414's email-header preamble injection AND the `email.*` `metadata_filter` namespace both gate on `Document.email_message_id IS NOT NULL`. That column was only ever populated by `mail/ingest.py::create_email_document` (the **IMAP** sync path). Watched-folder `.eml` files take a different code path (`watcher/events.py::_create_doc_and_enqueue`) and never had `email_*` columns set, so PR #414's investment was completely dormant on every `.eml` ever loaded via a watched folder — **10,576+ docs on the live Enron corpus alone.**

## Three-part fix

| Layer | What |
|---|---|
| Watcher ingest (`watcher/events.py`) | New `_try_parse_eml` + `_apply_email_fields` helpers. `_create_doc_and_enqueue` calls them when `mime == "message/rfc822"`. Best-effort: any parse failure leaves email_* NULL and falls through to a generic Document with an extract job enqueued. Title becomes `parsed.subject`; `created_at` slides to `parsed.date_sent` to match IMAP semantics. |
| Watcher reprocess (`_reprocess_doc`) | Same re-parse on SHA-change so in-place .eml edits don't leave stale email_* columns. |
| Extract-stage backfill (`worker/stages/extract.py`) | New block before the preamble-injection check: if mime is `.eml` and `email_message_id IS NULL` (pre-this-PR ingest), `parse_eml` from the bytes already loaded for extraction. This is the operator's backfill path — `kb_reprocess` on each legacy doc populates email_* + injects the preamble into chunk 0 in a single pass. No separate backfill script. |

## Out of scope

- **Attachment extraction.** IMAP creates separate Documents per attachment with `email_parent_doc_id`. Watched-folder ingest keeps the `.eml` as one Document; attachments aren't surfaced separately. Separate-PR follow-up if the gap matters.
- **Storage push to MinIO of the original `.eml` bytes.** Watched-folder docs are referenced in place via `source_path`; that's the established contract.
- **One-shot SQL backfill migration.** The extract-stage fallback handles the same case via `kb_reprocess` and is safer (uses the regular pipeline path with `pipeline_seq` + idempotent re-extract).

## Tests

- **4 new watcher tests** (`tests/watcher/test_events.py`): happy-path .eml ingest, malformed .eml fall-through (no crash), non-.eml sanity guard (email_* stay NULL), SHA-change re-parse.
- **2 new extract-stage tests** (`tests/worker/test_extract_metadata_persistence.py`): backfill populates email_* on a legacy NULL-`email_message_id` .eml, no-clobber guard preserves IMAP-side values.
- **Full suite: 1327 passed, 9 skipped, 0 failed.**

## Fresh-eyes review

Dispatched against `24633aa` before opening this PR. Two findings ≥80, both fixed in follow-up commit `9c91a2b`:
1. `_apply_email_fields` was sliding `updated_at` backwards to `date_sent` on every reprocess (confidence 82). Now only `_create_doc_and_enqueue` sets `updated_at` at first-ingest; reprocess leaves it alone. Test strengthened with `assert doc.updated_at < doc.email_date_sent` on the modify-path test to lock the behavior.
2. `Path("").stem == ""` would have enabled a false-positive title clobber on pathological legacy docs missing both `source_path` and `canonical_filename` (confidence 80). Added `stem and ...` guard.

Other reviewer concerns (`email_message_id` no-clobber semantics, mime-detection on reprocess, test coverage gaps) were checked and confirmed safe.

## Operator runbook (post-merge)

```sql
-- Inspect the gap before backfilling:
SELECT mime_type, email_message_id IS NOT NULL AS has_email_meta, COUNT(*)
FROM documents
WHERE status='active' AND (mime_type='message/rfc822' OR canonical_filename LIKE '%.eml')
GROUP BY mime_type, has_email_meta;

-- Trigger backfill via the existing reprocess endpoint (one doc at a time
-- via the Documents page button, or bulk via the admin API). Each
-- reprocess re-runs extract → backfill block fires → email_* populated +
-- preamble injected into chunk 0.
```

After backfill:
- Documents page sorts emails by send date (`created_at = email_date_sent`).
- Observatory's file-type breakdown counts `message/rfc822` correctly (after PR #423's mime fix lands).
- `kb_search(metadata_filter={"email.from_address": ...})` resolves against the populated columns.
- `kb_search(query="...")` returns hits whose chunk-0 includes the rendered header preamble (From / To / Cc / Subject / Date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
