### PR TITLE
fix(cli): align search output with MCP contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Current state lives in this file plus `README.md` and `docs/architecture.md`.
 
+## PR Review Policy
+
+Feature PRs must receive a fresh-eyes review before merge. In practice, any PR
+should get an explicit review unless it is extremely small and low-risk: tiny
+documentation-only edits, one-line mechanical changes, or very obvious bug
+fixes. If a PR touches more than three files, changes behavior, modifies public
+APIs/tool contracts, adjusts security/auth, or affects ingest/retrieval/LLM
+flows, assume review is required.
+
+When an agent opens or updates a non-trivial PR, it should either request a
+fresh-eyes review from another agent/person or perform a separate review pass
+that treats the change as if someone else wrote it. Review findings should lead
+with bugs, regressions, missing tests, and user-facing contract risks.
+
 ## Architecture
 
 ### Docker Compose (DIY/Linux)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ graph LR
 ```bash
 export HARBOR_CLERK_API_KEY=hc_...
 harbor-clerk --help                  # full subcommand list
-harbor-clerk search "termination clause" | jq '.results[].citation'
+harbor-clerk search "termination clause" | jq '.hits[] | {title: .doc_title, pages, chunk_id}'
 ```
 
 A copy-pasteable agent skill for these harnesses is in **System Settings → Integrations**.

--- a/docs/superpowers/specs/2026-05-23-cli-for-agentic-harnesses-design.md
+++ b/docs/superpowers/specs/2026-05-23-cli-for-agentic-harnesses-design.md
@@ -145,7 +145,7 @@ description: Search and read documents from a local Harbor Clerk knowledge base.
 
 # Harbor Clerk — extended memory for agents
 
-Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-preserving reads. This skill exposes it via the `harbor-clerk` CLI.
+Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-ready reads. This skill exposes it via the `harbor-clerk` CLI.
 
 ## First step: discover the surface
 Run `harbor-clerk --help` for the full command list, then `harbor-clerk <cmd> --help` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
@@ -157,8 +157,8 @@ Run `harbor-clerk --help` for the full command list, then `harbor-clerk <cmd> --
 3. **Check ingest status before searching for new content**: `harbor-clerk ingest-status <doc_id>` returns per-stage state.
 
 ## What you can trust
-- Every search result includes a `citation` field — quote it back to the user.
-- `possible_conflict: true` means top hits disagree across documents; surface both sources.
+- Search returns top-level `.hits[]`; each hit includes `doc_title`, `pages` when available, and `chunk_id`. Use those fields as the citation, then call `read-passages` when you need exact surrounding text.
+- `possible_conflict: true` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
 - The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.
 ```
 

--- a/frontend/src/components/CliAccessCard.tsx
+++ b/frontend/src/components/CliAccessCard.tsx
@@ -8,7 +8,7 @@ description: Search and read documents from a local Harbor Clerk knowledge base.
 
 # Harbor Clerk — extended memory for agents
 
-Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-preserving reads. This skill exposes it via the \`harbor-clerk\` CLI.
+Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-ready reads. This skill exposes it via the \`harbor-clerk\` CLI.
 
 ## First step: discover the surface
 Run \`harbor-clerk --help\` for the full command list, then \`harbor-clerk <cmd> --help\` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
@@ -20,8 +20,8 @@ Run \`harbor-clerk --help\` for the full command list, then \`harbor-clerk <cmd>
 3. **Check ingest status before searching for new content**: \`harbor-clerk ingest-status <doc_id>\` returns per-stage state.
 
 ## What you can trust
-- Every search result includes a \`citation\` field — quote it back to the user.
-- \`possible_conflict: true\` means top hits disagree across documents; surface both sources.
+- Search returns top-level \`.hits[]\`; each hit includes \`doc_title\`, \`pages\` when available, and \`chunk_id\`. Use those fields as the citation, then call \`read-passages\` when you need exact surrounding text.
+- \`possible_conflict: true\` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
 - The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.
 `
 

--- a/skills/harbor-clerk/SKILL.md
+++ b/skills/harbor-clerk/SKILL.md
@@ -5,7 +5,7 @@ description: Search and read documents from a local Harbor Clerk knowledge base.
 
 # Harbor Clerk — extended memory for agents
 
-Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-preserving reads. This skill exposes it via the `harbor-clerk` CLI.
+Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-ready reads. This skill exposes it via the `harbor-clerk` CLI.
 
 ## First step: discover the surface
 Run `harbor-clerk --help` for the full command list, then `harbor-clerk <cmd> --help` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
@@ -17,6 +17,6 @@ Run `harbor-clerk --help` for the full command list, then `harbor-clerk <cmd> --
 3. **Check ingest status before searching for new content**: `harbor-clerk ingest-status <doc_id>` returns per-stage state.
 
 ## What you can trust
-- Every search result includes a `citation` field — quote it back to the user.
-- `possible_conflict: true` means top hits disagree across documents; surface both sources.
+- Search returns top-level `.hits[]`; each hit includes `doc_title`, `pages` when available, and `chunk_id`. Use those fields as the citation, then call `read-passages` when you need exact surrounding text.
+- `possible_conflict: true` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
 - The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.

--- a/src/harbor_clerk/cli/commands/batch_search.py
+++ b/src/harbor_clerk/cli/commands/batch_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json as _json
 import sys
 
 from harbor_clerk.cli.client import McpHttpClient
@@ -10,6 +11,13 @@ from harbor_clerk.cli.commands import _common_parser
 from harbor_clerk.cli.config import resolve_config
 from harbor_clerk.cli.help import load
 from harbor_clerk.cli.output import render, resolve_mode
+
+_LANGUAGE_ALIASES = {
+    "en": "english",
+    "fr": "french",
+    "english": "english",
+    "french": "french",
+}
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -23,7 +31,18 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     p.add_argument("queries", nargs="+", help="One or more search query strings")
     p.add_argument("-k", "--k", type=int, default=5, help="Number of results per query (default: 5)")
-    p.add_argument("-d", "--detail", choices=["full", "brief"], default="brief")
+    p.add_argument("-d", "--detail", choices=["full", "brief", "compact"], default="brief")
+    p.add_argument("--brief-chars", type=int, default=None, help="When --detail=brief, chars per hit text")
+    p.add_argument("--doc-id", help="Restrict searches to one document UUID")
+    p.add_argument("--doc-ids", help="Comma-separated doc UUIDs")
+    p.add_argument("--after", help="YYYY-MM-DD; only docs ingested after this date")
+    p.add_argument("--before", help="YYYY-MM-DD; only docs ingested before this date")
+    p.add_argument("--language", choices=sorted(_LANGUAGE_ALIASES))
+    p.add_argument("--mime-type", help="Restrict by MIME type (e.g. application/pdf)")
+    p.add_argument(
+        "--metadata-filter",
+        help='JSON string of {"namespace.key": value} pairs (e.g. \'{"email.from": "alice@example.com"}\')',
+    )
     p.set_defaults(_handler=run)
 
 
@@ -33,6 +52,30 @@ def run(args) -> int:
         "k": args.k,
         "detail": args.detail,
     }
+    if args.brief_chars is not None:
+        arguments["brief_chars"] = args.brief_chars
+    if args.doc_id:
+        arguments["doc_id"] = args.doc_id
+    if args.doc_ids:
+        arguments["doc_ids"] = [d.strip() for d in args.doc_ids.split(",") if d.strip()]
+    if args.after:
+        arguments["after"] = args.after
+    if args.before:
+        arguments["before"] = args.before
+    if args.language:
+        arguments["language"] = _LANGUAGE_ALIASES[args.language]
+    if args.mime_type:
+        arguments["mime_type"] = args.mime_type
+    if args.metadata_filter:
+        try:
+            metadata_filter = _json.loads(args.metadata_filter)
+        except _json.JSONDecodeError as exc:
+            sys.stderr.write(f"harbor-clerk: --metadata-filter must be valid JSON: {exc}\n")
+            return 1
+        if not isinstance(metadata_filter, dict):
+            sys.stderr.write("harbor-clerk: --metadata-filter must be a JSON object\n")
+            return 1
+        arguments["metadata_filter"] = metadata_filter
 
     cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
     mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())

--- a/src/harbor_clerk/cli/commands/search.py
+++ b/src/harbor_clerk/cli/commands/search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json as _json
 import sys
 
 from harbor_clerk.cli.client import McpHttpClient
@@ -10,6 +11,13 @@ from harbor_clerk.cli.commands import _common_parser
 from harbor_clerk.cli.config import resolve_config
 from harbor_clerk.cli.help import load
 from harbor_clerk.cli.output import render, resolve_mode
+
+_LANGUAGE_ALIASES = {
+    "en": "english",
+    "fr": "french",
+    "english": "english",
+    "french": "french",
+}
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -24,14 +32,19 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("query", help="The search query")
     p.add_argument("-k", "--k", type=int, default=10, help="Number of results (default: 10, max: 50)")
     p.add_argument("-o", "--offset", type=int, default=0, help="Pagination offset (default: 0)")
-    p.add_argument("-d", "--detail", choices=["full", "brief"], default="full")
-    p.add_argument("--brief-chars", type=int, default=None, help="When --detail=brief, chars per snippet")
+    p.add_argument("-d", "--detail", choices=["full", "brief", "compact"], default="full")
+    p.add_argument("--brief-chars", type=int, default=None, help="When --detail=brief, chars per hit text")
     p.add_argument("--doc-id", help="Restrict search to one document UUID")
     p.add_argument("--doc-ids", help="Comma-separated doc UUIDs")
     p.add_argument("--after", help="YYYY-MM-DD; only docs ingested after this date")
     p.add_argument("--before", help="YYYY-MM-DD; only docs ingested before this date")
-    p.add_argument("--language", choices=["en", "fr"])
+    p.add_argument("--language", choices=sorted(_LANGUAGE_ALIASES))
     p.add_argument("--mime-type", help="Restrict by MIME type (e.g. application/pdf)")
+    p.add_argument(
+        "--metadata-filter",
+        help='JSON string of {"namespace.key": value} pairs (e.g. \'{"email.from": "alice@example.com"}\')',
+    )
+    p.add_argument("--text-contains", help="Require an exact substring in the chunk text")
     p.add_argument("--faceted", action="store_true", help="Include facet counts in response")
     p.set_defaults(_handler=run)
 
@@ -54,9 +67,21 @@ def run(args) -> int:
     if args.before:
         arguments["before"] = args.before
     if args.language:
-        arguments["language"] = args.language
+        arguments["language"] = _LANGUAGE_ALIASES[args.language]
     if args.mime_type:
         arguments["mime_type"] = args.mime_type
+    if args.metadata_filter:
+        try:
+            metadata_filter = _json.loads(args.metadata_filter)
+        except _json.JSONDecodeError as exc:
+            sys.stderr.write(f"harbor-clerk: --metadata-filter must be valid JSON: {exc}\n")
+            return 1
+        if not isinstance(metadata_filter, dict):
+            sys.stderr.write("harbor-clerk: --metadata-filter must be a JSON object\n")
+            return 1
+        arguments["metadata_filter"] = metadata_filter
+    if args.text_contains:
+        arguments["text_contains"] = args.text_contains
     if args.faceted:
         arguments["faceted"] = True
 

--- a/src/harbor_clerk/cli/help/batch-search.txt
+++ b/src/harbor_clerk/cli/help/batch-search.txt
@@ -24,7 +24,18 @@ USAGE
 
 OPTIONS
   -k, --k INT               Results per query (default: 5, max: 50)
-  -d, --detail full|brief   Result detail level (default: brief)
+  -d, --detail full|brief|compact
+                             Result detail level (default: brief)
+      --brief-chars INT     When --detail=brief, chars per hit text
+      --doc-id UUID         Restrict searches to one document
+      --doc-ids UUID,UUID   Restrict searches to multiple documents
+      --after YYYY-MM-DD    Only docs ingested after this date
+      --before YYYY-MM-DD   Only docs ingested before this date
+      --language english|french|en|fr
+                             Restrict to one language
+      --mime-type MIME      Restrict by MIME type (e.g. application/pdf)
+      --metadata-filter JSON
+                             JSON metadata containment filter
 
 RETURNS (JSON)
   {
@@ -36,11 +47,10 @@ RETURNS (JSON)
             "chunk_id":   "uuid",      // pass to read-passages or expand-context
             "doc_id":     "uuid",      // document identifier
             "doc_title":  "string",    // document title
-            "page":       42,          // 1-indexed page (null for non-paginated)
-            "snippet":    "string",    // matched text (full or truncated per --detail)
+            "pages":      "42",        // page or page range (omitted when unavailable)
+            "text":       "string",    // matched chunk text; omitted with --detail=compact
             "score":      0.87,        // hybrid score, higher = better
-            "language":   "en",        // "en" or "fr"
-            "citation":   "Title, p.42"
+            "language":   "english"    // "english" or "french"
           }
         ],
         "total_candidates": 14,        // total matching chunks before k cap
@@ -83,6 +93,8 @@ COMMON MISTAKES
     offsets. Use individual `search` calls with --offset when you need page 2.
   - Using --detail=full on large -k across 5 queries: full detail can return
     several KB per hit, 5 × 10 = 50 chunks of text. default `brief` is safer.
+  - Expecting a standalone `citation` field; cite with doc_title + pages +
+    chunk_id, or call `read-passages` to verify exact context.
 
 SEE ALSO
   search, read-passages, expand-context

--- a/src/harbor_clerk/cli/help/expand-context.txt
+++ b/src/harbor_clerk/cli/help/expand-context.txt
@@ -5,7 +5,7 @@ DESCRIPTION
   same document, returned in sequential order. The target chunk is marked
   with `"is_target": true` so callers can identify it in the window.
 
-  Use this when a search result snippet is too short to fully understand a
+  Use this when search hit text is too short to fully understand a
   clause, argument, or table that spans multiple chunks. The window size is
   symmetric: -n 2 fetches up to 2 chunks before AND up to 2 chunks after the
   target, for a maximum window of 5 chunks. If the target is near the
@@ -54,7 +54,7 @@ EXAMPLES
 
   # Two-stage: search for a hit then expand its context
   CHUNK=$(harbor-clerk search "limitation of liability" -k 1 \
-    | jq -r '.results[0].chunk_id')
+    | jq -r '.hits[0].chunk_id')
   harbor-clerk expand-context "$CHUNK" -n 3
 
   # Extract only the text blocks in window order
@@ -67,7 +67,7 @@ EXAMPLES
 
 COMMON MISTAKES
   - Passing a doc_id instead of a chunk_id: the single positional argument
-    is a chunk UUID (from .results[].chunk_id in search output), not a
+    is a chunk UUID (from .hits[].chunk_id in search output), not a
     document UUID.
   - Expecting exactly 2n+1 chunks: chunks near the beginning or end of a
     document produce a shorter window. Check .chunks | length rather than

--- a/src/harbor_clerk/cli/help/find-related.txt
+++ b/src/harbor_clerk/cli/help/find-related.txt
@@ -69,13 +69,13 @@ EXAMPLES
 
   # Two-stage: find the doc_id from a search hit, then find related docs
   DOC=$(harbor-clerk search "employment agreement" -k 1 \
-    | jq -r '.results[0].doc_id')
+    | jq -r '.hits[0].doc_id')
   harbor-clerk find-related "$DOC" -k 5
 
 COMMON MISTAKES
   - Passing a chunk_id as doc_id: find-related takes a document UUID
-    (from .results[].doc_id in search output or from `list-recent`), not
-    a chunk UUID. Chunk IDs come from .results[].chunk_id.
+    (from .hits[].doc_id in search output or from `list-recent`), not
+    a chunk UUID. Chunk IDs come from .hits[].chunk_id.
   - Expecting text-overlap matching: similarity is based on dense vector
     embeddings, not keyword overlap. A document sharing unusual phrasing
     may rank higher than one sharing common words.

--- a/src/harbor_clerk/cli/help/read-passages.txt
+++ b/src/harbor_clerk/cli/help/read-passages.txt
@@ -50,7 +50,7 @@ EXAMPLES
 
   # Fetch all top hits from a search in one call
   CHUNKS=$(harbor-clerk search "termination clause" -k 5 \
-    | jq -r '.results[].chunk_id')
+    | jq -r '.hits[].chunk_id')
   harbor-clerk read-passages $CHUNKS
 
   # Read a passage and include surrounding context
@@ -59,13 +59,13 @@ EXAMPLES
 
   # Multi-step: brief search, then read full text of the top 3 results
   harbor-clerk search "force majeure" -k 3 -d brief \
-    | jq -r '.results[].chunk_id' \
+    | jq -r '.hits[].chunk_id' \
     | xargs harbor-clerk read-passages
 
 COMMON MISTAKES
   - Passing a doc_id instead of a chunk_id: chunk_id and doc_id are
-    distinct UUIDs. chunk_id comes from .results[].chunk_id in search
-    output; doc_id comes from .results[].doc_id.
+    distinct UUIDs. chunk_id comes from .hits[].chunk_id in search
+    output; doc_id comes from .hits[].doc_id.
   - Expecting all IDs back when some are invalid: the server silently skips
     chunk_ids that are not found or are out of scope. If .passages is shorter
     than the number of IDs you passed, some were not found.

--- a/src/harbor_clerk/cli/help/search.txt
+++ b/src/harbor_clerk/cli/help/search.txt
@@ -4,12 +4,13 @@ DESCRIPTION
   Runs a hybrid retrieval combining PostgreSQL full-text search (bilingual,
   English + French) and pgvector cosine similarity over the corpus. Scores
   are normalized and merged per-chunk with a small OCR-confidence boost.
-  Results include citations (doc_id, page, chunk_id) usable with
-  `read-passages` and `expand-context`.
+  Results include citation-ready fields (doc_id, doc_title, pages,
+  chunk_id) usable with `read-passages` and `expand-context`.
 
   If top hits have similar scores across multiple documents, the response
-  includes `possible_conflict: true` and a `conflict_sources` array — quote
-  both sides to the user.
+  includes `possible_conflict: true` and a `conflict_sources` array. Treat
+  this as an ambiguity signal and inspect the relevant sources before
+  answering.
 
 USAGE
   harbor-clerk search <query> [options]
@@ -17,30 +18,37 @@ USAGE
 OPTIONS
   -k, --k INT               Number of results (default: 10, max: 50)
   -o, --offset INT          Pagination offset (default: 0)
-  -d, --detail full|brief   Result detail level (default: full)
-      --brief-chars INT     When --detail=brief, chars per snippet (default: 200)
+  -d, --detail full|brief|compact
+                             Result detail level (default: full)
+      --brief-chars INT     When --detail=brief, chars per hit text (default: 200)
       --doc-id UUID         Restrict search to one document
       --doc-ids UUID,UUID   Restrict search to multiple documents
       --after YYYY-MM-DD    Only docs ingested after this date
       --before YYYY-MM-DD   Only docs ingested before this date
-      --language en|fr      Restrict to one language
+      --language english|french|en|fr
+                             Restrict to one language
       --mime-type MIME      Restrict by MIME type (e.g. application/pdf)
-      --faceted             Include facet counts in response
+      --metadata-filter JSON
+                             JSON metadata containment filter
+      --text-contains TEXT  Require an exact substring in chunk text
+      --faceted             Include document-grouped results
 
 RETURNS (JSON)
   {
-    "results": [
+    "hits": [
       {
         "chunk_id":   "uuid",        // pass to read-passages or expand-context
         "doc_id":     "uuid",        // document identifier
-        "title":      "string",      // document title
-        "page":       42,            // 1-indexed page (or null for non-paginated)
-        "snippet":    "string",      // matched text with context
+        "doc_title":  "string",      // document title
+        "pages":      "42",          // page or page range (omitted when unavailable)
+        "section":    "string",      // nearest heading, when available
+        "text":       "string",      // matched chunk text; omitted with --detail=compact
         "score":      0.87,          // hybrid score, higher = better
-        "language":   "en" | "fr",
-        "citation":   "Title, p.42"  // human-readable citation
+        "language":   "english" | "french"
       }
     ],
+    "total_candidates": 14,
+    "has_more": false,
     "possible_conflict": false,
     "conflict_sources": []           // present only when possible_conflict=true
   }
@@ -52,19 +60,21 @@ EXAMPLES
   # Restrict to PDFs ingested in the last month, JSON to jq
   harbor-clerk search "force majeure" \
     --mime-type application/pdf \
-    --after 2026-04-23 | jq '.results[] | {title, page, snippet}'
+    --after 2026-04-23 | jq '.hits[] | {title: .doc_title, pages, text}'
 
   # Two-stage: search then expand the best hit
-  CHUNK=$(harbor-clerk search "indemnification" -k 1 | jq -r '.results[0].chunk_id')
+  CHUNK=$(harbor-clerk search "indemnification" -k 1 | jq -r '.hits[0].chunk_id')
   harbor-clerk expand-context "$CHUNK" -n 3
 
   # Faceted overview before drilling in
-  harbor-clerk search "audit" --faceted | jq '.facets'
+  harbor-clerk search "audit" --faceted | jq '.documents'
 
 COMMON MISTAKES
   - Passing a chunk_id as --doc-id (chunk_id and doc_id are distinct UUIDs).
   - Forgetting --detail=brief on large k — default `full` returns the entire
     matching chunk text, which can be 1–2KB per result.
+  - Expecting a standalone `citation` field; cite with doc_title + pages +
+    chunk_id, or call `read-passages` to verify exact context.
   - Using --after/--before with timestamps; only dates (YYYY-MM-DD) are accepted.
 
 SEE ALSO

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -57,19 +57,29 @@ def _render_search(payload: Any, stream: TextIO) -> None:
     if not isinstance(payload, dict):
         stream.write(repr(payload) + "\n")
         return
-    results = payload.get("results", [])
-    for i, r in enumerate(results, 1):
-        title = r.get("title", "")
-        citation = r.get("citation", "")
+    hits = payload.get("hits")
+    if hits is None:
+        # Backwards-compatible fallback for pre-MCP-contract fixtures.
+        hits = payload.get("results", [])
+    if not hits:
+        stream.write("0 results\n")
+    for i, r in enumerate(hits, 1):
+        title = r.get("doc_title") or r.get("title") or ""
         score = r.get("score")
-        snippet = (r.get("snippet") or "").strip().replace("\n", " ")
-        if len(snippet) > 200:
-            snippet = snippet[:200] + "…"
+        text = (r.get("text") or r.get("snippet") or "").strip().replace("\n", " ")
+        if len(text) > 200:
+            text = text[:200] + "..."
         score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "?"
-        stream.write(f"{i}. {title}  [{score_str}]  {citation}\n")
-        stream.write(f"   {snippet}\n\n")
+        pages = r.get("pages") or r.get("page")
+        location = f" p. {pages}" if pages else ""
+        chunk_id = r.get("chunk_id")
+        chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
+        stream.write(f"{i}. {title}{location}  [{score_str}]{chunk_suffix}\n")
+        if text:
+            stream.write(f"   {text}\n")
+        stream.write("\n")
     if payload.get("possible_conflict"):
-        stream.write("⚠  possible_conflict=true — top hits disagree across documents\n")
+        stream.write("possible_conflict=true - top hits span multiple similarly scored documents\n")
 
 
 # --- Verify identifier pretty-printer ---

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -57,6 +57,9 @@ def _render_search(payload: Any, stream: TextIO) -> None:
     if not isinstance(payload, dict):
         stream.write(repr(payload) + "\n")
         return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
     hits = payload.get("hits")
     if hits is None:
         # Backwards-compatible fallback for pre-MCP-contract fixtures.

--- a/tests/cli/test_commands_batch_search.py
+++ b/tests/cli/test_commands_batch_search.py
@@ -35,3 +35,48 @@ def test_batch_search_defaults():
     assert args["k"] == 5
     assert args["detail"] == "brief"
     assert args["queries"] == ["only-query"]
+
+
+def test_batch_search_forwards_optional_filters():
+    rc, client = _run(
+        [
+            "batch-search",
+            "q1",
+            "q2",
+            "--k",
+            "3",
+            "--detail",
+            "compact",
+            "--brief-chars",
+            "120",
+            "--doc-ids",
+            "d1,d2",
+            "--language",
+            "fr",
+            "--mime-type",
+            "application/pdf",
+            "--metadata-filter",
+            '{"sidecar.vendor": "Pinnacle"}',
+            "--json",
+        ],
+        {"results": []},
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args == {
+        "queries": ["q1", "q2"],
+        "k": 3,
+        "detail": "compact",
+        "brief_chars": 120,
+        "doc_ids": ["d1", "d2"],
+        "language": "french",
+        "mime_type": "application/pdf",
+        "metadata_filter": {"sidecar.vendor": "Pinnacle"},
+    }
+
+
+def test_batch_search_invalid_metadata_filter_exits_1(capsys):
+    rc, client = _run(["batch-search", "q1", "--metadata-filter", "not-json", "--json"], {"results": []})
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "--metadata-filter must be valid JSON" in capsys.readouterr().err

--- a/tests/cli/test_commands_search.py
+++ b/tests/cli/test_commands_search.py
@@ -21,14 +21,14 @@ def _run(args, mock_response):
 
 
 def test_search_calls_kb_search_with_query_and_defaults(capsys):
-    rc, client = _run(["search", "termination", "--json"], {"results": []})
+    rc, client = _run(["search", "termination", "--json"], {"hits": []})
     assert rc == 0
     client.call_tool.assert_called_once_with(
         "kb_search",
         {"query": "termination", "k": 10, "offset": 0, "detail": "full"},
     )
     out = capsys.readouterr().out
-    assert json.loads(out) == {"results": []}
+    assert json.loads(out) == {"hits": []}
 
 
 def test_search_forwards_optional_filters(capsys):
@@ -39,35 +39,47 @@ def test_search_forwards_optional_filters(capsys):
             "--k",
             "5",
             "--detail",
-            "brief",
+            "compact",
             "--language",
             "en",
             "--after",
             "2026-01-01",
+            "--metadata-filter",
+            '{"email.from": "alice@example.com"}',
+            "--text-contains",
+            "force majeure",
             "--json",
         ],
-        {"results": []},
+        {"hits": []},
     )
     assert rc == 0
     args = client.call_tool.call_args.args[1]
     assert args["k"] == 5
-    assert args["detail"] == "brief"
-    assert args["language"] == "en"
+    assert args["detail"] == "compact"
+    assert args["language"] == "english"
     assert args["after"] == "2026-01-01"
+    assert args["metadata_filter"] == {"email.from": "alice@example.com"}
+    assert args["text_contains"] == "force majeure"
+
+
+def test_search_invalid_metadata_filter_exits_1(capsys):
+    rc, client = _run(["search", "foo", "--metadata-filter", "not-json", "--json"], {"hits": []})
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "--metadata-filter must be valid JSON" in capsys.readouterr().err
 
 
 def test_search_text_mode_prints_human_readable(capsys):
     payload = {
-        "results": [
+        "hits": [
             {
                 "chunk_id": "c1",
                 "doc_id": "d1",
-                "title": "Contract A",
-                "page": 4,
-                "snippet": "shall terminate",
+                "doc_title": "Contract A",
+                "pages": "4",
+                "text": "shall terminate",
                 "score": 0.87,
-                "language": "en",
-                "citation": "Contract A, p.4",
+                "language": "english",
             }
         ],
         "possible_conflict": False,

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -53,6 +53,14 @@ def test_render_text_search_results_uses_pretty_printer():
     assert "0.9" in out or "0.90" in out
 
 
+def test_render_text_search_error_prints_error():
+    buf = io.StringIO()
+    render({"error": "Cannot specify both doc_id and doc_ids"}, mode=OutputMode.TEXT, command="search", stream=buf)
+    out = buf.getvalue()
+    assert "error: Cannot specify both doc_id and doc_ids" in out
+    assert "0 results" not in out
+
+
 def test_render_text_falls_back_to_json_for_unknown_command():
     buf = io.StringIO()
     render({"foo": "bar"}, mode=OutputMode.TEXT, command="unknown-command", stream=buf)

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -33,16 +33,15 @@ def test_render_json_emits_indented_json():
 def test_render_text_search_results_uses_pretty_printer():
     buf = io.StringIO()
     payload = {
-        "results": [
+        "hits": [
             {
                 "chunk_id": "c1",
                 "doc_id": "d1",
-                "title": "Doc A",
-                "page": 1,
-                "snippet": "hello world",
+                "doc_title": "Doc A",
+                "pages": "1",
+                "text": "hello world",
                 "score": 0.9,
-                "language": "en",
-                "citation": "Doc A, p.1",
+                "language": "english",
             },
         ],
         "possible_conflict": False,


### PR DESCRIPTION
## Summary
- align CLI search rendering, help, README, and agent skill text with MCP search's top-level hits contract
- add compact detail, metadata filters, exact text filters, and language alias handling to search/batch-search where supported
- update CLI tests around the real MCP result shape

## Tests
- uv run --extra test pytest tests/cli
- uv run --extra test ruff check src/harbor_clerk/cli/commands/search.py src/harbor_clerk/cli/commands/batch_search.py src/harbor_clerk/cli/output.py tests/cli/test_commands_search.py tests/cli/test_commands_batch_search.py tests/cli/test_output.py
- git diff --check