### PR TITLE
chore(models): drop deepseek-r1-0528-8b from curated set

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
@@ -144,7 +144,6 @@ private let modelOptions: [(id: String, name: String)] = [
     ("", "None"),
     ("qwen3-8b", "Qwen3 8B (5.0 GB)"),
     ("qwen3-4b", "Qwen3 4B (2.5 GB)"),
-    ("deepseek-r1-0528-8b", "DeepSeek R1 0528 8B (5.0 GB)"),
     ("gpt-oss-20b", "GPT-OSS 20B (11.6 GB)"),
     ("qwen36-35b-a3b", "Qwen3.6 35B-A3B (22.1 GB)"),
     ("gemma4-26b-a4b", "Gemma 4 26B-A4B (17.0 GB)"),

--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -125,7 +125,6 @@ final class AppSettings: @unchecked Sendable {
         let filenames: [String: String] = [
             "qwen3-8b": "Qwen3-8B-Q4_K_M.gguf",
             "qwen3-4b": "Qwen3-4B-Q4_K_M.gguf",
-            "deepseek-r1-0528-8b": "DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
             "gpt-oss-20b": "gpt-oss-20b-Q4_K_M.gguf",
             "qwen36-35b-a3b": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
             "gemma4-26b-a4b": "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
@@ -140,7 +139,6 @@ final class AppSettings: @unchecked Sendable {
         let contextWindows: [String: Int] = [
             "qwen3-8b": 32768,
             "qwen3-4b": 32768,
-            "deepseek-r1-0528-8b": 32768,
             "gpt-oss-20b": 128000,
             "qwen36-35b-a3b": 262144,
             "gemma4-26b-a4b": 128000,
@@ -162,7 +160,6 @@ final class AppSettings: @unchecked Sendable {
         let configs: [String: YarnConfig] = [
             "qwen3-8b": YarnConfig(extendedContext: 131072, ropeScale: 4.0, originalContext: 32768, attnFactor: nil),
             "qwen3-4b": YarnConfig(extendedContext: 131072, ropeScale: 4.0, originalContext: 32768, attnFactor: nil),
-            "deepseek-r1-0528-8b": YarnConfig(extendedContext: 131072, ropeScale: 4.0, originalContext: 32768, attnFactor: 0.8782),
         ]
         return configs[modelId]
     }
@@ -178,7 +175,6 @@ final class AppSettings: @unchecked Sendable {
         let slots: [String: Int] = [
             "qwen3-8b": 2,             // mid (32K context)
             "qwen3-4b": 1,             // small but -np 1 — 8K/slot under -np 4 too tight for tools schema + ambiguous results (v3 sweep, models.py)
-            "deepseek-r1-0528-8b": 2,  // mid (32K context)
             "gpt-oss-20b": 1,          // heavy — MoE active params are small but 128K context → KV too big for 2 slots
             "gemma4-26b-a4b": 1,       // heavy
             "qwen36-35b-a3b": 1,       // heavy

--- a/macos/HarborClerkServer/HarborClerkServerTests/AppSettingsTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/AppSettingsTests.swift
@@ -126,7 +126,6 @@ final class AppSettingsTests: XCTestCase {
         let expected: [String: String] = [
             "qwen3-8b": "Qwen3-8B-Q4_K_M.gguf",
             "qwen3-4b": "Qwen3-4B-Q4_K_M.gguf",
-            "deepseek-r1-0528-8b": "DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
             "gpt-oss-20b": "gpt-oss-20b-Q4_K_M.gguf",
             "qwen36-35b-a3b": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
             "gemma4-26b-a4b": "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
@@ -162,7 +161,6 @@ final class AppSettingsTests: XCTestCase {
     private static let knownModelIds: Set<String> = [
         "qwen3-8b",
         "qwen3-4b",
-        "deepseek-r1-0528-8b",
         "gpt-oss-20b",
         "qwen36-35b-a3b",
         "gemma4-26b-a4b",
@@ -182,7 +180,6 @@ final class AppSettingsTests: XCTestCase {
             "qwen3-4b": 1,
             // Mid (5-12 GB, ≤32K context) → 2 slots
             "qwen3-8b": 2,
-            "deepseek-r1-0528-8b": 2,
             // Heavy (>15 GB OR 128K+ context) → 1 slot
             "gpt-oss-20b": 1,  // 128K context → KV cache too big for 2 slots on 18 GB
             "gemma4-26b-a4b": 1,

--- a/scripts/test_corpora/conftest.py
+++ b/scripts/test_corpora/conftest.py
@@ -26,7 +26,6 @@ ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
 ALL_MODELS = [
     "qwen3-8b",
     "qwen3-4b",
-    "deepseek-r1-0528-8b",
     "gemma4-26b-a4b",
     "gpt-oss-20b",
     "qwen36-35b-a3b",

--- a/scripts/test_corpora/tests/test_plan_units.py
+++ b/scripts/test_corpora/tests/test_plan_units.py
@@ -57,8 +57,8 @@ def test_models_filter_excludes_phase2_smoke_when_qwen35_filtered_out():
 def test_no_models_filter_means_all_models():
     units = _plan_units(_qbc(["cuad"]), phases={4}, depth="standard", models_filter=None)
     models = {u.model for u in units}
-    # Should be exactly the 6 ALL_MODELS
-    assert len(models) == 6
+    # Should be exactly the 5 ALL_MODELS
+    assert len(models) == 5
 
 
 def test_corpora_filter_phase0_only_lists_provided_corpora():

--- a/src/harbor_clerk/llm/models.py
+++ b/src/harbor_clerk/llm/models.py
@@ -97,17 +97,6 @@ MODELS: dict[str, ModelInfo] = {
             parallel_slots=1,
         ),
         ModelInfo(
-            id="deepseek-r1-0528-8b",
-            name="DeepSeek R1 0528 8B",
-            huggingface_repo="unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF",
-            filename="DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-            size_bytes=5_400_000_000,
-            context_window=32768,
-            supports_tools=True,
-            yarn=YarnConfig(extended_context=131072, rope_scale=4.0, original_context=32768, attn_factor=0.8782),
-            parallel_slots=2,  # mid tier (5-12 GB)
-        ),
-        ModelInfo(
             id="gemma4-26b-a4b",
             name="Gemma 4 26B-A4B",
             huggingface_repo="bartowski/google_gemma-4-26B-A4B-it-GGUF",

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -54,7 +54,6 @@ def test_curated_models_parallel_slots_tiered_by_size():
         "qwen3-4b": 1,
         # Mid (≤32K native context)
         "qwen3-8b": 2,
-        "deepseek-r1-0528-8b": 2,
         # Heavy
         "gpt-oss-20b": 1,  # 128K context → KV cache too big for 2 slots on 18 GB
         "gemma4-26b-a4b": 1,


### PR DESCRIPTION
## Summary
- Removes DeepSeek R1 0528 8B from the curated registry (6 → 5 models)
- Same surgery pattern as PR #434 (phi4-mini / smollm3-3b drop)

## Why
The 2026-05-31 v3 sweep (final readout) ranked DeepSeek last on correctness average across 3 corpora:

| model | corr | grnd | comp |
|---|---|---|---|
| qwen36-35b-a3b | 3.85 | 3.60 | 3.04 |
| gemma4-26b-a4b | 3.82 | 3.66 | 2.98 |
| gpt-oss-20b | 3.65 | 3.18 | 3.11 |
| qwen3-8b | 3.11 | 3.13 | 2.14 |
| qwen3-4b | 2.15 | 2.15 | 1.49 |
| **deepseek-r1-0528-8b** | **2.05** | **1.96** | **1.54** |

On synthetic specifically it scored corr=1.72 — below qwen3-4b's already-degraded 1.28 (and qwen3-4b's number was depressed by a separate context-squeeze fixed in PR #438). Two structural reasons it underperforms:

1. **Reasoning-model design** (chain-of-thought wrapped in `<think>…</think>` blocks) doesn't fit the answer-eval grading. The judge sees only the final answer, which is thin because the model spends most of its budget on the reasoning trace.
2. **Watchdog incompatibility** ([project_deepseek_research_watchdog.md](memory)) — DeepSeek's quiet-while-thinking pattern trips the harness SSE-silence detector on research-mode units. Separate ergonomics issue.

DeepSeek remains usable outside this harness for reasoning-favoring deployments, but inside the curated picker it's dominated. Removing it simplifies the UX and unblocks the eval cycle from having to special-case its behavior.

## Out of scope / Deferred
- The GGUF on disk is not deleted — users who have it active will fall through the "unknown model" guard and need to repick in Preferences, but the file itself stays. Cleanup can happen via the future Models page "delete download" affordance.
- `_LEGACY_MODEL_ID_RENAMES["deepseek-r1-8b"] = "deepseek-r1-0528-8b"` stays in `sweep.py` — same rationale as the phi4-mini rename kept in PR #439.

## Test plan
- [x] `pytest tests/test_llm_models.py` — 4/4 pass with updated 5-model expected dict
- [x] `pytest scripts/test_corpora/tests/test_plan_units.py` — 7/7 pass with `len(models) == 5`
- [x] `ruff check`, `ruff format --check` — clean
- [ ] Swift tests run via Xcode (`make test`) — Settings + AppSettingsTests mirrors updated to match Python registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
