### PR TITLE
feat(frontend): default Home to Search or Folders

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ export default function App() {
       <Route element={<ProtectedRoute />}>
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/ask" element={<ChatPage />} />
           <Route path="/c/:conversationId" element={<ChatPage />} />
           <Route path="/folders" element={<FoldersPage />} />
           <Route path="/docs" element={<DocumentsPage />} />
@@ -49,7 +50,7 @@ export default function App() {
           <Route path="/explore" element={<ExplorePage />} />
           <Route path="/research/:researchId?" element={<ResearchPage />} />
           <Route path="/stats" element={<StatsPage />} />
-          <Route path="/chat" element={<Navigate to="/" replace />} />
+          <Route path="/chat" element={<Navigate to="/ask" replace />} />
           <Route path="/chat/:conversationId" element={<ChatRedirect />} />
           <Route path="/preferences" element={<PreferencesPage />} />
           <Route element={<AdminRoute />}>

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -1,6 +1,17 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 
-const TOP_LEVEL = new Set(['/', '/docs', '/search', '/explore', '/stats', '/admin', '/preferences', '/login', '/setup'])
+const TOP_LEVEL = new Set([
+  '/',
+  '/ask',
+  '/docs',
+  '/search',
+  '/explore',
+  '/stats',
+  '/admin',
+  '/preferences',
+  '/login',
+  '/setup',
+])
 
 function isTopLevel(pathname: string): boolean {
   if (TOP_LEVEL.has(pathname)) return true

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -85,8 +85,7 @@ export default function Layout() {
           <div className="flex h-12 items-center justify-between">
             <div className="flex items-center space-x-1">
               <NavLink
-                to="/"
-                end
+                to="/ask"
                 className={({ isActive }) =>
                   `relative mr-2 flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-semibold transition-colors ${
                     isActive

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -177,7 +177,7 @@ export default function ChatPage() {
         )
       })
       .catch(() => {
-        navigate('/')
+        navigate('/ask')
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId])
@@ -243,7 +243,7 @@ export default function ChatPage() {
   const handleNewChat = useCallback(() => {
     if (isStreaming) stopStreaming()
     loadMessages('', [])
-    navigate('/')
+    navigate('/ask')
     inputRef.current?.focus()
   }, [isStreaming, stopStreaming, loadMessages, navigate])
 
@@ -253,7 +253,7 @@ export default function ChatPage() {
       setConversations((prev) => prev.filter((c) => c.conversation_id !== convId))
       if (conversationId === convId) {
         loadMessages('', [])
-        navigate('/')
+        navigate('/ask')
       }
     },
     [conversationId, loadMessages, navigate],

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get } from '../api'
+import HomePage from './HomePage'
+
+vi.mock('../api', () => ({
+  get: vi.fn(),
+}))
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}))
+
+const getMock = vi.mocked(get)
+
+function renderHome() {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/folders" element={<div>Folders route</div>} />
+        <Route path="/search" element={<div>Search route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+  })
+
+  it('routes to folders when no watched folders exist', async () => {
+    getMock.mockResolvedValueOnce([]).mockResolvedValueOnce({ total: 0 })
+
+    renderHome()
+
+    expect(await screen.findByText('Folders route')).toBeInTheDocument()
+    expect(getMock).toHaveBeenCalledWith('/api/watch/folders')
+    expect(getMock).toHaveBeenCalledWith('/api/docs', { limit: 0 })
+  })
+
+  it('routes to folders when watched folders have no documents', async () => {
+    getMock.mockResolvedValueOnce([{ folder_id: 'folder-1' }]).mockResolvedValueOnce({ total: 0 })
+
+    renderHome()
+
+    expect(await screen.findByText('Folders route')).toBeInTheDocument()
+  })
+
+  it('routes to search when the corpus has documents', async () => {
+    getMock.mockResolvedValueOnce([{ folder_id: 'folder-1' }]).mockResolvedValueOnce({ total: 3 })
+
+    renderHome()
+
+    expect(await screen.findByText('Search route')).toBeInTheDocument()
+  })
+
+  it('falls back to search on routing probe failure', async () => {
+    getMock.mockRejectedValueOnce(new Error('network'))
+
+    renderHome()
+
+    await waitFor(() => expect(screen.getByText('Search route')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,14 +1,44 @@
-import ChatPage from './ChatPage'
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { get } from '../api'
+import { useAuth } from '../auth'
 
-/**
- * Home route ('/'). Renders the chat experience unconditionally; the
- * empty-corpus signaling is handled globally by Layout.tsx's
- * <CorpusEmptyBanner /> and the first-run <OnboardingWizard />.
- *
- * Stage 2 dropped the previous "redirect to /upload when doc count is
- * zero" behaviour — that route is gone, and yanking users off chat on
- * arrival was confusing once direct upload became internal-only.
- */
+interface FolderRow {
+  folder_id: string
+}
+
+interface DocsCount {
+  total: number
+}
+
 export default function HomePage() {
-  return <ChatPage />
+  const { token } = useAuth()
+  const [target, setTarget] = useState<'/folders' | '/search' | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+
+    let cancelled = false
+
+    async function chooseTarget() {
+      try {
+        const [folders, docs] = await Promise.all([
+          get<FolderRow[]>('/api/watch/folders'),
+          get<DocsCount>('/api/docs', { limit: 0 }),
+        ])
+        if (cancelled) return
+        setTarget(folders.length === 0 || docs.total === 0 ? '/folders' : '/search')
+      } catch {
+        if (!cancelled) setTarget('/search')
+      }
+    }
+
+    chooseTarget()
+    return () => {
+      cancelled = true
+    }
+  }, [token])
+
+  if (target) return <Navigate to={target} replace />
+  return <div className="text-sm text-(--color-text-secondary)">Loading...</div>
 }


### PR DESCRIPTION
## Summary
- change `/` from always rendering Ask/Chat to a corpus-aware redirect
- route to `/folders` when there are no watched folders or no documents
- route to `/search` when the corpus has documents
- add HomePage tests covering empty, populated, and probe-failure paths

## Tests
- `npm run test -- HomePage.test.tsx --run`
- `npm run type-check`
- `npx eslint src/pages/HomePage.tsx src/pages/HomePage.test.tsx`
- `npx prettier --check src/pages/HomePage.tsx src/pages/HomePage.test.tsx`
- `npm run build`
