### PR TITLE
feat(research): verifier loop — stage 1 (verdict emission)

### DIFF
--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -106,6 +106,13 @@ class Settings(BaseSettings):
     research_search_paginated: bool = Field(default=True)
     research_search_k: int = Field(default=20)
 
+    # Research verifier loop — staged in via PR series tracked under
+    # docs/superpowers/specs/2026-06-01-verifier-loop-design.md.
+    # When enabled, after synthesis the model re-judges each cited source
+    # against the report and (in stage 2) revises if mismatches are found.
+    # Default off until the A/B clears the +0.30 groundedness bar.
+    research_verifier_enabled: bool = Field(default=False)
+
     # Chat history
     max_history_messages: int = Field(default=40)
 

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -22,6 +22,7 @@ from harbor_clerk.config import get_settings
 from harbor_clerk.db import async_session_factory
 from harbor_clerk.llm.health import report_llm_error, report_llm_success
 from harbor_clerk.llm.models import get_model
+from harbor_clerk.llm.research_prompts import VERIFIER_SYSTEM, render_verifier_user
 from harbor_clerk.llm.tools import execute_tool
 from harbor_clerk.models.chat_message import ChatMessage
 from harbor_clerk.models.conversation import Conversation
@@ -955,6 +956,143 @@ async def _check_gaps(
 
 
 # ---------------------------------------------------------------------------
+# Verifier loop — re-judges cited sources against the synthesized report.
+# Stage 1: emit per-citation verdicts via SSE. Stage 2 (not in this file
+# yet) will gate a revision pass on the verdicts. Spec:
+# docs/superpowers/specs/2026-06-01-verifier-loop-design.md
+# ---------------------------------------------------------------------------
+
+_VERIFIER_TIMEOUT = 120.0
+_VERIFIER_MAX_TOKENS = 200
+_VERIFIER_REPORT_WINDOW = 400
+_VERIFIER_SOURCE_WINDOW = 600
+_VALID_VERDICTS = ("supported", "partial", "unsupported")
+
+
+def _excerpt_around(text: str, needle: str, *, context_chars: int) -> str:
+    """Return a window of `text` around the first occurrence of `needle`,
+    or empty string if not found.
+
+    Used by the verifier to locate the portion of a report or notes block
+    that mentions a specific document title. The window is bounded so the
+    verifier prompt stays cheap regardless of report length.
+    """
+    if not needle or not text:
+        return ""
+    idx = text.find(needle)
+    if idx < 0:
+        return ""
+    start = max(0, idx - context_chars)
+    end = min(len(text), idx + len(needle) + context_chars)
+    return text[start:end]
+
+
+async def _verify_citations(
+    *,
+    client: httpx.AsyncClient,
+    llm_url: str,
+    report_content: str,
+    research_citations: list[dict],
+    notes: str,
+) -> AsyncGenerator[dict, None]:
+    """Verify each cited source against the synthesized report.
+
+    Yields one verdict dict per citation:
+
+        {"doc_id", "doc_title", "page", "verdict", "reason", "index", "total"}
+
+    Sequential per the spec (parallelization deferred to stage 2). Fails open
+    on unparseable output or LLM error — a malformed verdict is logged and
+    treated as 'supported' so a brittle verifier can't drop a real report.
+    """
+    total = len(research_citations)
+    for i, cite in enumerate(research_citations):
+        doc_title = (cite.get("doc_title") or "").strip()
+        page = cite.get("page")
+        doc_id = cite.get("doc_id") or ""
+
+        report_excerpt = _excerpt_around(report_content, doc_title, context_chars=_VERIFIER_REPORT_WINDOW)
+        source_excerpt = _excerpt_around(notes, doc_title, context_chars=_VERIFIER_SOURCE_WINDOW)
+
+        if not report_excerpt:
+            # Report doesn't mention this doc's title — the citation was
+            # tracked as an evidence doc but the synthesizer chose not to
+            # reference it. No claim to verify.
+            yield {
+                "doc_id": doc_id,
+                "doc_title": doc_title,
+                "page": page,
+                "verdict": "skipped",
+                "reason": "Source was retrieved but not referenced in the report",
+                "index": i,
+                "total": total,
+            }
+            continue
+
+        if not source_excerpt:
+            # Notes didn't capture this doc — likely a chunking quirk where
+            # the cited title differs from how it appears in retrieved notes.
+            # Can't verify without source text.
+            yield {
+                "doc_id": doc_id,
+                "doc_title": doc_title,
+                "page": page,
+                "verdict": "skipped",
+                "reason": "Source evidence text not located in the research notes",
+                "index": i,
+                "total": total,
+            }
+            continue
+
+        user_content = render_verifier_user(
+            report_excerpt=report_excerpt,
+            doc_title=doc_title,
+            page=page,
+            source_excerpt=source_excerpt,
+        )
+        messages = [
+            {"role": "system", "content": VERIFIER_SYSTEM},
+            {"role": "user", "content": user_content},
+        ]
+
+        verdict = "supported"
+        reason = ""
+        try:
+            raw = await _llm_complete(
+                client,
+                llm_url,
+                messages,
+                timeout=_VERIFIER_TIMEOUT,
+                max_tokens=_VERIFIER_MAX_TOKENS,
+                phase="verifier",
+                json_mode=True,
+            )
+            parsed = _parse_json_from_llm(raw)
+            if not parsed:
+                # _parse_json_from_llm returns {} on unparseable input rather
+                # than raising; treat that as a verifier-call failure so the
+                # fail-open path lights up.
+                raise ValueError("Empty JSON object from verifier")
+            raw_verdict = parsed.get("verdict")
+            if raw_verdict in _VALID_VERDICTS:
+                verdict = raw_verdict
+            reason = str(parsed.get("reason") or "").strip()[:300]
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError, KeyError) as exc:
+            logger.warning("Verifier failed for citation %d (%s): %r", i, doc_title, exc)
+            reason = f"Verifier call failed: {type(exc).__name__}"
+
+        yield {
+            "doc_id": doc_id,
+            "doc_title": doc_title,
+            "page": page,
+            "verdict": verdict,
+            "reason": reason,
+            "index": i,
+            "total": total,
+        }
+
+
+# ---------------------------------------------------------------------------
 # Main research engine
 # ---------------------------------------------------------------------------
 
@@ -1443,12 +1581,40 @@ async def research_stream(
                 )
             )
 
+            # Stage-1 verifier loop: emit per-citation verdicts via SSE. The
+            # revision pass (stage 2) is not wired up here; for now we only
+            # surface verdicts so the frontend and eval harness can capture
+            # them. Gated by `research_verifier_enabled` so the default
+            # research path is unchanged until the A/B clears.
+            verifier_verdicts: list[dict] = []
+            if settings.research_verifier_enabled and report_content and research_citations:
+                try:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(_VERIFIER_TIMEOUT)) as v_client:
+                        async for verdict in _verify_citations(
+                            client=v_client,
+                            llm_url=llm_url,
+                            report_content=report_content,
+                            research_citations=research_citations,
+                            notes=notes,
+                        ):
+                            verifier_verdicts.append(verdict)
+                            yield _sse({"type": "verifier_pass", **verdict})
+                except Exception:
+                    # Verifier is best-effort. A failure here must not abort
+                    # a research run that already produced a report.
+                    logger.exception("Verifier loop failed; proceeding with unverified report")
+
             state.status = "completed"
             state.notes = notes
             state.citations = research_citations
             state.current_round = step_count
             state.completed_at = datetime.now(UTC)
             state.progress = {"step": step_count}
+            if verifier_verdicts:
+                # Persist the verdicts on the progress blob until ResearchState
+                # gets a dedicated `verifier_verdicts` column (stage 2). This
+                # lets the eval harness read them back without an SSE replay.
+                state.progress = {"step": step_count, "verifier_verdicts": verifier_verdicts}
             await session.commit()
 
             done_payload: dict = {"type": "done", "conversation_id": str(conversation_id)}

--- a/src/harbor_clerk/llm/research_prompts.py
+++ b/src/harbor_clerk/llm/research_prompts.py
@@ -1,0 +1,52 @@
+"""Prompts for the research verifier loop.
+
+Lives separately from research.py so prompt-tuning is decoupled from the
+pipeline code. The verifier asks the model to judge whether a cited
+source actually supports the claims the report attributes to it; the
+revision prompt (added in stage 2) feeds those verdicts back to the
+synthesizer for one corrective pass.
+
+See `docs/superpowers/specs/2026-06-01-verifier-loop-design.md`.
+"""
+
+from __future__ import annotations
+
+# Verifier system prompt — keep terse. The judge model only needs the verdict
+# vocabulary and the JSON shape; everything else is in the user content.
+VERIFIER_SYSTEM = (
+    "You are a citation verifier. Given a report excerpt that cites a source, "
+    "and the source's evidence, judge whether the evidence supports the "
+    "claims attributed to it.\n"
+    "\n"
+    "Verdicts:\n"
+    "- supported: the evidence directly states or clearly entails every claim "
+    "the report makes about this source.\n"
+    "- partial: the evidence relates to the claims but is missing at least one "
+    "key element (a number, a date, a name, a qualifier).\n"
+    "- unsupported: the evidence does not address the claims; the report has "
+    "fabricated or substantially misattributed.\n"
+    "\n"
+    "Reply with ONLY a JSON object on a single line:\n"
+    '{"verdict": "supported"|"partial"|"unsupported", "reason": "<one short sentence>"}'
+)
+
+
+def render_verifier_user(*, report_excerpt: str, doc_title: str, page: str | None, source_excerpt: str) -> str:
+    """Build the user-content side of the verifier prompt for a single citation.
+
+    `report_excerpt` is the portion of the synthesized report that references
+    this source. `source_excerpt` is the corresponding evidence text from the
+    research notes. Both are truncated upstream — this function does no
+    additional length management beyond inlining them as-is.
+    """
+    page_label = f", p{page}" if page else ""
+    return (
+        f"## REPORT EXCERPT (cites {doc_title}{page_label})\n"
+        f"{report_excerpt}\n"
+        f"\n"
+        f"## SOURCE EVIDENCE (from {doc_title}{page_label})\n"
+        f"{source_excerpt}\n"
+        f"\n"
+        "Judge whether the source evidence supports what the report says about "
+        "it. Reply with the JSON verdict object."
+    )

--- a/tests/test_research_verifier.py
+++ b/tests/test_research_verifier.py
@@ -1,0 +1,273 @@
+"""Stage-1 verifier loop — unit tests.
+
+Covers the pure-Python helpers (`_excerpt_around`) and the
+`_verify_citations` async generator with a mocked `_llm_complete`. The
+revision pass (stage 2) lives in a follow-up PR and gets its own test
+file when it lands.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from harbor_clerk.llm.research import (
+    _excerpt_around,
+    _verify_citations,
+)
+
+# ---------------------------------------------------------------------------
+# _excerpt_around — substring locator with bounded context windows
+# ---------------------------------------------------------------------------
+
+
+def test_excerpt_around_returns_window_around_needle():
+    text = "A" * 1000 + "FOOBAR" + "B" * 1000
+    out = _excerpt_around(text, "FOOBAR", context_chars=20)
+    assert "FOOBAR" in out
+    # Window is 20 chars on each side plus the needle
+    assert len(out) == 20 + len("FOOBAR") + 20
+
+
+def test_excerpt_around_returns_empty_when_needle_missing():
+    assert _excerpt_around("nothing here", "absent", context_chars=10) == ""
+
+
+def test_excerpt_around_returns_empty_on_empty_inputs():
+    assert _excerpt_around("", "FOOBAR", context_chars=10) == ""
+    assert _excerpt_around("FOOBAR", "", context_chars=10) == ""
+
+
+def test_excerpt_around_handles_needle_at_start():
+    text = "FOOBAR" + "B" * 100
+    out = _excerpt_around(text, "FOOBAR", context_chars=30)
+    assert out.startswith("FOOBAR")
+    assert len(out) == len("FOOBAR") + 30
+
+
+def test_excerpt_around_handles_needle_at_end():
+    text = "A" * 100 + "FOOBAR"
+    out = _excerpt_around(text, "FOOBAR", context_chars=30)
+    assert out.endswith("FOOBAR")
+
+
+# ---------------------------------------------------------------------------
+# _verify_citations — async generator producing per-citation verdicts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_client():
+    """An httpx.AsyncClient stand-in — verifier doesn't touch it directly,
+    only passes it to the mocked _llm_complete."""
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+async def _collect(agen):
+    out = []
+    async for v in agen:
+        out.append(v)
+    return out
+
+
+async def test_verify_citations_skips_when_report_does_not_mention_doc(fake_client):
+    """If the synthesizer didn't reference a cited doc in the final report,
+    there's no claim to verify — skip."""
+    cites = [{"doc_id": "D1", "doc_title": "MissingDoc", "page": "1"}]
+    notes = "[MissingDoc, page 1] some evidence"
+    report = "report text that never mentions the doc title"
+
+    out = await _collect(
+        _verify_citations(
+            client=fake_client,
+            llm_url="http://x",
+            report_content=report,
+            research_citations=cites,
+            notes=notes,
+        )
+    )
+    assert len(out) == 1
+    assert out[0]["verdict"] == "skipped"
+    assert "not referenced" in out[0]["reason"]
+
+
+async def test_verify_citations_skips_when_notes_missing_doc(fake_client):
+    """If notes don't have the doc's text, can't verify — skip without LLM."""
+    cites = [{"doc_id": "D1", "doc_title": "MissingDoc", "page": "1"}]
+    notes = "notes that don't mention this doc title at all"
+    report = "the report cites MissingDoc heavily but notes are empty for it"
+
+    out = await _collect(
+        _verify_citations(
+            client=fake_client,
+            llm_url="http://x",
+            report_content=report,
+            research_citations=cites,
+            notes=notes,
+        )
+    )
+    assert len(out) == 1
+    assert out[0]["verdict"] == "skipped"
+    assert "not located" in out[0]["reason"]
+
+
+async def test_verify_citations_emits_supported_verdict(fake_client):
+    """LLM returns supported — verdict propagates."""
+    cites = [{"doc_id": "D1", "doc_title": "ContractA", "page": "3"}]
+    notes = "[ContractA, page 3] The agreement was signed on 2024-01-15."
+    report = "ContractA was signed in early 2024 [ContractA, p3]."
+
+    with patch(
+        "harbor_clerk.llm.research._llm_complete",
+        new=AsyncMock(return_value=json.dumps({"verdict": "supported", "reason": "Date matches."})),
+    ):
+        out = await _collect(
+            _verify_citations(
+                client=fake_client,
+                llm_url="http://x",
+                report_content=report,
+                research_citations=cites,
+                notes=notes,
+            )
+        )
+
+    assert len(out) == 1
+    assert out[0]["verdict"] == "supported"
+    assert out[0]["reason"] == "Date matches."
+    assert out[0]["doc_id"] == "D1"
+    assert out[0]["index"] == 0
+    assert out[0]["total"] == 1
+
+
+async def test_verify_citations_fails_open_on_unparseable_llm_output(fake_client):
+    """A brittle LLM that returns prose instead of JSON shouldn't drop a real
+    report. Stage 1 fails open with verdict='supported' and a logged reason."""
+    cites = [{"doc_id": "D1", "doc_title": "DocX", "page": "1"}]
+    notes = "[DocX, page 1] some evidence"
+    report = "The report says DocX is relevant."
+
+    with patch(
+        "harbor_clerk.llm.research._llm_complete",
+        new=AsyncMock(return_value="not json at all, the model rambled"),
+    ):
+        out = await _collect(
+            _verify_citations(
+                client=fake_client,
+                llm_url="http://x",
+                report_content=report,
+                research_citations=cites,
+                notes=notes,
+            )
+        )
+
+    assert len(out) == 1
+    assert out[0]["verdict"] == "supported"  # fail-open
+    assert "Verifier call failed" in out[0]["reason"]
+
+
+async def test_verify_citations_rejects_invalid_verdict_string(fake_client):
+    """Model returns a JSON object with a verdict outside the allowed
+    vocabulary — fall back to 'supported' (fail-open) rather than
+    propagating garbage."""
+    cites = [{"doc_id": "D1", "doc_title": "DocX", "page": "1"}]
+    notes = "[DocX, page 1] some evidence"
+    report = "The report says DocX is relevant."
+
+    with patch(
+        "harbor_clerk.llm.research._llm_complete",
+        new=AsyncMock(return_value=json.dumps({"verdict": "maybe", "reason": "unsure"})),
+    ):
+        out = await _collect(
+            _verify_citations(
+                client=fake_client,
+                llm_url="http://x",
+                report_content=report,
+                research_citations=cites,
+                notes=notes,
+            )
+        )
+
+    assert out[0]["verdict"] == "supported"  # fell back from 'maybe'
+
+
+async def test_verify_citations_handles_multiple_citations_in_order(fake_client):
+    """Each citation gets its own LLM call; output preserves order with
+    index/total reflecting position."""
+    cites = [
+        {"doc_id": "D1", "doc_title": "AlphaDoc", "page": "1"},
+        {"doc_id": "D2", "doc_title": "BetaDoc", "page": "2"},
+        {"doc_id": "D3", "doc_title": "GammaDoc", "page": "3"},
+    ]
+    notes = "[AlphaDoc, p1] a [BetaDoc, p2] b [GammaDoc, p3] c"
+    report = "AlphaDoc says X. BetaDoc says Y. GammaDoc says Z."
+
+    with patch(
+        "harbor_clerk.llm.research._llm_complete",
+        new=AsyncMock(return_value=json.dumps({"verdict": "supported", "reason": "ok"})),
+    ):
+        out = await _collect(
+            _verify_citations(
+                client=fake_client,
+                llm_url="http://x",
+                report_content=report,
+                research_citations=cites,
+                notes=notes,
+            )
+        )
+
+    assert [v["doc_id"] for v in out] == ["D1", "D2", "D3"]
+    assert [v["index"] for v in out] == [0, 1, 2]
+    assert all(v["total"] == 3 for v in out)
+
+
+async def test_verify_citations_propagates_partial_verdict(fake_client):
+    """Verdicts other than supported/unsupported (i.e. 'partial') must
+    propagate verbatim — they're the lever the revision pass acts on."""
+    cites = [{"doc_id": "D1", "doc_title": "DocX", "page": "1"}]
+    notes = "[DocX, page 1] approximate evidence"
+    report = "DocX says X happened on Tuesday."
+
+    with patch(
+        "harbor_clerk.llm.research._llm_complete",
+        new=AsyncMock(return_value=json.dumps({"verdict": "partial", "reason": "no date in source"})),
+    ):
+        out = await _collect(
+            _verify_citations(
+                client=fake_client,
+                llm_url="http://x",
+                report_content=report,
+                research_citations=cites,
+                notes=notes,
+            )
+        )
+
+    assert out[0]["verdict"] == "partial"
+    assert out[0]["reason"] == "no date in source"
+
+
+async def test_verify_citations_truncates_long_reason(fake_client):
+    """A verbose LLM that puts an essay in 'reason' should be capped so
+    the SSE payload stays bounded."""
+    cites = [{"doc_id": "D1", "doc_title": "DocX", "page": "1"}]
+    notes = "[DocX, page 1] some evidence"
+    report = "DocX is relevant"
+    long_reason = "x" * 5000
+
+    with patch(
+        "harbor_clerk.llm.research._llm_complete",
+        new=AsyncMock(return_value=json.dumps({"verdict": "supported", "reason": long_reason})),
+    ):
+        out = await _collect(
+            _verify_citations(
+                client=fake_client,
+                llm_url="http://x",
+                report_content=report,
+                research_citations=cites,
+                notes=notes,
+            )
+        )
+
+    assert len(out[0]["reason"]) <= 300


### PR DESCRIPTION
## Summary
- Stage 1 of the verifier-loop design ([spec PR #442](../pull/442))
- Emits per-citation verdicts via SSE; gated by `research_verifier_enabled` (default `False`)
- **No revision pass yet** — stage 2 ships in a follow-up

## Why (recap from #442)
The 2026-05-31 v3 sweep readout showed local groundedness trailing cloud by ~0.72 on enron and synthetic. The verifier-loop pass — re-judge each cited source against the report — is the lever I picked first because it targets the gap directly and is bounded in cost (O(citations) per question).

Stage 1 alone ships as a transparency feature: verdicts surface in the SSE stream and persist on `state.progress.verifier_verdicts` for the eval harness. Real quality lift comes when stage 2 (revision pass) lands.

## What's in the PR
- `src/harbor_clerk/config.py` — `research_verifier_enabled: bool = False`
- `src/harbor_clerk/llm/research_prompts.py` (new) — `VERIFIER_SYSTEM` prompt + `render_verifier_user(...)` template
- `src/harbor_clerk/llm/research.py` — `_excerpt_around` helper + `_verify_citations` async generator; integration in `research_stream` between report-save and final `done` SSE
- `tests/test_research_verifier.py` (new) — 13 unit tests with mocked `_llm_complete`

## Behavior
- For each entry in `research_citations`:
  - Find a window of the report mentioning the doc title → `report_excerpt`
  - Find a window of the research notes mentioning the doc title → `source_excerpt`
  - If either is missing, emit `verdict="skipped"` without calling the LLM
  - Otherwise call the verifier; emit one of `supported`/`partial`/`unsupported`
- Emit `verifier_pass` SSE event with `{doc_id, doc_title, page, verdict, reason, index, total}`

## Fail-open semantics
Three failure modes all default to `verdict="supported"`:
1. LLM returns prose instead of JSON → `_parse_json_from_llm` returns `{}` → treated as failure → reason carries the type name
2. LLM returns JSON with an unknown verdict string → fall back to `supported` silently
3. LLM call raises (timeout, HTTP error, etc.) → caught, reason carries the exception type

Rationale: a brittle verifier model cannot drop a real report. Logged via `logger.warning` so we can spot patterns in production.

## Out of scope / Deferred
- **Stage 2 — revision pass.** After all verdicts collected, if any are `partial` or `unsupported`, call the synthesizer one more time with the verdict feedback to revise the report. Spec covers this; landing as a separate PR after stage 1 settles.
- **Parallel verifier calls.** Sequential per the spec; trivially parallelizable per citation. Defer until A/B shows wall time is the binding constraint.
- **ResearchState column for verdicts.** Stored in `state.progress` for now (a JSON blob already). Stage 2 will add a dedicated column with an Alembic migration.
- **Frontend verifier panel.** The SSE event ships; the React UI to display it (collapsed by default, expand-to-see-verdicts) is queued for a separate frontend PR.
- **Verifier-judge model selection.** Stage 1 uses the same active model as the verifier. Cross-model judging (e.g., always Sonnet) is a stage-3 consideration.

## Test plan
- [x] 13 new unit tests in `tests/test_research_verifier.py` — pass
- [x] Full python test suite (`pytest tests/ --ignore=tests/cli --ignore=tests/watcher --ignore=tests/worker`) — 1180 passed, 17 skipped
- [x] `ruff check`, `ruff format --check` — clean
- [ ] End-to-end smoke once bundle rebuilds — enable `research_verifier_enabled=True` in config, run a research query, confirm `verifier_pass` events flow through the SSE stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
