### PR TITLE
feat(frontend): inline retry on the Summary Failed chip

### DIFF
--- a/frontend/src/components/SummaryChip.tsx
+++ b/frontend/src/components/SummaryChip.tsx
@@ -1,9 +1,17 @@
 // frontend/src/components/SummaryChip.tsx
 
+import { useState } from 'react'
+
 export type SummaryState = 'generating' | 'pending' | 'extractive' | 'summarized' | 'failed' | 'none'
 
 interface SummaryChipProps {
   state: SummaryState
+  /**
+   * Optional retry handler. When provided AND state is 'failed', the chip
+   * becomes a clickable button that re-runs the summarize stage. No-op for
+   * every other state (the chip stays a passive label).
+   */
+  onRetry?: () => void | Promise<void>
 }
 
 const LABELS: Record<Exclude<SummaryState, 'none'>, string> = {
@@ -35,23 +43,52 @@ const STYLES: Record<Exclude<SummaryState, 'none'>, { bg: string; fg: string }> 
  * collapse naturally. The chip is left-anchored within its <td>, so the
  * dot's X position is constant across rows.
  */
-export default function SummaryChip({ state }: SummaryChipProps) {
+export default function SummaryChip({ state, onRetry }: SummaryChipProps) {
+  const [retrying, setRetrying] = useState(false)
   if (state === 'none') return null
   const { bg, fg } = STYLES[state]
-  const label = LABELS[state]
-  const tooltip = TOOLTIPS[state]
   const pulseDot = state === 'generating'
+  const canRetry = state === 'failed' && !!onRetry
+
+  if (canRetry) {
+    const handleClick = async () => {
+      if (retrying) return
+      setRetrying(true)
+      try {
+        await onRetry!()
+      } finally {
+        setRetrying(false)
+      }
+    }
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={retrying}
+        className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium whitespace-nowrap cursor-pointer transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-60"
+        style={{ background: bg, color: fg }}
+        title="Click to re-run the summary for this document."
+      >
+        <span
+          className={`h-1.5 w-1.5 rounded-full ${retrying ? 'animate-pulse' : ''}`}
+          style={{ background: fg, flex: '0 0 auto' }}
+        />
+        {retrying ? 'Retrying…' : 'Summary Failed ↻'}
+      </button>
+    )
+  }
+
   return (
     <span
       className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium whitespace-nowrap"
       style={{ background: bg, color: fg }}
-      title={tooltip}
+      title={TOOLTIPS[state]}
     >
       <span
         className={`h-1.5 w-1.5 rounded-full ${pulseDot ? 'animate-pulse' : ''}`}
         style={{ background: fg, flex: '0 0 auto' }}
       />
-      {label}
+      {LABELS[state]}
     </span>
   )
 }

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1019,6 +1019,14 @@ export default function DocumentsPage() {
                         <td className="px-4 py-3" style={{ width: 170 }}>
                           <SummaryChip
                             state={resolveSummaryState(doc.summary, doc.summary_model, doc.summarize_job_status)}
+                            onRetry={async () => {
+                              try {
+                                await post(`/api/docs/${doc.doc_id}/resummarize`)
+                                loadDocs(currentPage, pageSize, filter)
+                              } catch (e) {
+                                setError(e instanceof Error ? e.message : 'Re-summarize failed')
+                              }
+                            }}
                           />
                         </td>
                         <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- The `SummaryChip` "Summary Failed" state becomes clickable, re-running the summarize stage inline
- Backend route already existed (`POST /api/docs/{id}/resummarize`); this wires it to the chip

## Why
A non-technical admin who saw "Summary Failed" on the Documents page had no inline way to recover — they had to select the doc and find the bulk Re-Summarize action in the selection menu. #2 of the product-surface "final touches" sweep.

## Changes
- `SummaryChip` gains an optional `onRetry` prop. When provided AND state is `failed`, the chip renders as a `<button>` (cursor-pointer, hover opacity, "Summary Failed ↻", "Retrying…" while in flight, disabled during the request). Every other state stays a passive `<span>` — `onRetry` is a no-op outside `failed`.
- `DocumentsPage` passes an `onRetry` that POSTs the single-doc resummarize and reloads so the chip transitions to Generating/Pending.

## Test plan
- [x] `tsc --noEmit` clean; `eslint src/` exits 0 (warnings pre-existing); prettier clean
- [ ] Browser: a doc with a failed summary shows the clickable chip → click → "Retrying…" → row reloads to Generating/Pending. Non-failed chips remain non-interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)