### PR TITLE
feat(chat): expose verify_identifier as a chat tool

### DIFF
--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -357,6 +357,34 @@ _BASE_CHAT_TOOLS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "verify_identifier",
+            "description": (
+                "Resolve a specific document identifier (title, filename, or "
+                "metadata identifier) to exactly one doc_id. Call BEFORE "
+                "quoting a named document so you do not confuse it with "
+                "similarly-named documents. Returns status='unique' with "
+                "doc_id + title; status='ambiguous' with discriminating "
+                "fields per candidate; or status='not_found' (the document "
+                "does not exist in the corpus — do NOT fall back to similarity "
+                "search)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "identifier": {
+                        "type": "string",
+                        "description": (
+                            "The identifier to verify (full title, filename, or metadata identifier substring)."
+                        ),
+                    },
+                },
+                "required": ["identifier"],
+            },
+        },
+    },
 ]
 
 
@@ -512,6 +540,10 @@ def _map_args_corpus_topics(args: dict) -> dict:
     return {}
 
 
+def _map_args_verify_identifier(args: dict) -> dict:
+    return {"identifier": args["identifier"]}
+
+
 def _map_args_find_all(args: dict) -> dict:
     """Map chat-tool args to find_all() kwargs. Drops unknown keys."""
     allowed = {
@@ -541,6 +573,7 @@ _TOOL_DISPATCH: dict[str, tuple[str, callable]] = {
     "ingest_status": ("kb_ingest_status", _map_args_ingest_status),
     "corpus_topics": ("kb_corpus_topics", _map_args_corpus_topics),
     "find_all_documents": ("kb_find_all", _map_args_find_all),
+    "verify_identifier": ("kb_verify_identifier", _map_args_verify_identifier),
 }
 
 

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -94,3 +94,49 @@ def test_get_chat_tools_falls_back_to_100_when_model_default_none():
     tools = get_chat_tools(model=null_model)
     fa = next(t for t in tools if t["function"]["name"] == "find_all_documents")
     assert fa["function"]["parameters"]["properties"]["max_results"]["default"] == 100
+
+
+def test_verify_identifier_in_base_chat_tools():
+    """verify_identifier resolves a named document to one doc_id before
+    quoting it — closes the local-vs-cloud groundedness gap by giving local
+    models the same fabrication-prevention surface MCP-direct callers use."""
+    from harbor_clerk.llm.tools import _BASE_CHAT_TOOLS
+
+    names = {t["function"]["name"] for t in _BASE_CHAT_TOOLS}
+    assert "verify_identifier" in names
+
+
+def test_verify_identifier_schema_requires_identifier():
+    from harbor_clerk.llm.tools import _BASE_CHAT_TOOLS
+
+    vi = next(t for t in _BASE_CHAT_TOOLS if t["function"]["name"] == "verify_identifier")
+    params = vi["function"]["parameters"]
+    assert params["required"] == ["identifier"]
+    assert "identifier" in params["properties"]
+    assert params["properties"]["identifier"]["type"] == "string"
+
+
+def test_map_args_verify_identifier_passes_identifier():
+    from harbor_clerk.llm.tools import _map_args_verify_identifier
+
+    assert _map_args_verify_identifier({"identifier": "2ThemartComInc_19990826"}) == {
+        "identifier": "2ThemartComInc_19990826"
+    }
+
+
+def test_dispatch_routes_verify_identifier_to_kb_verify_identifier():
+    """Catch typos in the dispatch table — without this, a chat-mode call to
+    verify_identifier would silently return 'Unknown tool' at runtime."""
+    from harbor_clerk.llm.tools import _TOOL_DISPATCH
+
+    mcp_name, _ = _TOOL_DISPATCH["verify_identifier"]
+    assert mcp_name == "kb_verify_identifier"
+
+
+def test_research_dispatch_inherits_verify_identifier():
+    """Research mode dispatch inherits from chat dispatch via spread; the new
+    tool must be reachable in both modes."""
+    from harbor_clerk.llm.tools import _RESEARCH_TOOL_DISPATCH
+
+    assert "verify_identifier" in _RESEARCH_TOOL_DISPATCH
+    assert _RESEARCH_TOOL_DISPATCH["verify_identifier"][0] == "kb_verify_identifier"


### PR DESCRIPTION
## Summary
- Adds verify_identifier to HC chat tool surface (was missing — chat had 15 of MCP's 19 tools)
- Closes the local-vs-cloud groundedness gap caused by citation flood

## Why
The 2026-05-29 local sweep (PR #425) showed local models lagging cloud Sonnet by 1.0-2.5 groundedness points across all three corpora. Side-by-side capture inspection found that cloud Sonnet started named-document questions with kb_verify_identifier to resolve to a single doc_id, then issued a narrow kb_search filtered to that doc. Local models had no verify_identifier available, so they started with a broad search_documents query that surfaced 5-10 candidate hits. Every hit ended up in cited_doc_titles (via extract_citations_from_tool_result), which the judge read as an unfocused, ungrounded citation list.

Example (qwen36-35b-a3b × cuad-gt-agreementdate-2themart):
- Cloud Sonnet: 1 doc cited (the right one), groundedness 5
- Local qwen36: 9 docs cited (8 wrong Co-Branding Agreements + the right one), groundedness lower

## Changes
- _BASE_CHAT_TOOLS gains a verify_identifier entry with a single identifier string parameter
- _map_args_verify_identifier passes the arg through
- _TOOL_DISPATCH routes to kb_verify_identifier; _RESEARCH_TOOL_DISPATCH inherits via spread

## Test plan
- [x] 5 new unit tests in tests/test_chat_tools.py — schema, arg mapper, chat dispatch routing, research dispatch routing, required-fields contract
- [x] pytest tests/test_chat_tools.py — 12/12 pass
- [x] ruff check, ruff format --check — clean
- [ ] Validate end-to-end by re-running the local answer-eval sweep (after PR #425 merges, requires LocalProvider fix from that PR to actually see the result_summary in transcripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
