### PR TITLE
feat(frontend): add Search Find All mode

### DIFF
--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { post } from '../api'
+import SearchPage from './SearchPage'
+
+vi.mock('../api', () => ({
+  post: vi.fn(),
+}))
+
+vi.mock('../hooks/useWatchedFolders', () => ({
+  useWatchedFolders: () => ({
+    folders: [],
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    refetch: () => undefined,
+  }),
+}))
+
+const postMock = vi.mocked(post)
+
+function storageMock(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => store.delete(key),
+    setItem: (key: string, value: string) => store.set(key, value),
+  }
+}
+
+function resetStorage() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storageMock(),
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: storageMock(),
+    configurable: true,
+  })
+}
+
+function renderSearchPage() {
+  render(
+    <MemoryRouter>
+      <SearchPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SearchPage', () => {
+  beforeEach(() => {
+    resetStorage()
+    postMock.mockReset()
+  })
+
+  it('uses the search endpoint by default', async () => {
+    postMock.mockResolvedValueOnce({
+      hits: [],
+      total_candidates: 0,
+      has_more: false,
+      possible_conflict: false,
+      conflict_sources: [],
+    })
+
+    renderSearchPage()
+
+    const input = screen.getByPlaceholderText('Search documents...')
+    fireEvent.change(input, { target: { value: 'arbitration' } })
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search', {
+        query: 'arbitration',
+        k: 25,
+        offset: 0,
+      })
+    })
+    expect(await screen.findByText('No results found.')).toBeInTheDocument()
+  })
+
+  it('uses the find-all endpoint and renders document results', async () => {
+    postMock.mockResolvedValueOnce({
+      results: [
+        {
+          doc_id: 'doc-1',
+          doc_title: 'Vendor Contract',
+          mime_type: 'application/pdf',
+          language: 'en',
+          score: 0.87,
+          ingested_at: '2026-06-01T00:00:00Z',
+          page_range: '2',
+          top_chunk: {
+            chunk_id: 'chunk-1',
+            text: 'Force majeure clause excerpt.',
+            page: 2,
+            heading: 'Terms',
+          },
+          source: {
+            doc_id: 'doc-1',
+            doc_title: 'Vendor Contract',
+            chunk_id: 'chunk-1',
+            pages: '2',
+            section: 'Terms',
+            source_kind: 'document',
+            source_label: 'Vendor Contract',
+            folder_label: 'Contracts',
+            relative_path: 'vendors/contract.pdf',
+            citation: 'Vendor Contract, p. 2',
+          },
+          citation: 'Vendor Contract, p. 2',
+        },
+      ],
+      total_matches: 1,
+      returned: 1,
+      offset: 0,
+      truncated: false,
+      sort_by: 'relevance',
+      presentation: 'full',
+    })
+
+    renderSearchPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Find All mode' }))
+    const input = screen.getByPlaceholderText('Find all matching documents...')
+    fireEvent.change(input, { target: { value: 'force majeure' } })
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search/find-all', {
+        query: 'force majeure',
+        max_results: 25,
+        offset: 0,
+        presentation: 'full',
+        sort_by: 'relevance',
+      })
+    })
+    expect(await screen.findByText('Vendor Contract')).toBeInTheDocument()
+    expect(screen.getByText('Force majeure clause excerpt.')).toBeInTheDocument()
+    expect(screen.getByText('Vendor Contract, p. 2')).toBeInTheDocument()
+    expect(screen.getByText('vendors/contract.pdf')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -6,6 +6,21 @@ import { FolderPicker } from '../components/FolderPicker'
 import { PageHeader } from '../components/PageHeader'
 import { useWatchedFolders } from '../hooks/useWatchedFolders'
 
+type SearchMode = 'search' | 'find_all'
+
+interface SourceRef {
+  doc_id: string
+  doc_title: string
+  chunk_id?: string
+  pages?: string
+  section?: string
+  source_kind: 'document' | 'email' | 'attachment' | 'unknown'
+  source_label: string
+  folder_label?: string
+  relative_path?: string
+  citation: string
+}
+
 interface SearchHit {
   chunk_id: string
   doc_id: string
@@ -18,6 +33,8 @@ interface SearchHit {
   ocr_confidence?: number
   score: number
   doc_title?: string
+  source?: SourceRef
+  citation?: string
 }
 
 interface ConflictSource {
@@ -33,14 +50,47 @@ interface SearchResponse {
   conflict_sources: ConflictSource[]
 }
 
+interface FindAllTopChunk {
+  chunk_id?: string
+  text?: string
+  page?: number
+  heading?: string
+}
+
+interface FindAllHit {
+  doc_id: string
+  doc_title: string
+  mime_type: string
+  language?: string
+  score: number
+  ingested_at?: string
+  page_range?: string
+  top_chunk?: FindAllTopChunk
+  source?: SourceRef
+  citation?: string
+}
+
+interface FindAllResponse {
+  results: FindAllHit[]
+  total_matches: number
+  returned: number
+  offset: number
+  truncated: boolean
+  sort_by: 'relevance' | 'date_desc' | 'date_asc'
+  presentation: 'brief' | 'full'
+}
+
+type SearchResults = SearchResponse | FindAllResponse
+
 const HISTORY_KEY = 'search_history'
 const STATE_KEY = 'search_state'
 const MAX_HISTORY = 10
 const PAGE_SIZES = [10, 25, 50]
 
 interface SearchState {
+  mode?: SearchMode
   query: string
-  results: SearchResponse | null
+  results: SearchResults | null
   currentPage: number
   pageSize: number
   lastQuery: string
@@ -85,6 +135,16 @@ function addToHistory(query: string) {
   const history = getHistory().filter((q) => q !== trimmed)
   history.unshift(trimmed)
   saveHistory(history.slice(0, MAX_HISTORY))
+}
+
+function isFindAllResponse(results: SearchResults | null): results is FindAllResponse {
+  return !!results && 'results' in results
+}
+
+function firstPageFromRange(pageRange?: string): number | null {
+  if (!pageRange) return null
+  const match = pageRange.match(/^\d+/)
+  return match ? Number(match[0]) : null
 }
 
 function Pagination({
@@ -146,8 +206,9 @@ function Pagination({
 
 export default function SearchPage() {
   const [initial] = useState(loadSearchState)
+  const [mode, setMode] = useState<SearchMode>(initial?.mode === 'find_all' ? 'find_all' : 'search')
   const [query, setQuery] = useState(initial?.query || '')
-  const [results, setResults] = useState<SearchResponse | null>(initial?.results || null)
+  const [results, setResults] = useState<SearchResults | null>(initial?.results || null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [history, setHistory] = useState<string[]>(getHistory)
@@ -161,8 +222,8 @@ export default function SearchPage() {
 
   // Persist search state to sessionStorage
   useEffect(() => {
-    saveSearchState({ query, results, currentPage, pageSize, lastQuery: lastQuery.current })
-  }, [query, results, currentPage, pageSize])
+    saveSearchState({ mode, query, results, currentPage, pageSize, lastQuery: lastQuery.current })
+  }, [mode, query, results, currentPage, pageSize])
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -175,7 +236,13 @@ export default function SearchPage() {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  async function doSearch(q: string, page: number, size: number, folderIds: string[] = scopeFolderIds) {
+  async function doSearch(
+    q: string,
+    page: number,
+    size: number,
+    folderIds: string[] = scopeFolderIds,
+    searchMode: SearchMode = mode,
+  ) {
     const trimmed = q.trim()
     if (!trimmed) return
     setError('')
@@ -185,15 +252,25 @@ export default function SearchPage() {
     lastQuery.current = trimmed
     try {
       const offset = (page - 1) * size
-      const data = await post<SearchResponse>('/api/search', {
-        query: trimmed,
-        k: size,
-        offset,
-        ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
-      })
+      const data =
+        searchMode === 'find_all'
+          ? await post<FindAllResponse>('/api/search/find-all', {
+              query: trimmed,
+              max_results: size,
+              offset,
+              presentation: 'full',
+              sort_by: 'relevance',
+              ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
+            })
+          : await post<SearchResponse>('/api/search', {
+              query: trimmed,
+              k: size,
+              offset,
+              ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
+            })
       setResults(data)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Search failed')
+      setError(e instanceof Error ? e.message : searchMode === 'find_all' ? 'Find All failed' : 'Search failed')
     } finally {
       setLoading(false)
     }
@@ -219,6 +296,14 @@ export default function SearchPage() {
     }
   }
 
+  function handleModeChange(nextMode: SearchMode) {
+    if (nextMode === mode) return
+    setMode(nextMode)
+    setResults(null)
+    setCurrentPage(1)
+    lastQuery.current = ''
+  }
+
   function selectHistoryItem(q: string) {
     setQuery(q)
     setShowHistory(false)
@@ -232,13 +317,44 @@ export default function SearchPage() {
     setShowHistory(false)
   }
 
-  const maxScore = results?.hits[0]?.score || 1
-  const totalPages = results ? Math.max(1, Math.ceil(results.total_candidates / pageSize)) : 1
+  const searchResults = mode === 'search' && results && !isFindAllResponse(results) ? results : null
+  const findAllResults = mode === 'find_all' && isFindAllResponse(results) ? results : null
+  const totalCount = findAllResults?.total_matches ?? searchResults?.total_candidates ?? 0
+  const maxScore = searchResults?.hits[0]?.score || findAllResults?.results[0]?.score || 1
+  const totalPages = results ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1
   const startIdx = (currentPage - 1) * pageSize
 
   return (
     <div>
       <PageHeader title="Search" subtitle="Hybrid lexical + semantic retrieval" />
+      <div className="mb-4 inline-flex rounded-lg bg-(--color-bg-secondary) p-0.5 shadow-mac ring-1 ring-(--color-border)">
+        <button
+          type="button"
+          aria-label="Search mode"
+          aria-pressed={mode === 'search'}
+          onClick={() => handleModeChange('search')}
+          className={`min-w-24 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            mode === 'search'
+              ? 'bg-white text-(--color-text-primary) shadow-mac dark:bg-[#3a3a3c]'
+              : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+          }`}
+        >
+          Search
+        </button>
+        <button
+          type="button"
+          aria-label="Find All mode"
+          aria-pressed={mode === 'find_all'}
+          onClick={() => handleModeChange('find_all')}
+          className={`min-w-24 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            mode === 'find_all'
+              ? 'bg-white text-(--color-text-primary) shadow-mac dark:bg-[#3a3a3c]'
+              : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+          }`}
+        >
+          Find All
+        </button>
+      </div>
       <form onSubmit={handleSearch} className="mb-6 flex items-center gap-2">
         <div className="relative flex-1" ref={wrapperRef}>
           <input
@@ -249,7 +365,7 @@ export default function SearchPage() {
             onKeyDown={(e) => {
               if (e.key === 'Escape') setShowHistory(false)
             }}
-            placeholder="Search documents..."
+            placeholder={mode === 'find_all' ? 'Find all matching documents...' : 'Search documents...'}
             autoFocus
             className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-4 py-2 text-sm"
           />
@@ -305,7 +421,13 @@ export default function SearchPage() {
             border: '1px solid var(--area-accent)',
           }}
         >
-          {loading ? 'Searching...' : 'Search'}
+          {loading
+            ? mode === 'find_all'
+              ? 'Finding...'
+              : 'Searching...'
+            : mode === 'find_all'
+              ? 'Find All'
+              : 'Search'}
         </button>
       </form>
 
@@ -315,12 +437,12 @@ export default function SearchPage() {
         </div>
       )}
 
-      {results && (
+      {searchResults && (
         <>
-          {results.possible_conflict && results.conflict_sources.length > 0 && (
+          {searchResults.possible_conflict && searchResults.conflict_sources.length > 0 && (
             <div className="mb-4 rounded-sm bg-amber-50 dark:bg-amber-900/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-400">
               <strong>Possible conflict:</strong> Similar content found across multiple sources:{' '}
-              {results.conflict_sources.map((s, i) => (
+              {searchResults.conflict_sources.map((s, i) => (
                 <span key={s.doc_id}>
                   {i > 0 && ', '}
                   <Link to={`/docs/${s.doc_id}`} className="font-medium text-amber-900 dark:text-amber-300 underline">
@@ -331,11 +453,11 @@ export default function SearchPage() {
             </div>
           )}
 
-          {results.hits.length === 0 && currentPage === 1 ? (
+          {searchResults.hits.length === 0 && currentPage === 1 ? (
             <p className="text-gray-500 dark:text-gray-400">No results found.</p>
           ) : (
             <div className="space-y-3">
-              {results.hits.map((hit) => {
+              {searchResults.hits.map((hit) => {
                 const linkTo =
                   hit.page_start != null
                     ? `/docs/${hit.doc_id}?showContent=true&page=${hit.page_start}`
@@ -370,6 +492,7 @@ export default function SearchPage() {
                     </div>
                     <p className="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{hit.chunk_text}</p>
                     <div className="flex items-center space-x-3 text-xs text-gray-400">
+                      {hit.citation && <span>{hit.citation}</span>}
                       {hit.page_start != null && (
                         <span>
                           Page {hit.page_start}
@@ -377,6 +500,7 @@ export default function SearchPage() {
                         </span>
                       )}
                       <span>Lang: {hit.language}</span>
+                      {hit.source?.relative_path && <span>{hit.source.relative_path}</span>}
                       {hit.ocr_used && (
                         <span className="rounded-md text-[11px] font-medium bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5">
                           OCR
@@ -391,8 +515,96 @@ export default function SearchPage() {
               <div className="flex items-center justify-between pt-2">
                 <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
                   <span>
-                    Showing {results.total_candidates === 0 ? 0 : startIdx + 1}&ndash;
-                    {Math.min(startIdx + pageSize, results.total_candidates)} of {results.total_candidates} results
+                    Showing {searchResults.total_candidates === 0 ? 0 : startIdx + 1}&ndash;
+                    {Math.min(startIdx + pageSize, searchResults.total_candidates)} of {searchResults.total_candidates}{' '}
+                    results
+                  </span>
+                  <select
+                    value={pageSize}
+                    onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+                    className="rounded-md border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) py-0.5 pl-2 pr-6 text-sm"
+                  >
+                    {PAGE_SIZES.map((s) => (
+                      <option key={s} value={s}>
+                        {s} / page
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {findAllResults && (
+        <>
+          {findAllResults.results.length === 0 && currentPage === 1 ? (
+            <p className="text-gray-500 dark:text-gray-400">No documents found.</p>
+          ) : (
+            <div className="space-y-3">
+              {findAllResults.results.map((hit) => {
+                const page = hit.top_chunk?.page ?? firstPageFromRange(hit.page_range)
+                const linkTo =
+                  page != null
+                    ? `/docs/${hit.doc_id}?showContent=true&page=${page}`
+                    : `/docs/${hit.doc_id}?showContent=true`
+                const linkState =
+                  hit.top_chunk?.text || hit.top_chunk?.chunk_id
+                    ? {
+                        highlightChunkText: hit.top_chunk?.text,
+                        highlightChunkId: hit.top_chunk?.chunk_id,
+                      }
+                    : undefined
+
+                return (
+                  <Card key={hit.doc_id} className="p-4">
+                    <div className="mb-2 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <Link
+                          to={linkTo}
+                          state={linkState}
+                          className="font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                        >
+                          {hit.doc_title || 'Untitled'}
+                        </Link>
+                        {hit.source?.folder_label && (
+                          <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{hit.source.folder_label}</div>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 items-center space-x-2">
+                        <div className="h-1.5 w-24 rounded-full bg-gray-200 dark:bg-gray-600">
+                          <div
+                            className="h-1.5 rounded-full bg-blue-500"
+                            style={{
+                              width: `${Math.round((hit.score / maxScore) * 100)}%`,
+                            }}
+                          />
+                        </div>
+                        <span className="text-xs text-gray-400">{hit.score.toFixed(3)}</span>
+                      </div>
+                    </div>
+                    {hit.top_chunk?.text && (
+                      <p className="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{hit.top_chunk.text}</p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
+                      {hit.citation && <span>{hit.citation}</span>}
+                      {hit.page_range && <span>Pages {hit.page_range}</span>}
+                      {hit.language && <span>Lang: {hit.language}</span>}
+                      {hit.mime_type && <span>{hit.mime_type}</span>}
+                      {hit.source?.relative_path && <span>{hit.source.relative_path}</span>}
+                    </div>
+                  </Card>
+                )
+              })}
+
+              <div className="flex items-center justify-between pt-2">
+                <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                  <span>
+                    Showing {findAllResults.total_matches === 0 ? 0 : startIdx + 1}&ndash;
+                    {Math.min(startIdx + pageSize, findAllResults.total_matches)} of {findAllResults.total_matches}{' '}
+                    documents
                   </span>
                   <select
                     value={pageSize}


### PR DESCRIPTION
## Summary
- add a Search / Find All mode toggle to the Search page
- call `POST /api/search/find-all` in Find All mode with full presentation
- render document-deduped results with top chunk text, citations, source folder/path, and pagination
- add SearchPage tests for default Search and Find All endpoint/rendering behavior

## Tests
- `npm run test -- SearchPage.test.tsx --run`
- `npm run type-check`
- `npx eslint src/pages/SearchPage.tsx src/pages/SearchPage.test.tsx`
- `npx prettier --check src/pages/SearchPage.tsx src/pages/SearchPage.test.tsx`
- `npm run build`

## Browser check
- Started Vite at `http://127.0.0.1:5173/`; `/search` redirects to login without an auth context, so live page interaction was covered by mocked React tests instead of the live backend.
