### PR TITLE
fix(macos): self-heal a zombied API listener via a liveness probe

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/Services/APIService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/APIService.swift
@@ -8,17 +8,34 @@ final class APIService: PythonService {
     override var executableName: String { "harbor-clerk-api" }
 
     override func healthCheck() async -> Bool {
-        // Process alive ⇒ healthy. The API event loop can be temporarily
-        // blocked during research/synthesis (LLM prompt processing, DB
-        // commits) and that's not a crash, so we deliberately don't gate
-        // on an HTTP probe here. The previous implementation kept an
-        // ephemeral URLSession probe alongside the process check, but
-        // its return value was effectively ignored — alive-process
-        // always reported healthy regardless of HTTP outcome — so the
-        // probe was just a wasted in-flight URLSession task per
-        // healthCheck tick. Dropped to reduce CFNetwork pressure during
-        // model-load transitions (see
+        // Liveness, not just process-alive. The python process can stay alive
+        // while the uvicorn listener stops accepting/serving connections — the
+        // "zombie" failure mode observed after the Mac sleeps and wakes (see
+        // project_menubar_process_management_audit.md / the PR #385 idle-
+        // unreachable note). A process-only check never reports that as
+        // unhealthy, so the HealthChecker's auto-restart never fires and the
+        // whole app stays unreachable until the user manually restarts.
+        //
+        // We probe the dependency-free /api/system/ping (NOT /system/health,
+        // which checks Postgres/Tika/reranker — a slow dependency there would
+        // wrongly fail an API-liveness check and bounce a healthy API). A 200
+        // means the event loop is turning. The stdout-pipe deadlock that used
+        // to block the loop mid-research — the original reason this was
+        // process-only — was fixed in PR #190, so a failing probe now
+        // genuinely indicates a dead listener rather than a busy one.
+        //
+        // httpProbeOK uses an ephemeral, short-timeout, invalidated URLSession
+        // (the sanctioned pattern that avoids the CFNetwork pointer-auth crash
+        // from concurrent URLSession.shared probes during model load —
         // project_menubar_crashes_during_model_switch.md).
-        return process?.isRunning == true
+        //
+        // The HealthChecker needs consecutiveFailuresBeforeError (6 = 60s) of
+        // these before it errors+restarts, which absorbs transient
+        // unavailability (model-switch churn, a brief synchronous spike)
+        // without false-tripping.
+        guard process?.isRunning == true else { return false }
+        let port = AppSettings.shared.apiPort
+        guard let url = URL(string: "http://127.0.0.1:\(port)/api/system/ping") else { return false }
+        return await httpProbeOK(url)
     }
 }

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -100,6 +100,24 @@ async def setup_status(
     return {"needs_setup": count == 0}
 
 
+@router.get("/system/ping")
+async def ping() -> dict[str, str]:
+    """Liveness probe — no dependency checks, no DB session, no I/O.
+
+    Deliberately distinct from ``/system/health`` (which probes Postgres,
+    storage, Tika, and the reranker and is a *readiness/diagnostic* check). A
+    200 from this endpoint means exactly one thing: the uvicorn listener is
+    accepting connections and the asyncio event loop scheduled this handler.
+
+    The macOS menubar's HealthChecker probes this to detect a *zombied* API
+    listener — process alive but no longer serving HTTP, as observed after a
+    system sleep — and trip its auto-restart. Using the heavy health endpoint
+    for that would conflate API liveness with backend health: a slow or hung
+    Tika would fail the probe and needlessly bounce a perfectly healthy API.
+    """
+    return {"status": "ok"}
+
+
 @router.get("/system/health")
 async def health_check(
     session: AsyncSession = Depends(get_session),

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -15,6 +15,15 @@ async def test_setup_status_with_users(client, admin_user):
     assert resp.json()["needs_setup"] is False
 
 
+async def test_ping_liveness_is_unauthenticated_and_dependency_free(client):
+    """The liveness probe returns 200 {"status": "ok"} with no auth and without
+    touching Postgres/Tika/storage — the macOS HealthChecker relies on this to
+    distinguish a zombied API listener from a degraded backend."""
+    resp = await client.get("/api/system/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
 async def test_health_check(client):
     resp = await client.get("/api/system/health")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

`APIService.healthCheck()` returned `process?.isRunning == true` — a **process-liveness** check only. But the uvicorn listener can *zombie*: the python process stays alive while the asyncio event loop stops accepting/serving connections, which leaves the whole app unreachable. This was observed after the Mac sleeps and wakes (the "HC silently goes unreachable after ~90 min idle; restart recovers" note from the PR #385 sweep). Because the process was still alive, the menubar `HealthChecker`'s consecutive-failure auto-restart never fired — only a manual restart recovered it.

This wires the existing auto-restart machinery to a real liveness signal:

- **`APIService.healthCheck()`** now probes the listener over HTTP via `httpProbeOK` (the existing ephemeral, short-timeout, invalidated-`URLSession` helper that avoids the CFNetwork pointer-auth crash from concurrent shared-session probes during model load). A failing probe across the `HealthChecker`'s existing **6-tick / 60s** threshold trips the auto-restart, so a zombied listener **self-heals**. The 60s buffer absorbs model-switch churn and brief synchronous spikes without false-tripping. A fast `process?.isRunning` guard short-circuits a definitively-dead process before the HTTP round-trip.

- **New `GET /api/system/ping`** — a dependency-free liveness endpoint (`{"status": "ok"}`, no DB session, no I/O), deliberately separate from `/api/system/health` (which probes Postgres/Tika/reranker). A liveness probe must not fail just because a backend is slow, or it would bounce a perfectly healthy API. `127.0.0.1` reaches the listener whether `API_HOST` is `127.0.0.1` or `0.0.0.0`.

### Why a probe is safe now

The original process-only check existed because the event loop used to block mid-research — but that was a **stdout-pipe deadlock fixed in PR #190** (the rotating-file-handler change). Post-#190 the loop stays responsive to a cheap endpoint even during research/synthesis, so a failing `ping` now genuinely indicates a dead listener rather than a busy one.

## Test plan

- [x] `uv run pytest tests/test_api_system.py` — incl. new `test_ping_liveness_is_unauthenticated_and_dependency_free`
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green
- [ ] Manual: after a rebuild, let the app idle (or sleep/wake the Mac) until the listener zombies, confirm the menubar logs `Health check failed (n/6)` and auto-restarts the API; confirm a model switch does **not** trip a restart

## Notes

The fresh-eyes review flagged two **pre-existing** concerns in `LlamaService.swift` (`pidsHoldingPort()` using the `DispatchQueue + waitUntilExit` pattern rather than the safer `runAndAwait`; `ensurePortReleased` straggler kill using `kill` rather than `killpg`). Both are on `main` and unrelated to this change — left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
