### PR TITLE
feat(cli): add find-all command

### DIFF
--- a/src/harbor_clerk/cli/commands/__init__.py
+++ b/src/harbor_clerk/cli/commands/__init__.py
@@ -28,6 +28,7 @@ def _common_parser() -> argparse.ArgumentParser:
 
 _COMMAND_NAMES = [
     "search",
+    "find-all",
     "batch-search",
     "read-passages",
     "expand-context",

--- a/src/harbor_clerk/cli/commands/find_all.py
+++ b/src/harbor_clerk/cli/commands/find_all.py
@@ -1,0 +1,105 @@
+"""harbor-clerk find-all - enumerate matching documents."""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+
+from harbor_clerk.cli.client import McpHttpClient
+from harbor_clerk.cli.commands import _common_parser
+from harbor_clerk.cli.config import resolve_config
+from harbor_clerk.cli.help import load
+from harbor_clerk.cli.output import render, resolve_mode
+
+_LANGUAGE_ALIASES = {
+    "en": "english",
+    "fr": "french",
+    "english": "english",
+    "french": "french",
+}
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    description = load("find-all") or "Enumerate documents matching a query."
+    p = subparsers.add_parser(
+        "find-all",
+        help="Enumerate documents matching a query",
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common_parser()],
+    )
+    p.add_argument("query_arg", nargs="?", help="Relevance query")
+    p.add_argument("--query", dest="query", help="Relevance query; alternative to positional query")
+    p.add_argument("--text-contains", help="Require an exact substring in matching chunk text")
+    p.add_argument("--max-results", type=int, default=100, help="Max documents returned (default: 100)")
+    p.add_argument("-o", "--offset", type=int, default=0, help="Pagination offset (default: 0)")
+    p.add_argument("--presentation", choices=["brief", "full"], default="brief", help="Result detail (default: brief)")
+    p.add_argument(
+        "--sort-by",
+        choices=["relevance", "date_desc", "date_asc"],
+        default="relevance",
+        help="Sort order (default: relevance)",
+    )
+    p.add_argument("--doc-id", help="Restrict enumeration to one document UUID")
+    p.add_argument("--doc-ids", help="Comma-separated doc UUIDs")
+    p.add_argument("--after", help="YYYY-MM-DD or ISO 8601 datetime; only docs after this date")
+    p.add_argument("--before", help="YYYY-MM-DD or ISO 8601 datetime; only docs before this date")
+    p.add_argument("--language", choices=sorted(_LANGUAGE_ALIASES))
+    p.add_argument("--mime-type", help="Restrict by MIME type (e.g. application/pdf)")
+    p.add_argument(
+        "--metadata-filter-json",
+        "--metadata-filter",
+        dest="metadata_filter",
+        help='JSON string of {"namespace.key": value} pairs (e.g. \'{"email.from_address": "alice@example.com"}\')',
+    )
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    query = args.query or args.query_arg
+    if args.query and args.query_arg:
+        sys.stderr.write("harbor-clerk: provide query either positionally or with --query, not both\n")
+        return 1
+    if not query:
+        sys.stderr.write("harbor-clerk: find-all requires a query or --query\n")
+        return 1
+
+    arguments: dict = {
+        "query": query,
+        "max_results": args.max_results,
+        "offset": args.offset,
+        "presentation": args.presentation,
+        "sort_by": args.sort_by,
+    }
+    if args.text_contains:
+        arguments["text_contains"] = args.text_contains
+    if args.doc_id:
+        arguments["doc_id"] = args.doc_id
+    if args.doc_ids:
+        arguments["doc_ids"] = [d.strip() for d in args.doc_ids.split(",") if d.strip()]
+    if args.after:
+        arguments["after"] = args.after
+    if args.before:
+        arguments["before"] = args.before
+    if args.language:
+        arguments["language"] = _LANGUAGE_ALIASES[args.language]
+    if args.mime_type:
+        arguments["mime_type"] = args.mime_type
+    if args.metadata_filter:
+        try:
+            metadata_filter = _json.loads(args.metadata_filter)
+        except _json.JSONDecodeError as exc:
+            sys.stderr.write(f"harbor-clerk: --metadata-filter-json must be valid JSON: {exc}\n")
+            return 1
+        if not isinstance(metadata_filter, dict):
+            sys.stderr.write("harbor-clerk: --metadata-filter-json must be a JSON object\n")
+            return 1
+        arguments["metadata_filter"] = metadata_filter
+
+    cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
+    mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())
+    with McpHttpClient(cfg) as client:
+        payload = client.call_tool("kb_find_all", arguments)
+    render(payload, mode=mode, command="find-all")
+    return 0

--- a/src/harbor_clerk/cli/help/find-all.txt
+++ b/src/harbor_clerk/cli/help/find-all.txt
@@ -1,0 +1,79 @@
+harbor-clerk find-all - enumerate matching documents
+
+DESCRIPTION
+  Enumerates documents matching a query, deduped by document. Use this when
+  the task is to list every matching document rather than retrieve the single
+  best passage. This mirrors the MCP `kb_find_all` tool for shell-based agents.
+
+  Results preserve the MCP response shape in JSON, including `citation` and
+  structured `source` fields when available. Text output renders citations and,
+  with --presentation=full, the best matching chunk for each document.
+
+USAGE
+  harbor-clerk find-all <query> [options]
+  harbor-clerk find-all --query <query> [options]
+
+OPTIONS
+      --query TEXT             Relevance query; alternative to positional query
+      --text-contains TEXT     Require an exact substring in matching chunk text
+      --max-results INT        Max documents returned (default: 100)
+  -o, --offset INT             Pagination offset (default: 0)
+      --presentation brief|full
+                                brief omits chunk text; full includes best chunk
+      --sort-by relevance|date_desc|date_asc
+                                Sort order (default: relevance)
+      --doc-id UUID            Restrict to one document
+      --doc-ids UUID,UUID      Restrict to multiple documents
+      --after YYYY-MM-DD       Only docs after this date
+      --before YYYY-MM-DD      Only docs before this date
+      --language english|french|en|fr
+                                Restrict to one language
+      --mime-type MIME         Restrict by MIME type (e.g. application/pdf)
+      --metadata-filter-json JSON
+                                JSON metadata filter; --metadata-filter also works
+
+RETURNS (JSON)
+  {
+    "results": [
+      {
+        "doc_id": "uuid",
+        "doc_title": "Contract A",
+        "mime_type": "application/pdf",
+        "language": "english",
+        "score": 0.91,
+        "ingested_at": "2026-06-03T12:00:00+00:00",
+        "page_range": "4-5",
+        "citation": "Contract A, pp. 4-5",
+        "source": { "...": "SourceRef object" },
+        "top_chunk": {
+          "chunk_id": "uuid",
+          "text": "matching chunk text",
+          "page": 4,
+          "heading": "Termination"
+        }
+      }
+    ],
+    "total_matches": 42,
+    "returned": 25,
+    "offset": 0,
+    "truncated": true,
+    "sort_by": "relevance",
+    "presentation": "full"
+  }
+
+EXAMPLES
+  # Enumerate documents mentioning a concept
+  harbor-clerk find-all "force majeure"
+
+  # Require a literal phrase and include the best matching chunk
+  harbor-clerk find-all "contracts" \
+    --text-contains "termination for convenience" \
+    --presentation full
+
+  # Agent-friendly JSON with a raw metadata filter
+  harbor-clerk find-all --query "invoice" \
+    --metadata-filter-json '{"email.from_address": "alice@example.com"}' \
+    --json
+
+SEE ALSO
+  search, batch-search, read-passages, documents-by-date

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -107,6 +107,38 @@ def _render_search(payload: Any, stream: TextIO) -> None:
         stream.write("possible_conflict=true - top hits span multiple similarly scored documents\n")
 
 
+# --- Find all pretty-printer ---
+
+
+@register_text_renderer("find-all")
+def _render_find_all(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+    results = payload.get("results") or []
+    total = payload.get("total_matches", 0)
+    returned = payload.get("returned", len(results))
+    offset = payload.get("offset", 0)
+    truncated = " truncated" if payload.get("truncated") else ""
+    stream.write(f"{returned} of {total} matches (offset {offset}){truncated}\n")
+    if not results:
+        return
+    stream.write("\n")
+    for i, result in enumerate(results, 1):
+        record = dict(result)
+        top_chunk = record.get("top_chunk")
+        if isinstance(top_chunk, dict):
+            record.setdefault("chunk_id", top_chunk.get("chunk_id"))
+            record.setdefault("text", top_chunk.get("text"))
+            record.setdefault("page", top_chunk.get("page"))
+        if record.get("page_range") and not record.get("pages"):
+            record["pages"] = record["page_range"]
+        _render_hit_line(i, record, stream)
+
+
 # --- Batch search pretty-printer ---
 
 

--- a/tests/cli/test_commands_find_all.py
+++ b/tests/cli/test_commands_find_all.py
@@ -1,0 +1,153 @@
+"""CLI tests for harbor-clerk find-all."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from harbor_clerk.cli import main as cli_main
+
+
+def _run(args, mock_response):
+    """Invoke CLI in-process with a mocked McpHttpClient."""
+    with (
+        patch("harbor_clerk.cli.commands.find_all.McpHttpClient") as MockClient,
+        patch("harbor_clerk.cli.commands.find_all.resolve_config") as MockResolve,
+    ):
+        instance = MagicMock()
+        instance.call_tool.return_value = mock_response
+        instance.__enter__.return_value = instance
+        instance.__exit__.return_value = False
+        MockClient.return_value = instance
+        MockResolve.return_value = MagicMock(url="https://test", api_key="hc_t", insecure=False)
+        rc = cli_main.main(args)
+        return rc, instance
+
+
+_EMPTY = {
+    "results": [],
+    "total_matches": 0,
+    "returned": 0,
+    "offset": 0,
+    "truncated": False,
+    "sort_by": "relevance",
+    "presentation": "brief",
+}
+
+
+def test_find_all_defaults_with_positional_query(capsys):
+    rc, client = _run(["find-all", "termination", "--json"], _EMPTY)
+    assert rc == 0
+    client.call_tool.assert_called_once_with(
+        "kb_find_all",
+        {
+            "query": "termination",
+            "max_results": 100,
+            "offset": 0,
+            "presentation": "brief",
+            "sort_by": "relevance",
+        },
+    )
+    assert json.loads(capsys.readouterr().out) == _EMPTY
+
+
+def test_find_all_query_flag_and_filters_forwarded():
+    rc, client = _run(
+        [
+            "find-all",
+            "--query",
+            "invoice",
+            "--text-contains",
+            "total due",
+            "--max-results",
+            "25",
+            "--offset",
+            "50",
+            "--presentation",
+            "full",
+            "--sort-by",
+            "date_desc",
+            "--doc-ids",
+            "d1,d2",
+            "--after",
+            "2026-01-01",
+            "--before",
+            "2026-02-01",
+            "--language",
+            "fr",
+            "--mime-type",
+            "message/rfc822",
+            "--metadata-filter-json",
+            '{"email.from_address": "alice@example.com"}',
+            "--json",
+        ],
+        _EMPTY,
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args == {
+        "query": "invoice",
+        "text_contains": "total due",
+        "max_results": 25,
+        "offset": 50,
+        "presentation": "full",
+        "sort_by": "date_desc",
+        "doc_ids": ["d1", "d2"],
+        "after": "2026-01-01",
+        "before": "2026-02-01",
+        "language": "french",
+        "mime_type": "message/rfc822",
+        "metadata_filter": {"email.from_address": "alice@example.com"},
+    }
+
+
+def test_find_all_rejects_missing_query(capsys):
+    rc, client = _run(["find-all", "--json"], _EMPTY)
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "requires a query" in capsys.readouterr().err
+
+
+def test_find_all_rejects_duplicate_query(capsys):
+    rc, client = _run(["find-all", "foo", "--query", "bar", "--json"], _EMPTY)
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "not both" in capsys.readouterr().err
+
+
+def test_find_all_invalid_metadata_filter_exits_1(capsys):
+    rc, client = _run(["find-all", "foo", "--metadata-filter-json", "not-json", "--json"], _EMPTY)
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "--metadata-filter-json must be valid JSON" in capsys.readouterr().err
+
+
+def test_find_all_text_mode_renders_citation_and_top_chunk(capsys):
+    payload = {
+        "results": [
+            {
+                "doc_id": "d1",
+                "doc_title": "Contract A",
+                "citation": "Contract A, p. 4",
+                "score": 0.87,
+                "page_range": "4",
+                "top_chunk": {
+                    "chunk_id": "c1",
+                    "text": "shall terminate",
+                    "page": 4,
+                    "heading": "Termination",
+                },
+            }
+        ],
+        "total_matches": 1,
+        "returned": 1,
+        "offset": 0,
+        "truncated": False,
+        "sort_by": "relevance",
+        "presentation": "full",
+    }
+    rc, _client = _run(["find-all", "terminate", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 of 1 matches" in out
+    assert "Contract A, p. 4" in out
+    assert "chunk=c1" in out
+    assert "shall terminate" in out

--- a/tests/cli/test_e2e.py
+++ b/tests/cli/test_e2e.py
@@ -291,6 +291,19 @@ def test_documents_by_date_help_loads(capsys):
     assert "earliest" in out and "latest" in out
 
 
+def test_find_all_help_loads(capsys):
+    """Test that find-all --help loads correctly from the .txt file."""
+    from harbor_clerk.cli import main as cli_main
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["find-all", "--help"])
+    assert exc.value.code == 0
+
+    out = capsys.readouterr().out
+    assert "find-all" in out
+    assert "Enumerate" in out or "enumerate" in out
+
+
 # ---------------------------------------------------------------------------
 # Test: top-level --help lists new commands
 # ---------------------------------------------------------------------------
@@ -305,5 +318,6 @@ def test_top_level_help_lists_new_commands(capsys):
     assert exc.value.code == 0
 
     out = capsys.readouterr().out
+    assert "find-all" in out
     assert "verify-identifier" in out
     assert "documents-by-date" in out

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -19,11 +19,12 @@ def test_cli_version_flag():
     assert "harbor-clerk-cli/" in out
 
 
-def test_cli_help_flag_lists_all_18_commands():
+def test_cli_help_flag_lists_all_19_commands():
     out, _err, rc = run_cli("--help")
     assert rc == 0
     for cmd in [
         "search",
+        "find-all",
         "batch-search",
         "read-passages",
         "expand-context",

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -74,6 +74,32 @@ def test_render_text_search_prefers_citation():
     assert "chunk=c1" in out
 
 
+def test_render_text_find_all_uses_citations_and_top_chunk():
+    buf = io.StringIO()
+    payload = {
+        "results": [
+            {
+                "doc_id": "d1",
+                "doc_title": "Contract A",
+                "citation": "Contract A, p. 4",
+                "score": 0.87,
+                "page_range": "4",
+                "top_chunk": {"chunk_id": "c1", "text": "shall terminate"},
+            }
+        ],
+        "total_matches": 1,
+        "returned": 1,
+        "offset": 0,
+        "truncated": False,
+    }
+    render(payload, mode=OutputMode.TEXT, command="find-all", stream=buf)
+    out = buf.getvalue()
+    assert "1 of 1 matches" in out
+    assert "Contract A, p. 4" in out
+    assert "chunk=c1" in out
+    assert "shall terminate" in out
+
+
 def test_render_text_batch_search_uses_citations():
     buf = io.StringIO()
     payload = {


### PR DESCRIPTION
## Summary
- add harbor-clerk find-all as CLI parity for MCP kb_find_all
- support positional or --query input, text_contains, pagination, sort/presentation, doc/date/language/MIME filters, and metadata-filter JSON
- add text rendering for find-all results using citations and top_chunk text when present

## Tests
- uv run pytest tests/cli -v
- uv run ruff check src/harbor_clerk/cli/commands/find_all.py src/harbor_clerk/cli/commands/__init__.py src/harbor_clerk/cli/output.py tests/cli/test_commands_find_all.py tests/cli/test_main.py tests/cli/test_output.py tests/cli/test_e2e.py
- uv run ruff format --check src/harbor_clerk/cli/commands/find_all.py src/harbor_clerk/cli/commands/__init__.py src/harbor_clerk/cli/output.py tests/cli/test_commands_find_all.py tests/cli/test_main.py tests/cli/test_output.py tests/cli/test_e2e.py