### PR TITLE
fix(research): refresh research_verifier_enabled from config.json at runtime

### DIFF
--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -202,6 +202,8 @@ def refresh_llm_settings() -> None:
             settings.llm_yarn_enabled = bool(data["llm_yarn_enabled"])
         if "summary_force_apple_intelligence" in data:
             settings.summary_force_apple_intelligence = bool(data["summary_force_apple_intelligence"])
+        if "research_verifier_enabled" in data:
+            settings.research_verifier_enabled = bool(data["research_verifier_enabled"])
     except Exception:
         logger.debug("Failed to refresh LLM settings from %s", path, exc_info=True)
 

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -18,7 +18,7 @@ import httpx
 from sqlalchemy import select
 
 from harbor_clerk.api.scope import UserScope, apply_folder_scope, build_user_scope
-from harbor_clerk.config import get_settings
+from harbor_clerk.config import get_settings, refresh_llm_settings
 from harbor_clerk.db import async_session_factory
 from harbor_clerk.llm.health import report_llm_error, report_llm_success
 from harbor_clerk.llm.models import get_model
@@ -1115,6 +1115,11 @@ async def research_stream(
     Each LLM call is bounded and context-managed. Search/read steps are
     pure Python with no LLM involvement.
     """
+    # Pick up runtime-mutable settings (active model, verifier flag) from
+    # config.json before the pipeline starts. Without this, a setting flipped
+    # via the menubar Preferences (or the API) after process start would be
+    # invisible to research_stream — see chat.py for the same call pattern.
+    refresh_llm_settings()
     settings = get_settings()
     active_model_id = settings.llm_model_id or None
     llm_url = f"{settings.llama_server_url}/v1/chat/completions"


### PR DESCRIPTION
## Summary
- 8-line fix-up to PR #443
- `research_verifier_enabled` is now actually readable from `config.json` at runtime instead of frozen at process start

## Why
PR #443 added the setting but didn't wire it into `refresh_llm_settings`, and `research_stream` never called the refresher. As a result the smoke test caught the wiring miss: 530 token events + clean `done` event, zero `verifier_pass` events, even with `research_verifier_enabled: true` in config.json.

Direct inspection of the api process env showed no `HARBOR_CLERK_RESEARCH_VERIFIER_*` override — so the runtime value was the default `False`, and the `if settings.research_verifier_enabled and ...` guard in research.py skipped the verifier block.

## Changes
- `config.py::refresh_llm_settings` reads `research_verifier_enabled` from the JSON, matching the pattern for `llm_model_id`, `llm_yarn_enabled`, and `summary_force_apple_intelligence`
- `research.py::research_stream` calls `refresh_llm_settings()` at the top. Same pattern as `chat.py:213`. Side benefit: also picks up active-model switches mid-flight that silently regressed before

## Out of scope / Deferred
- An end-to-end test that asserts the verifier runs when the flag flips. The integration is hard to mock without a live llama-server; the unit tests in `tests/test_research_verifier.py` already cover the verifier logic, and this fix lights up the live path.

## Test plan
- [x] All 56 tests in the verifier + chat-tools + llm-models + discriminator suites pass
- [x] `ruff check` clean
- [ ] Live smoke after merge + rebuild: confirm `verifier_pass` events flow in the SSE stream from `POST /api/research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
