### PR TITLE
feat(chat): expose kb_batch_search for mid-tier and heavier models

### DIFF
--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -390,6 +390,47 @@ _BASE_CHAT_TOOLS = [
     },
 ]
 
+# Tool defined separately because it's added to chat conditionally — only
+# for mid-tier and heavier models. Small models tend to either ignore the
+# multi-query affordance or saturate their per-slot context budget on the
+# concatenated results.
+_BATCH_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "batch_search",
+        "description": (
+            "Run several search_documents queries in parallel and get all "
+            "hits back in one tool result. Cheaper than N sequential "
+            "search_documents calls — use when the question maps to "
+            'obviously distinct sub-queries ("compare X and Y", '
+            '"every email about A or B").'
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "queries": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "2-8 distinct queries. Each gets its own search; results are grouped by query in the response."
+                    ),
+                },
+                "k": {
+                    "type": "integer",
+                    "description": "Hits per query (default 5).",
+                },
+            },
+            "required": ["queries"],
+        },
+    },
+}
+
+# Models below this weight threshold do not get batch_search in their chat
+# tool surface. The v3 sweep showed small models (4B/8B) struggle with the
+# multi-query result aggregation; 8B+ comfortably drives 2-4 queries per
+# batch. Threshold tracks the small-vs-mid tier boundary in models.py.
+_BATCH_SEARCH_MIN_SIZE_BYTES = 5_000_000_000
+
 
 # ---------------------------------------------------------------------------
 # Dynamic tool builders — read settings at call time
@@ -433,8 +474,10 @@ def _apply_find_all_settings(tools: list[dict], *, model: "ModelInfo | None") ->
 def get_chat_tools(*, model: "ModelInfo | None" = None) -> list[dict]:
     """Build chat tool schema, respecting current retrieval settings.
 
-    model: optional active ModelInfo — used to set the find_all_documents
-    max_results default from model.find_all_default_max_results (None → 100).
+    model: optional active ModelInfo. Used to (a) set the find_all_documents
+    max_results default from model.find_all_default_max_results (None → 100),
+    and (b) gate batch_search — only included for models with size_bytes >=
+    `_BATCH_SEARCH_MIN_SIZE_BYTES`.
     """
     from harbor_clerk.config import get_settings
 
@@ -444,6 +487,8 @@ def get_chat_tools(*, model: "ModelInfo | None" = None) -> list[dict]:
     else:
         tools = _apply_search_settings(_BASE_CHAT_TOOLS, paginated=False, max_k=s.chat_search_k, default_k=5)
     _apply_find_all_settings(tools, model=model)
+    if model is not None and model.size_bytes >= _BATCH_SEARCH_MIN_SIZE_BYTES:
+        tools.append(copy.deepcopy(_BATCH_SEARCH_TOOL))
     return tools
 
 
@@ -547,6 +592,23 @@ def _map_args_verify_identifier(args: dict) -> dict:
     return {"identifier": args["identifier"]}
 
 
+def _map_args_batch_search_chat(args: dict) -> dict:
+    """Chat-mode batch_search mapper. Caps `queries` length so a confused
+    model can't flood the search backend, and clamps `k` to the chat search
+    setting the same way single search_documents does.
+    """
+    from harbor_clerk.config import get_settings
+
+    s = get_settings()
+    max_k = 50 if s.chat_search_paginated else s.chat_search_k
+    queries = list(args.get("queries") or [])[:8]
+    return {
+        "queries": queries,
+        "k": min(int(args.get("k", 5)), max_k),
+        "detail": "full",
+    }
+
+
 def _map_args_find_all(args: dict) -> dict:
     """Map chat-tool args to find_all() kwargs. Drops unknown keys."""
     allowed = {
@@ -577,6 +639,7 @@ _TOOL_DISPATCH: dict[str, tuple[str, callable]] = {
     "corpus_topics": ("kb_corpus_topics", _map_args_corpus_topics),
     "find_all_documents": ("kb_find_all", _map_args_find_all),
     "verify_identifier": ("kb_verify_identifier", _map_args_verify_identifier),
+    "batch_search": ("kb_batch_search", _map_args_batch_search_chat),
 }
 
 

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -140,3 +140,115 @@ def test_research_dispatch_inherits_verify_identifier():
 
     assert "verify_identifier" in _RESEARCH_TOOL_DISPATCH
     assert _RESEARCH_TOOL_DISPATCH["verify_identifier"][0] == "kb_verify_identifier"
+
+
+# ---------------------------------------------------------------------------
+# batch_search — gated by model size
+# ---------------------------------------------------------------------------
+
+
+def _mk_model(*, size_bytes: int, mid: str = "test-model"):
+    """Build a ModelInfo with a chosen size_bytes for gate tests."""
+    from harbor_clerk.llm.models import ModelInfo
+
+    return ModelInfo(
+        id=mid,
+        name=mid,
+        huggingface_repo="x",
+        filename="x.gguf",
+        size_bytes=size_bytes,
+        context_window=32768,
+        supports_tools=True,
+    )
+
+
+def test_batch_search_excluded_for_small_model():
+    """Small models (< 5 GB GGUF) get the chat surface without batch_search.
+    The v3 sweep showed multi-query result aggregation overwhelmed them."""
+    from harbor_clerk.llm.tools import get_chat_tools
+
+    small = _mk_model(size_bytes=2_500_000_000, mid="small")
+    tools = get_chat_tools(model=small)
+    names = {t["function"]["name"] for t in tools}
+    assert "batch_search" not in names
+    # And the existing tools are still there
+    assert "search_documents" in names
+
+
+def test_batch_search_included_for_mid_tier():
+    """Models at the threshold (5 GB) or above get batch_search added to
+    their chat surface for compare-and-contrast questions."""
+    from harbor_clerk.llm.tools import get_chat_tools
+
+    mid = _mk_model(size_bytes=5_000_000_000, mid="mid")
+    tools = get_chat_tools(model=mid)
+    names = {t["function"]["name"] for t in tools}
+    assert "batch_search" in names
+
+
+def test_batch_search_included_for_heavy():
+    from harbor_clerk.llm.tools import get_chat_tools
+
+    heavy = _mk_model(size_bytes=20_000_000_000, mid="heavy")
+    tools = get_chat_tools(model=heavy)
+    names = {t["function"]["name"] for t in tools}
+    assert "batch_search" in names
+
+
+def test_batch_search_omitted_when_model_is_none():
+    """No active model means no per-model surface decisions — fall back to
+    the base set without batch_search."""
+    from harbor_clerk.llm.tools import get_chat_tools
+
+    tools = get_chat_tools(model=None)
+    names = {t["function"]["name"] for t in tools}
+    assert "batch_search" not in names
+
+
+def test_batch_search_schema_requires_queries():
+    from harbor_clerk.llm.tools import _BATCH_SEARCH_TOOL
+
+    params = _BATCH_SEARCH_TOOL["function"]["parameters"]
+    assert params["required"] == ["queries"]
+    assert params["properties"]["queries"]["type"] == "array"
+    assert params["properties"]["queries"]["items"]["type"] == "string"
+
+
+def test_map_args_batch_search_chat_caps_queries_at_8():
+    """A misbehaving model issuing 50 queries shouldn't flood the search
+    backend. The chat mapper truncates at 8."""
+    from harbor_clerk.llm.tools import _map_args_batch_search_chat
+
+    out = _map_args_batch_search_chat({"queries": [f"q{i}" for i in range(50)]})
+    assert len(out["queries"]) == 8
+    assert out["queries"][0] == "q0"
+    assert out["queries"][7] == "q7"
+
+
+def test_map_args_batch_search_chat_clamps_k():
+    """k must be clamped to the chat-search settings cap, same as
+    single search_documents."""
+    from harbor_clerk.llm.tools import _map_args_batch_search_chat
+
+    out = _map_args_batch_search_chat({"queries": ["a", "b"], "k": 999})
+    # Cap is 50 in paginated mode, settings.chat_search_k otherwise.
+    # Either way, 999 must come back smaller.
+    assert out["k"] < 999
+
+
+def test_dispatch_routes_batch_search_to_kb_batch_search():
+    from harbor_clerk.llm.tools import _TOOL_DISPATCH
+
+    mcp_name, _ = _TOOL_DISPATCH["batch_search"]
+    assert mcp_name == "kb_batch_search"
+
+
+def test_research_dispatch_overrides_batch_search_with_research_mapper():
+    """Research mode has its own batch_search mapper (brief detail, larger
+    k cap). Verify the explicit override wins over the chat dispatch
+    inherited via spread."""
+    from harbor_clerk.llm.tools import _RESEARCH_TOOL_DISPATCH, _map_args_batch_search_chat
+
+    assert "batch_search" in _RESEARCH_TOOL_DISPATCH
+    _, mapper = _RESEARCH_TOOL_DISPATCH["batch_search"]
+    assert mapper is not _map_args_batch_search_chat


### PR DESCRIPTION
## Summary
- Conditionally exposes `kb_batch_search` to chat for models with `size_bytes >= 5 GB`
- Keeps it hidden from qwen3-4b (the only sub-5GB curated model) to avoid the per-slot context squeeze

## Why
The chat tool surface previously omitted `batch_search` with the rationale "small models don't issue multi-query patterns" (see `src/harbor_clerk/llm/tools.py` docstring, refreshed in PR #439). With the curated set now ranging 4B–35B and the empty-answer regression fixed in PR #438, the omission no longer applies to the larger half of the registry. Bigger models can productively issue 2–4 distinct queries in one tool turn for compare/contrast questions ("every email about A or B", "differences between X and Y") — saves a turn vs. issuing N sequential `search_documents` calls.

Pulled forward from the deferred entry in `pr_followups.md` (PR #439 deferred item).

## Mechanism
- `_BATCH_SEARCH_TOOL` defined separately, **not** appended to `_BASE_CHAT_TOOLS`
- `get_chat_tools(model=...)` deep-copies and appends it only when `model.size_bytes >= 5_000_000_000`
- `_map_args_batch_search_chat`: caps `queries` at 8 (defense against a confused model), clamps `k` to chat-search settings
- `_TOOL_DISPATCH["batch_search"]` routes to `kb_batch_search`; pre-existing `_RESEARCH_TOOL_DISPATCH` override at line 745 still wins for `mode="research"`

## Models that get batch_search (post-PR #440)
- qwen3-8b (5.0 GB)
- gpt-oss-20b (11.6 GB)
- gemma4-26b-a4b (17 GB)
- qwen36-35b-a3b (22 GB)

## Models that don't (kept lean)
- qwen3-4b (2.5 GB) — already squeezed; batch_search would aggravate the per-slot budget

## Out of scope / Deferred
- An ablation showing how often the bigger models actually pick batch_search over sequential search_documents on the eval corpora. Worth a follow-up if usage stays at zero — could mean the schema needs a stronger nudge in the description, or that the question-types in our corpora don't naturally drive multi-query.
- Per-model `find_all_default_max_results` calibration. Currently None for all 6 models; could be tuned upward for capable models if the find-iteration coverage gaps from the readout warrant it.

## Test plan
- [x] 9 new unit tests in `tests/test_chat_tools.py` — size-gate boundary (below/at/above), None case, schema required-fields, mapper caps, both dispatches
- [x] `pytest tests/test_chat_tools.py` — 21/21 pass
- [x] `ruff check`, `ruff format --check` — clean
- [ ] End-to-end: verify mid-tier model on a compare-and-contrast question actually picks batch_search (requires bundle rebuild + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
