### PR TITLE
feat(search): compact non-scalar discriminator_hint values

### DIFF
--- a/src/harbor_clerk/mcp_discriminator.py
+++ b/src/harbor_clerk/mcp_discriminator.py
@@ -29,6 +29,14 @@ _PROVENANCE_KEY = "_source_provenance"
 # response. Ordered by distinctness (most discriminating first).
 _MAX_FIELDS_IN_HINT = 3
 
+# Cap on collection summaries embedded in differing_metadata. The full
+# list/dict values per candidate can run thousands of chars (e.g.
+# `sidecar.attendees` for 5 board-minutes docs is ~3 KB). The judge —
+# and small-context models — don't need the full table; they need
+# enough to recognize the field is non-scalar and pick a different
+# discriminator. A length + first-element summary is sufficient.
+_COLLECTION_SUMMARY_FIRST_CHARS = 60
+
 
 async def _compute_discriminator_hint(hits, session) -> dict | None:
     """Return a discriminator_hint dict if top hits are ambiguous on a
@@ -78,18 +86,67 @@ async def _compute_discriminator_hint(hits, session) -> dict | None:
     if not differing:
         return None
 
-    # Order by number of distinct values (most discriminating first).
-    top_fields = sorted(
-        differing.items(),
-        key=lambda kv: -len({_make_hashable(v) for v in kv[1].values()}),
-    )[:_MAX_FIELDS_IN_HINT]
+    # Order by: scalar fields first (so the suggestion can name a usable
+    # metadata_filter value), then number of distinct values (most
+    # discriminating first). A scalar field is something the LLM can put
+    # back into a metadata_filter directly — strings, numbers, bools.
+    # Lists/dicts get compacted in `differing_metadata` and are not
+    # useful targets for the suggestion.
+    def _sort_key(kv: tuple[str, dict[str, Any]]) -> tuple[int, int]:
+        _, values_by_title = kv
+        is_scalar = all(_is_scalar(v) for v in values_by_title.values())
+        distinct = len({_make_hashable(v) for v in values_by_title.values()})
+        # Lower tuple = higher priority. Scalar gets 0; non-scalar 1. Distinct
+        # is negated so higher distinctness ranks first.
+        return (0 if is_scalar else 1, -distinct)
+
+    top_fields = sorted(differing.items(), key=_sort_key)[:_MAX_FIELDS_IN_HINT]
+
+    # Compact non-scalar values so a list of 8 attendees doesn't expand to a
+    # 3 KB block per doc. Scalar values pass through unchanged.
+    compacted = {
+        path: {t: _compact_value(v) for t, v in values_by_title.items()} for path, values_by_title in top_fields
+    }
 
     return {
         "ambiguous_doc_ids": candidates,
         "ambiguous_doc_titles": [titles[d] for d in candidates],
-        "differing_metadata": dict(top_fields),
+        "differing_metadata": compacted,
         "suggestion": _build_suggestion(top_fields, titles),
     }
+
+
+def _is_scalar(v: Any) -> bool:
+    """Treat strings, numbers, bools, and None as scalars. Lists/dicts/etc.
+    are non-scalars and get compacted before reaching the LLM."""
+    return v is None or isinstance(v, str | int | float | bool)
+
+
+def _compact_value(v: Any) -> Any:
+    """Return a JSON-serializable summary of v that is small even when v
+    itself is a large list/dict. Scalars pass through.
+
+    For lists: ``{"len": N, "first": str(v[0])[:60]}`` so the LLM can see
+    the field is multi-valued and recognize the type without paying the
+    serialization cost of every element.
+
+    For dicts: ``{"keys": sorted(v.keys())[:5], "len": N}`` — keys are
+    usually short and distinctive; values can be arbitrarily large.
+
+    For anything else non-scalar (sets, custom objects): stringify and
+    truncate.
+    """
+    if _is_scalar(v):
+        return v
+    if isinstance(v, list):
+        out: dict[str, Any] = {"len": len(v)}
+        if v:
+            out["first"] = str(v[0])[:_COLLECTION_SUMMARY_FIRST_CHARS]
+        return out
+    if isinstance(v, dict):
+        keys = sorted(str(k) for k in v)
+        return {"len": len(v), "keys": keys[:5]}
+    return str(v)[:_COLLECTION_SUMMARY_FIRST_CHARS]
 
 
 def _find_differing_metadata_fields(

--- a/tests/test_mcp_discriminator_hint.py
+++ b/tests/test_mcp_discriminator_hint.py
@@ -245,6 +245,114 @@ def test_find_differing_metadata_fields_returns_empty_for_identical_metadata():
     assert _find_differing_metadata_fields(["a", "b"], metadata, titles) == {}
 
 
+async def test_compute_compacts_non_scalar_values_in_differing_metadata():
+    """Long list values (e.g. sidecar.attendees) bloat the response and crowd
+    out small-context models. Lists must be summarized to {len, first} so the
+    LLM sees the field is non-scalar without paying for every element.
+    """
+    a = str(uuid.uuid4())
+    b = str(uuid.uuid4())
+    long_attendees_a = [
+        "Eleanor Voss",
+        "Raymond Holt",
+        "Sandra Kimura",
+        "Frederick Osei",
+        "Diana Marchetti",
+        "Thomas Blaine",
+        "Priya Nandakumar",
+        "Gerald Whitmore",
+    ]
+    long_attendees_b = [
+        "Eleanor Voss",
+        "Raymond Calloway",
+        "Priya Nanthakumar",
+        "Theodore Birch",
+        "Sandra Ouellet",
+        "Marcus Hensley",
+    ]
+    hits = [
+        _FakeHit(doc_id=a, doc_title="0101_board_minutes", score=0.997),
+        _FakeHit(doc_id=b, doc_title="0107_board_minutes", score=0.994),
+    ]
+    session = _fake_session_for(
+        {
+            a: {"sidecar": {"date": "2025-03-07", "attendees": long_attendees_a}},
+            b: {"sidecar": {"date": "2025-03-03", "attendees": long_attendees_b}},
+        }
+    )
+    hint = await _compute_discriminator_hint(hits, session)
+    assert hint is not None
+    # Date (scalar) is surfaced unchanged
+    assert hint["differing_metadata"]["sidecar.date"] == {
+        "0101_board_minutes": "2025-03-07",
+        "0107_board_minutes": "2025-03-03",
+    }
+    # Attendees (list) is compacted to {len, first}, not the full 8-name list
+    att = hint["differing_metadata"]["sidecar.attendees"]
+    assert att["0101_board_minutes"]["len"] == 8
+    assert att["0101_board_minutes"]["first"].startswith("Eleanor Voss")
+    assert att["0107_board_minutes"]["len"] == 6
+    # Verify we didn't accidentally embed the full list
+    import json
+
+    serialized = json.dumps(hint)
+    assert "Raymond Holt" not in serialized  # would appear if the full list leaked through
+    assert "Gerald Whitmore" not in serialized
+
+
+async def test_compute_prefers_scalar_fields_for_suggestion():
+    """When both scalar and non-scalar fields differ, the suggestion should
+    reference a scalar field — the LLM can put it back into a metadata_filter
+    directly. A list-valued field is not a usable filter target.
+    """
+    a = str(uuid.uuid4())
+    b = str(uuid.uuid4())
+    hits = [
+        _FakeHit(doc_id=a, doc_title="A", score=0.9),
+        _FakeHit(doc_id=b, doc_title="B", score=0.88),
+    ]
+    session = _fake_session_for(
+        {
+            # type (scalar) and attendees (list) both differ; only type should
+            # be the basis for the suggestion text.
+            a: {"sidecar": {"type": "board-minutes", "attendees": ["Alice", "Bob"]}},
+            b: {"sidecar": {"type": "vendor-contract", "attendees": ["Carol", "Dave"]}},
+        }
+    )
+    hint = await _compute_discriminator_hint(hits, session)
+    assert hint is not None
+    # Suggestion references the scalar type field, not attendees
+    assert "sidecar.type" in hint["suggestion"]
+    # And the suggestion does NOT include a list literal — a list-valued
+    # metadata_filter is not something the LLM can use.
+    assert "['Alice'" not in hint["suggestion"]
+    assert "Bob" not in hint["suggestion"]
+
+
+async def test_compute_compacts_dict_values_to_keys_and_len():
+    """Dict-valued metadata fields are also compacted; the LLM sees the
+    shape (keys + count) without the full nested content."""
+    a = str(uuid.uuid4())
+    b = str(uuid.uuid4())
+    hits = [
+        _FakeHit(doc_id=a, doc_title="A", score=0.9),
+        _FakeHit(doc_id=b, doc_title="B", score=0.88),
+    ]
+    session = _fake_session_for(
+        {
+            a: {"sidecar": {"nested": {"x": "long " * 100, "y": "verbose " * 100}}},
+            b: {"sidecar": {"nested": {"x": "different long " * 100, "z": "completely other " * 50}}},
+        }
+    )
+    hint = await _compute_discriminator_hint(hits, session)
+    assert hint is not None
+    nested = hint["differing_metadata"]["sidecar.nested"]
+    # Both summaries carry keys + len, not the full nested content
+    assert nested["A"]["keys"] == ["x", "y"]
+    assert nested["A"]["len"] == 2
+    assert "long " * 100 not in str(nested["A"])
+
+
 def test_build_suggestion_mentions_top_field_value():
     """The suggestion string should reference at least one concrete
     metadata_filter call the model can use."""


### PR DESCRIPTION
## Summary
- Compacts list/dict values in `discriminator_hint` so an ambiguous `kb_search` doesn't blow past small-model context budgets
- Sorts differing fields scalar-first so the suggestion always names a field the LLM can put into `metadata_filter`

## Why
The local sweep (2026-05-29-local-aeval-v2) showed qwen3-4b returning 12 empty answers out of 29 on the synthetic corpus. Reproducing one — `Who attended the Marbledock board meeting on 2025-03-07?` — via direct curl against the running HC API yielded:

```
{"type":"error","message":"Context window full",
 "detail":"request (9788 tokens) exceeds the available context size (8192 tokens)"}
```

5 board-minutes docs matched. Each carried sidecar metadata with full attendees lists (6-9 names) and decisions arrays (6 multi-line strings). The discriminator pumped all of that into `differing_metadata`, producing a ~12 KB tool result. qwen3-4b runs with `-c 32768 -np 4` (PR #430), giving 8192 tokens per request — the result alone is bigger than the model's budget once the tools schema and history are factored in.

## Changes (single source file)
- `_sort_key`: scalar-first ordering, distinctness tiebreaker
- `_compact_value`: lists → `{len, first[:60]}`, dicts → `{len, keys[:5]}`, scalars pass through
- `_build_suggestion` receives uncompacted `top_fields` so the suggestion can quote a real value, and the scalar-first sort guarantees the top field is suggestable

## Out of scope / Deferred
- An opt-in `expand_discriminator=true` arg on `kb_search` would let big-context models recover the full table. Skipped because the existing `kb_get_document` already covers that path — a model that wants the full metadata for a known doc_id has a dedicated tool.
- The `-np` ÷ context tradeoff in PR #430 still bites long-context-needing small models. Not addressed here.

## Test plan
- [x] 3 new unit tests in `tests/test_mcp_discriminator_hint.py`:
  - non-scalar values compact to `{len, first}`
  - suggestion prefers scalar fields when both scalar and non-scalar differ
  - dict values compact to `{len, keys}`
- [x] All 15 prior tests still pass (18 total)
- [x] `ruff check`, `ruff format --check` clean
- [ ] End-to-end: re-run the 24-cell local answer-eval sweep on 6 models (after PR #434 merges) and confirm empty-answer count drops on synthetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
