### PR TITLE
chore(test-corpora): drop phi4-mini / smollm3-3b stale refs

### DIFF
--- a/scripts/test_corpora/conftest.py
+++ b/scripts/test_corpora/conftest.py
@@ -17,17 +17,17 @@ from pathlib import Path
 API_BASE = os.environ.get("HC_API_BASE", "http://localhost:8100")
 ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
 
-# All eight downloaded models, by Harbor Clerk model_id. These MUST match the
-# canonical ids in src/harbor_clerk/llm/models.py — anything else 404s on
+# The curated downloaded models, by Harbor Clerk model_id. These MUST match
+# the canonical ids in src/harbor_clerk/llm/models.py — anything else 404s on
 # PUT /api/chat/models/<id>/activate. Phase 4 sweeps over this list. Phase 5
-# uses TOP_MODELS only.
+# uses TOP_MODELS only. The list shrank from 8 to 6 in PR #434 when phi4-mini
+# and smollm3-3b were dropped after the 2026-05-29 sweep showed both well
+# below the quality threshold.
 ALL_MODELS = [
     "qwen3-8b",
     "qwen3-4b",
-    "phi4-mini",
     "deepseek-r1-0528-8b",
     "gemma4-26b-a4b",
-    "smollm3-3b",
     "gpt-oss-20b",
     "qwen36-35b-a3b",
 ]

--- a/scripts/test_corpora/runner/providers/factory.py
+++ b/scripts/test_corpora/runner/providers/factory.py
@@ -7,9 +7,9 @@ String matching by prefix:
   anything else      -> LocalProvider (HC-hosted llama-server via chat API)
 
 The local fallback is intentional: local HC-hosted model ids vary widely
-(qwen3-8b, deepseek-r1-0528-8b, phi4-mini, gemma4-26b-a4b, ...) and don't
-share a stable prefix. The factory accepts them all and lets HC's chat
-model registry decide whether the activate call succeeds.
+(qwen3-8b, deepseek-r1-0528-8b, gemma4-26b-a4b, ...) and don't share a
+stable prefix. The factory accepts them all and lets HC's chat model
+registry decide whether the activate call succeeds.
 
 Cloud providers lazily construct their underlying client (anthropic.Anthropic()
 or openai.OpenAI()) inside the matched branch via the provider's own

--- a/scripts/test_corpora/tests/test_plan_units.py
+++ b/scripts/test_corpora/tests/test_plan_units.py
@@ -23,10 +23,10 @@ def test_models_filter_restricts_phase4_loop():
         _qbc(["cuad"]),
         phases={4},
         depth="standard",
-        models_filter={"qwen3-8b", "phi4-mini"},
+        models_filter={"qwen3-8b", "qwen3-4b"},
     )
     models = {u.model for u in units}
-    assert models == {"qwen3-8b", "phi4-mini"}
+    assert models == {"qwen3-8b", "qwen3-4b"}
 
 
 def test_models_filter_restricts_phase5_to_top_subset():
@@ -49,7 +49,7 @@ def test_models_filter_excludes_phase2_smoke_when_qwen35_filtered_out():
         _qbc(["cuad"]),
         phases={2},
         depth="standard",
-        models_filter={"phi4-mini"},
+        models_filter={"qwen3-4b"},
     )
     assert units == []
 
@@ -57,8 +57,8 @@ def test_models_filter_excludes_phase2_smoke_when_qwen35_filtered_out():
 def test_no_models_filter_means_all_models():
     units = _plan_units(_qbc(["cuad"]), phases={4}, depth="standard", models_filter=None)
     models = {u.model for u in units}
-    # Should be exactly the 8 ALL_MODELS
-    assert len(models) == 8
+    # Should be exactly the 6 ALL_MODELS
+    assert len(models) == 6
 
 
 def test_corpora_filter_phase0_only_lists_provided_corpora():
@@ -75,7 +75,7 @@ def test_phase4_corpus_then_model_ordering_minimizes_db_wipes():
         _qbc(["cuad", "enron"]),
         phases={4},
         depth="standard",
-        models_filter={"qwen3-8b", "phi4-mini"},
+        models_filter={"qwen3-8b", "qwen3-4b"},
     )
     # Walk the unit list and count corpus transitions
     transitions = sum(1 for a, b in zip(units, units[1:]) if a.corpus != b.corpus)

--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -1,10 +1,13 @@
 """Chat tool definitions and executor — delegates to MCP tool functions.
 
-Chat tools are simplified versions of the full MCP tools, tailored for
-small local LLMs (4-8B params). Not all MCP tools are exposed here:
+Chat tools are simplified versions of the full MCP tools, sized for the
+current curated local-LLM range (4B–35B). Not all MCP tools are exposed
+here:
 
   Omitted (MCP-only):
-    - kb_batch_search: multi-query patterns unlikely from small models
+    - kb_batch_search: original rationale was that small models don't
+      issue multi-query patterns. With 20B+ models now in the curated
+      set this is worth revisiting; today's omission is inertia.
     - kb_reprocess / kb_system_health: admin-only, not useful in chat
 
   Simplified:


### PR DESCRIPTION
## Summary
- Removes the last stale references to phi4-mini and smollm3-3b from the test-corpora sweep harness after PR #434 dropped both from the curated registry
- Updates the factory docstring and the test fixture model names so future readers see only currently-supported model ids

## Why
PR #434 removed phi4-mini and smollm3-3b from the curated set. The harness still listed them in `conftest.ALL_MODELS`, so a Phase 4 sweep against the current API would try to `PUT /api/chat/models/phi4-mini/activate` and 404. The plan-unit tests asserted `len(models) == 8` against the unfiltered list. The factory docstring example named phi4-mini as a typical local model id.

## Out of scope / Deferred
- `_LEGACY_MODEL_ID_RENAMES["phi-4-mini"] = "phi4-mini"` in `sweep.py` is preserved. It's a one-way alias used only when rehydrating a state.json from before the model-id alignment; removing it would break resume on old state files without any upside.
- Historical comments in `runner/quality.py` and `tests/test_quality.py` that name phi4-mini as the source of empirically-grounded "garbage answer" fingerprints are left as-is. They're point-in-time commentary, not active behavior.

## Test plan
- [x] `pytest scripts/test_corpora/tests/test_plan_units.py` — 7/7 pass (count assertion was the only thing that needed updating; the filter semantics were unchanged)
- [x] `ruff check`, `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
