### PR TITLE
feat(cli): render SourceRef citations

### DIFF
--- a/src/harbor_clerk/cli/help/batch-search.txt
+++ b/src/harbor_clerk/cli/help/batch-search.txt
@@ -3,6 +3,8 @@ harbor-clerk batch-search — run multiple searches in one call
 DESCRIPTION
   Runs up to 5 hybrid searches in a single round-trip. Each query gets its
   own result set with the same hybrid FTS + pgvector scoring as `search`.
+  Hits include the same `citation` and structured `source` object returned
+  by `search`.
   All filter flags are shared across every query in the batch.
 
   Use this for comparative analysis — "do any of these contract files mention
@@ -48,6 +50,8 @@ RETURNS (JSON)
             "doc_id":     "uuid",      // document identifier
             "doc_title":  "string",    // document title
             "pages":      "42",        // page or page range (omitted when unavailable)
+            "citation":   "Contract A, p. 42",
+            "source":     { "...": "same SourceRef object as search" },
             "text":       "string",    // matched chunk text; omitted with --detail=compact
             "score":      0.87,        // hybrid score, higher = better
             "language":   "english"    // "english" or "french"
@@ -93,8 +97,8 @@ COMMON MISTAKES
     offsets. Use individual `search` calls with --offset when you need page 2.
   - Using --detail=full on large -k across 5 queries: full detail can return
     several KB per hit, 5 × 10 = 50 chunks of text. default `brief` is safer.
-  - Expecting a standalone `citation` field; cite with doc_title + pages +
-    chunk_id, or call `read-passages` to verify exact context.
+  - Treating `citation` as proof without reading the passage: use
+    `read-passages` to verify exact context before making a specific claim.
 
 SEE ALSO
   search, read-passages, expand-context

--- a/src/harbor_clerk/cli/help/read-passages.txt
+++ b/src/harbor_clerk/cli/help/read-passages.txt
@@ -11,8 +11,9 @@ DESCRIPTION
   Returns passages in the same order as the input chunk_ids, skipping any
   that are not found or are outside the API key's document scope.
 
-  Each passage includes the document title and language. Page numbers are
-  included when available (PDFs and other paginated formats); plain-text
+  Each passage includes the document id, document title, language, a
+  human-readable `citation`, and a structured `source` object. Page numbers
+  are included when available (PDFs and other paginated formats); plain-text
   documents may omit the `pages` field.
 
   Pass --include-context to also receive the immediately preceding and following
@@ -33,7 +34,10 @@ RETURNS (JSON)
     "passages": [
       {
         "chunk_id":  "uuid",       // same UUID you passed in
+        "doc_id":    "uuid",       // containing document
         "doc_title": "string",     // title of the containing document
+        "citation":  "Contract A, pp. 12-13",
+        "source":    { "...": "SourceRef object with doc/chunk/page identity" },
         "text":      "string",     // full chunk text (≈1000 chars)
         "language":  "en" | "fr",
         "pages":     "12-13"       // page range (omitted for non-paginated docs)

--- a/src/harbor_clerk/cli/help/search.txt
+++ b/src/harbor_clerk/cli/help/search.txt
@@ -4,8 +4,9 @@ DESCRIPTION
   Runs a hybrid retrieval combining PostgreSQL full-text search (bilingual,
   English + French) and pgvector cosine similarity over the corpus. Scores
   are normalized and merged per-chunk with a small OCR-confidence boost.
-  Results include citation-ready fields (doc_id, doc_title, pages,
-  chunk_id) usable with `read-passages` and `expand-context`.
+  Results include `citation` and `source` fields alongside the legacy
+  doc_id, doc_title, pages, and chunk_id fields. Use `source` for structured
+  agent workflows and `citation` for human-readable output.
 
   If top hits have similar scores across multiple documents, the response
   includes `possible_conflict: true` and a `conflict_sources` array. Treat
@@ -42,6 +43,16 @@ RETURNS (JSON)
         "doc_title":  "string",      // document title
         "pages":      "42",          // page or page range (omitted when unavailable)
         "section":    "string",      // nearest heading, when available
+        "citation":   "Contract A, p. 42",
+        "source": {
+          "doc_id": "uuid",
+          "doc_title": "string",
+          "chunk_id": "uuid",
+          "pages": "42",
+          "source_kind": "document",
+          "source_label": "string",
+          "citation": "Contract A, p. 42"
+        },
         "text":       "string",      // matched chunk text; omitted with --detail=compact
         "score":      0.87,          // hybrid score, higher = better
         "language":   "english" | "french"
@@ -73,8 +84,8 @@ COMMON MISTAKES
   - Passing a chunk_id as --doc-id (chunk_id and doc_id are distinct UUIDs).
   - Forgetting --detail=brief on large k — default `full` returns the entire
     matching chunk text, which can be 1–2KB per result.
-  - Expecting a standalone `citation` field; cite with doc_title + pages +
-    chunk_id, or call `read-passages` to verify exact context.
+  - Treating `citation` as proof without reading the passage: use
+    `read-passages` to verify exact context before making a specific claim.
   - Using --after/--before with timestamps; only dates (YYYY-MM-DD) are accepted.
 
 SEE ALSO

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -52,6 +52,41 @@ def render(payload: Any, *, mode: OutputMode, command: str, stream: TextIO | Non
 # --- Search results pretty-printer ---
 
 
+def _source_obj(record: dict) -> dict:
+    source = record.get("source")
+    if not isinstance(source, dict):
+        source = record.get("source_ref")
+    return source if isinstance(source, dict) else {}
+
+
+def _citation(record: dict) -> str:
+    source = _source_obj(record)
+    citation = record.get("citation") or source.get("citation")
+    if citation:
+        return str(citation)
+    title = record.get("doc_title") or record.get("title") or source.get("doc_title") or ""
+    pages = record.get("pages") or record.get("page") or source.get("pages")
+    if title and pages:
+        prefix = "pp." if "-" in str(pages) else "p."
+        return f"{title}, {prefix} {pages}"
+    return str(title)
+
+
+def _render_hit_line(index: int, record: dict, stream: TextIO) -> None:
+    label = _citation(record)
+    score = record.get("score")
+    text = (record.get("text") or record.get("snippet") or "").strip().replace("\n", " ")
+    if len(text) > 200:
+        text = text[:200] + "..."
+    score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "?"
+    chunk_id = record.get("chunk_id") or _source_obj(record).get("chunk_id")
+    chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
+    stream.write(f"{index}. {label}  [{score_str}]{chunk_suffix}\n")
+    if text:
+        stream.write(f"   {text}\n")
+    stream.write("\n")
+
+
 @register_text_renderer("search")
 def _render_search(payload: Any, stream: TextIO) -> None:
     if not isinstance(payload, dict):
@@ -67,22 +102,57 @@ def _render_search(payload: Any, stream: TextIO) -> None:
     if not hits:
         stream.write("0 results\n")
     for i, r in enumerate(hits, 1):
-        title = r.get("doc_title") or r.get("title") or ""
-        score = r.get("score")
-        text = (r.get("text") or r.get("snippet") or "").strip().replace("\n", " ")
-        if len(text) > 200:
-            text = text[:200] + "..."
-        score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "?"
-        pages = r.get("pages") or r.get("page")
-        location = f" p. {pages}" if pages else ""
-        chunk_id = r.get("chunk_id")
-        chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
-        stream.write(f"{i}. {title}{location}  [{score_str}]{chunk_suffix}\n")
-        if text:
-            stream.write(f"   {text}\n")
-        stream.write("\n")
+        _render_hit_line(i, r, stream)
     if payload.get("possible_conflict"):
         stream.write("possible_conflict=true - top hits span multiple similarly scored documents\n")
+
+
+# --- Batch search pretty-printer ---
+
+
+@register_text_renderer("batch-search")
+def _render_batch_search(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+    for result in payload.get("results", []):
+        query = result.get("query") or ""
+        stream.write(f"query: {query}\n")
+        hits = result.get("hits") or []
+        if not hits:
+            stream.write("  0 results\n\n")
+            continue
+        for i, hit in enumerate(hits, 1):
+            stream.write("  ")
+            _render_hit_line(i, hit, stream)
+
+
+# --- Read passages pretty-printer ---
+
+
+@register_text_renderer("read-passages")
+def _render_read_passages(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+    passages = payload.get("passages") or []
+    if not passages:
+        stream.write("0 passages\n")
+        return
+    for i, passage in enumerate(passages, 1):
+        chunk_id = passage.get("chunk_id") or _source_obj(passage).get("chunk_id")
+        chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
+        stream.write(f"{i}. {_citation(passage)}{chunk_suffix}\n")
+        text = (passage.get("text") or "").strip()
+        if text:
+            stream.write(f"{text}\n")
+        stream.write("\n")
 
 
 # --- Verify identifier pretty-printer ---
@@ -106,7 +176,7 @@ def _render_verify_identifier(payload: Any, stream: TextIO) -> None:
 
     if status == "unique":
         m = payload.get("match", {})
-        stream.write(f"unique: {m.get('title', '')}  [{m.get('doc_id', '')}]\n")
+        stream.write(f"unique: {_citation(m)}  [{m.get('doc_id', '')}]\n")
         if m.get("canonical_filename"):
             stream.write(f"  filename: {m['canonical_filename']}\n")
         return
@@ -116,7 +186,7 @@ def _render_verify_identifier(payload: Any, stream: TextIO) -> None:
         overflow = " (overflow)" if payload.get("overflow") else ""
         stream.write(f"ambiguous: {count} candidates{overflow}\n")
         for c in payload.get("candidates", []):
-            stream.write(f"  - {c.get('title', '')}  [{c.get('doc_id', '')}]\n")
+            stream.write(f"  - {_citation(c)}  [{c.get('doc_id', '')}]\n")
             for path, value in (c.get("discriminating_fields") or {}).items():
                 stream.write(f"      {path}={value!r}\n")
         suggestion = payload.get("suggestion")
@@ -150,6 +220,5 @@ def _render_documents_by_date(payload: Any, stream: TextIO) -> None:
         date = r.get("date") or ""
         date_short = date[:10] if isinstance(date, str) and len(date) >= 10 else date
         src = r.get("date_source") or ""
-        title = r.get("title") or ""
         doc_id = r.get("doc_id") or ""
-        stream.write(f"  {date_short} [{src}]  {title}  ({doc_id})\n")
+        stream.write(f"  {date_short} [{src}]  {_citation(r)}  ({doc_id})\n")

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -53,6 +53,109 @@ def test_render_text_search_results_uses_pretty_printer():
     assert "0.9" in out or "0.90" in out
 
 
+def test_render_text_search_prefers_citation():
+    buf = io.StringIO()
+    payload = {
+        "hits": [
+            {
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "doc_title": "Doc A",
+                "pages": "1",
+                "citation": "Doc A, p. 1",
+                "text": "hello world",
+                "score": 0.9,
+            },
+        ]
+    }
+    render(payload, mode=OutputMode.TEXT, command="search", stream=buf)
+    out = buf.getvalue()
+    assert "Doc A, p. 1" in out
+    assert "chunk=c1" in out
+
+
+def test_render_text_batch_search_uses_citations():
+    buf = io.StringIO()
+    payload = {
+        "results": [
+            {
+                "query": "termination",
+                "hits": [
+                    {
+                        "doc_id": "d1",
+                        "chunk_id": "c1",
+                        "citation": "Contract A, p. 4",
+                        "text": "shall terminate",
+                        "score": 0.87,
+                    }
+                ],
+            }
+        ]
+    }
+    render(payload, mode=OutputMode.TEXT, command="batch-search", stream=buf)
+    out = buf.getvalue()
+    assert "query: termination" in out
+    assert "Contract A, p. 4" in out
+    assert "shall terminate" in out
+
+
+def test_render_text_read_passages_uses_citations():
+    buf = io.StringIO()
+    payload = {
+        "passages": [
+            {
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "citation": "Manual, p. 2",
+                "text": "Use the lockout checklist.",
+            }
+        ]
+    }
+    render(payload, mode=OutputMode.TEXT, command="read-passages", stream=buf)
+    out = buf.getvalue()
+    assert "Manual, p. 2" in out
+    assert "chunk=c1" in out
+    assert "Use the lockout checklist." in out
+
+
+def test_render_text_verify_identifier_uses_citation():
+    buf = io.StringIO()
+    payload = {
+        "status": "unique",
+        "match": {
+            "doc_id": "d1",
+            "title": "Contract A",
+            "citation": "Contract A",
+            "canonical_filename": "contract-a.pdf",
+        },
+    }
+    render(payload, mode=OutputMode.TEXT, command="verify-identifier", stream=buf)
+    out = buf.getvalue()
+    assert "unique: Contract A" in out
+    assert "filename: contract-a.pdf" in out
+
+
+def test_render_text_documents_by_date_uses_citation():
+    buf = io.StringIO()
+    payload = {
+        "direction": "earliest",
+        "count": 1,
+        "results": [
+            {
+                "doc_id": "d1",
+                "title": "Email title",
+                "citation": 'Email from Jane Doe, "Budget", Mar 7, 2025',
+                "date": "2025-03-07T12:00:00+00:00",
+                "date_source": "tika.created_at",
+            }
+        ],
+    }
+    render(payload, mode=OutputMode.TEXT, command="documents-by-date", stream=buf)
+    out = buf.getvalue()
+    assert 'Email from Jane Doe, "Budget", Mar 7, 2025' in out
+    assert "2025-03-07" in out
+
+
 def test_render_text_search_error_prints_error():
     buf = io.StringIO()
     render({"error": "Cannot specify both doc_id and doc_ids"}, mode=OutputMode.TEXT, command="search", stream=buf)


### PR DESCRIPTION
## Summary
- prefer formatted citation strings in CLI text rendering
- add text renderers for batch-search and read-passages
- keep JSON output as direct MCP pass-through, preserving source/source_ref objects
- update search, batch-search, and read-passages help text for citation/source fields

## Tests
- uv run pytest tests/cli/test_output.py tests/cli/test_commands_search.py tests/cli/test_commands_batch_search.py tests/cli/test_commands_read_passages.py tests/cli/test_commands_verify_identifier.py tests/cli/test_commands_documents_by_date.py -v
- uv run ruff check src/harbor_clerk/cli/output.py tests/cli/test_output.py
- uv run ruff format --check src/harbor_clerk/cli/output.py tests/cli/test_output.py

## Review
Fresh-eyes review requested per project policy; this changes CLI text output and help for agent-facing commands.