### PR TITLE
feat(mcp): response-level steering for the cloud-LLM tool surface

### DIFF
--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -49,6 +49,13 @@ _search_stats = {
     "detail_full": 0,
     "detail_brief": 0,
     "detail_compact": 0,
+    # continuation_offered: responses where has_more was true (we nudged the
+    # model to paginate). drain_rate = pagination_calls / continuation_offered
+    # measures whether the active-continuation nudge actually gets models to
+    # come back for the next page vs concluding from a partial set. Without
+    # this denominator, pagination_rate alone can't tell over- from under-
+    # iteration.
+    "continuation_offered": 0,
 }
 _STATS_LOG_INTERVAL = 50
 
@@ -623,6 +630,26 @@ def _format_search_response(
         "total_candidates": result.total_candidates,
         "has_more": has_more,
     }
+    if has_more:
+        # Active continuation nudge in the response payload. `has_more: true`
+        # alone is a passive flag the model has to remember to act on via the
+        # tool docstring — and frontier models reliably ignore that docstring
+        # guidance (the find-iteration short-stop: cloud completeness on the
+        # enumeration-heavy Enron corpus sits at 2.36/5). Putting the directive
+        # in the response means it's in context at the exact moment the model
+        # decides whether to conclude or paginate.
+        seen = offset + len(hits)
+        resp["continuation"] = {
+            "seen": seen,
+            "total": result.total_candidates,
+            "next_offset": offset + k,
+            "guidance": (
+                f"You have retrieved {seen} of {result.total_candidates} matching chunks. "
+                f"If the task is to enumerate, or you do not yet have a complete answer, "
+                f"call this tool again with offset={offset + k} to retrieve the next page "
+                f"BEFORE concluding. Do not answer from a partial result set."
+            ),
+        }
     if result.possible_conflict:
         resp["possible_conflict"] = True
         resp["conflict_sources"] = [{"doc_id": cs.doc_id, "title": cs.title} for cs in result.conflict_sources]
@@ -655,6 +682,8 @@ async def kb_search(
       - `total_candidates`: how many chunks matched before pagination
       - `has_more`: true if more results exist beyond your window — paginate via `offset`
         or refine your query if you don't yet have the answer
+      - `continuation` (when `has_more` is true): an explicit `next_offset` plus a
+        `seen`/`total` count. Calling with that `next_offset` retrieves the next page.
       - `discriminator_hint` (when present): top hits span multiple docs that differ on
         a structured metadata field. Use `metadata_filter` with the suggested key/value
         to pin the right doc. The hint includes `ambiguous_doc_titles`,
@@ -842,6 +871,10 @@ async def kb_search(
             "total_candidates": result.total_candidates,
             "has_more": base_resp["has_more"],
         }
+        # Carry the continuation nudge into the faceted shape too — pagination
+        # semantics are identical, just grouped by document.
+        if "continuation" in base_resp:
+            resp["continuation"] = base_resp["continuation"]
     else:
         resp = base_resp
 
@@ -865,18 +898,27 @@ async def kb_search(
         _search_stats["pagination_calls"] += 1
     if faceted:
         _search_stats["faceted_calls"] += 1
+    if resp.get("has_more"):
+        _search_stats["continuation_offered"] += 1
     _search_stats[f"detail_{detail}"] += 1
 
     if _search_stats["calls"] % _STATS_LOG_INTERVAL == 0:
         n = _search_stats["calls"]
+        offered = _search_stats["continuation_offered"]
+        # drain_rate is only meaningful once we've offered at least one
+        # continuation; guard the divide.
+        drain_rate = (100 * _search_stats["pagination_calls"] / offered) if offered else 0.0
         logger.info(
             "kb_search stats (%d calls): avg_k=%.0f, max_k=%d, cap_hit_rate=%.0f%%, "
-            "pagination_rate=%.0f%%, faceted_rate=%.0f%%, detail: full=%d brief=%d compact=%d",
+            "pagination_rate=%.0f%%, continuation_offered=%d, drain_rate=%.0f%%, "
+            "faceted_rate=%.0f%%, detail: full=%d brief=%d compact=%d",
             n,
             _search_stats["total_k"] / n,
             _search_stats["max_k"],
             100 * _search_stats["cap_hits"] / n,
             100 * _search_stats["pagination_calls"] / n,
+            offered,
+            drain_rate,
             100 * _search_stats["faceted_calls"] / n,
             _search_stats["detail_full"],
             _search_stats["detail_brief"],
@@ -2554,6 +2596,19 @@ async def kb_verify_identifier(identifier: str) -> str:
     """
     async with async_session_factory() as session:
         result = await _verify_identifier_impl(session, identifier)
+    # Response-level anti-hedge directive for the not_found case. The docstring
+    # already says "do NOT fall back to closest match", but the BEFORE/AFTER on
+    # PR-J showed frontier models reproduce the exact padding the docstring
+    # forbids ("the closest proxy is..."). The directive lands harder when it's
+    # in the tool RESULT the model is reading at decision time, not in the
+    # tools/list description it saw at session start.
+    if isinstance(result, dict) and result.get("status") == "not_found":
+        result["instruction"] = (
+            "This identifier does not exist in the corpus. State that plainly to the user. "
+            "Do NOT search for, suggest, or substitute a similar or adjacent document, and "
+            "do NOT pad the decline with 'the closest match is...' or 'you may be interested "
+            "in...'. The correct answer is that the document is absent."
+        )
     return json.dumps(result, default=str)
 
 

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -638,13 +638,18 @@ def _format_search_response(
         # enumeration-heavy Enron corpus sits at 2.36/5). Putting the directive
         # in the response means it's in context at the exact moment the model
         # decides whether to conclude or paginate.
+        # seen/total/next_offset are in CHUNK units — pagination is chunk-offset
+        # based regardless of whether the response is hit-listed or doc-faceted,
+        # so the guidance is worded to hold for both shapes (it must not assume
+        # the model is looking at a flat `hits` list; the faceted path copies
+        # this block into a `documents`-shaped response).
         seen = offset + len(hits)
         resp["continuation"] = {
             "seen": seen,
             "total": result.total_candidates,
             "next_offset": offset + k,
             "guidance": (
-                f"You have retrieved {seen} of {result.total_candidates} matching chunks. "
+                f"{seen} of {result.total_candidates} matching chunks have been returned so far. "
                 f"If the task is to enumerate, or you do not yet have a complete answer, "
                 f"call this tool again with offset={offset + k} to retrieve the next page "
                 f"BEFORE concluding. Do not answer from a partial result set."
@@ -1295,6 +1300,8 @@ async def kb_batch_search(
             _search_stats["max_k"] = max(_search_stats["max_k"], k)
             if k >= settings.mcp_max_k:
                 _search_stats["cap_hits"] += 1
+            if resp.get("has_more"):
+                _search_stats["continuation_offered"] += 1
             _search_stats[f"detail_{detail}"] += 1
 
     if _search_stats["calls"] % _STATS_LOG_INTERVAL == 0 and _search_stats["calls"] > 0:

--- a/tests/test_mcp_response_steering.py
+++ b/tests/test_mcp_response_steering.py
@@ -127,6 +127,18 @@ async def test_verify_identifier_ambiguous_has_no_instruction():
     assert "instruction" not in out
 
 
+async def test_verify_identifier_error_shape_gets_no_instruction():
+    """`verify_identifier` returns {"error": ...} for empty/whitespace input.
+    That shape has no `status` key — the guard must skip it, never attaching
+    the anti-hedge directive to an error response."""
+    fake = {"error": "identifier must be non-empty"}
+    with patch("harbor_clerk.mcp_server._verify_identifier_impl", new=AsyncMock(return_value=fake)):
+        raw = await kb_verify_identifier("   ")
+    out = json.loads(raw)
+    assert "error" in out
+    assert "instruction" not in out
+
+
 # ---------------------------------------------------------------------------
 # Stats — continuation_offered counter exists for drain-rate measurement
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_response_steering.py
+++ b/tests/test_mcp_response_steering.py
@@ -1,0 +1,138 @@
+"""Response-level steering for the cloud-LLM MCP surface.
+
+The kb_search/kb_batch_search tool docstrings already carry pagination and
+anti-hedge guidance, but the PR-J before/after showed frontier models
+reliably ignore tool-description guidance. These tests cover the
+response-payload levers that land in context at decision time:
+
+  - `_format_search_response` adds a `continuation` block when `has_more`,
+    with an explicit `next_offset` and a directive to drain the result set
+    before concluding (targets the Enron find-iteration short-stop).
+  - `kb_verify_identifier` adds an anti-hedge `instruction` to the
+    not_found response (targets negative-question padding).
+  - `_search_stats` tracks `continuation_offered` so the drain rate is
+    measurable.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from harbor_clerk.mcp_server import _format_search_response, kb_verify_identifier
+from harbor_clerk.search_types import SearchHit, SearchResult
+
+
+def _hit(i: int) -> SearchHit:
+    return SearchHit(
+        chunk_id=f"chunk-{i}",
+        doc_id=f"doc-{i}",
+        chunk_num=i,
+        chunk_text=f"text {i}",
+        page_start=1,
+        page_end=1,
+        language="english",
+        ocr_used=False,
+        ocr_confidence=None,
+        score=0.9 - i * 0.01,
+        doc_title=f"Doc {i}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Continuation block — active pagination nudge in the response payload
+# ---------------------------------------------------------------------------
+
+
+def test_continuation_block_present_when_has_more():
+    # 5 hits returned, k=5, offset=0, but 30 total → more pages exist.
+    result = SearchResult(hits=[_hit(i) for i in range(5)], total_candidates=30)
+    resp = _format_search_response(result, detail="full", effective_brief_chars=200, k=5, offset=0)
+
+    assert resp["has_more"] is True
+    assert "continuation" in resp
+    cont = resp["continuation"]
+    assert cont["seen"] == 5
+    assert cont["total"] == 30
+    assert cont["next_offset"] == 5
+    # The guidance must name the concrete next_offset and tell the model to
+    # paginate before concluding.
+    assert "offset=5" in cont["guidance"]
+    assert "BEFORE concluding" in cont["guidance"]
+
+
+def test_continuation_next_offset_advances_with_offset():
+    # Second page: offset=5, k=5, still 30 total.
+    result = SearchResult(hits=[_hit(i) for i in range(5)], total_candidates=30)
+    resp = _format_search_response(result, detail="full", effective_brief_chars=200, k=5, offset=5)
+
+    assert resp["has_more"] is True
+    assert resp["continuation"]["next_offset"] == 10
+    assert resp["continuation"]["seen"] == 10  # offset + len(hits)
+
+
+def test_no_continuation_block_when_all_results_fit():
+    # 5 hits, k=10, only 5 total → nothing more to drain.
+    result = SearchResult(hits=[_hit(i) for i in range(5)], total_candidates=5)
+    resp = _format_search_response(result, detail="full", effective_brief_chars=200, k=10, offset=0)
+
+    assert resp["has_more"] is False
+    assert "continuation" not in resp
+
+
+def test_no_continuation_block_on_exact_last_page():
+    # offset=25, k=5, total=30 → offset + k == total, no more.
+    result = SearchResult(hits=[_hit(i) for i in range(5)], total_candidates=30)
+    resp = _format_search_response(result, detail="full", effective_brief_chars=200, k=5, offset=25)
+
+    assert resp["has_more"] is False
+    assert "continuation" not in resp
+
+
+# ---------------------------------------------------------------------------
+# kb_verify_identifier — anti-hedge instruction on not_found
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_identifier_not_found_carries_anti_hedge_instruction():
+    fake = {"status": "not_found", "identifier": "does-not-exist"}
+    with patch("harbor_clerk.mcp_server._verify_identifier_impl", new=AsyncMock(return_value=fake)):
+        raw = await kb_verify_identifier("does-not-exist")
+    out = json.loads(raw)
+    assert out["status"] == "not_found"
+    assert "instruction" in out
+    # The directive must explicitly forbid the documented padding patterns.
+    instr = out["instruction"].lower()
+    assert "does not exist" in instr
+    assert "closest match" in instr
+    assert "do not" in instr
+
+
+async def test_verify_identifier_unique_has_no_instruction():
+    fake = {"status": "unique", "match": {"doc_id": "d1", "title": "T"}}
+    with patch("harbor_clerk.mcp_server._verify_identifier_impl", new=AsyncMock(return_value=fake)):
+        raw = await kb_verify_identifier("real-doc")
+    out = json.loads(raw)
+    assert out["status"] == "unique"
+    # The anti-hedge directive only belongs on the not_found path.
+    assert "instruction" not in out
+
+
+async def test_verify_identifier_ambiguous_has_no_instruction():
+    fake = {"status": "ambiguous", "candidates": [{"doc_id": "a"}, {"doc_id": "b"}]}
+    with patch("harbor_clerk.mcp_server._verify_identifier_impl", new=AsyncMock(return_value=fake)):
+        raw = await kb_verify_identifier("ambiguous-substring")
+    out = json.loads(raw)
+    assert out["status"] == "ambiguous"
+    assert "instruction" not in out
+
+
+# ---------------------------------------------------------------------------
+# Stats — continuation_offered counter exists for drain-rate measurement
+# ---------------------------------------------------------------------------
+
+
+def test_search_stats_has_continuation_offered_counter():
+    from harbor_clerk.mcp_server import _search_stats
+
+    assert "continuation_offered" in _search_stats

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -686,6 +686,36 @@ async def test_kb_search_faceted_output(
     assert result["documents"][1]["hit_count"] == 1
 
 
+async def test_kb_search_faceted_carries_continuation(
+    db_session,
+    admin_user,
+    mcp_principal,
+    mock_session_factory,
+    mock_hybrid_search,
+):
+    """The faceted response shape (grouped by doc) must still carry the
+    continuation nudge when more pages exist — pagination is chunk-offset
+    based regardless of grouping."""
+    captured, result_obj = mock_hybrid_search
+    d1 = str(uuid.uuid4())
+    # 3 hits returned at k=2 but total=30 → more pages exist.
+    _set_result(
+        result_obj,
+        [_make_hit(doc_id=d1, doc_title="Doc A", score=0.9)],
+        total=30,
+    )
+
+    raw = await kb_search("test", faceted=True, k=2, offset=0)
+    result = json.loads(raw)
+
+    assert "documents" in result
+    assert result["has_more"] is True
+    assert "continuation" in result
+    assert result["continuation"]["next_offset"] == 2
+    # Guidance must not assume a flat hit list (the faceted shape has none).
+    assert "hits" not in result["continuation"]["guidance"].lower()
+
+
 async def test_kb_search_faceted_detail_modes(
     db_session,
     admin_user,


### PR DESCRIPTION
## Summary
- Moves the two highest-value behavioral steers for frontier cloud LLMs from the (proven-weak) tool-docstring layer into the tool **response payloads**, which are in the model's context at the exact decision point
- Adds drain-rate instrumentation so the effect is measurable

## Why
PR-J (#409) strengthened the kb_search / kb_verify_identifier docstrings with explicit anti-pattern callouts. The post-merge before/after (recorded in session memory) showed frontier models **ignore tool-description guidance** — Sonnet reproduced almost verbatim the "the closest match is..." padding the docstring forbids. Docstrings are surfaced once at `tools/list` time and weighted weakly against the model's own defaults.

HC-as-MCP-server controls two things: docstrings (weak lever) and **responses** (strong lever, in-context at decision time, previously underused). This PR uses the strong one.

## Changes

**1. Active continuation nudge** (targets the worst cloud number — Enron completeness 2.36/5 for both Sonnet 4.6 and GPT-5.5, the find-iteration short-stop). When kb_search / kb_batch_search return `has_more: true`, the response now includes:
```json
"continuation": {
  "seen": 5, "total": 30, "next_offset": 5,
  "guidance": "5 of 30 matching chunks have been returned so far. If the task is to enumerate, or you do not yet have a complete answer, call this tool again with offset=5 to retrieve the next page BEFORE concluding. Do not answer from a partial result set."
}
```
Threaded through the faceted response shape; guidance is worded shape-agnostically (pagination is chunk-offset based regardless of grouping).

**2. Anti-hedge instruction on kb_verify_identifier not_found** (targets negative-question padding — the synthetic/CUAD correctness dip). The not_found response now carries an `instruction` field telling the model to decline plainly and not substitute/suggest a similar document. Guarded to fire only on `status == "not_found"` (error and unique/ambiguous shapes pass through clean).

**3. Pagination-depth instrumentation.** New `continuation_offered` stat; `drain_rate = pagination_calls / continuation_offered` logged every 50 calls. Without this denominator, `pagination_rate` alone can't distinguish under- from over-iteration after the nudge ships. Counted in both kb_search and kb_batch_search.

The kb_search docstring gains one line documenting the new `continuation` field.

## Not in this PR
- The MCP server `instructions=` field (a separate small PR). High real-world value — clients like Claude.ai surface it like a system prompt — but the answer-eval harness drives the model with its own system prompt and won't exercise it, so it's not measurable in our A/B.
- `would_match_unscoped` count suppression for scoped keys (security hygiene, low priority).

## Fresh-eyes review
A code-reviewer pass found three issues (all fixed before this PR opened): faceted seen/guidance unit mismatch, batch_search not counting `continuation_offered`, and a missing error-shape passthrough test.

## Test plan
- [x] 9 unit tests in `tests/test_mcp_response_steering.py` (continuation presence/absence at page boundaries, next_offset advancement, not_found instruction per status, error-shape passthrough, stat counter)
- [x] 1 faceted-continuation integration test in `tests/test_mcp_tools.py`
- [x] 154 existing MCP tests pass; `ruff check` + `format --check` clean
- [ ] Re-run cloud answer-eval (Sonnet 4.6 + GPT-5.5 × 3 corpora) against the 2026-05-28 baselines after merge — expect lift on Enron completeness and synthetic/CUAD correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
