### PR TITLE
feat(api): add REST find-all endpoint

### DIFF
--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -12,6 +12,10 @@ from harbor_clerk.api.schemas.search import (
     ConflictSourceOut,
     FacetedDocGroup,
     FacetedSearchResponse,
+    FindAllHitOut,
+    FindAllRequest,
+    FindAllResponse,
+    FindAllTopChunkOut,
     PassageDetail,
     ReadPassagesRequest,
     ReadPassagesResponse,
@@ -21,10 +25,12 @@ from harbor_clerk.api.schemas.search import (
 )
 from harbor_clerk.api.scope import apply_folder_scope, apply_key_scope
 from harbor_clerk.api.scope_validation import validate_scope_folders
+from harbor_clerk.config import get_settings
 from harbor_clerk.db import get_session
 from harbor_clerk.models import Chunk, Document
-from harbor_clerk.search import hybrid_search
-from harbor_clerk.source_ref import SourceRef, format_pages, load_source_ref_context
+from harbor_clerk.search import find_all, hybrid_search
+from harbor_clerk.search_types import FindAllHit
+from harbor_clerk.source_ref import SourceRef, format_document_citation, format_pages, load_source_ref_context
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["search"])
@@ -45,6 +51,80 @@ def _hit_to_out(h, source_ref: SourceRef | None = None) -> SearchHitOut:
         doc_title=h.doc_title,
         source=source_ref.to_dict() if source_ref else None,
         citation=source_ref.citation if source_ref else None,
+    )
+
+
+def _fallback_source_ref(
+    *,
+    doc_id: str,
+    doc_title: str | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+) -> SourceRef:
+    title = doc_title or "Untitled document"
+    return SourceRef(
+        doc_id=doc_id,
+        doc_title=title,
+        chunk_id=chunk_id,
+        pages=pages,
+        section=section,
+        source_kind="unknown",
+        source_label=title,
+        citation=format_document_citation(title, pages),
+    )
+
+
+def _source_ref_for_find_all_hit(hit: FindAllHit, source_ref: SourceRef | None = None) -> SourceRef:
+    if source_ref is not None and source_ref.doc_id:
+        return source_ref
+    return _fallback_source_ref(
+        doc_id=hit.doc_id,
+        doc_title=hit.doc_title,
+        chunk_id=hit.top_chunk_id,
+        pages=hit.page_range,
+        section=hit.top_chunk_heading,
+    )
+
+
+def _find_all_hit_to_out(hit: FindAllHit, source_ref: SourceRef | None = None) -> FindAllHitOut:
+    resolved_source = _source_ref_for_find_all_hit(hit, source_ref)
+    top_chunk = None
+    if hit.top_chunk_id is not None or hit.top_chunk_text is not None:
+        top_chunk = FindAllTopChunkOut(
+            chunk_id=hit.top_chunk_id,
+            text=hit.top_chunk_text,
+            page=hit.top_chunk_page,
+            heading=hit.top_chunk_heading,
+        )
+    return FindAllHitOut(
+        doc_id=hit.doc_id,
+        doc_title=hit.doc_title,
+        mime_type=hit.mime_type,
+        language=hit.language,
+        score=hit.score,
+        ingested_at=hit.ingested_at,
+        page_range=hit.page_range,
+        top_chunk=top_chunk,
+        source=resolved_source.to_dict(),
+        citation=resolved_source.citation,
+    )
+
+
+def _empty_find_all_response(
+    *,
+    offset: int,
+    sort_by: str,
+    presentation: str,
+) -> FindAllResponse:
+    return FindAllResponse(
+        results=[],
+        total_matches=0,
+        returned=0,
+        offset=offset,
+        truncated=False,
+        sort_by=sort_by,
+        presentation=presentation,
     )
 
 
@@ -197,6 +277,121 @@ async def search(
             for cs in result.conflict_sources
         ],
         reranker_status=result.reranker_status,
+    )
+
+
+@router.post("/search/find-all", response_model=FindAllResponse)
+async def search_find_all(
+    body: FindAllRequest,
+    principal: Principal = Depends(require_read_access),
+    session: AsyncSession = Depends(get_session),
+):
+    await validate_scope_folders(body.scope, session)
+
+    doc_id = body.doc_id
+    doc_ids = list(body.doc_ids) if body.doc_ids else None
+    max_results = max(1, min(body.max_results, get_settings().find_all_max_results_cap))
+
+    # Per-API-key scope: intersect with visible doc_ids for scoped keys.
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(select(Document.doc_id), principal)
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+        if not visible_ids:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in visible_ids]
+            if not doc_ids:
+                return _empty_find_all_response(
+                    offset=body.offset,
+                    sort_by=body.sort_by,
+                    presentation=body.presentation,
+                )
+        elif doc_id is None:
+            doc_ids = list(visible_ids)
+        if doc_id is not None and doc_id not in visible_ids:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+
+    # Per-request user scope: intersect with visible doc_ids for the requested folders.
+    if body.scope is not None and body.scope.folder_ids:
+        scoped_q = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            list(body.scope.folder_ids),
+        )
+        scoped_visible = {row[0] for row in (await session.execute(scoped_q)).all()}
+        if not scoped_visible:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in scoped_visible]
+            if not doc_ids:
+                return _empty_find_all_response(
+                    offset=body.offset,
+                    sort_by=body.sort_by,
+                    presentation=body.presentation,
+                )
+        elif doc_id is None:
+            doc_ids = list(scoped_visible)
+        if doc_id is not None and doc_id not in scoped_visible:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+
+    try:
+        result = await find_all(
+            session,
+            body.query,
+            max_results=max_results,
+            offset=body.offset,
+            sort_by=body.sort_by,
+            text_contains=body.text_contains,
+            doc_id=doc_id,
+            doc_ids=doc_ids,
+            after=body.after,
+            before=body.before,
+            language=body.language,
+            mime_type=body.mime_type,
+            metadata_filter=body.metadata_filter,
+            presentation=body.presentation,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+
+    source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits]) if result.hits else None
+    results = []
+    for hit in result.hits:
+        source_ref = (
+            source_context.ref_for_doc(
+                hit.doc_id,
+                chunk_id=hit.top_chunk_id,
+                pages=hit.page_range,
+                section=hit.top_chunk_heading,
+            )
+            if source_context is not None
+            else None
+        )
+        results.append(_find_all_hit_to_out(hit, source_ref))
+
+    return FindAllResponse(
+        results=results,
+        total_matches=result.total_matches,
+        returned=len(results),
+        offset=result.offset,
+        truncated=result.truncated,
+        sort_by=result.sort_by,
+        presentation=result.presentation,
     )
 
 

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from typing import Any, Literal
+from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -67,6 +68,59 @@ class SearchResponse(BaseModel):
     possible_conflict: bool = False
     conflict_sources: list[ConflictSourceOut] = []
     reranker_status: Literal["ok", "disabled", "failed"] = "disabled"
+
+
+class FindAllRequest(BaseModel):
+    query: str
+    text_contains: str | None = None
+    max_results: int = Field(default=100, ge=1)
+    offset: int = Field(default=0, ge=0)
+    presentation: Literal["brief", "full"] = "brief"
+    sort_by: Literal["relevance", "date_desc", "date_asc"] = "relevance"
+    after: datetime | None = None
+    before: datetime | None = None
+    doc_id: UUID | None = None
+    doc_ids: list[UUID] | None = Field(default=None, max_length=50)
+    language: str | None = None
+    mime_type: str | None = None
+    metadata_filter: dict[str, Any] | None = None
+    scope: ScopeSpec | None = None
+
+    @model_validator(mode="after")
+    def check_doc_id_mutual_exclusion(self):
+        if self.doc_id is not None and self.doc_ids is not None:
+            raise ValueError("Cannot specify both doc_id and doc_ids")
+        return self
+
+
+class FindAllTopChunkOut(BaseModel):
+    chunk_id: str | None = None
+    text: str | None = None
+    page: int | None = None
+    heading: str | None = None
+
+
+class FindAllHitOut(BaseModel):
+    doc_id: str
+    doc_title: str
+    mime_type: str
+    language: str | None = None
+    score: float
+    ingested_at: datetime | None = None
+    page_range: str | None = None
+    top_chunk: FindAllTopChunkOut | None = None
+    source: SourceRefOut | None = None
+    citation: str | None = None
+
+
+class FindAllResponse(BaseModel):
+    results: list[FindAllHitOut]
+    total_matches: int = 0
+    returned: int = 0
+    offset: int = 0
+    truncated: bool = False
+    sort_by: Literal["relevance", "date_desc", "date_asc"] = "relevance"
+    presentation: Literal["brief", "full"] = "brief"
 
 
 class FacetedDocGroup(BaseModel):

--- a/tests/api/test_find_all_route.py
+++ b/tests/api/test_find_all_route.py
@@ -1,0 +1,186 @@
+"""REST Find All route contract tests."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.routes import search as search_route
+from harbor_clerk.api.schemas.search import FindAllRequest, FindAllResponse
+from harbor_clerk.search_types import FindAllHit, FindAllResult
+from harbor_clerk.source_ref import SourceRef
+
+
+def test_search_find_all_route_is_registered() -> None:
+    assert any(
+        getattr(route, "path", None) == "/search/find-all" and "POST" in getattr(route, "methods", set())
+        for route in search_route.router.routes
+    )
+
+
+@pytest.mark.anyio
+async def test_search_find_all_forwards_filters_and_returns_sources(monkeypatch) -> None:
+    doc_id = uuid4()
+    chunk_id = uuid4()
+    captured: dict[str, object] = {}
+
+    async def fake_find_all(session, query, **kwargs):
+        captured["session"] = session
+        captured["query"] = query
+        captured.update(kwargs)
+        return FindAllResult(
+            hits=[
+                FindAllHit(
+                    doc_id=str(doc_id),
+                    doc_title="Vendor Contract",
+                    mime_type="application/pdf",
+                    language="en",
+                    score=0.87,
+                    ingested_at=datetime(2026, 6, 1, tzinfo=UTC),
+                    page_range="2",
+                    top_chunk_id=str(chunk_id),
+                    top_chunk_text="Force majeure clause excerpt.",
+                    top_chunk_page=2,
+                    top_chunk_heading="Terms",
+                )
+            ],
+            total_matches=1,
+            offset=5,
+            truncated=False,
+            sort_by="date_desc",
+            presentation="full",
+        )
+
+    class SourceContext:
+        def ref_for_doc(self, doc_or_id, *, chunk_id=None, pages=None, section=None, include_relative_path=True):
+            return SourceRef(
+                doc_id=str(doc_or_id),
+                doc_title="Vendor Contract",
+                chunk_id=str(chunk_id),
+                pages=pages,
+                section=section,
+                source_kind="document",
+                source_label="Vendor Contract",
+                folder_label="Contracts",
+                relative_path="vendors/contract.pdf",
+                citation="Vendor Contract, p. 2",
+            )
+
+    async def fake_load_source_ref_context(session, doc_ids):
+        captured["source_doc_ids"] = list(doc_ids)
+        return SourceContext()
+
+    monkeypatch.setattr(search_route, "find_all", fake_find_all)
+    monkeypatch.setattr(search_route, "load_source_ref_context", fake_load_source_ref_context)
+
+    session = object()
+    response = await search_route.search_find_all(
+        FindAllRequest(
+            query="vendor contract",
+            text_contains="force majeure",
+            max_results=10,
+            offset=5,
+            presentation="full",
+            sort_by="date_desc",
+            doc_ids=[doc_id],
+            language="en",
+            mime_type="application/pdf",
+            metadata_filter={"sidecar.vendor": "Pinnacle"},
+        ),
+        principal=Principal(type="user", id=uuid4(), role="admin"),
+        session=session,
+    )
+
+    assert isinstance(response, FindAllResponse)
+    assert captured["session"] is session
+    assert captured["query"] == "vendor contract"
+    assert captured["max_results"] == 10
+    assert captured["offset"] == 5
+    assert captured["presentation"] == "full"
+    assert captured["sort_by"] == "date_desc"
+    assert captured["text_contains"] == "force majeure"
+    assert captured["doc_ids"] == [doc_id]
+    assert captured["language"] == "en"
+    assert captured["mime_type"] == "application/pdf"
+    assert captured["metadata_filter"] == {"sidecar.vendor": "Pinnacle"}
+    assert captured["source_doc_ids"] == [str(doc_id)]
+
+    assert response.total_matches == 1
+    assert response.returned == 1
+    hit = response.results[0]
+    assert hit.doc_id == str(doc_id)
+    assert hit.citation == "Vendor Contract, p. 2"
+    assert hit.source is not None
+    assert hit.source.folder_label == "Contracts"
+    assert hit.source.relative_path == "vendors/contract.pdf"
+    assert hit.top_chunk is not None
+    assert hit.top_chunk.chunk_id == str(chunk_id)
+    assert hit.top_chunk.text == "Force majeure clause excerpt."
+
+
+@pytest.mark.anyio
+async def test_search_find_all_clamps_max_results(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Settings:
+        find_all_max_results_cap = 25
+
+    async def fake_find_all(session, query, **kwargs):
+        captured.update(kwargs)
+        return FindAllResult(
+            hits=[],
+            total_matches=0,
+            offset=0,
+            truncated=False,
+            sort_by="relevance",
+            presentation="brief",
+        )
+
+    async def fake_load_source_ref_context(session, doc_ids):
+        raise AssertionError("empty find-all results should not need source context")
+
+    monkeypatch.setattr(search_route, "get_settings", lambda: Settings())
+    monkeypatch.setattr(search_route, "find_all", fake_find_all)
+    monkeypatch.setattr(search_route, "load_source_ref_context", fake_load_source_ref_context)
+
+    response = await search_route.search_find_all(
+        FindAllRequest(query="vendor contract", max_results=999),
+        principal=Principal(type="user", id=uuid4(), role="admin"),
+        session=object(),
+    )
+
+    assert response.results == []
+    assert captured["max_results"] == 25
+
+
+@pytest.mark.anyio
+async def test_search_find_all_returns_422_for_invalid_filter(monkeypatch) -> None:
+    async def fake_find_all(*args, **kwargs):
+        raise ValueError("metadata_filter keys must be exactly 'namespace.key'")
+
+    monkeypatch.setattr(search_route, "find_all", fake_find_all)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await search_route.search_find_all(
+            FindAllRequest(query="vendor contract", metadata_filter={"too.many.dots": "x"}),
+            principal=Principal(type="user", id=uuid4(), role="admin"),
+            session=object(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "metadata_filter keys" in exc_info.value.detail
+
+
+def test_find_all_request_rejects_doc_id_and_doc_ids() -> None:
+    doc_id = uuid4()
+    with pytest.raises(ValidationError):
+        FindAllRequest.model_validate(
+            {
+                "query": "vendor contract",
+                "doc_id": str(doc_id),
+                "doc_ids": [str(doc_id)],
+            }
+        )


### PR DESCRIPTION
## Summary
- add `POST /api/search/find-all` for document-deduped Find All enumeration
- add Find All request/response schemas with SourceRef/citation fields
- preserve API-key/request scope intersections and MCP-style max-result clamping
- add direct route tests that mock `find_all` and avoid live database mutation

## Tests
- `uv run pytest tests/api/test_find_all_route.py tests/api/test_search_filter_parity.py tests/test_search_schemas.py -v`
- `uv run ruff check src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/api/test_find_all_route.py tests/api/test_search_filter_parity.py tests/test_search_schemas.py`
- `uv run ruff format --check src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py tests/api/test_find_all_route.py tests/api/test_search_filter_parity.py tests/test_search_schemas.py`