### PR TITLE
feat(api): add REST search filter parity

### DIFF
--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -130,18 +130,23 @@ async def search(
                 conflict_sources=[],
             )
 
-    result = await hybrid_search(
-        session,
-        body.query,
-        k=body.k,
-        doc_id=doc_id,
-        offset=body.offset,
-        doc_ids=doc_ids,
-        after=body.after,
-        before=body.before,
-        language=body.language,
-        mime_type=body.mime_type,
-    )
+    try:
+        result = await hybrid_search(
+            session,
+            body.query,
+            k=body.k,
+            doc_id=doc_id,
+            offset=body.offset,
+            doc_ids=doc_ids,
+            after=body.after,
+            before=body.before,
+            language=body.language,
+            mime_type=body.mime_type,
+            metadata_filter=body.metadata_filter,
+            text_contains=body.text_contains,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
 
     has_more = body.offset + body.k < result.total_candidates
     source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -1,7 +1,7 @@
 """Search and passage-reading schemas."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -19,6 +19,8 @@ class SearchRequest(BaseModel):
     before: datetime | None = None
     language: str | None = None
     mime_type: str | None = None
+    metadata_filter: dict[str, Any] | None = None
+    text_contains: str | None = None
     faceted: bool = False
     scope: ScopeSpec | None = None
 

--- a/tests/api/test_search_filter_parity.py
+++ b/tests/api/test_search_filter_parity.py
@@ -1,0 +1,75 @@
+"""REST search filter parity tests."""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.routes import search as search_route
+from harbor_clerk.api.schemas.search import SearchRequest, SearchResponse
+from harbor_clerk.search_types import SearchResult
+
+
+@pytest.mark.anyio
+async def test_rest_search_forwards_metadata_filter_and_text_contains(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_hybrid_search(session, query, **kwargs):
+        captured["session"] = session
+        captured["query"] = query
+        captured.update(kwargs)
+        return SearchResult(hits=[], total_candidates=0, reranker_status="disabled")
+
+    monkeypatch.setattr(search_route, "hybrid_search", fake_hybrid_search)
+
+    session = object()
+    principal = Principal(type="user", id=uuid4(), role="admin")
+    request = SearchRequest(
+        query="vendor contract",
+        metadata_filter={
+            "email.from_address": "alice@example.com",
+            "sidecar.vendor": "Pinnacle Tech Solutions",
+        },
+        text_contains="force majeure",
+    )
+
+    response = await search_route.search(request, principal=principal, session=session)
+
+    assert isinstance(response, SearchResponse)
+    assert captured["session"] is session
+    assert captured["query"] == "vendor contract"
+    assert captured["metadata_filter"] == {
+        "email.from_address": "alice@example.com",
+        "sidecar.vendor": "Pinnacle Tech Solutions",
+    }
+    assert captured["text_contains"] == "force majeure"
+
+
+@pytest.mark.anyio
+async def test_rest_search_returns_422_for_invalid_filter(monkeypatch) -> None:
+    async def fake_hybrid_search(*args, **kwargs):
+        raise ValueError("metadata_filter keys must be exactly 'namespace.key'")
+
+    monkeypatch.setattr(search_route, "hybrid_search", fake_hybrid_search)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await search_route.search(
+            SearchRequest(query="vendor contract", metadata_filter={"too.many.dots": "x"}),
+            principal=Principal(type="user", id=uuid4(), role="admin"),
+            session=object(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "metadata_filter keys" in exc_info.value.detail
+
+
+def test_search_request_rejects_non_object_metadata_filter() -> None:
+    with pytest.raises(ValidationError):
+        SearchRequest.model_validate(
+            {
+                "query": "vendor contract",
+                "metadata_filter": ["email.from_address", "alice@example.com"],
+            }
+        )


### PR DESCRIPTION
## Summary
- add `metadata_filter` and `text_contains` to the REST search request schema
- forward both filters through `/api/search` to `hybrid_search`
- add direct route/schema tests that avoid touching the database

## Tests
- `uv run pytest tests/api/test_search_filter_parity.py tests/test_search_schemas.py -v`
- `uv run ruff check src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/api/test_search_filter_parity.py tests/test_search_schemas.py`
- `uv run ruff format --check src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/api/test_search_filter_parity.py tests/test_search_schemas.py`