### PR TITLE
docs(integrations): align CLI find-all guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,12 +114,12 @@ Hybrid search: Postgres FTS (bilingual, queries both `fts_en` and `fts_fr` colum
 
 ## Key API Surface
 
-- REST: `/api/auth/login`, `/api/docs`, `/api/search`, `/api/passages/read`, `/api/system/health`
+- REST: `/api/auth/login`, `/api/docs`, `/api/search`, `/api/search/find-all`, `/api/passages/read`, `/api/system/health`
 - Watch: `/api/watch/system`, `/api/watch/folders` (CRUD; POST gated to macOS via `picker=ui`), `/api/watch/folders/{id}/progress`, `/api/watch/folders/stream`, `/api/watch/folders/{id}/rescan`, `/api/watch/ingest`, `/api/watch/remove`, `/api/watch/rename`, `/api/watch/allowed-extensions`
 - Source files: `/api/docs/{id}/download` (gated by `ALLOW_SOURCE_DOWNLOAD`, default off; macOS uses `window.harborclerk.revealInFinder` instead)
 - Legacy: `/api/uploads*` — endpoints retained for non-interactive ingest paths (planned email ingestion); no UI affordance
 - MCP: `POST /mcp` — 19 tools: `kb_search`, `kb_batch_search`, `kb_find_all`, `kb_read_passages`, `kb_expand_context`, `kb_get_document`, `kb_list_recent`, `kb_corpus_overview`, `kb_document_outline`, `kb_find_related`, `kb_entity_search`, `kb_entity_overview`, `kb_entity_cooccurrence`, `kb_read_document`, `kb_verify_identifier`, `kb_documents_by_date`, `kb_ingest_status`, `kb_reprocess`, `kb_system_health`
-- CLI: `harbor-clerk <command>` — 18 subcommands mirroring the MCP tools (all except `kb_find_all`), for CLI-orchestrating agent harnesses (OpenClaw, Claude Code, Codex, Aider). Off by default. macOS: toggle in **Harbor Clerk Server → Preferences** — `MCPAuthMiddleware` re-reads the config file on every CLI request, so the change takes effect in seconds without a service restart. Docker: set `ENABLE_CLI_ACCESS=true` in the env and restart the API service. Audit-logged as `request_type="cli_tool"`. Auth via `HARBOR_CLERK_API_KEY`. Skill markdown at `skills/harbor-clerk/SKILL.md`; Integrations page surfaces a copy-paste block.
+- CLI: `harbor-clerk <command>` — 19 subcommands mirroring the MCP tools, including `find-all` for document enumeration, for CLI-orchestrating agent harnesses (OpenClaw, Claude Code, Codex, Aider). Off by default. macOS: toggle in **Harbor Clerk Server → Preferences** — `MCPAuthMiddleware` re-reads the config file on every CLI request, so the change takes effect in seconds without a service restart. Docker: set `ENABLE_CLI_ACCESS=true` in the env and restart the API service. Audit-logged as `request_type="cli_tool"`. Auth via `HARBOR_CLERK_API_KEY`. Skill markdown at `skills/harbor-clerk/SKILL.md`; Integrations page surfaces a copy-paste block.
 - SSE: `GET /api/jobs/stream` — streams job progress events (server→client only)
 
 ## Database

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Connect ChatGPT, Claude Desktop, Claude Code, Gemini CLI, OpenClaw, or any MCP-c
 
 ### Agentic CLI — full surface
 
-The `harbor-clerk` CLI mirrors 18 of the 19 MCP tools as shell subcommands. See the [Three ways to use Harbor Clerk](#three-ways-to-use-harbor-clerk) overview above for the framing; this section is the operator detail.
+The `harbor-clerk` CLI mirrors the MCP tool surface as shell subcommands, including `find-all` for document enumeration. See the [Three ways to use Harbor Clerk](#three-ways-to-use-harbor-clerk) overview above for the framing; this section is the operator detail.
 
 **Enabling it:**
 
@@ -337,6 +337,7 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 | `/api/stats/entity-network` | GET | Entity co-occurrence network graph |
 | `/api/docs/{id}/stats` | GET | Per-document statistics |
 | `/api/search` | POST | Hybrid search (with optional filtering and facets) |
+| `/api/search/find-all` | POST | Enumerate matching documents with filters and pagination |
 | `/api/passages/read` | POST | Read passages by chunk IDs |
 | `/api/chat/conversations` | GET/POST | List or create chat conversations |
 | `/api/chat/conversations/{id}/messages` | POST | Send a message (streamed response with RAG) |
@@ -356,13 +357,13 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 
 ### MCP
 
-`POST /mcp` — Streamable HTTP transport. Authenticate with `Authorization: Bearer <api_key>`. 19 tools available; the CLI mirrors all of them except `kb_find_all` (which is an enumeration shape that agents use less than search).
+`POST /mcp` — Streamable HTTP transport. Authenticate with `Authorization: Bearer <api_key>`. 19 tools available; the CLI mirrors the same practical tool surface, including `kb_find_all` via `harbor-clerk find-all`.
 
 | Tool | Description |
 |---|---|
 | `kb_search` | Hybrid search with pagination, detail modes, and optional filters |
 | `kb_batch_search` | Run up to 5 search queries in a single call |
-| `kb_find_all` | Unified enumeration: list, filter, and paginate documents without scoring (MCP-only) |
+| `kb_find_all` | Unified enumeration: list, filter, and paginate matching documents |
 | `kb_read_passages` | Read specific passages by chunk ID |
 | `kb_expand_context` | Get surrounding chunks for a given chunk |
 | `kb_get_document` | Document metadata and summary |

--- a/frontend/src/components/CliAccessCard.tsx
+++ b/frontend/src/components/CliAccessCard.tsx
@@ -13,14 +13,15 @@ Harbor Clerk is a local document corpus with hybrid FTS+vector search and citati
 ## First step: discover the surface
 Run \`harbor-clerk --help\` for the full command list, then \`harbor-clerk <cmd> --help\` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
 
-## Three patterns you'll use most
+## Four patterns you'll use most
 
 1. **Search → expand**: \`harbor-clerk search "..."\` then \`harbor-clerk expand-context <chunk_id> -n 3\` on the best hit.
-2. **Read a known document**: \`harbor-clerk read-document <doc_id>\` for full text with pagination.
-3. **Check ingest status before searching for new content**: \`harbor-clerk ingest-status <doc_id>\` returns per-stage state.
+2. **Find every matching document**: \`harbor-clerk find-all "..." --text-contains "literal phrase" --presentation full\` when the task asks to list or enumerate.
+3. **Read a known document**: \`harbor-clerk read-document <doc_id>\` for full text with pagination.
+4. **Check ingest status before searching for new content**: \`harbor-clerk ingest-status <doc_id>\` returns per-stage state.
 
 ## What you can trust
-- Search returns top-level \`.hits[]\`; each hit includes \`doc_title\`, \`pages\` when available, and \`chunk_id\`. Use those fields as the citation, then call \`read-passages\` when you need exact surrounding text.
+- Search returns top-level \`.hits[]\`; Find All returns top-level \`.results[]\`. Result-bearing commands include \`source\`, \`citation\`, and \`chunk_id\` when available. Use those fields as the citation trail, then call \`read-passages\` when you need exact surrounding text.
 - \`possible_conflict: true\` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
 - The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.
 `

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -47,13 +47,21 @@ interface ScopePreview {
 }
 
 // Mirrors src/harbor_clerk/api/scope.py — keep in sync
-const SEARCH_TIER_TOOLS = ['kb_search', 'kb_batch_search', 'kb_corpus_overview', 'kb_list_recent'] as const
+const SEARCH_TIER_TOOLS = [
+  'kb_search',
+  'kb_batch_search',
+  'kb_corpus_overview',
+  'kb_list_recent',
+  'kb_find_all',
+  'kb_documents_by_date',
+] as const
 const READ_TIER_TOOLS = [
   ...SEARCH_TIER_TOOLS,
   'kb_read_passages',
   'kb_expand_context',
   'kb_document_outline',
   'kb_get_document',
+  'kb_verify_identifier',
 ] as const
 const FULL_TIER_TOOLS = [
   ...READ_TIER_TOOLS,


### PR DESCRIPTION
## Summary
- update API key tool-tier UI to include current search/read tools (`kb_find_all`, `kb_documents_by_date`, `kb_verify_identifier`)
- update the copy-paste CLI skill to teach `harbor-clerk find-all` and citation/source fields
- remove stale README/CLAUDE claims that `kb_find_all` is MCP-only
- add `/api/search/find-all` to README REST surface

## Tests
- `npm run type-check`
- `npx eslint src/pages/ApiKeysPage.tsx src/components/CliAccessCard.tsx`
- `npx prettier --check src/pages/ApiKeysPage.tsx src/components/CliAccessCard.tsx`
- `uv run ruff check src/harbor_clerk/api/scope.py tests/test_scoped_api_keys.py`
- stale-claim grep for old MCP/CLI mismatch wording
