### PR TITLE
fix(test-corpora): rebase missing LocalProvider commits onto main

### DIFF
--- a/scripts/test_corpora/runner/answer_eval.py
+++ b/scripts/test_corpora/runner/answer_eval.py
@@ -231,47 +231,56 @@ def run(
 def _live_capture_fn(*, api_base: str, corpus: str, model: str, insecure: bool) -> Callable[[GTItem], dict]:
     """Build the production capture function: a model+MCP run per item.
 
-    Uses make_provider() to dispatch on model name (claude-* -> AnthropicProvider,
-    gpt-* / o1-* / o3-* -> OpenAIProvider). The MCP session MUST be
+    Cloud models (claude-*, gpt-*, o1-*, o3-*) talk to HC's MCP endpoint
+    directly and drive the tool-use loop themselves. The MCP session MUST be
     authenticated with a corpus-scoped API key so HC's search is restricted to
     `corpus`: set HC_API_KEY to that scoped key. Falls back to a
     HC_USERNAME/HC_PASSWORD login, which yields an UNSCOPED (full-index)
-    session — correct only when `corpus` is the lone corpus loaded.
+    MCP session — correct only when `corpus` is the lone corpus loaded.
 
-    The provider's underlying API client (anthropic.Anthropic() or
-    openai.OpenAI()) is lazily constructed inside the provider; both read
-    their API keys from env (ANTHROPIC_API_KEY / OPENAI_API_KEY).
+    Local HC-hosted models (qwen3-*, gemma4-*, phi4-*, deepseek-*, gpt-oss-*,
+    smollm3-*, ...) live INSIDE HC and can't speak MCP themselves. We route
+    them through HC's chat API instead, scoping the conversation by folder.
+    That path needs admin auth (HC_USERNAME + HC_PASSWORD) because the
+    PUT /chat/models/{id}/activate endpoint is admin-only.
     """
     from scripts.test_corpora.runner.client import HarborClerkClient, SyncMcpSession
     from scripts.test_corpora.runner.providers import make_provider
+    from scripts.test_corpora.runner.providers.factory import model_is_cloud
 
-    token = os.environ.get("HC_API_KEY")
-    if not token:
+    if model_is_cloud(model):
+        token = os.environ.get("HC_API_KEY")
+        if not token:
+            user, password = os.environ.get("HC_USERNAME"), os.environ.get("HC_PASSWORD")
+            if not (user and password):
+                raise RuntimeError(
+                    "answer-eval cloud path needs HC_API_KEY (a corpus-scoped key) or HC_USERNAME + HC_PASSWORD in the environment"
+                )
+            hc = HarborClerkClient(api_base, verify=not insecure)
+            hc.login(user, password)
+            token = hc.get_bearer_token()
+            if not token:
+                raise RuntimeError("HC login did not yield a bearer token — check HC_USERNAME / HC_PASSWORD")
+            log.warning("HC_API_KEY unset — using an unscoped login; search is NOT corpus-restricted")
+
+        mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
+        mcp = SyncMcpSession(url=mcp_url, headers={"Authorization": f"Bearer {token}"})
+        provider = make_provider(model, mcp_session=mcp)
+    else:
+        # Local-model path — needs admin auth for PUT /chat/models/{id}/activate.
         user, password = os.environ.get("HC_USERNAME"), os.environ.get("HC_PASSWORD")
         if not (user and password):
             raise RuntimeError(
-                "answer-eval needs HC_API_KEY (a corpus-scoped key) or HC_USERNAME + HC_PASSWORD in the environment"
+                "answer-eval local path needs HC_USERNAME + HC_PASSWORD in the environment "
+                "(local models need admin auth for model activation)"
             )
         hc = HarborClerkClient(api_base, verify=not insecure)
         hc.login(user, password)
-        token = hc.get_bearer_token()
-        if not token:
-            raise RuntimeError("HC login did not yield a bearer token — check HC_USERNAME / HC_PASSWORD")
-        log.warning("HC_API_KEY unset — using an unscoped login; search is NOT corpus-restricted")
-
-    mcp_url = os.environ.get("HC_MCP_URL") or f"{api_base}/mcp/mcp"
-    mcp = SyncMcpSession(url=mcp_url, headers={"Authorization": f"Bearer {token}"})
-
-    # Build a single shared provider for the whole run — each call to
-    # make_provider() would otherwise construct a fresh openai.OpenAI() (and
-    # its httpx connection pool) per item; 29 leaked pools over a run.
-    # Cited-doc bookkeeping is per-question, so we wipe `_cited` between
-    # items to keep results comparable to the pre-refactor per-item model.
-    provider = make_provider(model, mcp_session=mcp)
+        provider = make_provider(model, hc_client=hc)
 
     def capture(item: GTItem) -> dict:
-        # Per-question reset: AnthropicProvider/OpenAIProvider both store
-        # cited docs in `_cited`. A fresh dict per item keeps each
+        # Per-question reset: AnthropicProvider/OpenAIProvider/LocalProvider all
+        # store cited docs in `_cited`. A fresh dict per item keeps each
         # BaselineResult's cited_doc_ids scoped to that question's tool calls.
         provider._cited = {}
         res = provider.run_question(question=item.question, question_id=item.id, corpus=corpus)

--- a/scripts/test_corpora/runner/providers/factory.py
+++ b/scripts/test_corpora/runner/providers/factory.py
@@ -2,14 +2,20 @@
 """make_provider — single dispatch point that maps model name → Provider.
 
 String matching by prefix:
-  claude-*           -> AnthropicProvider
-  gpt-* / o1-* / o3-* -> OpenAIProvider
+  claude-*           -> AnthropicProvider (cloud, direct MCP)
+  gpt-* / o1-* / o3-* -> OpenAIProvider (cloud, direct MCP)
+  anything else      -> LocalProvider (HC-hosted llama-server via chat API)
 
-Unknown prefixes raise ValueError with the supported list. The factory
-lazily constructs the underlying client (anthropic.Anthropic() or
-openai.OpenAI()) inside the matched branch via the provider's own
-constructor — both read API keys from the standard env vars
-(ANTHROPIC_API_KEY, OPENAI_API_KEY).
+The local fallback is intentional: local HC-hosted model ids vary widely
+(qwen3-8b, deepseek-r1-0528-8b, phi4-mini, gemma4-26b-a4b, ...) and don't
+share a stable prefix. The factory accepts them all and lets HC's chat
+model registry decide whether the activate call succeeds.
+
+Cloud providers lazily construct their underlying client (anthropic.Anthropic()
+or openai.OpenAI()) inside the matched branch via the provider's own
+constructor — both read API keys from the standard env vars (ANTHROPIC_API_KEY,
+OPENAI_API_KEY). LocalProvider requires ``hc_client`` (a HarborClerkClient
+already authenticated against HC's admin API for the model-activate call).
 """
 
 from __future__ import annotations
@@ -18,26 +24,48 @@ from typing import Any
 
 from scripts.test_corpora.runner.providers.anthropic_provider import AnthropicProvider
 from scripts.test_corpora.runner.providers.base import Provider
+from scripts.test_corpora.runner.providers.local_provider import LocalProvider
 from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
 
 _ANTHROPIC_PREFIXES = ("claude-",)
 _OPENAI_PREFIXES = ("gpt-", "o1-", "o3-")
 
 
+def model_is_cloud(model: str) -> bool:
+    """True for cloud-routed models (claude-*, gpt-*, o1-*, o3-*).
+
+    Callers use this to pick between the cloud path (open an MCP session
+    against HC) and the local path (drive HC's chat API for HC-hosted
+    llama-server models).
+    """
+    return model.startswith(_ANTHROPIC_PREFIXES + _OPENAI_PREFIXES)
+
+
 def make_provider(
     model: str,
     *,
-    mcp_session: Any,
+    mcp_session: Any = None,
+    hc_client: Any = None,
     doc_ids_seen: list[str] | None = None,
 ) -> Provider:
-    """Construct a Provider for `model` wired to `mcp_session`.
+    """Construct a Provider for `model`.
 
-    `doc_ids_seen` pre-seeds the cited-doc map (used by tests + by callers
+    Cloud models (claude-*, gpt-*, o1-*, o3-*) require ``mcp_session``.
+    Anything else is treated as an HC-hosted local model and requires
+    ``hc_client`` (admin-authed, since model activation needs JWT).
+
+    ``doc_ids_seen`` pre-seeds the cited-doc map (used by tests + by callers
     that want to anchor citations to a known starting set).
     """
     if model.startswith(_ANTHROPIC_PREFIXES):
         return AnthropicProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
     if model.startswith(_OPENAI_PREFIXES):
         return OpenAIProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
-    supported = ", ".join(_ANTHROPIC_PREFIXES + _OPENAI_PREFIXES)
-    raise ValueError(f"unknown model {model!r}; supported prefixes: {supported}")
+    if hc_client is None:
+        raise ValueError(f"model {model!r} is not a cloud model; LocalProvider needs hc_client=")
+    return LocalProvider(
+        hc_client=hc_client,
+        model=model,
+        mcp_session=mcp_session,
+        doc_ids_seen=doc_ids_seen,
+    )

--- a/scripts/test_corpora/runner/providers/factory.py
+++ b/scripts/test_corpora/runner/providers/factory.py
@@ -29,15 +29,25 @@ from scripts.test_corpora.runner.providers.openai_provider import OpenAIProvider
 
 _ANTHROPIC_PREFIXES = ("claude-",)
 _OPENAI_PREFIXES = ("gpt-", "o1-", "o3-")
+# Models whose name starts with an "OpenAI-looking" prefix but are actually
+# HC-hosted local llama-server models. They must be excluded from the cloud
+# routing decision so make_provider returns LocalProvider for them.
+_LOCAL_OVERRIDES = ("gpt-oss-",)
 
 
 def model_is_cloud(model: str) -> bool:
     """True for cloud-routed models (claude-*, gpt-*, o1-*, o3-*).
 
+    `gpt-oss-*` is explicitly excluded — it's a HC-hosted local model whose
+    name happens to start with `gpt-`. Without this carve-out the factory
+    would dispatch it to the OpenAI API and get a 404.
+
     Callers use this to pick between the cloud path (open an MCP session
     against HC) and the local path (drive HC's chat API for HC-hosted
     llama-server models).
     """
+    if model.startswith(_LOCAL_OVERRIDES):
+        return False
     return model.startswith(_ANTHROPIC_PREFIXES + _OPENAI_PREFIXES)
 
 
@@ -59,7 +69,7 @@ def make_provider(
     """
     if model.startswith(_ANTHROPIC_PREFIXES):
         return AnthropicProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
-    if model.startswith(_OPENAI_PREFIXES):
+    if model.startswith(_OPENAI_PREFIXES) and not model.startswith(_LOCAL_OVERRIDES):
         return OpenAIProvider(mcp_session=mcp_session, model=model, doc_ids_seen=doc_ids_seen)
     if hc_client is None:
         raise ValueError(f"model {model!r} is not a cloud model; LocalProvider needs hc_client=")

--- a/scripts/test_corpora/runner/providers/local_provider.py
+++ b/scripts/test_corpora/runner/providers/local_provider.py
@@ -1,0 +1,147 @@
+"""LocalProvider — answer-eval through HC's chat API.
+
+The cloud providers (AnthropicProvider, OpenAIProvider) connect directly to
+HC's MCP endpoint and drive the tool-use loop themselves. Local llama-server
+models can't do that — they live INSIDE HC and are reached only via HC's
+chat API. LocalProvider wraps that path so answer-eval mode can score them
+the same way it scores cloud models: same BaselineResult shape, same judge,
+same per-question report files.
+
+Mechanics per run_question:
+  1. Resolve the corpus's watch folder UUID once (cached).
+  2. POST /chat/conversations with scope={folder_ids: [uuid]} so HC's chat
+     engine restricts tool calls to that corpus's documents.
+  3. POST /chat/conversations/{id}/messages and drain the SSE event stream.
+  4. Collect tokens → answer; tool_call/tool_result events → tool_transcript;
+     done event's rag_context.citations → cited_doc_ids/cited_doc_titles.
+  5. Build BaselineResult identical in shape to the cloud captures.
+
+Model activation is handled at construction time — one PUT
+/chat/models/{id}/activate per LocalProvider instance. The activation
+endpoint requires admin JWT, so this path needs HC_USERNAME/HC_PASSWORD
+in the environment (the cloud answer-eval path can run with just
+HC_API_KEY).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from scripts.test_corpora.runner.client import HarborClerkClient
+from scripts.test_corpora.runner.providers.base import BaselineResult
+
+
+class LocalProvider:
+    """Run a local HC-hosted model through HC's chat API and return the answer
+    as a BaselineResult.
+
+    Note: ``mcp_session`` is accepted for factory-signature compatibility but
+    ignored — local models do tool calls through HC's chat engine, not direct
+    MCP. Pass it as None or whatever the caller has.
+    """
+
+    def __init__(
+        self,
+        *,
+        hc_client: HarborClerkClient,
+        model: str,
+        mcp_session: Any = None,
+        doc_ids_seen: list[str] | None = None,
+    ) -> None:
+        self._hc = hc_client
+        self._model = model
+        # Maintained for factory parity with cloud providers — answer-eval's
+        # per-question reset writes to this dict.
+        self._cited: dict[str, str] = {}
+        # Pre-seed per protocol; LocalProvider doesn't currently consult it.
+        self._doc_ids_seen = list(doc_ids_seen or [])
+        # Folder UUID cache so we don't re-fetch per question.
+        self._folder_id_by_corpus: dict[str, str] = {}
+        # Activate the model up-front so the first question doesn't pay the
+        # warmup cost inside the SSE stream's timeout budget.
+        self._hc.activate_model(model)
+        self._hc.wait_for_model_ready(model, max_wait_seconds=600)
+
+    def _folder_id_for(self, corpus: str) -> str:
+        if corpus not in self._folder_id_by_corpus:
+            self._folder_id_by_corpus[corpus] = self._hc.folder_id_for_corpus(corpus)
+        return self._folder_id_by_corpus[corpus]
+
+    def run_question(self, question: str, question_id: str, corpus: str) -> BaselineResult:
+        scope = {"folder_ids": [self._folder_id_for(corpus)]}
+        title = f"answer-eval/{corpus}/{self._model}/{question_id}"
+        conv_id = self._hc.create_conversation(title=title, scope=scope)
+
+        start = time.time()
+        events = list(self._hc.stream_ask(conv_id, question))
+        elapsed = time.time() - start
+
+        answer_chunks: list[str] = []
+        tool_transcript: list[dict] = []
+        cited_doc_ids: list[str] = []
+        cited_doc_titles: list[str] = []
+        tool_call_count = 0
+
+        # Index tool_result events by tool_call_id so we can pair them up in
+        # the transcript. HC's SSE emits tool_call (with id+args) and
+        # tool_result (with id+result) as separate events.
+        tool_results_by_id: dict[str, dict] = {}
+        tool_calls_by_id: dict[str, dict] = {}
+
+        for ev in events:
+            etype = ev.get("type")
+            if etype == "token":
+                content = ev.get("content")
+                if isinstance(content, str):
+                    answer_chunks.append(content)
+            elif etype == "tool_call":
+                tool_call_count += 1
+                tool_calls_by_id[ev.get("id") or f"_call_{tool_call_count}"] = ev
+            elif etype == "tool_result":
+                tool_results_by_id[ev.get("id") or f"_call_{tool_call_count}"] = ev
+            elif etype == "done":
+                rc = ev.get("rag_context") or {}
+                citations = rc.get("citations") or ev.get("citations") or []
+                for c in citations:
+                    if isinstance(c, dict):
+                        did = c.get("doc_id")
+                        title_str = c.get("doc_title") or c.get("title") or ""
+                        if did:
+                            cited_doc_ids.append(str(did))
+                            cited_doc_titles.append(str(title_str))
+                            # Populate _cited so answer_eval's bookkeeping
+                            # mirrors cloud providers' behavior.
+                            self._cited[str(did)] = str(title_str)
+
+        # Build a transcript in invocation order, pairing tool_call + tool_result.
+        for call_id, call_ev in tool_calls_by_id.items():
+            result_ev = tool_results_by_id.get(call_id, {})
+            raw_result = result_ev.get("result")
+            # Keep summary compact — full tool result blobs can be large.
+            if isinstance(raw_result, str):
+                summary = raw_result[:500]
+            elif isinstance(raw_result, dict):
+                summary = {k: v for k, v in raw_result.items() if k in ("hits", "passages", "count", "doc_id", "title")}
+            else:
+                summary = raw_result
+            tool_transcript.append(
+                {
+                    "tool": call_ev.get("name") or call_ev.get("tool") or "",
+                    "args": call_ev.get("arguments") or call_ev.get("args") or {},
+                    "result_summary": summary,
+                }
+            )
+
+        return BaselineResult(
+            question_id=question_id,
+            question=question,
+            answer="".join(answer_chunks),
+            cited_doc_ids=cited_doc_ids,
+            cited_doc_titles=cited_doc_titles,
+            tool_call_count=tool_call_count,
+            tool_transcript=tool_transcript,
+            elapsed_seconds=elapsed,
+            model=self._model,
+            timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(start)),
+        )

--- a/scripts/test_corpora/runner/providers/local_provider.py
+++ b/scripts/test_corpora/runner/providers/local_provider.py
@@ -83,11 +83,13 @@ class LocalProvider:
         cited_doc_titles: list[str] = []
         tool_call_count = 0
 
-        # Index tool_result events by tool_call_id so we can pair them up in
-        # the transcript. HC's SSE emits tool_call (with id+args) and
-        # tool_result (with id+result) as separate events.
-        tool_results_by_id: dict[str, dict] = {}
-        tool_calls_by_id: dict[str, dict] = {}
+        # Pair tool_call ↔ tool_result by stream order. HC's SSE shape is
+        # `{type:"tool_call", name, arguments}` followed by
+        # `{type:"tool_result", name, summary, raw_result}` — there is no id
+        # field, so we rely on the contract that result immediately follows
+        # call within the same model turn. Using a parallel list (vs. dict)
+        # also preserves the citation flood ordering for the judge.
+        pending_calls: list[dict] = []
 
         for ev in events:
             etype = ev.get("type")
@@ -97,9 +99,24 @@ class LocalProvider:
                     answer_chunks.append(content)
             elif etype == "tool_call":
                 tool_call_count += 1
-                tool_calls_by_id[ev.get("id") or f"_call_{tool_call_count}"] = ev
+                pending_calls.append(ev)
             elif etype == "tool_result":
-                tool_results_by_id[ev.get("id") or f"_call_{tool_call_count}"] = ev
+                # Read HC's actual field names. `summary` is already truncated
+                # by HC's summarize_tool_result; prefer it over raw_result so
+                # the captured transcript stays bounded.
+                summary = ev.get("summary")
+                if summary is None:
+                    summary = ev.get("raw_result")
+                if isinstance(summary, str) and len(summary) > 500:
+                    summary = summary[:500]
+                call_ev = pending_calls.pop(0) if pending_calls else {}
+                tool_transcript.append(
+                    {
+                        "tool": ev.get("name") or call_ev.get("name") or "",
+                        "args": call_ev.get("arguments") or {},
+                        "result_summary": summary,
+                    }
+                )
             elif etype == "done":
                 rc = ev.get("rag_context") or {}
                 citations = rc.get("citations") or ev.get("citations") or []
@@ -114,22 +131,14 @@ class LocalProvider:
                             # mirrors cloud providers' behavior.
                             self._cited[str(did)] = str(title_str)
 
-        # Build a transcript in invocation order, pairing tool_call + tool_result.
-        for call_id, call_ev in tool_calls_by_id.items():
-            result_ev = tool_results_by_id.get(call_id, {})
-            raw_result = result_ev.get("result")
-            # Keep summary compact — full tool result blobs can be large.
-            if isinstance(raw_result, str):
-                summary = raw_result[:500]
-            elif isinstance(raw_result, dict):
-                summary = {k: v for k, v in raw_result.items() if k in ("hits", "passages", "count", "doc_id", "title")}
-            else:
-                summary = raw_result
+        # Any tool_calls that never received a matching tool_result still
+        # belong in the transcript — the model invoked them.
+        for call_ev in pending_calls:
             tool_transcript.append(
                 {
-                    "tool": call_ev.get("name") or call_ev.get("tool") or "",
-                    "args": call_ev.get("arguments") or call_ev.get("args") or {},
-                    "result_summary": summary,
+                    "tool": call_ev.get("name") or "",
+                    "args": call_ev.get("arguments") or {},
+                    "result_summary": None,
                 }
             )
 

--- a/scripts/test_corpora/tests/test_local_provider.py
+++ b/scripts/test_corpora/tests/test_local_provider.py
@@ -1,0 +1,170 @@
+# scripts/test_corpora/tests/test_local_provider.py
+"""LocalProvider — exercises the SSE-event → BaselineResult shape, with
+the HC chat event names (`summary` / `raw_result`) rather than the older
+`result` key.
+
+The full provider talks to HC's chat API for model activation and
+conversation creation; these tests stub the HarborClerkClient surface
+just enough to drive `run_question`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.test_corpora.runner.providers.local_provider import LocalProvider
+
+
+class _StubHC:
+    """Minimal HarborClerkClient stub. Records calls; replays events."""
+
+    def __init__(self, events: list[dict[str, Any]], folder_id: str = "FOLDER-1") -> None:
+        self._events = events
+        self._folder_id = folder_id
+        self.created_conversations: list[dict] = []
+        self.streamed_questions: list[tuple[str, str]] = []
+
+    def activate_model(self, model: str) -> None:
+        return None
+
+    def wait_for_model_ready(self, model: str, max_wait_seconds: int = 600) -> None:
+        return None
+
+    def folder_id_for_corpus(self, corpus: str) -> str:
+        return self._folder_id
+
+    def create_conversation(self, *, title: str, scope: dict | None = None) -> str:
+        self.created_conversations.append({"title": title, "scope": scope})
+        return "CONV-1"
+
+    def stream_ask(self, conv_id: str, question: str):
+        self.streamed_questions.append((conv_id, question))
+        yield from self._events
+
+
+def _events_with_tool_summary(summary: str = '{"hits":[{"doc_id":"D1"}]}'):
+    return [
+        {"type": "tool_call", "name": "search_documents", "arguments": {"query": "x"}},
+        {"type": "tool_result", "name": "search_documents", "summary": summary, "raw_result": "FULL-" + summary},
+        {"type": "token", "content": "Answer "},
+        {"type": "token", "content": "text."},
+        {
+            "type": "done",
+            "rag_context": {
+                "citations": [
+                    {"doc_id": "D1", "doc_title": "Doc One"},
+                ]
+            },
+        },
+    ]
+
+
+def test_tool_result_summary_uses_summary_field():
+    """Regression: LocalProvider previously read `result_ev.get('result')`,
+    which always returned None because HC's SSE uses `summary` / `raw_result`.
+    The transcript's `result_summary` must contain the actual tool output so
+    the answer-judge can verify groundedness against retrieved evidence.
+    """
+    hc = _StubHC(_events_with_tool_summary())
+    provider = LocalProvider(hc_client=hc, model="qwen3-4b")
+
+    result = provider.run_question("q?", "qid-1", "cuad")
+
+    assert len(result.tool_transcript) == 1
+    entry = result.tool_transcript[0]
+    assert entry["tool"] == "search_documents"
+    assert entry["args"] == {"query": "x"}
+    assert entry["result_summary"] == '{"hits":[{"doc_id":"D1"}]}'
+
+
+def test_tool_result_summary_falls_back_to_raw_result():
+    """If HC ever emits only `raw_result` without `summary`, the transcript
+    should still capture the tool output rather than dropping it.
+    """
+    events = [
+        {"type": "tool_call", "name": "read_passages", "arguments": {"chunk_ids": ["c1"]}},
+        {"type": "tool_result", "name": "read_passages", "raw_result": "PASSAGE TEXT"},
+        {"type": "done", "rag_context": {"citations": []}},
+    ]
+    hc = _StubHC(events)
+    provider = LocalProvider(hc_client=hc, model="qwen3-4b")
+
+    result = provider.run_question("q?", "qid-2", "cuad")
+
+    assert result.tool_transcript[0]["result_summary"] == "PASSAGE TEXT"
+
+
+def test_tool_result_summary_truncates_long_strings():
+    """Captures get checked into JSON and shipped to the judge; an unbounded
+    raw_result would balloon both. Truncate at 500 chars to match the prior
+    cap.
+    """
+    long_summary = "x" * 5000
+    events = [
+        {"type": "tool_call", "name": "search_documents", "arguments": {}},
+        {"type": "tool_result", "name": "search_documents", "summary": long_summary},
+        {"type": "done", "rag_context": {"citations": []}},
+    ]
+    hc = _StubHC(events)
+    provider = LocalProvider(hc_client=hc, model="qwen3-4b")
+
+    result = provider.run_question("q?", "qid-3", "cuad")
+
+    assert len(result.tool_transcript[0]["result_summary"]) == 500
+
+
+def test_tool_call_without_matching_result_still_appears_in_transcript():
+    """If a tool_call is emitted but the corresponding tool_result is dropped
+    (e.g., the stream ends mid-turn), the call still belongs in the
+    transcript — the model did invoke it. result_summary should be None.
+    """
+    events = [
+        {"type": "tool_call", "name": "search_documents", "arguments": {"query": "y"}},
+        {"type": "done", "rag_context": {"citations": []}},
+    ]
+    hc = _StubHC(events)
+    provider = LocalProvider(hc_client=hc, model="qwen3-4b")
+
+    result = provider.run_question("q?", "qid-4", "cuad")
+
+    assert len(result.tool_transcript) == 1
+    assert result.tool_transcript[0]["tool"] == "search_documents"
+    assert result.tool_transcript[0]["args"] == {"query": "y"}
+    assert result.tool_transcript[0]["result_summary"] is None
+
+
+def test_citations_populate_cited_ids_titles_in_order():
+    """HC chat emits done.rag_context.citations as the accumulated set; the
+    provider should preserve order and populate both ids and titles.
+    """
+    events = [
+        {
+            "type": "done",
+            "rag_context": {
+                "citations": [
+                    {"doc_id": "D1", "doc_title": "T1"},
+                    {"doc_id": "D2", "doc_title": "T2"},
+                ]
+            },
+        }
+    ]
+    hc = _StubHC(events)
+    provider = LocalProvider(hc_client=hc, model="qwen3-4b")
+
+    result = provider.run_question("q?", "qid-5", "cuad")
+
+    assert result.cited_doc_ids == ["D1", "D2"]
+    assert result.cited_doc_titles == ["T1", "T2"]
+
+
+def test_scope_is_set_to_folder_for_corpus():
+    """run_question should pass the corpus's watched-folder UUID to the
+    conversation's scope so HC restricts tool calls to that corpus.
+    """
+    events = [{"type": "done", "rag_context": {"citations": []}}]
+    hc = _StubHC(events, folder_id="FOLDER-CUAD-UUID")
+    provider = LocalProvider(hc_client=hc, model="qwen3-4b")
+
+    provider.run_question("q?", "qid-6", "cuad")
+
+    assert hc.created_conversations[0]["scope"] == {"folder_ids": ["FOLDER-CUAD-UUID"]}

--- a/scripts/test_corpora/tests/test_providers_factory.py
+++ b/scripts/test_corpora/tests/test_providers_factory.py
@@ -40,9 +40,11 @@ def test_factory_dispatches_o3_to_openai():
     assert isinstance(p, OpenAIProvider)
 
 
-def test_factory_raises_value_error_on_unknown_model():
-    """An unknown prefix raises ValueError with the supported list in the message."""
-    with pytest.raises(ValueError, match=r"unknown model.*supported prefixes.*claude-.*gpt-"):
+def test_factory_raises_value_error_on_local_model_without_hc_client():
+    """Non-cloud prefixes fall through to LocalProvider, which requires
+    hc_client. Without it the factory raises ValueError naming the missing
+    keyword — callers must wire up HC auth for local models."""
+    with pytest.raises(ValueError, match=r"is not a cloud model.*LocalProvider needs hc_client"):
         make_provider("llama-3.1-70b", mcp_session=MagicMock())
 
 


### PR DESCRIPTION
## Summary
- Rebases LocalProvider + factory carve-out + tool-result-extraction fix onto current main
- These commits were created during the 2026-05-29 session, pushed to the already-merged `feat/test-corpora-scoped-local-runs` branch from PR #425, and consequently never reached main — leaving every local-model cell of the test-corpora answer-eval sweep failing with `ValueError: unknown model 'qwen3-4b'; supported prefixes: claude-, gpt-, o1-, o3-`

## Why
PR #425 merged on May 28 with only the folder-scope client/sweep plumbing. The next session pushed three additional commits to the same branch ref after the PR was closed; pushes to a closed-PR branch do not re-open or rebase. The local sweep ran successfully because the new code existed in the worktree, but the merged main never picked it up. The chat verify_identifier work in PR #431 was built and shipped on top of an assumed-merged-but-unmerged baseline.

## Changes (4 commits, cherry-picked from the closed branch)
- `feat(test-corpora): LocalProvider for answer-eval over HC-hosted models` (29b1bad → 5f31236)
  - New `LocalProvider` class that drives HC's `/api/chat/conversations` SSE stream
  - `factory.make_provider` falls through to LocalProvider for non-cloud prefixes, requires `hc_client` kwarg
  - `answer_eval._live_capture_fn` picks the cloud vs local path via `model_is_cloud()`
- `fix(test_corpora): carve out gpt-oss-* from OpenAI routing` (b5e2269 → 43e222f)
  - `_LOCAL_OVERRIDES = ("gpt-oss-",)` keeps `gpt-oss-20b` (HC-hosted llama-server model) off the OpenAI API
- `fix(test_corpora): LocalProvider — pull tool result from summary/raw_result` (fe3f71a → 3c486f2)
  - LocalProvider was reading `ev.get("result")`; HC SSE emits `summary` and `raw_result`
  - Adds 6 unit tests in `tests/test_local_provider.py`
- `test(test_corpora): update factory test for LocalProvider fallback`
  - The existing factory ValueError test asserted the pre-LocalProvider error message; rewritten to assert the new fall-through contract

## Test plan
- [x] `pytest tests/test_local_provider.py tests/test_providers_factory.py` — 14/14 pass
- [x] `ruff check scripts/test_corpora/` clean, `ruff format --check` clean
- [ ] Re-run 24-cell local answer-eval sweep once this merges to validate end-to-end (LocalProvider fix + factory carve-out + #431's verify_identifier all wire up together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
