### PR TITLE
feat(ingest): magic-bytes correction for misnamed files at extract

### DIFF
--- a/src/harbor_clerk/file_types.py
+++ b/src/harbor_clerk/file_types.py
@@ -149,6 +149,12 @@ def sniff_mime(data: bytes) -> str | None:
     (ZIP-based Office vs ODF vs EPUB; OLE2 .doc vs .xls vs .ppt) return the
     generic container type — the caller hands those to Tika, which does the
     fine-grained detection from the full byte stream.
+
+    Image detection is deliberately limited to the formats the OCR stage can
+    process (JPEG/PNG/TIFF — see ``IMAGE_MIMES`` in ``worker/stages/extract``).
+    Don't add a signature here (e.g. GIF, BMP) without also adding it to the
+    OCR dispatch, or the extract-stage corrector will route the file to a path
+    that silently drops it.
     """
     if len(data) < 4:
         return None
@@ -162,8 +168,6 @@ def sniff_mime(data: bytes) -> str | None:
         return "image/jpeg"
     if data[:4] in (b"II*\x00", b"MM\x00*"):
         return "image/tiff"
-    if data[:6] in (b"GIF87a", b"GIF89a"):
-        return "image/gif"
     if data[:5] == b"{\\rtf":
         return "text/rtf"
     if data[:4] == b"PK\x03\x04":

--- a/src/harbor_clerk/file_types.py
+++ b/src/harbor_clerk/file_types.py
@@ -121,6 +121,7 @@ __all__ = [
     "ALLOWED_EXTENSIONS",
     "guess_mime_type",
     "is_excalidraw",
+    "sniff_mime",
 ]
 
 
@@ -132,3 +133,44 @@ def is_excalidraw(path: str) -> bool:
     every ingest entry point.
     """
     return path.lower().endswith(".excalidraw.md")
+
+
+def sniff_mime(data: bytes) -> str | None:
+    """Best-effort content-based MIME detection from a file's leading bytes.
+
+    Returns a canonical MIME string when the leading bytes carry a recognized
+    magic-number signature, else ``None`` (unknown / text / not enough bytes).
+    Pure-stdlib, no native dependency — covers the binary formats an office
+    routinely mis-extensions (an Excel workbook saved as ``.pdf``, a scanned
+    image renamed to ``.docx``, etc.). The extract stage uses this to correct
+    a misrouted file before handing it to the wrong extractor.
+
+    Container formats that magic bytes alone can't fully disambiguate
+    (ZIP-based Office vs ODF vs EPUB; OLE2 .doc vs .xls vs .ppt) return the
+    generic container type — the caller hands those to Tika, which does the
+    fine-grained detection from the full byte stream.
+    """
+    if len(data) < 4:
+        return None
+
+    # Exact-prefix signatures, longest / most-specific first.
+    if data[:5] == b"%PDF-":
+        return "application/pdf"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:4] in (b"II*\x00", b"MM\x00*"):
+        return "image/tiff"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:5] == b"{\\rtf":
+        return "text/rtf"
+    if data[:4] == b"PK\x03\x04":
+        # ZIP container — modern Office (docx/xlsx/pptx), ODF, EPUB, etc.
+        return "application/zip"
+    if data[:8] == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1":
+        # OLE2 compound document — legacy Office (.doc/.xls/.ppt), .msg.
+        return "application/x-ole-storage"
+
+    return None

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -260,8 +260,9 @@ def run_extract(doc_id: uuid.UUID) -> None:
         is_image = mime in IMAGE_MIMES
 
         # Dispatch by type
-        # Extension-based image detection (covers .png, .tif, .tiff not in MIME)
-        if not is_image and obj_key.endswith((".png", ".tif", ".tiff")):
+        # Extension-based image detection (covers image extensions when MIME is
+        # absent — e.g. legacy rows with mime_type NULL). Mirror _IMAGE_EXTENSIONS.
+        if not is_image and obj_key.endswith((".jpg", ".jpeg", ".png", ".tif", ".tiff")):
             is_image = True
 
         # Magic-bytes correction. A misnamed file — e.g. an Excel workbook saved
@@ -272,6 +273,12 @@ def run_extract(doc_id: uuid.UUID) -> None:
         # declared routing, trust the bytes. Conservative: only fires for
         # recognized binary signatures, and only when they disagree with the
         # current decision. RTF is already content-sniffed above.
+        #
+        # When we reroute to image or PDF we MUST persist the corrected MIME on
+        # the doc: the ocr stage re-derives image-vs-PDF from doc.mime_type
+        # (not from this local routing), so without the write a JPEG-renamed-as-
+        # .docx would be marked needs_ocr here but then fall through ocr's
+        # dispatch and get silently dropped (empty page, no text).
         sniffed = sniff_mime(data)
         if sniffed is not None and sniffed != "text/rtf":
             sniffed_is_image = sniffed in IMAGE_MIMES
@@ -283,6 +290,7 @@ def run_extract(doc_id: uuid.UUID) -> None:
                     sniffed,
                 )
                 is_image, is_pdf = True, False
+                mime = doc.mime_type = sniffed
             elif sniffed == "application/pdf" and not is_pdf and not is_image:
                 logger.warning(
                     "extract: doc %s declared %r but magic bytes are PDF — routing as PDF",
@@ -290,11 +298,14 @@ def run_extract(doc_id: uuid.UUID) -> None:
                     mime or obj_key,
                 )
                 is_pdf = True
+                mime = doc.mime_type = "application/pdf"
             elif (is_pdf and sniffed != "application/pdf") or (is_image and not sniffed_is_image):
                 # Declared PDF/image but the bytes say otherwise (Office/ZIP/OLE
                 # saved with the wrong extension). Hand it to Tika with
                 # auto-detect — passing octet-stream makes Tika detect the
-                # specific Office subtype from the full byte stream.
+                # specific Office subtype from the full byte stream. Leave
+                # doc.mime_type as declared: needs_ocr will be False (not image,
+                # not PDF) so ocr is skipped, and we can't name the subtype yet.
                 logger.warning(
                     "extract: doc %s declared %s but magic bytes are %s — routing to Tika auto-detect",
                     doc_id,

--- a/src/harbor_clerk/worker/stages/extract.py
+++ b/src/harbor_clerk/worker/stages/extract.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 
 from harbor_clerk.config import get_settings
 from harbor_clerk.db_sync import get_sync_session
-from harbor_clerk.file_types import MARKDOWN_EXTENSIONS, PLAIN_TEXT_EXTENSIONS
+from harbor_clerk.file_types import MARKDOWN_EXTENSIONS, PLAIN_TEXT_EXTENSIONS, sniff_mime
 from harbor_clerk.ingest.metadata_extractors import run_all as run_metadata_extractors
 from harbor_clerk.models import Document, DocumentHeading, DocumentLink, DocumentPage
 from harbor_clerk.models.enums import JobStage
@@ -263,6 +263,46 @@ def run_extract(doc_id: uuid.UUID) -> None:
         # Extension-based image detection (covers .png, .tif, .tiff not in MIME)
         if not is_image and obj_key.endswith((".png", ".tif", ".tiff")):
             is_image = True
+
+        # Magic-bytes correction. A misnamed file — e.g. an Excel workbook saved
+        # with a .pdf extension, or a scanned image renamed to .docx — declares
+        # an extension/MIME that routes it to the wrong extractor, which then
+        # fails (Tika 422, or a PDF parser choking on ZIP bytes). When the
+        # leading bytes carry a recognized signature that contradicts the
+        # declared routing, trust the bytes. Conservative: only fires for
+        # recognized binary signatures, and only when they disagree with the
+        # current decision. RTF is already content-sniffed above.
+        sniffed = sniff_mime(data)
+        if sniffed is not None and sniffed != "text/rtf":
+            sniffed_is_image = sniffed in IMAGE_MIMES
+            if sniffed_is_image and not is_image:
+                logger.warning(
+                    "extract: doc %s declared %r but magic bytes are %s — routing as image",
+                    doc_id,
+                    mime or obj_key,
+                    sniffed,
+                )
+                is_image, is_pdf = True, False
+            elif sniffed == "application/pdf" and not is_pdf and not is_image:
+                logger.warning(
+                    "extract: doc %s declared %r but magic bytes are PDF — routing as PDF",
+                    doc_id,
+                    mime or obj_key,
+                )
+                is_pdf = True
+            elif (is_pdf and sniffed != "application/pdf") or (is_image and not sniffed_is_image):
+                # Declared PDF/image but the bytes say otherwise (Office/ZIP/OLE
+                # saved with the wrong extension). Hand it to Tika with
+                # auto-detect — passing octet-stream makes Tika detect the
+                # specific Office subtype from the full byte stream.
+                logger.warning(
+                    "extract: doc %s declared %s but magic bytes are %s — routing to Tika auto-detect",
+                    doc_id,
+                    "PDF" if is_pdf else "image",
+                    sniffed,
+                )
+                is_pdf, is_image = False, False
+                mime = "application/octet-stream"
 
         # Sentinel that downstream code (heading-writing) checks to decide
         # whether to use Markdown-derived headings or fall back to Tika XHTML.

--- a/tests/test_file_types.py
+++ b/tests/test_file_types.py
@@ -8,6 +8,7 @@ from harbor_clerk.file_types import (
     PLAIN_TEXT_EXTENSIONS,
     guess_mime_type,
     is_excalidraw,
+    sniff_mime,
 )
 
 
@@ -160,3 +161,51 @@ def test_guess_mime_type_unknown_falls_back_to_octet_stream():
     """RFC 2046 'no information' sentinel — what Tika expects when given bytes blindly."""
     assert guess_mime_type("opaque.zzzzz") == "application/octet-stream"
     assert guess_mime_type("noextension") == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# sniff_mime — content-based detection for misnamed files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (b"%PDF-1.7\n...", "application/pdf"),
+        (b"\x89PNG\r\n\x1a\n....", "image/png"),
+        (b"\xff\xd8\xff\xe0\x00\x10JFIF", "image/jpeg"),
+        (b"II*\x00\x08\x00", "image/tiff"),
+        (b"MM\x00*\x00\x00", "image/tiff"),
+        (b"GIF89a....", "image/gif"),
+        (b"GIF87a....", "image/gif"),
+        (b"{\\rtf1\\ansi", "text/rtf"),
+        (b"PK\x03\x04\x14\x00", "application/zip"),
+        (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", "application/x-ole-storage"),
+    ],
+)
+def test_sniff_mime_recognizes_signatures(data, expected):
+    assert sniff_mime(data) == expected
+
+
+def test_sniff_mime_returns_none_for_plain_text():
+    assert sniff_mime(b"Dear Bob,\n\nThis is a plain text email.") is None
+
+
+def test_sniff_mime_returns_none_for_too_short():
+    assert sniff_mime(b"") is None
+    assert sniff_mime(b"PK") is None  # 2 bytes — below the 4-byte floor
+
+
+def test_sniff_mime_office_as_pdf_is_detected_as_zip():
+    """The core misnamed-file case: an .xlsx workbook saved with a .pdf
+    extension declares application/pdf but its bytes are a ZIP container.
+    sniff_mime sees the ZIP magic, letting the extract stage reroute to Tika
+    instead of the PDF parser (which would 422)."""
+    xlsx_bytes = b"PK\x03\x04" + b"\x14\x00\x06\x00" + b"...[Content_Types].xml..."
+    assert sniff_mime(xlsx_bytes) == "application/zip"
+
+
+def test_sniff_mime_legacy_excel_is_ole():
+    """A legacy .xls (OLE2 compound) renamed to .pdf is detected as OLE."""
+    xls_bytes = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 8
+    assert sniff_mime(xls_bytes) == "application/x-ole-storage"

--- a/tests/test_file_types.py
+++ b/tests/test_file_types.py
@@ -176,8 +176,6 @@ def test_guess_mime_type_unknown_falls_back_to_octet_stream():
         (b"\xff\xd8\xff\xe0\x00\x10JFIF", "image/jpeg"),
         (b"II*\x00\x08\x00", "image/tiff"),
         (b"MM\x00*\x00\x00", "image/tiff"),
-        (b"GIF89a....", "image/gif"),
-        (b"GIF87a....", "image/gif"),
         (b"{\\rtf1\\ansi", "text/rtf"),
         (b"PK\x03\x04\x14\x00", "application/zip"),
         (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", "application/x-ole-storage"),
@@ -185,6 +183,14 @@ def test_guess_mime_type_unknown_falls_back_to_octet_stream():
 )
 def test_sniff_mime_recognizes_signatures(data, expected):
     assert sniff_mime(data) == expected
+
+
+def test_sniff_mime_does_not_detect_gif():
+    """GIF is deliberately not sniffed — it is not an accepted ingest format and
+    the OCR stage has no GIF dispatch, so detecting it would only let the
+    extract-stage corrector reroute a renamed GIF to a path that drops it."""
+    assert sniff_mime(b"GIF89a\x01\x00") is None
+    assert sniff_mime(b"GIF87a\x01\x00") is None
 
 
 def test_sniff_mime_returns_none_for_plain_text():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -712,6 +712,102 @@ async def test_run_extract_markdown_writes_headings_and_overrides_title(db_sessi
 
 
 @pytest.mark.asyncio
+async def test_run_extract_image_renamed_as_office_persists_image_mime(db_session, tmp_path):
+    """A JPEG saved with a .docx extension must reroute to the image/OCR path
+    AND have doc.mime_type corrected to image/jpeg. The ocr stage dispatches on
+    doc.mime_type (not extract's local routing), so without the persisted
+    correction the doc would be flagged needs_ocr here but then dropped by
+    ocr's mime dispatch — empty page, no searchable text."""
+    from unittest.mock import patch
+
+    from harbor_clerk.worker.stages import extract as extract_mod
+    from harbor_clerk.worker.stages.extract import run_extract
+
+    # Minimal JPEG header (SOI + APP0/JFIF). Extract only sniffs the leading
+    # bytes — it sets an empty page for images and ocr does the real work — so
+    # a valid signature is all this needs.
+    jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9"
+    path = tmp_path / "report.docx"
+    path.write_bytes(jpeg_bytes)
+
+    doc = Document(
+        title=path.stem,
+        canonical_filename=path.name,
+        status="active",
+        sha256=hashlib.sha256(jpeg_bytes).digest(),
+        source_path=str(path),
+        mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        pipeline_status=PipelineStatus.queued,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.queued))
+    await db_session.commit()
+
+    with patch.object(extract_mod, "run_metadata_extractors", return_value={}):
+        run_extract(doc.doc_id)
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc.doc_id)).scalar_one()
+        assert refreshed.mime_type == "image/jpeg"  # corrected so ocr will dispatch to the image branch
+        assert refreshed.needs_ocr is True
+    finally:
+        sync_session.close()
+
+
+@pytest.mark.asyncio
+async def test_run_extract_office_renamed_as_pdf_routes_to_tika_autodetect(db_session, tmp_path):
+    """An .xlsx workbook saved with a .pdf extension declares application/pdf
+    but its bytes are a ZIP container. Extract must NOT send it down the PDF
+    path (PDFBox 422s on ZIP bytes); it reroutes to Tika with
+    application/octet-stream so Tika auto-detects the Office subtype from the
+    full stream."""
+    from unittest.mock import patch
+
+    from harbor_clerk.worker.stages import extract as extract_mod
+    from harbor_clerk.worker.stages.extract import run_extract
+
+    # ZIP local-file header — the prefix every modern Office / ODF / EPUB
+    # container starts with.
+    zip_bytes = b"PK\x03\x04\x14\x00\x06\x00" + b"\x00" * 64
+    path = tmp_path / "budget.pdf"
+    path.write_bytes(zip_bytes)
+
+    doc = Document(
+        title=path.stem,
+        canonical_filename=path.name,
+        status="active",
+        sha256=hashlib.sha256(zip_bytes).digest(),
+        source_path=str(path),
+        mime_type="application/pdf",
+        pipeline_status=PipelineStatus.queued,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    db_session.add(IngestionJob(doc_id=doc.doc_id, stage=JobStage.extract, status=JobStatus.queued))
+    await db_session.commit()
+
+    with (
+        patch.object(extract_mod, "_extract_via_tika", return_value=[(1, "Sheet1 revenue 100")]) as mock_tika,
+        patch.object(extract_mod, "_extract_headings_via_tika", return_value=[]),
+        patch.object(extract_mod, "run_metadata_extractors", return_value={}),
+    ):
+        run_extract(doc.doc_id)
+
+    # Tika was asked to auto-detect (octet-stream), NOT to parse the bytes as PDF.
+    assert mock_tika.called
+    assert mock_tika.call_args.args[1] == "application/octet-stream"
+
+    sync_session = get_sync_session()
+    try:
+        refreshed = sync_session.execute(select(Document).where(Document.doc_id == doc.doc_id)).scalar_one()
+        assert refreshed.needs_ocr is False  # neither image nor PDF → ocr correctly skipped
+    finally:
+        sync_session.close()
+
+
+@pytest.mark.asyncio
 async def test_wikilink_graph_resolves_and_kb_find_related_returns_linked(db_session, _engine, tmp_path, monkeypatch):
     """Integration: doc A and doc B link to each other via [[…]]. After
     extract + finalize, the document_links rows resolve in both directions.


### PR DESCRIPTION
## Summary

A non-technical office routinely produces **misnamed files** — an Excel workbook "saved as PDF" (really a `.xlsx` renamed `.pdf`), a scan dropped in with a `.docx` extension. The extract stage dispatched purely on the declared extension/MIME, so these were handed to the wrong extractor and failed: the PDF path choked on ZIP bytes, Tika returned 422 on a content-type that did not match the bytes, or the file just looked "stuck" with no useful error.

This adds a content-based correction at the extract stage:

- **`sniff_mime()`** in `file_types.py` — a pure-stdlib magic-number sniffer (no libmagic / native dep, so nothing new to vendor into the mac bundle) covering the binary formats an office mis-extensions: PDF, PNG, JPEG, TIFF, RTF, ZIP-container (modern Office/ODF/EPUB), OLE2 (legacy Office).
- The extract stage consults it **after** extension-based routing and, only when the bytes carry a recognized signature that **contradicts** the declared routing, trusts the bytes: route to image/OCR, route to PDF, or hand to Tika auto-detect (`application/octet-stream`) so Tika resolves the specific Office subtype from the full stream. Correctly-named files are never touched — the override fires only on disagreement.

## Cross-stage correctness (caught in fresh-eyes review)

The OCR stage re-derives image-vs-PDF from `doc.mime_type`, **not** from extract's local routing. So the initial cut had a latent bug: a JPEG renamed `.docx` was flagged `needs_ocr` in extract but then matched neither of OCR's mime branches and was silently dropped (empty page, no searchable text). Fixed by **persisting the corrected `doc.mime_type`** when extract reroutes to image or PDF, so OCR dispatches correctly.

GIF was also dropped from the sniffer: it is not an accepted ingest extension and OCR has no GIF dispatch, so detecting it only let the corrector demote a renamed GIF to Tika auto-detect (losing OCR).

## Out of scope / future work

- **GIF/BMP as first-class accepted image formats.** Would require wiring `_IMAGE_EXTENSIONS` + `IMAGE_MIMES` + the OCR dispatch + `sniff_mime` together as a deliberate feature, not a side effect of sniffing.
- **Unify OCR's hardcoded image-mime tuple** (`ocr.py` `("image/jpeg","image/png","image/tiff")`) with `IMAGE_MIMES` so the two cannot drift.

## Test plan

- [x] `uv run pytest tests/test_file_types.py tests/test_extract_helpers.py` — sniff signatures, no-GIF, short/unknown input
- [x] `uv run pytest tests/test_pipeline.py` — incl. two new `run_extract` integration tests: JPEG-as-`.docx` persists `image/jpeg` + `needs_ocr`; ZIP-as-`.pdf` routes to Tika with `octet-stream`, `needs_ocr=False`
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
