### PR TITLE
fix(research): split revision pass behind its own opt-in flag (default off)

### DIFF
--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -106,12 +106,27 @@ class Settings(BaseSettings):
     research_search_paginated: bool = Field(default=True)
     research_search_k: int = Field(default=20)
 
-    # Research verifier loop — staged in via PR series tracked under
+    # Research verifier loop — design spec at
     # docs/superpowers/specs/2026-06-01-verifier-loop-design.md.
-    # When enabled, after synthesis the model re-judges each cited source
-    # against the report and (in stage 2) revises if mismatches are found.
-    # Default off until the A/B clears the +0.30 groundedness bar.
+    #
+    # research_verifier_enabled: stage 1. When True, after synthesis the
+    # model re-judges each cited source against the report. Verdicts stream
+    # via `verifier_pass` SSE events and persist on `state.progress` for the
+    # eval harness. Default off; opt-in via config.json. The verifier itself
+    # was a real product feature in the 2026-06-01 A/B — it surfaced
+    # grounding problems that match the failure modes the design targets.
+    #
+    # research_verifier_revision_enabled: stage 2. When True (and the
+    # verifier is also enabled), partial/unsupported verdicts trigger a
+    # single revision pass that rewrites the report. The 2026-06-01 v3 A/B
+    # (3 models × 3 corpora × 5 questions, judged 0-10 by Sonnet 4.5)
+    # showed the revision pass net-NEGATIVE on overall groundedness: qwen36
+    # -0.93, gpt-oss -1.00, gemma +0.29. The mechanism is the documented
+    # "LLM-as-revisor degrades already-good reports" failure mode. Until
+    # there is a cleaner revision prompt or scoping (deferred), the
+    # revision pass is opt-in for users who want to experiment.
     research_verifier_enabled: bool = Field(default=False)
+    research_verifier_revision_enabled: bool = Field(default=False)
 
     # Chat history
     max_history_messages: int = Field(default=40)
@@ -204,6 +219,8 @@ def refresh_llm_settings() -> None:
             settings.summary_force_apple_intelligence = bool(data["summary_force_apple_intelligence"])
         if "research_verifier_enabled" in data:
             settings.research_verifier_enabled = bool(data["research_verifier_enabled"])
+        if "research_verifier_revision_enabled" in data:
+            settings.research_verifier_revision_enabled = bool(data["research_verifier_revision_enabled"])
     except Exception:
         logger.debug("Failed to refresh LLM settings from %s", path, exc_info=True)
 

--- a/src/harbor_clerk/llm/research.py
+++ b/src/harbor_clerk/llm/research.py
@@ -1637,12 +1637,16 @@ async def research_stream(
                 )
                 return
 
-            # Verifier loop. Stage 1: emit per-citation verdicts via SSE.
-            # Stage 2: if any verdict is partial/unsupported, run a single
-            # revision pass that consumes the feedback and replaces
-            # report_content with the revised text. Both are gated by
-            # `research_verifier_enabled` so the default research path is
-            # unchanged until the A/B clears.
+            # Verifier loop.
+            # Stage 1 — verdict emission. Gated by `research_verifier_enabled`.
+            # The 2026-06-01 A/B confirmed the verifier itself surfaces real
+            # grounding problems; it's a usable transparency feature today.
+            # Stage 2 — revision pass. Separately gated by
+            # `research_verifier_revision_enabled`. The same A/B showed the
+            # revision pass net-NEGATIVE on overall groundedness across the
+            # top three models (qwen36 -0.93, gpt-oss -1.00, gemma +0.29).
+            # Default off; opt-in via config.json for users who want to
+            # experiment with it.
             verifier_verdicts: list[dict] = []
             original_draft = report_content
             revised = False
@@ -1668,7 +1672,7 @@ async def research_stream(
                     logger.exception("Verifier loop failed; proceeding with unverified report")
                     verifier_verdicts = []
 
-                if _needs_revision(verifier_verdicts):
+                if settings.research_verifier_revision_enabled and _needs_revision(verifier_verdicts):
                     flagged_count = sum(1 for v in verifier_verdicts if v.get("verdict") in _VERDICTS_NEEDING_REVISION)
                     yield _sse({"type": "revision_started", "flagged_count": flagged_count})
                     revision_chunks: list[str] = []

--- a/tests/test_research_verifier.py
+++ b/tests/test_research_verifier.py
@@ -399,3 +399,51 @@ async def test_revise_with_feedback_includes_original_question_and_draft():
     assert "What were the Q3 board decisions?" in user_content
     assert "DRAFT REPORT BODY" in user_content
     assert "NOTES BODY" in user_content
+
+
+# ---------------------------------------------------------------------------
+# Settings — revision pass is gated separately from verifier emission.
+# Regression coverage for the 2026-06-01 A/B finding that the revision
+# pass is net-negative on quality.
+# ---------------------------------------------------------------------------
+
+
+def test_research_verifier_settings_default_off():
+    """Both stage-1 and stage-2 flags default False so a fresh install gets
+    the unverified research path without surprise extra LLM calls."""
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.research_verifier_enabled is False
+    assert s.research_verifier_revision_enabled is False
+
+
+def test_research_verifier_revision_setting_is_separately_gated():
+    """The revision pass must be opt-in via its own flag, NOT bundled into
+    `research_verifier_enabled`. The A/B (2026-06-01) showed revision is
+    net-negative on overall groundedness; users who want verifier-only
+    transparency should not also get the revision degradation."""
+    from harbor_clerk.config import Settings
+
+    # Verifier on, revision off — the recommended config for shipping
+    s = Settings(research_verifier_enabled=True, research_verifier_revision_enabled=False)
+    assert s.research_verifier_enabled is True
+    assert s.research_verifier_revision_enabled is False
+
+
+def test_refresh_llm_settings_reads_research_verifier_revision_enabled(tmp_path, monkeypatch):
+    """Like the stage-1 setting, the revision flag must be runtime-mutable
+    via config.json so users can toggle it without a process restart."""
+    import json
+
+    from harbor_clerk.config import get_settings, refresh_llm_settings
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"research_verifier_revision_enabled": True}))
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "native_config_file", str(cfg))
+    settings.research_verifier_revision_enabled = False  # baseline before refresh
+
+    refresh_llm_settings()
+    assert settings.research_verifier_revision_enabled is True


### PR DESCRIPTION
## Summary
- Splits the stage-2 revision pass (PR #446) behind its own opt-in flag, default off
- Keeps the stage-1 verifier (PR #443) intact as a transparency feature

## Why
The 2026-06-01 verifier-loop A/B v3 — **3 top local models × 3 corpora × 5 research questions × verifier-on/off = 90 cells**, judged 0-10 by Sonnet 4.5 — showed the revision pass is **net-negative on overall groundedness**:

| model | Δcorr | Δgrnd | Δcomp | n |
|---|---|---|---|---|
| qwen36-35b-a3b | -0.50 | **-0.93** | -0.21 | 14 |
| gemma4-26b-a4b | +0.36 | **+0.29** | -1.07 | 14 |
| gpt-oss-20b | -2.07 | **-1.00** | -2.00 | 14 |

Only gemma cleared the spec's +0.30 Δgrnd bar (within rounding). qwen36 and gpt-oss regressed. The mechanism is the documented "LLM-as-revisor degrades already-good reports" failure mode — when the baseline draft is strong, revision softens or deletes claims that were actually fine.

The catastrophic case was **gpt-oss × synthetic** (-4.00 corr, -2.20 grnd, -4.20 comp): gpt-oss was already the most-grounded model in v3, and revision degraded it worst.

### Why not a verdict-density gate?
Considered and rejected. A density threshold (e.g., "only revise when ≥30% of verdicts are partial/unsupported") would have been a number tuned post-hoc to make the A/B look better — a test-set retrofit rather than a real product improvement. The data doesn't support a confident gate value; it supports turning the pass off until either a cleaner revision prompt or a stronger gating signal is designed.

### What stays
Stage 1 — the verifier itself — surfaces real grounding problems. The 2026-06-01 smoke (qwen3-4b synthesizing fake `$420K/$900K/$950K` figures and the verifier catching every one) is the canonical example. It's a usable transparency feature today: verdicts stream via SSE, persist on `state.progress.verifier_verdicts`, and the eval harness reads them back.

## Changes
- `config.py` — new `research_verifier_revision_enabled: bool = False`. `refresh_llm_settings` reads it from `config.json` so the flag is runtime-mutable, same as `research_verifier_enabled`.
- `research.py` — revision block gated on the new flag. The `_needs_revision()` check still runs; if it's True but the flag is False, no `revision_started` / `revision_token` / `revision_complete` SSE events fire. The original draft is saved as-is.
- `tests/test_research_verifier.py` — 3 new tests cover default-off, independence of the two gates, and the runtime-refresh path.

## Out of scope / Deferred
- **Better revision prompt.** The current prompt asks the model to rewrite the whole report given verdict feedback. A scoped prompt ("revise ONLY this specific claim; leave everything else byte-identical") might avoid the degradation, but designing and validating it is real product work. Deferred.
- **Per-question revision targeting.** Instead of feeding all verdicts at once, revise one flagged claim at a time. Bounded scope; more LLM calls. Deferred.
- **Cross-model verifier judging.** Use a smaller / cheaper / different model as the verifier so it's not biased toward the active model's framing. Deferred.

## Test plan
- [x] 3 new tests for the gate split — pass
- [x] All 24 verifier tests pass (no regressions in existing logic)
- [x] `ruff check`, `ruff format --check` clean
- [ ] Verify after merge that a research call with `research_verifier_enabled: true` and `research_verifier_revision_enabled: false` (the new recommended config) still emits `verifier_pass` events and skips the revision block end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
