### PR TITLE
feat(citations): add SourceRef foundation

### DIFF
--- a/docs/superpowers/plans/2026-06-03-source-ref-citation-contract.md
+++ b/docs/superpowers/plans/2026-06-03-source-ref-citation-contract.md
@@ -1,0 +1,730 @@
+# SourceRef and Citation Contract - Implementation Plan
+
+> **For agentic workers:** This is a detailed implementation plan. Execute task-by-task, preserving backwards-compatible response fields while adding the new `source` object and `citation` string. Do not remove legacy fields in this rollout.
+
+**Goal:** Add a central `SourceRef` builder and thread it through the highest-value REST, MCP, CLI, chat, and research citation paths so Harbor Clerk has one stable source/citation contract.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-source-ref-citation-contract-design.md`
+
+**Release plan:** `docs/superpowers/plans/2026-06-03-release-readiness-action-plan.md`
+
+**Architecture:** A new pure builder module formats document, email, attachment, page, section, folder-label, and relative-path information into a structured `SourceRef` object. Thin async context loaders bulk-fetch watched-folder and parent-email data so routes/tools do not N+1 query. Existing response shapes keep their legacy top-level fields, but gain `source` and `citation`. LLM citation extraction prefers `source` when present and falls back to legacy fields.
+
+**Non-goals for this plan:**
+
+- No path-disclosure API-key scope yet.
+- No absolute paths in MCP/CLI/cloud-visible payloads.
+- No removal of legacy `doc_id`, `doc_title`, `pages`, `page_start`, or `page_end` fields.
+- No full UI citation-chip rewrite beyond adding types/compatibility hooks if needed.
+- No verifier/citation-support UI.
+
+**Research/verifier decision:** Research citations normalize later, while preserving verifier compatibility. In practice: new research citation records may gain `source`, `citation`, and `pages`, but the existing `doc_title` and `page` fields must remain until the verifier loop is deliberately migrated. Do not break `_verify_citations` as part of the SourceRef rollout.
+
+---
+
+## Current State Snapshot
+
+- REST `POST /api/search` returns `SearchHitOut` with top-level `chunk_id`, `doc_id`, `doc_title`, `page_start`, `page_end`, and no citation string.
+- REST `POST /api/passages/read` returns `PassageDetail` with similar top-level fields and no `source`.
+- MCP builds result dicts inline in `src/harbor_clerk/mcp_server.py`.
+- CLI JSON passes MCP output through; text rendering builds its own title/page line.
+- `src/harbor_clerk/llm/citations.py` extracts best-effort citation records from several ad hoc tool-result shapes.
+- `tests/test_mcp_metadata_filter.py::test_kb_get_document_does_not_leak_source_path` already pins a no-host-path rule for MCP document metadata.
+- Watched-folder source identity lives in `watched_files.relative_path` plus `watched_folders.display_name`/`path`.
+- Email identity usually lives in `Document.email_*` columns. Tika fallback metadata may exist under `doc.doc_metadata["tika"]["email_*"]`. Attachments link to parent email via `Document.email_parent_doc_id`.
+
+---
+
+## Contract
+
+Every new `source` object should have this shape, omitting null values on JSON output where practical:
+
+```json
+{
+  "doc_id": "uuid",
+  "doc_title": "string",
+  "chunk_id": "uuid",
+  "pages": "4-5",
+  "section": "string",
+  "source_kind": "document",
+  "source_label": "string",
+  "folder_label": "string",
+  "relative_path": "string",
+  "citation": "Contract A, pp. 4-5"
+}
+```
+
+Accepted `source_kind` values:
+
+- `document`
+- `email`
+- `attachment`
+- `unknown`
+
+Compatibility rule:
+
+- Add top-level `citation` as an alias of `source.citation`.
+- Keep old top-level fields for now.
+
+Path rule:
+
+- Human REST document endpoints may keep existing local path fields.
+- MCP and CLI result payloads must not include absolute paths.
+- `folder_label` and `relative_path` are allowed by default.
+- Future path-disclosure scope handles filename-only/relative/absolute modes.
+
+---
+
+## Task 1: Pure SourceRef builder
+
+**Why:** Centralize citation formatting and source-policy decisions before touching any route/tool.
+
+**Files:**
+
+- Create: `src/harbor_clerk/source_ref.py`
+- Create: `tests/test_source_ref.py`
+
+### Step 1.1: Write builder tests first
+
+Cover:
+
+- Document citation with one page: `Contract A, p. 4`.
+- Document citation with range: `Contract A, pp. 4-5`.
+- Document citation without page: `Contract A`.
+- Missing title falls back to canonical filename, then `Untitled document`.
+- Email citation uses native metadata: `Email from Jane Doe, "Budget follow-up", Mar 7, 2025`.
+- Email citation with missing sender still includes subject/date when present.
+- `.eml` fallback uses Tika metadata if native `email_*` fields are missing.
+- `.eml` fallback uses file/title metadata if email parsing failed.
+- Attachment citation includes attachment filename/title and parent email identity.
+- `source_label` and `citation` both exist and can differ.
+- No field renders `"None"`, `"null"`, or empty quotes.
+- No absolute path appears in `source.to_dict()`.
+
+### Step 1.2: Add core dataclass and helpers
+
+Implement:
+
+```python
+@dataclass(frozen=True)
+class SourceRef:
+    doc_id: str
+    doc_title: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    source_kind: Literal["document", "email", "attachment", "unknown"] = "document"
+    source_label: str = ""
+    folder_label: str | None = None
+    relative_path: str | None = None
+    citation: str = ""
+
+    def to_dict(self) -> dict: ...
+```
+
+Helpers:
+
+- `format_pages(page_start, page_end) -> str | None`
+- `format_document_citation(title, pages) -> str`
+- `format_email_citation(...) -> str`
+- `format_attachment_citation(...) -> str`
+- `build_source_ref(...) -> SourceRef`
+
+Recommended `build_source_ref` signature:
+
+```python
+def build_source_ref(
+    *,
+    doc: Document | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+    watched_file: WatchedFile | None = None,
+    watched_folder: WatchedFolder | None = None,
+    parent_email_doc: Document | None = None,
+    include_relative_path: bool = True,
+) -> SourceRef:
+    ...
+```
+
+Do not let this function query the database. Keep it pure.
+
+### Step 1.3: Implement email fallback order
+
+For email docs:
+
+1. Native `Document.email_from_*`, `email_subject`, `email_date_sent`.
+2. Tika metadata fallback under `doc.doc_metadata["tika"]`:
+   - `email_from`
+   - `email_subject`
+   - `email_date`
+3. File/title fallback:
+   - `doc.title`
+   - `doc.canonical_filename`
+   - relative path leaf
+
+Email detection:
+
+- `doc.email_parent_doc_id is None` and any native email field exists.
+- `doc.mime_type == "message/rfc822"`.
+- `doc.canonical_filename` or `relative_path` ends with `.eml`.
+
+Attachment detection:
+
+- `doc.email_parent_doc_id is not None`.
+- Use `parent_email_doc` when available to build parent email citation.
+
+### Step 1.4: Implement path handling
+
+Folder label:
+
+- Prefer `WatchedFolder.display_name`.
+- Else basename of `WatchedFolder.path`.
+- Else `None`.
+
+Relative path:
+
+- Include `WatchedFile.relative_path` only when `include_relative_path=True`.
+- Never derive a relative path by slicing `Document.source_path`; use watched-folder data.
+- Never output `Document.source_path`.
+
+### Step 1.5: Run tests
+
+Run:
+
+```bash
+uv run pytest tests/test_source_ref.py -v
+```
+
+---
+
+## Task 2: Bulk SourceRef context loader
+
+**Why:** Routes/tools need watched-folder and parent-email context without repeating ad hoc joins.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/source_ref.py`
+- Create: `tests/test_source_ref_context.py`
+
+### Step 2.1: Add `SourceRefContext`
+
+Implement a small context object:
+
+```python
+@dataclass
+class SourceRefContext:
+    docs_by_id: dict[uuid.UUID, Document]
+    watched_files_by_doc: dict[uuid.UUID, WatchedFile]
+    watched_folders_by_id: dict[uuid.UUID, WatchedFolder]
+    parent_email_docs_by_id: dict[uuid.UUID, Document]
+
+    def ref_for_doc(...): ...
+```
+
+`ref_for_doc` should call the pure builder.
+
+### Step 2.2: Add async loader
+
+Implement:
+
+```python
+async def load_source_ref_context(
+    session: AsyncSession,
+    doc_ids: Iterable[uuid.UUID | str],
+) -> SourceRefContext:
+    ...
+```
+
+Behavior:
+
+- Load `Document` rows for `doc_ids`.
+- Load active `WatchedFile` rows for those docs.
+- Load `WatchedFolder` rows for those watched files.
+- Load parent email documents for any `doc.email_parent_doc_id`.
+- Do not raise if watched tables are absent or missing rows; return partial context.
+
+### Step 2.3: Add context tests
+
+Cover:
+
+- Folder display name and relative path included.
+- Parent email doc loaded for attachment citation.
+- Missing watched rows still produces a valid source.
+- No absolute path appears in `ref.to_dict()`.
+
+Run:
+
+```bash
+uv run pytest tests/test_source_ref.py tests/test_source_ref_context.py -v
+```
+
+---
+
+## Task 3: REST search and passages
+
+**Why:** Human Search is becoming the default surface and should get structured citations early.
+
+**Files:**
+
+- Create: `src/harbor_clerk/api/schemas/source_ref.py`
+- Modify: `src/harbor_clerk/api/schemas/search.py`
+- Modify: `src/harbor_clerk/api/routes/search.py`
+- Create: `tests/api/test_search_source_ref.py`
+
+### Step 3.1: Add Pydantic schema
+
+Create `SourceRefOut` mirroring the dataclass:
+
+```python
+class SourceRefOut(BaseModel):
+    doc_id: str
+    doc_title: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    source_kind: Literal["document", "email", "attachment", "unknown"]
+    source_label: str
+    folder_label: str | None = None
+    relative_path: str | None = None
+    citation: str
+```
+
+### Step 3.2: Extend search schemas compatibly
+
+Add optional fields:
+
+- `SearchHitOut.source: SourceRefOut | None = None`
+- `SearchHitOut.citation: str | None = None`
+- `PassageDetail.source: SourceRefOut | None = None`
+- `PassageDetail.citation: str | None = None`
+
+Do not remove existing fields.
+
+### Step 3.3: Enrich `POST /api/search`
+
+After `hybrid_search`, bulk-load source context for `result.hits` doc IDs.
+
+Update `_hit_to_out` to accept `source_ref`:
+
+- `pages = format_pages(h.page_start, h.page_end)`
+- `chunk_id = h.chunk_id`
+- `section = None` for first REST pass unless heading lookup is added.
+- `citation = source_ref.citation`
+
+### Step 3.4: Enrich `POST /api/passages/read`
+
+After loading chunks/docs, use `SourceRefContext.ref_for_doc` for each passage.
+
+The existing route already has chunk rows and doc rows; the only new DB work should be watched-folder/parent-email context.
+
+### Step 3.5: REST tests
+
+Cover:
+
+- Search hit includes `source` and top-level `citation`.
+- Legacy top-level fields still exist.
+- Passage includes `source` and `citation`.
+- Email search result has email-native citation.
+- Attachment passage includes parent email context when available.
+- MCP/cloud-visible path policy is not directly tested here, but REST search should still not add absolute paths to `source`.
+
+Run:
+
+```bash
+uv run pytest tests/api/test_search_source_ref.py -v
+```
+
+---
+
+## Task 4: MCP high-volume citation-bearing tools
+
+**Why:** MCP is the main cloud/agent interface. Search/read tools should get `source` early.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Modify/create tests in `tests/test_mcp_tools.py` or `tests/test_mcp_source_ref.py`
+
+### Step 4.1: Add source refs to `kb_search` and `kb_batch_search`
+
+Modify `_format_search_response` to accept a source-ref map keyed by `(doc_id, chunk_id)`.
+
+Each hit keeps:
+
+- `chunk_id`
+- `doc_id`
+- `doc_title`
+- `pages`
+- `section`
+- `score`
+- `language`
+- `text`
+
+Each hit gains:
+
+- `source`
+- `citation`
+
+Build the map in `kb_search` and each `kb_batch_search` query after `hybrid_search`.
+
+### Step 4.2: Add source refs to `kb_find_all`
+
+Each `results[]` row keeps current fields and gains:
+
+- `source`
+- `citation`
+
+For `presentation="full"`, the row source should include `top_chunk_id` and `page_range` when available. If no chunk exists, emit a document-level source.
+
+### Step 4.3: Add source refs to `kb_read_passages`
+
+Each `passages[]` row gains:
+
+- `doc_id` if not already present in the current MCP shape
+- `source`
+- `citation`
+
+This is a useful small compatibility improvement: `llm/citations.py` currently has to keep chunk-only records from `kb_read_passages` because the MCP passage shape omits `doc_id`.
+
+### Step 4.4: Add source refs to `kb_expand_context`
+
+Each `chunks[]` row gains:
+
+- `source`
+- `citation`
+
+The top-level document identity remains unchanged.
+
+### Step 4.5: MCP tests
+
+Cover:
+
+- `kb_search` hit includes `source.citation` and top-level `citation`.
+- `kb_batch_search` nested hits include source refs.
+- `kb_find_all` rows include source refs.
+- `kb_read_passages` includes `doc_id`, `source`, and `citation`.
+- `kb_expand_context` chunks include source refs.
+- No MCP response includes `Document.source_path`.
+- No MCP response includes `/Users/` when source path is seeded as `/Users/alex/private/foo.pdf`.
+
+Run targeted tests:
+
+```bash
+uv run pytest tests/test_mcp_tools.py tests/test_mcp_metadata_filter.py -k "source_ref or source_path or search or read_passages or find_all" -v
+```
+
+---
+
+## Task 5: MCP document-row tools
+
+**Why:** Agents often pivot from search to document-listing and document-metadata tools. Those rows should carry the same source identity.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Modify: `src/harbor_clerk/mcp_lookup_tools.py`
+- Modify/create tests in `tests/test_mcp_tools.py`, `tests/test_mcp_lookup_tools.py`, or `tests/test_mcp_source_ref.py`
+
+### Step 5.1: Add document-level source refs
+
+Add `source` and `citation` to document rows returned by:
+
+- `kb_get_document`
+- `kb_list_recent`
+- `kb_corpus_overview`
+- `kb_document_outline`
+- `kb_find_related`
+- `kb_documents_by_date`
+- `kb_verify_identifier` unique match and ambiguous candidates
+
+Keep all current fields.
+
+### Step 5.2: Consider `kb_entity_search`
+
+If `kb_entity_search` returns per-mention `doc_id` and `chunk_id`, add source refs there too. If this becomes messy, defer it explicitly in the PR description and follow-up list.
+
+### Step 5.3: Tests
+
+Cover at least:
+
+- `kb_get_document` includes `source` but still does not leak `source_path`.
+- `kb_documents_by_date` result includes `source` and `citation`.
+- `kb_verify_identifier` unique match includes `source`.
+- `kb_find_related` related rows include `source`.
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_lookup_tools.py tests/test_mcp_metadata_filter.py tests/test_mcp_tools.py -k "verify_identifier or documents_by_date or get_document or find_related or source_path" -v
+```
+
+---
+
+## Task 6: LLM citation extraction compatibility
+
+**Why:** Ask and Research already persist citations from tool results. Once tool results carry `source`, the extractor should preserve the richer object.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/llm/citations.py`
+- Modify: `tests/test_llm_citations.py`
+
+### Step 6.1: Prefer `source` objects
+
+In `_record`, if a result row has a dict `source`:
+
+- Copy the `source` dict into the citation record.
+- Populate legacy flattened keys from `source` when absent:
+  - `doc_id`
+  - `doc_title`
+  - `chunk_id`
+  - `pages`
+  - `citation`
+- Preserve numeric `score` from the result row.
+
+Do not mutate the parsed tool result.
+
+### Step 6.2: Keep legacy fallback
+
+The extractor must continue to pass all existing tests for old shapes.
+
+### Step 6.3: Add extractor tests
+
+Cover:
+
+- `kb_search` hit with `source` yields citation with nested `source` and flattened legacy keys.
+- Top-level `citation` is preserved.
+- Legacy hit without `source` still works.
+- Dedup keeps richer `source` record when replacing by higher score.
+- Chunk-only legacy records still survive.
+
+Run:
+
+```bash
+uv run pytest tests/test_llm_citations.py -v
+```
+
+---
+
+## Task 7: CLI output and help compatibility
+
+**Why:** CLI is the shell-first agent surface. JSON should preserve `source`; text should prefer the formatted citation when available.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/cli/output.py`
+- Modify: `src/harbor_clerk/cli/help/search.txt`
+- Modify: `src/harbor_clerk/cli/help/batch-search.txt`
+- Modify: `src/harbor_clerk/cli/help/read-passages.txt`
+- Modify/create tests in `tests/cli/test_output.py`
+
+### Step 7.1: Update text renderer
+
+For search text mode:
+
+- Prefer `r["citation"]`.
+- Else prefer `r["source"]["citation"]`.
+- Else fall back to `doc_title` + `pages`.
+
+Keep chunk id visible for agents/humans.
+
+### Step 7.2: Update CLI help
+
+Help should say JSON results include:
+
+- `source`
+- `citation`
+- legacy citation-ready fields
+
+Update any current "expecting a standalone citation field" caveats to reflect the new field.
+
+### Step 7.3: CLI tests
+
+Cover:
+
+- Text search output uses `citation` when present.
+- JSON rendering preserves nested `source`.
+- Legacy payload still renders.
+
+Run:
+
+```bash
+uv run pytest tests/cli/test_output.py tests/cli/test_commands_search.py -v
+```
+
+---
+
+## Task 8: Research citation normalization
+
+**Why:** Research citations currently persist as doc/page records built inside `_read_evidence`. They should converge toward SourceRef so future citation-support validation has structured inputs.
+
+**Memorialized decision:** Research citations normalize later, while preserving verifier compatibility. This task is intentionally late in the plan because the verifier currently consumes `doc_title` and `page`; SourceRef must enrich that shape, not replace it, until a separate verifier migration exists.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/llm/research.py`
+- Modify: `src/harbor_clerk/api/routes/research.py` if read-time compatibility is needed
+- Modify: `src/harbor_clerk/api/schemas/research.py` only if adding typed source schema is low-risk
+- Modify: `tests/test_api_research_citations.py`
+- Modify: `tests/test_research_verifier.py` only if verifier input shape changes
+
+### Step 8.1: Update `_read_evidence`
+
+Where it currently appends:
+
+```python
+{"doc_id": ..., "doc_title": ..., "page": ...}
+```
+
+append a richer record:
+
+```python
+{
+  "doc_id": ...,
+  "doc_title": ...,
+  "page": ...,
+  "pages": ...,
+  "citation": source_ref.citation,
+  "source": source_ref.to_dict(),
+}
+```
+
+Keep `page` for verifier compatibility until that code is deliberately updated.
+
+### Step 8.2: Preserve old persisted citations
+
+`GET /api/research/{id}` must still handle old `research_state.citations` values that lack `source`.
+
+Either:
+
+- return old citations as-is, or
+- enrich old citations best-effort when `doc_id` is present.
+
+Prefer the simpler path unless UI needs the richer shape immediately.
+
+### Step 8.3: Verifier compatibility
+
+The verifier currently reads `doc_title` and `page`. Do not break it.
+
+If changing verifier input, update tests in `tests/test_research_verifier.py`.
+
+### Step 8.4: Research tests
+
+Cover:
+
+- New research citations can include `source` and `citation`.
+- Old citations still round-trip.
+- Dedupe does not drop `source`.
+
+Run:
+
+```bash
+uv run pytest tests/test_api_research_citations.py tests/test_research_verifier.py -v
+```
+
+---
+
+## Task 9: Frontend type hook, minimal
+
+**Why:** Even if full citation-chip rendering is a later UI task, frontend code should have a stable type to consume.
+
+**Files:**
+
+- Create or modify: `frontend/src/types/sourceRef.ts`
+- Modify: `frontend/src/pages/SearchPage.tsx` only if this PR updates REST search UI immediately
+- Modify: `frontend/src/components/CitedMarkdown.tsx` only if accepting structured citations is low-risk
+
+### Step 9.1: Add TypeScript type
+
+```ts
+export interface SourceRef {
+  doc_id: string
+  doc_title: string
+  chunk_id?: string | null
+  pages?: string | null
+  section?: string | null
+  source_kind: 'document' | 'email' | 'attachment' | 'unknown'
+  source_label: string
+  folder_label?: string | null
+  relative_path?: string | null
+  citation: string
+}
+```
+
+### Step 9.2: Minimal UI use
+
+If SearchPage is touched in this PR:
+
+- Add `source?: SourceRef | null` and `citation?: string | null` to `SearchHit`.
+- Render `hit.citation` where page/title citation text is currently assembled.
+- Keep links based on existing `doc_id`/page fields.
+
+If this makes the PR too broad, leave UI rendering to the Search Workbench plan and only add the type.
+
+---
+
+## Task 10: Full verification
+
+Run targeted tests first, then broader suites:
+
+```bash
+uv run pytest tests/test_source_ref.py tests/test_source_ref_context.py -v
+uv run pytest tests/api/test_search_source_ref.py tests/test_llm_citations.py -v
+uv run pytest tests/test_mcp_tools.py tests/test_mcp_lookup_tools.py tests/test_mcp_metadata_filter.py -k "source_ref or source_path or search or read_passages or find_all or documents_by_date or verify_identifier" -v
+uv run pytest tests/cli/test_output.py tests/cli/test_commands_search.py -v
+```
+
+If frontend files changed:
+
+```bash
+cd frontend && npm run type-check
+cd frontend && npm run lint
+```
+
+If the change touches many MCP response shapes, also run:
+
+```bash
+uv run pytest tests/test_mcp_tools.py tests/test_mcp_response_steering.py tests/test_llm_citations.py -v
+```
+
+---
+
+## Backwards Compatibility Checklist
+
+- Legacy top-level fields are still present.
+- `llm/citations.py` still parses old tool result JSON.
+- CLI text output still handles old payloads.
+- Existing tests that assert old fields continue to pass.
+- No existing endpoint requires clients to understand `source`.
+- No absolute paths appear in MCP/CLI `source` payloads.
+- `kb_get_document` still omits `source_path`.
+
+---
+
+## Suggested PR Boundaries
+
+If this becomes too large, split into:
+
+1. **PR 1:** Pure builder, context loader, tests.
+2. **PR 2:** REST search/passages SourceRef.
+3. **PR 3:** MCP search/read/find-all SourceRef plus citation extractor.
+4. **PR 4:** MCP document-row tools and CLI help/output.
+5. **PR 5:** Research citation normalization and minimal frontend type/rendering.
+
+PR 1 and PR 2 should land before Search Workbench implementation.
+
+---
+
+## Fresh-Eyes Review Triggers
+
+Require review before merge if any PR:
+
+- changes MCP or CLI response contracts;
+- changes API schemas;
+- changes path/source disclosure;
+- changes chat/research citation extraction;
+- changes verifier inputs;
+- touches more than three files.
+
+This work almost certainly triggers review.

--- a/docs/superpowers/specs/2026-06-03-source-ref-citation-contract-design.md
+++ b/docs/superpowers/specs/2026-06-03-source-ref-citation-contract-design.md
@@ -1,0 +1,223 @@
+# SourceRef and Citation Contract - Design Spec
+
+**Date:** 2026-06-03
+**Status:** Accepted for planning
+**Scope:** Common source/citation object across REST, MCP, CLI, local chat/research, and UI. This spec is about response contracts and citation policy, not retrieval ranking.
+
+## Overview
+
+Harbor Clerk's strongest product promise is that search and AI answers are grounded in inspectable sources. That promise gets weaker if each surface invents its own citation string, omits chunk identifiers, exposes filesystem paths inconsistently, or handles email differently from documents.
+
+This spec introduces a shared `SourceRef` contract: responses should include both a structured `source` object and a derived human-readable `citation` string. The structured object gives agents and UI code stable fields; the string gives cloud LLMs and humans a compact citation they can quote directly.
+
+## Goals
+
+- One citation/source schema used by REST search, MCP tools, CLI commands, local chat tools, Ask, Research, and document UI where practical.
+- Include `chunk_id` whenever the result is chunk-backed.
+- Include a derived `citation` string in tool/API responses, not only in UI rendering.
+- Give email and email attachments first-class citation formats.
+- Avoid exposing absolute local filesystem paths to MCP/cloud/agent responses.
+- Allow folder aliases/labels and relative paths to be exposed as contextual source identity when policy permits.
+- Make citation generation testable and centrally maintained.
+
+## Non-goals
+
+- No rewrite of the retrieval algorithm.
+- No guarantee that every legacy endpoint immediately returns the new object in the first PR.
+- No source-file download policy change.
+- No cryptographic citation verification.
+- No full provenance graph for derived summaries.
+
+## SourceRef schema
+
+Initial shape:
+
+```json
+{
+  "doc_id": "uuid",
+  "doc_title": "string",
+  "chunk_id": "uuid|null",
+  "pages": "4-5|null",
+  "section": "string|null",
+  "source_kind": "document|email|attachment|unknown",
+  "source_label": "string",
+  "folder_label": "string|null",
+  "relative_path": "string|null",
+  "citation": "string"
+}
+```
+
+Field semantics:
+
+- `doc_id`: stable Harbor Clerk document identifier.
+- `doc_title`: display title for the document.
+- `chunk_id`: stable chunk/passage identifier when the result is chunk-backed. Null for document-level results without a specific passage.
+- `pages`: normalized page or page range when known, such as `"4"` or `"4-5"`.
+- `section`: heading, email part label, or other structural context when known.
+- `source_kind`: broad source category.
+- `source_label`: concise human-readable source name. For normal documents this is usually the title. For email it may include sender/subject/date.
+- `folder_label`: watched-folder alias/name, not an absolute path.
+- `relative_path`: path relative to the watched-folder root when policy permits.
+- `citation`: human-readable citation derived from the same fields.
+
+## Citation formats
+
+### Documents
+
+- `Contract A, p. 4`
+- `Contract A, pp. 4-5`
+- `Contract A`
+
+Use `p.` for one page and `pp.` for a range. If pages are unknown, omit page text rather than inventing location.
+
+### Email bodies
+
+- `Email from Jane Doe, "Budget follow-up", Mar 7, 2025`
+- `Email from Jane Doe to Sam Lee, "Budget follow-up", Mar 7, 2025`
+
+The short form should prefer sender, subject, and date. Include recipient when it materially disambiguates or when email metadata is central to the result.
+
+For `.eml` files on disk, default to email-native metadata. If parsing failed or key email fields are missing, fall back to file metadata rather than producing a broken email citation. Example fallback order:
+
+1. Parsed email sender/subject/date.
+2. Document title plus whatever email metadata is available.
+3. File name or relative path plus page/section context if no usable email metadata exists.
+
+### Email attachments
+
+- `Attachment "invoice.pdf" to Email from Jane Doe, "Budget follow-up", Mar 7, 2025`
+- `Attachment "contract.pdf", p. 2, to Email from Jane Doe, "Budget follow-up", Mar 7, 2025`
+
+Attachments should keep both identities: the attachment as the retrieved document and the parent email as provenance.
+
+### Unknown or partial source data
+
+When metadata is missing, degrade gracefully:
+
+- `Untitled document`
+- `Email "Budget follow-up"`
+- `Attachment "invoice.pdf"`
+
+Do not emit placeholders like `None`, `unknown.pdf`, or `page null`.
+
+## Path and security policy
+
+Absolute paths are sensitive because MCP and cloud LLMs may receive them. They can reveal usernames, project names, client names, folder structure, or mounted-volume details.
+
+Policy:
+
+- MCP responses: no absolute paths.
+- CLI responses: no absolute paths by default. Provide an explicit local-only flag later if needed.
+- REST responses used by the web UI: may include source-path data only when the endpoint already requires human auth and the UI needs local reveal/open behavior.
+- Cloud LLM bridge, if built: no absolute paths in model-visible payloads.
+- Folder labels and relative paths may be exposed if they are deliberately user-facing. This is still mildly sensitive, so docs should state it clearly.
+
+For watched folders, prefer:
+
+```json
+{
+  "folder_label": "Enron-ingest",
+  "relative_path": "lay/2001/forwarded/foo.eml"
+}
+```
+
+over:
+
+```json
+{
+  "path": "/Users/alex/Documents/private-client/lay/2001/forwarded/foo.eml"
+}
+```
+
+### Fast-follow: path disclosure scope
+
+Path disclosure should become an explicit API-key/tool policy rather than a one-size-fits-all default. Some local-agent use cases may already grant an agent broad filesystem access, making absolute paths acceptable and useful. Cloud-facing keys should remain conservative.
+
+Possible enum:
+
+- `filename`: expose only source/file label.
+- `relative_path`: expose folder label plus path relative to the watched-folder root.
+- `absolute_path`: expose full local path.
+
+Default recommendation:
+
+- Cloud/MCP keys: `relative_path` at most, possibly `filename` for conservative setups.
+- CLI/local-agent keys: `relative_path` by default, `absolute_path` opt-in.
+- Human UI: can use absolute paths for local reveal/open affordances where already authenticated and expected.
+
+## Surface matrix
+
+### REST search
+
+Search hits should include:
+
+- `source`
+- top-level `citation` alias, if compatibility requires it
+- `chunk_id`
+- existing snippet/score fields
+
+The frontend should render citations from `source.citation` rather than recreating page strings ad hoc.
+
+### REST document detail
+
+Document detail can expose richer local metadata because it is a human-authenticated UI endpoint. It should still separate:
+
+- `source` fields safe for citations.
+- local file fields used for reveal/open/download affordances.
+
+### MCP
+
+Every result-bearing tool should use the same source shape where it returns passages or documents:
+
+- `kb_search`
+- `kb_batch_search`
+- `kb_find_all`
+- `kb_read_passages`
+- `kb_expand_context`
+- `kb_get_document`
+- `kb_document_outline`
+- `kb_find_related`
+- `kb_documents_by_date`
+- `kb_verify_identifier`
+
+Tools that return operational data, such as health or ingest status, do not need `SourceRef` unless they include document rows.
+
+### CLI
+
+CLI JSON output should preserve the same structure as MCP. Friendly/table output should render citation strings and keep full source objects available under `--json`.
+
+This is important for agent harnesses that shell out to CLI and parse output.
+
+### Ask and Research
+
+Local chat and research tool results should preserve `SourceRef` internally. Final answers should cite using `citation` strings and carry enough metadata for UI citation chips to open the correct document/chunk.
+
+### UI citation component
+
+`CitedMarkdown` and result components should accept normalized citation/source data instead of parsing strings wherever practical. String parsing is acceptable only as a backwards-compatibility shim.
+
+## Implementation notes
+
+- Add a central citation builder in Python.
+- Add a TypeScript type mirroring `SourceRef`.
+- Keep old fields temporarily if existing UI code depends on them.
+- Avoid a large single PR if the surface is too broad. Recommended order:
+  1. Shared backend type and builder.
+  2. REST search plus UI search result rendering.
+  3. MCP/CLI result normalization.
+  4. Ask/Research final answer citation chips.
+  5. Legacy cleanup.
+
+## Tests
+
+- Unit tests for citation string generation, including page ranges, missing pages, email, and attachments.
+- Contract tests for MCP/CLI JSON shape.
+- REST schema tests for search hits.
+- Frontend render tests for citation chips if existing test harness supports it.
+- Security regression test that MCP/CLI result payloads do not include absolute paths unless an explicitly local-only mode is introduced.
+
+## Open questions
+
+- Whether emails on disk (`.eml`) should get both a document citation and an email citation. Recommendation: the primary citation should be email-native; the source object can still include relative path and document title.
+- Whether `relative_path` should always be included in MCP payloads. Recommendation: include only when the folder label is user-facing and the path is useful for disambiguation; otherwise omit.
+- Whether `source_label` and `citation` are redundant. Decision: keep both. `source_label` is identity; `citation` is a formatted quote target. Extra source signal is worth preserving.

--- a/src/harbor_clerk/source_ref.py
+++ b/src/harbor_clerk/source_ref.py
@@ -138,20 +138,23 @@ async def load_source_ref_context(
     watched_files_by_doc: dict[uuid.UUID, WatchedFile] = {}
     watched_folders_by_id: dict[uuid.UUID, WatchedFolder] = {}
     try:
-        wf_result = await session.execute(
-            select(WatchedFile).where(
-                WatchedFile.doc_id.in_(unique_ids),
-                WatchedFile.status == WatchedFileStatus.active,
+        async with session.begin_nested():
+            wf_result = await session.execute(
+                select(WatchedFile).where(
+                    WatchedFile.doc_id.in_(unique_ids),
+                    WatchedFile.status == WatchedFileStatus.active,
+                )
             )
-        )
-        for watched_file in wf_result.scalars().all():
-            if watched_file.doc_id is not None and watched_file.doc_id not in watched_files_by_doc:
-                watched_files_by_doc[watched_file.doc_id] = watched_file
+            for watched_file in wf_result.scalars().all():
+                if watched_file.doc_id is not None and watched_file.doc_id not in watched_files_by_doc:
+                    watched_files_by_doc[watched_file.doc_id] = watched_file
 
-        folder_ids = list({wf.folder_id for wf in watched_files_by_doc.values()})
-        if folder_ids:
-            folder_result = await session.execute(select(WatchedFolder).where(WatchedFolder.folder_id.in_(folder_ids)))
-            watched_folders_by_id = {folder.folder_id: folder for folder in folder_result.scalars().all()}
+            folder_ids = list({wf.folder_id for wf in watched_files_by_doc.values()})
+            if folder_ids:
+                folder_result = await session.execute(
+                    select(WatchedFolder).where(WatchedFolder.folder_id.in_(folder_ids))
+                )
+                watched_folders_by_id = {folder.folder_id: folder for folder in folder_result.scalars().all()}
     except (sa_exc.OperationalError, sa_exc.ProgrammingError):
         logger.debug("Failed to load watched-folder context for SourceRef", exc_info=True)
 
@@ -310,7 +313,13 @@ def _safe_relative_path(relative_path: str | None) -> str | None:
     normalized = clean.replace("\\", "/")
     if posixpath.isabs(normalized):
         return posixpath.basename(normalized)
+    if _looks_windows_drive_path(normalized):
+        return posixpath.basename(normalized[2:].lstrip("/")) or None
     return normalized
+
+
+def _looks_windows_drive_path(path: str) -> bool:
+    return len(path) >= 2 and path[0].isalpha() and path[1] == ":"
 
 
 def _page_label(pages: str | None) -> str | None:

--- a/src/harbor_clerk/source_ref.py
+++ b/src/harbor_clerk/source_ref.py
@@ -1,0 +1,390 @@
+"""Structured source references and citation formatting.
+
+This module is intentionally small and mostly pure. The builder never queries
+the database; callers that need watched-folder or parent-email context should
+load it up front with ``load_source_ref_context`` and then call into the pure
+builder.
+"""
+
+from __future__ import annotations
+
+import logging
+import posixpath
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from email.utils import parsedate_to_datetime
+from typing import Any, Literal
+
+from sqlalchemy import exc as sa_exc
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+
+logger = logging.getLogger(__name__)
+
+SourceKind = Literal["document", "email", "attachment", "unknown"]
+
+
+@dataclass(frozen=True)
+class SourceRef:
+    """A stable source/citation object for API, MCP, CLI, and UI payloads."""
+
+    doc_id: str
+    doc_title: str
+    source_kind: SourceKind
+    source_label: str
+    citation: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    folder_label: str | None = None
+    relative_path: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-ready dict, omitting absent optional fields."""
+        out = {
+            "doc_id": self.doc_id,
+            "doc_title": self.doc_title,
+            "source_kind": self.source_kind,
+            "source_label": self.source_label,
+            "citation": self.citation,
+        }
+        if self.chunk_id:
+            out["chunk_id"] = self.chunk_id
+        if self.pages:
+            out["pages"] = self.pages
+        if self.section:
+            out["section"] = self.section
+        if self.folder_label:
+            out["folder_label"] = self.folder_label
+        if self.relative_path:
+            out["relative_path"] = self.relative_path
+        return out
+
+
+@dataclass
+class SourceRefContext:
+    """Bulk-loaded context for building SourceRefs without N+1 queries."""
+
+    docs_by_id: dict[uuid.UUID, Document]
+    watched_files_by_doc: dict[uuid.UUID, WatchedFile]
+    watched_folders_by_id: dict[uuid.UUID, WatchedFolder]
+    parent_email_docs_by_id: dict[uuid.UUID, Document]
+
+    def ref_for_doc(
+        self,
+        doc_or_id: Document | uuid.UUID | str,
+        *,
+        chunk_id: str | uuid.UUID | None = None,
+        pages: str | None = None,
+        section: str | None = None,
+        include_relative_path: bool = True,
+    ) -> SourceRef:
+        """Build a SourceRef for a loaded document or document id."""
+        if isinstance(doc_or_id, Document):
+            doc = doc_or_id
+            doc_id = doc.doc_id
+        else:
+            doc_id = _coerce_uuid(doc_or_id)
+            doc = self.docs_by_id.get(doc_id)
+
+        watched_file = self.watched_files_by_doc.get(doc_id)
+        watched_folder = self.watched_folders_by_id.get(watched_file.folder_id) if watched_file else None
+        parent_email_doc = None
+        if doc is not None and doc.email_parent_doc_id is not None:
+            parent_email_doc = self.parent_email_docs_by_id.get(doc.email_parent_doc_id)
+
+        return build_source_ref(
+            doc=doc,
+            chunk_id=str(chunk_id) if chunk_id else None,
+            pages=pages,
+            section=section,
+            watched_file=watched_file,
+            watched_folder=watched_folder,
+            parent_email_doc=parent_email_doc,
+            include_relative_path=include_relative_path,
+        )
+
+
+async def load_source_ref_context(
+    session: AsyncSession,
+    doc_ids: Iterable[uuid.UUID | str],
+) -> SourceRefContext:
+    """Bulk-load source context for the given document ids."""
+    normalized_ids = [_coerce_uuid(doc_id) for doc_id in doc_ids]
+    unique_ids = list(dict.fromkeys(normalized_ids))
+    if not unique_ids:
+        return SourceRefContext({}, {}, {}, {})
+
+    docs_result = await session.execute(select(Document).where(Document.doc_id.in_(unique_ids)))
+    docs_by_id = {doc.doc_id: doc for doc in docs_result.scalars().all()}
+
+    parent_ids = list(
+        {
+            doc.email_parent_doc_id
+            for doc in docs_by_id.values()
+            if doc.email_parent_doc_id is not None and doc.email_parent_doc_id not in docs_by_id
+        }
+    )
+    parent_email_docs_by_id: dict[uuid.UUID, Document] = {}
+    if parent_ids:
+        parent_result = await session.execute(select(Document).where(Document.doc_id.in_(parent_ids)))
+        parent_email_docs_by_id = {doc.doc_id: doc for doc in parent_result.scalars().all()}
+
+    watched_files_by_doc: dict[uuid.UUID, WatchedFile] = {}
+    watched_folders_by_id: dict[uuid.UUID, WatchedFolder] = {}
+    try:
+        wf_result = await session.execute(
+            select(WatchedFile).where(
+                WatchedFile.doc_id.in_(unique_ids),
+                WatchedFile.status == WatchedFileStatus.active,
+            )
+        )
+        for watched_file in wf_result.scalars().all():
+            if watched_file.doc_id is not None and watched_file.doc_id not in watched_files_by_doc:
+                watched_files_by_doc[watched_file.doc_id] = watched_file
+
+        folder_ids = list({wf.folder_id for wf in watched_files_by_doc.values()})
+        if folder_ids:
+            folder_result = await session.execute(select(WatchedFolder).where(WatchedFolder.folder_id.in_(folder_ids)))
+            watched_folders_by_id = {folder.folder_id: folder for folder in folder_result.scalars().all()}
+    except (sa_exc.OperationalError, sa_exc.ProgrammingError):
+        logger.debug("Failed to load watched-folder context for SourceRef", exc_info=True)
+
+    return SourceRefContext(
+        docs_by_id=docs_by_id,
+        watched_files_by_doc=watched_files_by_doc,
+        watched_folders_by_id=watched_folders_by_id,
+        parent_email_docs_by_id=parent_email_docs_by_id,
+    )
+
+
+def format_pages(page_start: int | None, page_end: int | None = None) -> str | None:
+    """Format a page or page range as ``"4"`` or ``"4-5"``."""
+    if page_start is None:
+        return None
+    if page_end is None or page_end == page_start:
+        return str(page_start)
+    return f"{page_start}-{page_end}"
+
+
+def format_document_citation(title: str, pages: str | None = None) -> str:
+    """Format a document citation."""
+    title = _clean(title) or "Untitled document"
+    page_label = _page_label(pages)
+    return f"{title}, {page_label}" if page_label else title
+
+
+def format_email_citation(
+    *,
+    from_name: str | None = None,
+    from_address: str | None = None,
+    subject: str | None = None,
+    date_sent: datetime | date | str | None = None,
+) -> str:
+    """Format an email-native citation from the available metadata."""
+    sender = _display_sender(from_name=from_name, from_address=from_address)
+    pieces = [f"Email from {sender}" if sender else "Email"]
+    clean_subject = _clean(subject)
+    if clean_subject:
+        pieces.append(f'"{clean_subject}"')
+    formatted_date = _format_date(date_sent)
+    if formatted_date:
+        pieces.append(formatted_date)
+    return ", ".join(pieces)
+
+
+def format_attachment_citation(
+    *,
+    attachment_label: str,
+    pages: str | None = None,
+    parent_email_doc: Document | None = None,
+) -> str:
+    """Format an attachment citation, including parent email context when available."""
+    label = _clean(attachment_label) or "attachment"
+    base = f'Attachment "{label}"'
+    page_label = _page_label(pages)
+    if page_label:
+        base = f"{base}, {page_label}"
+    if parent_email_doc is None:
+        return base
+    return f"{base}, to {_email_citation_for_doc(parent_email_doc)}"
+
+
+def build_source_ref(
+    *,
+    doc: Document | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+    watched_file: WatchedFile | None = None,
+    watched_folder: WatchedFolder | None = None,
+    parent_email_doc: Document | None = None,
+    include_relative_path: bool = True,
+) -> SourceRef:
+    """Build a SourceRef from preloaded document/source context."""
+    doc_id = str(doc.doc_id) if doc is not None and doc.doc_id is not None else ""
+    relative_path = _safe_relative_path(watched_file.relative_path if watched_file else None)
+    doc_title = _document_title(doc, relative_path)
+    folder_label = _folder_label(watched_folder)
+
+    if doc is None:
+        source_kind: SourceKind = "unknown"
+        source_label = doc_title
+        citation = format_document_citation(doc_title, pages)
+    elif _is_attachment_doc(doc):
+        source_kind = "attachment"
+        source_label = _clean(doc.title) or _clean(doc.canonical_filename) or _leaf(relative_path) or "attachment"
+        citation = format_attachment_citation(
+            attachment_label=source_label,
+            pages=pages,
+            parent_email_doc=parent_email_doc,
+        )
+    elif _is_email_doc(doc, relative_path):
+        source_kind = "email"
+        email_fields = _email_fields_for_doc(doc)
+        citation = format_email_citation(**email_fields)
+        source_label = citation
+        if citation == "Email":
+            source_label = doc_title
+            citation = format_document_citation(doc_title, pages)
+    else:
+        source_kind = "document"
+        source_label = doc_title
+        citation = format_document_citation(doc_title, pages)
+
+    return SourceRef(
+        doc_id=doc_id,
+        doc_title=doc_title,
+        chunk_id=chunk_id,
+        pages=_clean(pages),
+        section=_clean(section),
+        source_kind=source_kind,
+        source_label=source_label,
+        folder_label=folder_label,
+        relative_path=relative_path if include_relative_path else None,
+        citation=citation,
+    )
+
+
+def _coerce_uuid(value: uuid.UUID | str) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
+
+
+def _clean(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _leaf(path: str | None) -> str | None:
+    clean = _clean(path)
+    if not clean:
+        return None
+    return posixpath.basename(clean)
+
+
+def _document_title(doc: Document | None, relative_path: str | None) -> str:
+    if doc is None:
+        return _leaf(relative_path) or "Untitled document"
+    return _clean(doc.title) or _clean(doc.canonical_filename) or _leaf(relative_path) or "Untitled document"
+
+
+def _folder_label(folder: WatchedFolder | None) -> str | None:
+    if folder is None:
+        return None
+    return _clean(folder.display_name) or _leaf(folder.path)
+
+
+def _safe_relative_path(relative_path: str | None) -> str | None:
+    clean = _clean(relative_path)
+    if not clean:
+        return None
+    normalized = clean.replace("\\", "/")
+    if posixpath.isabs(normalized):
+        return posixpath.basename(normalized)
+    return normalized
+
+
+def _page_label(pages: str | None) -> str | None:
+    clean = _clean(pages)
+    if not clean:
+        return None
+    return f"pp. {clean}" if "-" in clean else f"p. {clean}"
+
+
+def _display_sender(*, from_name: str | None, from_address: str | None) -> str | None:
+    return _clean(from_name) or _clean(from_address)
+
+
+def _format_date(value: datetime | date | str | None) -> str | None:
+    parsed = _parse_date(value)
+    if parsed is None:
+        return None
+    return f"{parsed.strftime('%b')} {parsed.day}, {parsed.year}"
+
+
+def _parse_date(value: datetime | date | str | None) -> datetime | date | None:
+    if isinstance(value, datetime | date):
+        return value
+    text = _clean(value)
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+    try:
+        return parsedate_to_datetime(text)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+
+
+def _is_attachment_doc(doc: Document) -> bool:
+    return doc.email_parent_doc_id is not None
+
+
+def _is_email_doc(doc: Document, relative_path: str | None) -> bool:
+    if any(
+        _clean(v)
+        for v in (
+            doc.email_message_id,
+            doc.email_from_address,
+            doc.email_from_name,
+            doc.email_subject,
+        )
+    ):
+        return True
+    if doc.email_date_sent is not None:
+        return True
+    if _clean(doc.mime_type) == "message/rfc822":
+        return True
+    filename = (_clean(doc.canonical_filename) or _leaf(relative_path) or "").lower()
+    return filename.endswith(".eml")
+
+
+def _email_fields_for_doc(doc: Document) -> dict[str, str | datetime | date | None]:
+    tika = doc.doc_metadata.get("tika") if isinstance(doc.doc_metadata, dict) else None
+    if not isinstance(tika, dict):
+        tika = {}
+    return {
+        "from_name": doc.email_from_name,
+        "from_address": doc.email_from_address or _clean(tika.get("email_from")),
+        "subject": doc.email_subject or _clean(tika.get("email_subject")),
+        "date_sent": doc.email_date_sent or _clean(tika.get("email_date")),
+    }
+
+
+def _email_citation_for_doc(doc: Document) -> str:
+    fields = _email_fields_for_doc(doc)
+    citation = format_email_citation(**fields)
+    if citation != "Email":
+        return citation
+    return format_document_citation(_document_title(doc, None))

--- a/tests/test_source_ref.py
+++ b/tests/test_source_ref.py
@@ -1,0 +1,189 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFolder
+from harbor_clerk.source_ref import (
+    build_source_ref,
+    format_document_citation,
+    format_email_citation,
+    format_pages,
+)
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "doc_id": uuid4(),
+        "title": "Contract A",
+        "canonical_filename": "contract-a.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+def test_format_pages() -> None:
+    assert format_pages(None) is None
+    assert format_pages(4) == "4"
+    assert format_pages(4, 4) == "4"
+    assert format_pages(4, 5) == "4-5"
+
+
+def test_format_document_citation_single_page_and_range() -> None:
+    assert format_document_citation("Contract A", "4") == "Contract A, p. 4"
+    assert format_document_citation("Contract A", "4-5") == "Contract A, pp. 4-5"
+    assert format_document_citation("Contract A") == "Contract A"
+
+
+def test_document_source_ref() -> None:
+    doc = _doc(title="Contract A")
+    ref = build_source_ref(doc=doc, chunk_id=str(uuid4()), pages="4-5", section="Termination")
+
+    payload = ref.to_dict()
+    assert payload["doc_id"] == str(doc.doc_id)
+    assert payload["doc_title"] == "Contract A"
+    assert payload["source_kind"] == "document"
+    assert payload["source_label"] == "Contract A"
+    assert payload["citation"] == "Contract A, pp. 4-5"
+    assert payload["pages"] == "4-5"
+    assert payload["section"] == "Termination"
+
+
+def test_document_title_falls_back_to_filename_then_untitled() -> None:
+    with_filename = _doc(title="", canonical_filename="fallback.pdf")
+    assert build_source_ref(doc=with_filename).citation == "fallback.pdf"
+
+    untitled = _doc(title="", canonical_filename=None)
+    assert build_source_ref(doc=untitled).citation == "Untitled document"
+
+
+def test_email_citation_uses_native_metadata() -> None:
+    sent = datetime(2025, 3, 7, 14, 30, tzinfo=UTC)
+    doc = _doc(
+        title="Budget follow-up",
+        canonical_filename="budget-follow-up.eml",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_from_address="jane@example.com",
+        email_subject="Budget follow-up",
+        email_date_sent=sent,
+    )
+
+    ref = build_source_ref(doc=doc)
+
+    assert ref.source_kind == "email"
+    assert ref.citation == 'Email from Jane Doe, "Budget follow-up", Mar 7, 2025'
+    assert ref.source_label == ref.citation
+
+
+def test_email_citation_handles_missing_sender() -> None:
+    assert (
+        format_email_citation(subject="Budget follow-up", date_sent="2025-03-07T00:00:00+00:00")
+        == 'Email, "Budget follow-up", Mar 7, 2025'
+    )
+
+
+def test_email_source_ref_falls_back_to_tika_metadata() -> None:
+    doc = _doc(
+        title="legacy",
+        canonical_filename="legacy.eml",
+        mime_type="message/rfc822",
+        email_subject=None,
+        doc_metadata={
+            "tika": {
+                "email_from": "alice@example.com",
+                "email_subject": "Legacy email",
+                "email_date": "Wed, 28 May 2026 12:00:00 +0000",
+            }
+        },
+    )
+
+    ref = build_source_ref(doc=doc)
+
+    assert ref.source_kind == "email"
+    assert ref.citation == 'Email from alice@example.com, "Legacy email", May 28, 2026'
+
+
+def test_eml_with_unparsed_metadata_falls_back_to_file_metadata() -> None:
+    doc = _doc(
+        title="legacy",
+        canonical_filename="legacy.eml",
+        mime_type="message/rfc822",
+        email_subject=None,
+        doc_metadata={},
+    )
+
+    ref = build_source_ref(doc=doc)
+
+    assert ref.source_kind == "email"
+    assert ref.citation == "legacy"
+
+
+def test_attachment_citation_includes_parent_email() -> None:
+    parent = _doc(
+        title="Budget follow-up",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_subject="Budget follow-up",
+        email_date_sent=datetime(2025, 3, 7, tzinfo=UTC),
+    )
+    child = _doc(
+        title="invoice.pdf",
+        canonical_filename="invoice.pdf",
+        mime_type="application/pdf",
+        email_parent_doc_id=parent.doc_id,
+    )
+
+    ref = build_source_ref(doc=child, pages="2", parent_email_doc=parent)
+
+    assert ref.source_kind == "attachment"
+    assert ref.source_label == "invoice.pdf"
+    assert ref.citation == 'Attachment "invoice.pdf", p. 2, to Email from Jane Doe, "Budget follow-up", Mar 7, 2025'
+
+
+def test_folder_label_and_relative_path_are_included_without_absolute_path() -> None:
+    doc = _doc(title="NDA")
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    watched_file = WatchedFile(
+        folder_id=uuid4(),
+        relative_path="client-a/nda.pdf",
+        bookmark_data=b"",
+        sha256=b"x" * 32,
+        doc_id=doc.doc_id,
+    )
+
+    payload = build_source_ref(doc=doc, watched_file=watched_file, watched_folder=folder).to_dict()
+
+    assert payload["folder_label"] == "Contracts"
+    assert payload["relative_path"] == "client-a/nda.pdf"
+    assert "/Users/alex" not in str(payload)
+
+
+def test_absolute_relative_path_degrades_to_filename() -> None:
+    doc = _doc(title="")
+    watched_file = WatchedFile(
+        folder_id=uuid4(),
+        relative_path="/Users/alex/private/secret.pdf",
+        bookmark_data=b"",
+        sha256=b"x" * 32,
+        doc_id=doc.doc_id,
+    )
+
+    payload = build_source_ref(doc=doc, watched_file=watched_file).to_dict()
+
+    assert payload["relative_path"] == "secret.pdf"
+    assert "/Users/alex" not in str(payload)
+
+
+def test_to_dict_omits_empty_optional_fields() -> None:
+    payload = build_source_ref(doc=_doc()).to_dict()
+
+    assert "chunk_id" not in payload
+    assert "pages" not in payload
+    assert "section" not in payload
+    assert "None" not in str(payload)
+    assert "null" not in str(payload)

--- a/tests/test_source_ref.py
+++ b/tests/test_source_ref.py
@@ -179,6 +179,23 @@ def test_absolute_relative_path_degrades_to_filename() -> None:
     assert "/Users/alex" not in str(payload)
 
 
+def test_windows_absolute_relative_path_degrades_to_filename() -> None:
+    doc = _doc(title="")
+    watched_file = WatchedFile(
+        folder_id=uuid4(),
+        relative_path=r"C:\Users\alex\private\secret.pdf",
+        bookmark_data=b"",
+        sha256=b"x" * 32,
+        doc_id=doc.doc_id,
+    )
+
+    payload = build_source_ref(doc=doc, watched_file=watched_file).to_dict()
+
+    assert payload["relative_path"] == "secret.pdf"
+    assert "C:" not in str(payload)
+    assert "Users" not in str(payload)
+
+
 def test_to_dict_omits_empty_optional_fields() -> None:
     payload = build_source_ref(doc=_doc()).to_dict()
 

--- a/tests/test_source_ref_context.py
+++ b/tests/test_source_ref_context.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from harbor_clerk.models.document import Document
 from harbor_clerk.models.enums import PipelineStatus
@@ -96,6 +97,27 @@ async def test_context_handles_missing_watched_rows(db_session) -> None:
     assert payload["citation"] == "Loose Document"
     assert "folder_label" not in payload
     assert "relative_path" not in payload
+
+
+@pytest.mark.asyncio
+async def test_context_soft_fails_watched_lookup_without_poisoning_session(db_session) -> None:
+    doc = _doc(title="Loose Document")
+    db_session.add(doc)
+    await db_session.flush()
+
+    original_name = WatchedFile.__table__.name
+    WatchedFile.__table__.name = "watched_files_missing_for_source_ref_test"
+    try:
+        ctx = await load_source_ref_context(db_session, [doc.doc_id])
+        ref = ctx.ref_for_doc(doc.doc_id)
+
+        assert ref.citation == "Loose Document"
+        # The optional watched-folder lookup failed, but the caller's session
+        # must remain usable for later route/tool queries.
+        loaded_doc_id = await db_session.scalar(select(Document.doc_id).where(Document.doc_id == doc.doc_id))
+        assert loaded_doc_id == doc.doc_id
+    finally:
+        WatchedFile.__table__.name = original_name
 
 
 @pytest.mark.asyncio

--- a/tests/test_source_ref_context.py
+++ b/tests/test_source_ref_context.py
@@ -1,0 +1,111 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+from harbor_clerk.source_ref import load_source_ref_context
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "title": "Contract A",
+        "canonical_filename": "contract-a.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_context_loads_folder_label_and_relative_path(db_session) -> None:
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    db_session.add(folder)
+    await db_session.flush()
+
+    doc = _doc(title="NDA", source_path="/Users/alex/private/contracts/client-a/nda.pdf")
+    db_session.add(doc)
+    await db_session.flush()
+
+    db_session.add(
+        WatchedFile(
+            folder_id=folder.folder_id,
+            relative_path="client-a/nda.pdf",
+            bookmark_data=b"",
+            sha256=doc.sha256,
+            doc_id=doc.doc_id,
+            status=WatchedFileStatus.active,
+        )
+    )
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [doc.doc_id])
+    ref = ctx.ref_for_doc(doc.doc_id)
+    payload = ref.to_dict()
+
+    assert payload["folder_label"] == "Contracts"
+    assert payload["relative_path"] == "client-a/nda.pdf"
+    assert payload["citation"] == "NDA"
+    assert "/Users/alex" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_context_loads_parent_email_for_attachment(db_session) -> None:
+    parent = _doc(
+        title="Budget follow-up",
+        canonical_filename="budget-follow-up.eml",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_subject="Budget follow-up",
+        email_date_sent=datetime(2025, 3, 7, tzinfo=UTC),
+    )
+    db_session.add(parent)
+    await db_session.flush()
+
+    attachment = _doc(
+        title="invoice.pdf",
+        canonical_filename="invoice.pdf",
+        mime_type="application/pdf",
+        email_parent_doc_id=parent.doc_id,
+    )
+    db_session.add(attachment)
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [attachment.doc_id])
+    ref = ctx.ref_for_doc(attachment.doc_id, pages="2")
+
+    assert ref.source_kind == "attachment"
+    assert ref.citation == 'Attachment "invoice.pdf", p. 2, to Email from Jane Doe, "Budget follow-up", Mar 7, 2025'
+
+
+@pytest.mark.asyncio
+async def test_context_handles_missing_watched_rows(db_session) -> None:
+    doc = _doc(title="Loose Document")
+    db_session.add(doc)
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [doc.doc_id])
+    ref = ctx.ref_for_doc(doc.doc_id)
+    payload = ref.to_dict()
+
+    assert payload["citation"] == "Loose Document"
+    assert "folder_label" not in payload
+    assert "relative_path" not in payload
+
+
+@pytest.mark.asyncio
+async def test_context_accepts_string_doc_ids(db_session) -> None:
+    doc = _doc(title="String id")
+    db_session.add(doc)
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [str(doc.doc_id)])
+    ref = ctx.ref_for_doc(str(doc.doc_id), chunk_id=uuid4(), pages="1")
+
+    assert ref.doc_id == str(doc.doc_id)
+    assert ref.citation == "String id, p. 1"


### PR DESCRIPTION
## Summary
- add the SourceRef citation/source contract spec and implementation plan
- add a pure SourceRef builder for document, email, attachment, and unknown sources
- add a bulk async SourceRef context loader for watched-folder and parent-email context
- memorialize that research citations normalize later while preserving verifier compatibility

## Tests
- uv run pytest tests/test_source_ref.py tests/test_source_ref_context.py -v
- uv run ruff check src/harbor_clerk/source_ref.py tests/test_source_ref.py tests/test_source_ref_context.py
- uv run ruff format --check src/harbor_clerk/source_ref.py tests/test_source_ref.py tests/test_source_ref_context.py

## Review
Fresh-eyes review requested per project policy; this touches citation behavior and future public response contracts.