### PR TITLE
feat(api): add SourceRef to search responses

### DIFF
--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -24,12 +24,13 @@ from harbor_clerk.api.scope_validation import validate_scope_folders
 from harbor_clerk.db import get_session
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.search import hybrid_search
+from harbor_clerk.source_ref import SourceRef, format_pages, load_source_ref_context
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["search"])
 
 
-def _hit_to_out(h) -> SearchHitOut:
+def _hit_to_out(h, source_ref: SourceRef | None = None) -> SearchHitOut:
     return SearchHitOut(
         chunk_id=h.chunk_id,
         doc_id=h.doc_id,
@@ -42,6 +43,8 @@ def _hit_to_out(h) -> SearchHitOut:
         ocr_confidence=h.ocr_confidence,
         score=h.score,
         doc_title=h.doc_title,
+        source=source_ref.to_dict() if source_ref else None,
+        citation=source_ref.citation if source_ref else None,
     )
 
 
@@ -141,7 +144,18 @@ async def search(
     )
 
     has_more = body.offset + body.k < result.total_candidates
-    hits_out = [_hit_to_out(h) for h in result.hits]
+    source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])
+    hits_out = [
+        _hit_to_out(
+            h,
+            source_context.ref_for_doc(
+                h.doc_id,
+                chunk_id=h.chunk_id,
+                pages=format_pages(h.page_start, h.page_end),
+            ),
+        )
+        for h in result.hits
+    ]
 
     if body.faceted:
         groups: dict[str, list[SearchHitOut]] = {}
@@ -221,6 +235,7 @@ async def read_passages(
     doc_ids = {c.doc_id for c in chunks.values()}
     docs_result = await session.execute(select(Document).where(Document.doc_id.in_(list(doc_ids))))
     docs_by_id = {d.doc_id: d for d in docs_result.scalars().all()}
+    source_context = await load_source_ref_context(session, doc_ids)
 
     # Optionally load surrounding chunks for context
     context_before: dict[uuid.UUID, str] = {}
@@ -256,6 +271,11 @@ async def read_passages(
         if chunk is None:
             continue
         doc = docs_by_id.get(chunk.doc_id)
+        source_ref = source_context.ref_for_doc(
+            chunk.doc_id,
+            chunk_id=cid,
+            pages=format_pages(chunk.page_start, chunk.page_end),
+        )
         passages.append(
             PassageDetail(
                 chunk_id=str(cid),
@@ -270,6 +290,8 @@ async def read_passages(
                 doc_title=doc.title if doc else None,
                 context_before=context_before.get(cid),
                 context_after=context_after.get(cid),
+                source=source_ref.to_dict(),
+                citation=source_ref.citation,
             )
         )
 

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -6,6 +6,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, model_validator
 
 from harbor_clerk.api.schemas.scope import ScopeSpec
+from harbor_clerk.api.schemas.source_ref import SourceRefOut
 
 
 class SearchRequest(BaseModel):
@@ -53,6 +54,8 @@ class SearchHitOut(BaseModel):
     score: float
     doc_title: str | None = None
     score_breakdown: ScoreBreakdown | None = None
+    source: SourceRefOut | None = None
+    citation: str | None = None
 
 
 class SearchResponse(BaseModel):
@@ -96,6 +99,8 @@ class PassageDetail(BaseModel):
     doc_title: str | None = None
     context_before: str | None = None
     context_after: str | None = None
+    source: SourceRefOut | None = None
+    citation: str | None = None
 
 
 class ReadPassagesResponse(BaseModel):

--- a/src/harbor_clerk/api/schemas/source_ref.py
+++ b/src/harbor_clerk/api/schemas/source_ref.py
@@ -1,0 +1,18 @@
+"""Shared source/citation response schemas."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class SourceRefOut(BaseModel):
+    doc_id: str
+    doc_title: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    source_kind: Literal["document", "email", "attachment", "unknown"]
+    source_label: str
+    folder_label: str | None = None
+    relative_path: str | None = None
+    citation: str

--- a/tests/api/test_search_source_ref.py
+++ b/tests/api/test_search_source_ref.py
@@ -1,0 +1,208 @@
+"""REST search and passage SourceRef contract tests."""
+
+from uuid import uuid4
+
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+from harbor_clerk.search_types import SearchHit, SearchResult
+from tests.conftest import auth_header
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "title": "NDA",
+        "canonical_filename": "nda.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "source_path": "/Users/alex/private/contracts/client-a/nda.pdf",
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+async def _add_watched_doc(db_session, *, doc: Document, relative_path: str = "client-a/nda.pdf") -> WatchedFolder:
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    db_session.add(folder)
+    await db_session.flush()
+
+    db_session.add(doc)
+    await db_session.flush()
+
+    db_session.add(
+        WatchedFile(
+            folder_id=folder.folder_id,
+            relative_path=relative_path,
+            bookmark_data=b"",
+            sha256=doc.sha256,
+            doc_id=doc.doc_id,
+            status=WatchedFileStatus.active,
+        )
+    )
+    await db_session.commit()
+    return folder
+
+
+async def test_search_hit_includes_source_and_citation(client, admin_token, db_session, monkeypatch) -> None:
+    doc = _doc()
+    await _add_watched_doc(db_session, doc=doc)
+    chunk_id = uuid4()
+
+    async def fake_hybrid_search(*args, **kwargs):
+        return SearchResult(
+            hits=[
+                SearchHit(
+                    chunk_id=str(chunk_id),
+                    doc_id=str(doc.doc_id),
+                    chunk_num=0,
+                    chunk_text="The NDA terminates on written notice.",
+                    page_start=4,
+                    page_end=5,
+                    language="en",
+                    ocr_used=False,
+                    ocr_confidence=None,
+                    score=0.91,
+                    doc_title="NDA",
+                )
+            ],
+            total_candidates=1,
+            reranker_status="disabled",
+        )
+
+    monkeypatch.setattr("harbor_clerk.api.routes.search.hybrid_search", fake_hybrid_search)
+
+    resp = await client.post(
+        "/api/search",
+        json={"query": "termination"},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    hit = resp.json()["hits"][0]
+    assert hit["doc_id"] == str(doc.doc_id)
+    assert hit["doc_title"] == "NDA"
+    assert hit["page_start"] == 4
+    assert hit["page_end"] == 5
+    assert hit["citation"] == "NDA, pp. 4-5"
+    assert hit["source"]["doc_id"] == str(doc.doc_id)
+    assert hit["source"]["chunk_id"] == str(chunk_id)
+    assert hit["source"]["source_kind"] == "document"
+    assert hit["source"]["folder_label"] == "Contracts"
+    assert hit["source"]["relative_path"] == "client-a/nda.pdf"
+    assert hit["source"]["citation"] == "NDA, pp. 4-5"
+    assert "/Users/alex" not in str(hit["source"])
+
+
+async def test_faceted_search_hit_includes_source(client, admin_token, db_session, monkeypatch) -> None:
+    doc = _doc(title="Policy")
+    await _add_watched_doc(db_session, doc=doc, relative_path="policy.pdf")
+    chunk_id = uuid4()
+
+    async def fake_hybrid_search(*args, **kwargs):
+        return SearchResult(
+            hits=[
+                SearchHit(
+                    chunk_id=str(chunk_id),
+                    doc_id=str(doc.doc_id),
+                    chunk_num=0,
+                    chunk_text="Policy excerpt",
+                    page_start=1,
+                    page_end=1,
+                    language="en",
+                    ocr_used=False,
+                    ocr_confidence=None,
+                    score=0.72,
+                    doc_title="Policy",
+                )
+            ],
+            total_candidates=1,
+            reranker_status="disabled",
+        )
+
+    monkeypatch.setattr("harbor_clerk.api.routes.search.hybrid_search", fake_hybrid_search)
+
+    resp = await client.post(
+        "/api/search",
+        json={"query": "policy", "faceted": True},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    hit = resp.json()["documents"][0]["hits"][0]
+    assert hit["citation"] == "Policy, p. 1"
+    assert hit["source"]["citation"] == "Policy, p. 1"
+
+
+async def test_read_passages_includes_source_and_citation(client, admin_token, db_session) -> None:
+    doc = _doc(title="Operations Manual", canonical_filename="ops.pdf")
+    await _add_watched_doc(db_session, doc=doc, relative_path="manuals/ops.pdf")
+    chunk = Chunk(
+        doc_id=doc.doc_id,
+        chunk_num=0,
+        chunk_text="Use the lockout checklist before maintenance.",
+        page_start=2,
+        page_end=2,
+        language="en",
+        ocr_used=False,
+    )
+    db_session.add(chunk)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/passages/read",
+        json={"chunk_ids": [str(chunk.chunk_id)]},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    passage = resp.json()["passages"][0]
+    assert passage["doc_id"] == str(doc.doc_id)
+    assert passage["citation"] == "Operations Manual, p. 2"
+    assert passage["source"]["chunk_id"] == str(chunk.chunk_id)
+    assert passage["source"]["relative_path"] == "manuals/ops.pdf"
+    assert passage["source"]["citation"] == "Operations Manual, p. 2"
+    assert "/Users/alex" not in str(passage["source"])
+
+
+async def test_read_passages_attachment_source_uses_parent_email(client, admin_token, db_session) -> None:
+    parent = _doc(
+        title="Budget follow-up",
+        canonical_filename="budget-follow-up.eml",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_subject="Budget follow-up",
+    )
+    db_session.add(parent)
+    await db_session.flush()
+
+    attachment = _doc(
+        title="invoice.pdf",
+        canonical_filename="invoice.pdf",
+        mime_type="application/pdf",
+        email_parent_doc_id=parent.doc_id,
+    )
+    await _add_watched_doc(db_session, doc=attachment, relative_path="mail/attachments/invoice.pdf")
+    chunk = Chunk(
+        doc_id=attachment.doc_id,
+        chunk_num=0,
+        chunk_text="Invoice total is due on receipt.",
+        page_start=2,
+        page_end=2,
+        language="en",
+        ocr_used=False,
+    )
+    db_session.add(chunk)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/passages/read",
+        json={"chunk_ids": [str(chunk.chunk_id)]},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    passage = resp.json()["passages"][0]
+    assert passage["source"]["source_kind"] == "attachment"
+    assert passage["citation"] == 'Attachment "invoice.pdf", p. 2, to Email from Jane Doe, "Budget follow-up"'


### PR DESCRIPTION
## Summary
- add a typed REST SourceRef schema
- add source/citation fields to /api/search hits, including faceted hits
- add source/citation fields to /api/passages/read results
- preserve legacy top-level search and passage fields

## Tests
- uv run pytest tests/api/test_search_source_ref.py tests/test_search_schemas.py tests/test_source_ref.py tests/test_source_ref_context.py -v
- uv run ruff check src/harbor_clerk/api/schemas/source_ref.py src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/api/test_search_source_ref.py
- uv run ruff format --check src/harbor_clerk/api/schemas/source_ref.py src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/api/test_search_source_ref.py

## Review
Fresh-eyes review requested per project policy; this changes REST response contracts, albeit additively.