### PR TITLE
feat(frontend): refresh settings navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,7 +53,7 @@ export default function App() {
           <Route path="/chat" element={<Navigate to="/ask" replace />} />
           <Route path="/chat/:conversationId" element={<ChatRedirect />} />
           <Route path="/settings" element={<SystemSettingsPage />} />
-          <Route path="/settings/preferences" element={<Navigate to="/preferences" replace />} />
+          <Route path="/settings/preferences" element={<PreferencesPage />} />
           <Route path="/preferences" element={<PreferencesPage />} />
           <Route element={<AdminRoute />}>
             <Route path="/integrations" element={<IntegrationsPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,9 +52,23 @@ export default function App() {
           <Route path="/stats" element={<StatsPage />} />
           <Route path="/chat" element={<Navigate to="/ask" replace />} />
           <Route path="/chat/:conversationId" element={<ChatRedirect />} />
+          <Route path="/settings" element={<SystemSettingsPage />} />
+          <Route path="/settings/preferences" element={<Navigate to="/preferences" replace />} />
           <Route path="/preferences" element={<PreferencesPage />} />
           <Route element={<AdminRoute />}>
             <Route path="/integrations" element={<IntegrationsPage />} />
+            <Route path="/settings/integrations" element={<IntegrationsPage />} />
+            <Route path="/settings/users" element={<UsersPage />} />
+            <Route path="/settings/api-keys" element={<ApiKeysPage />} />
+            <Route path="/settings/api-keys/:keyId" element={<ApiKeyDashboardPage />} />
+            <Route path="/settings/models" element={<ModelsPage />} />
+            <Route path="/settings/languages" element={<LanguagesPage />} />
+            <Route path="/settings/retrieval" element={<RetrievalSettingsPage />} />
+            <Route path="/settings/rate-limits" element={<RateLimitSettingsPage />} />
+            <Route path="/settings/status" element={<SystemStatusPage />} />
+            <Route path="/settings/diagnostics" element={<ServiceLogsPage />} />
+            <Route path="/settings/maintenance" element={<SystemMaintenancePage />} />
+            <Route path="/settings/security" element={<SecuritySettingsPage />} />
             <Route path="/admin" element={<SystemSettingsPage />} />
             <Route path="/admin/users" element={<UsersPage />} />
             <Route path="/admin/keys" element={<ApiKeysPage />} />

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -8,6 +8,7 @@ const TOP_LEVEL = new Set([
   '/explore',
   '/stats',
   '/admin',
+  '/settings',
   '/preferences',
   '/login',
   '/setup',

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,20 +9,33 @@ import OnboardingWizard from './OnboardingWizard'
 import { useCorpusBannerState } from '../hooks/useCorpusBannerState'
 import { useAreaAccent } from '../hooks/useAreaAccent'
 
-function TabLink({ to, end, icon, children }: { to: string; end?: boolean; icon?: string; children: React.ReactNode }) {
+function TabLink({
+  to,
+  end,
+  icon,
+  activeWhen,
+  children,
+}: {
+  to: string
+  end?: boolean
+  icon?: string
+  activeWhen?: (pathname: string) => boolean
+  children: React.ReactNode
+}) {
+  const location = useLocation()
   return (
     <NavLink
       to={to}
       end={end}
       className={({ isActive }) =>
         `relative inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors ${
-          isActive
+          isActive || activeWhen?.(location.pathname)
             ? 'text-(--area-accent-text)'
             : 'text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 hover:text-(--color-text-primary)'
         }`
       }
       style={({ isActive }) =>
-        isActive
+        isActive || activeWhen?.(location.pathname)
           ? {
               backgroundColor: 'var(--area-accent-tint)',
               boxShadow: 'inset 0 0 0 1px var(--area-accent)',
@@ -98,7 +111,7 @@ export default function Layout() {
               <TabLink to="/docs" icon="📄">
                 Documents
               </TabLink>
-              <TabLink to="/ask" icon="💬">
+              <TabLink to="/ask" icon="💬" activeWhen={(pathname) => pathname.startsWith('/c/')}>
                 Ask
               </TabLink>
               <TabLink to="/research" icon="🐙">
@@ -115,7 +128,15 @@ export default function Layout() {
               <TabLink to="/stats" icon="📊">
                 Observatory
               </TabLink>
-              <TabLink to="/settings" icon="⚙️">
+              <TabLink
+                to="/settings"
+                icon="⚙️"
+                activeWhen={(pathname) =>
+                  pathname.startsWith('/admin') ||
+                  pathname.startsWith('/integrations') ||
+                  pathname.startsWith('/preferences')
+                }
+              >
                 Settings
               </TabLink>
               <div className="relative ml-2" ref={menuRef}>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -47,6 +47,7 @@ export default function Layout() {
   const bannerSuppressedPath =
     location.pathname === '/folders' ||
     location.pathname.startsWith('/admin') ||
+    location.pathname.startsWith('/settings') ||
     location.pathname.startsWith('/preferences')
   const showBanner = bannerState !== null && !bannerSuppressedPath
   const showWizard = !!user && !user.preferences?.onboardingComplete
@@ -85,48 +86,38 @@ export default function Layout() {
           <div className="flex h-12 items-center justify-between">
             <div className="flex items-center space-x-1">
               <NavLink
-                to="/ask"
-                className={({ isActive }) =>
-                  `relative mr-2 flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-semibold transition-colors ${
-                    isActive
-                      ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 ring-1 ring-amber-200/60 dark:ring-amber-700/40'
-                      : 'text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6'
-                  }`
-                }
+                to="/"
+                className="relative mr-2 flex items-center rounded-lg px-2 py-1 transition-colors text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6"
+                aria-label="Harbor Clerk home"
               >
                 <img src="/favicon.svg" alt="" className="h-6 w-6" />
-                <span>Ask</span>
               </NavLink>
+              <TabLink to="/search" icon="🔍">
+                Search
+              </TabLink>
+              <TabLink to="/docs" icon="📄">
+                Documents
+              </TabLink>
+              <TabLink to="/ask" icon="💬">
+                Ask
+              </TabLink>
               <TabLink to="/research" icon="🐙">
                 Research
               </TabLink>
               <TabLink to="/folders" icon="📁">
                 Folders
               </TabLink>
-              <TabLink to="/docs" icon="📄">
-                Documents
-              </TabLink>
               <TabLink to="/explore" icon="🌍">
                 Explore
-              </TabLink>
-              <TabLink to="/search" icon="🔍">
-                Search
               </TabLink>
             </div>
             <div className="flex items-center space-x-1">
               <TabLink to="/stats" icon="📊">
                 Observatory
               </TabLink>
-              {isAdmin && (
-                <TabLink to="/integrations" icon="🔌">
-                  Integrations
-                </TabLink>
-              )}
-              {isAdmin && (
-                <TabLink to="/admin" icon="⚙️">
-                  System Settings
-                </TabLink>
-              )}
+              <TabLink to="/settings" icon="⚙️">
+                Settings
+              </TabLink>
               <div className="relative ml-2" ref={menuRef}>
                 <button
                   onClick={() => setMenuOpen(!menuOpen)}

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -111,7 +111,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
         await patch('/api/me/preferences', { enabled_languages: installed })
       } catch (e) {
         // Pref-save failed but packs are on disk. Surface so the
-        // operator can flip the toggle in System Settings → Languages.
+        // operator can flip the toggle in Settings → Languages.
         failures.push(`preferences save (${e instanceof Error ? e.message : 'unknown'})`)
       }
     }
@@ -121,7 +121,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
     if (failures.length > 0) {
       setError(
         `Some languages failed to install: ${failures.join(', ')}. ` +
-          `Successfully installed languages are still available — manage them under System Settings → Languages.`,
+          `Successfully installed languages are still available — manage them under Settings → Languages.`,
       )
       // Stay on this page so the user sees the error; they can click
       // Skip to advance once they've read it.

--- a/frontend/src/components/SummaryChip.tsx
+++ b/frontend/src/components/SummaryChip.tsx
@@ -24,7 +24,7 @@ const LABELS: Record<Exclude<SummaryState, 'none'>, string> = {
 
 const TOOLTIPS: Partial<Record<Exclude<SummaryState, 'none'>, string>> = {
   extractive:
-    'No language model was active when this summary was generated, so the system fell back to an extractive heuristic. Configure an LLM in System Settings → Models for higher-quality summaries on future documents.',
+    'No language model was active when this summary was generated, so the system fell back to an extractive heuristic. Configure a local AI model in Settings → Models for higher-quality summaries on future documents.',
   failed: 'The summarize stage errored. The document is otherwise fully ingested and searchable.',
 }
 

--- a/frontend/src/hooks/useAreaAccent.ts
+++ b/frontend/src/hooks/useAreaAccent.ts
@@ -13,7 +13,11 @@ const ROUTE_TO_AREA: { test: (path: string) => boolean; area: AreaHue }[] = [
   { test: (p) => p.startsWith('/search'), area: 'search' },
   { test: (p) => p.startsWith('/stats'), area: 'observatory' },
   {
-    test: (p) => p.startsWith('/admin') || p.startsWith('/integrations') || p.startsWith('/preferences'),
+    test: (p) =>
+      p.startsWith('/admin') ||
+      p.startsWith('/settings') ||
+      p.startsWith('/integrations') ||
+      p.startsWith('/preferences'),
     area: 'settings',
   },
   // Ask is the default — matches '/' and '/c/:conversationId'.

--- a/frontend/src/pages/ApiKeyDashboardPage.tsx
+++ b/frontend/src/pages/ApiKeyDashboardPage.tsx
@@ -185,7 +185,7 @@ export default function ApiKeyDashboardPage() {
   if (!keyInfo) {
     return (
       <div className="animate-slide-in">
-        <Link to="/admin/keys" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+        <Link to="/settings/api-keys" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
           &larr; API Keys
         </Link>
         <p className="mt-4 text-gray-500 dark:text-gray-400">API key not found.</p>
@@ -214,7 +214,10 @@ export default function ApiKeyDashboardPage() {
     <div className="animate-slide-in space-y-6">
       {/* Header */}
       <div>
-        <Link to="/admin/keys" className="mb-2 inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline">
+        <Link
+          to="/settings/api-keys"
+          className="mb-2 inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
           &larr; API Keys
         </Link>
         <PageHeader

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -317,7 +317,10 @@ export default function ApiKeysPage() {
             {keys.map((k) => (
               <tr key={k.key_id} className="hover:bg-black/3 dark:hover:bg-white/3">
                 <td className="px-4 py-3 text-sm font-medium">
-                  <Link to={`/admin/keys/${k.key_id}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                  <Link
+                    to={`/settings/api-keys/${k.key_id}`}
+                    className="text-blue-600 dark:text-blue-400 hover:underline"
+                  >
                     {k.name}
                   </Link>
                 </td>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -597,7 +597,7 @@ function ModelNudge() {
           — strong reasoning, tool use, and bilingual support.
         </p>
         <Link
-          to="/admin/models"
+          to="/settings/models"
           className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
         >
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -640,10 +640,10 @@ export default function DocumentsPage() {
             summaries, activate a model.
           </span>
           <Link
-            to="/admin/models"
+            to="/settings/models"
             className="ml-3 shrink-0 rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700"
           >
-            System Settings → Models
+            Settings → Models
           </Link>
         </div>
       )}

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -316,7 +316,7 @@ export default function IntegrationsPage() {
             </p>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
-                <Link to="/admin/keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
                   Create an API key
                 </Link>{' '}
                 if you don&apos;t have one already.
@@ -357,7 +357,7 @@ export default function IntegrationsPage() {
           <>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
-                <Link to="/admin/keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
                   Create an API key
                 </Link>{' '}
                 if you don&apos;t have one already.
@@ -396,7 +396,7 @@ export default function IntegrationsPage() {
             </p>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
-                <Link to="/admin/keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
                   Create a scoped API key
                 </Link>{' '}
                 with the following recommended settings:
@@ -449,7 +449,10 @@ export default function IntegrationsPage() {
                 OpenClaw agents run autonomously and may make many tool calls in rapid succession. Always scope the API
                 key to only the documents and tools the agent needs, set rate limits to prevent runaway loops, and use
                 the{' '}
-                <Link to="/admin/keys" className="text-amber-800 dark:text-amber-200 underline hover:no-underline">
+                <Link
+                  to="/settings/api-keys"
+                  className="text-amber-800 dark:text-amber-200 underline hover:no-underline"
+                >
                   audit dashboard
                 </Link>{' '}
                 to monitor usage.

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -988,7 +988,7 @@ function ModelNudge() {
         Deep Research drives a local LLM through many tool calls — pick a model first.
       </p>
       <Link
-        to="/admin/models"
+        to="/settings/models"
         className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2 text-[13px] font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
       >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/pages/SystemSettingsPage.test.tsx
+++ b/frontend/src/pages/SystemSettingsPage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuth } from '../auth'
+import SystemSettingsPage from './SystemSettingsPage'
+
+vi.mock('../auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+const useAuthMock = vi.mocked(useAuth)
+
+function mockAuth(isAdmin: boolean) {
+  useAuthMock.mockReturnValue({
+    user: {
+      user_id: 'user-1',
+      email: isAdmin ? 'admin@example.com' : 'user@example.com',
+      role: isAdmin ? 'admin' : 'user',
+      preferences: {},
+    },
+    token: 'test-token',
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    updatePreferences: vi.fn(),
+    isAdmin,
+  } as ReturnType<typeof useAuth>)
+}
+
+function renderSettings() {
+  render(
+    <MemoryRouter>
+      <SystemSettingsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SystemSettingsPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset()
+  })
+
+  it('shows the full settings hub for admins', () => {
+    mockAuth(true)
+
+    renderSettings()
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
+    expect(screen.getAllByText('Integrations').length).toBeGreaterThan(0)
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+    expect(screen.getByText('Models')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Diagnostics')).toBeInTheDocument()
+  })
+
+  it('keeps non-admin settings focused on preferences', () => {
+    mockAuth(false)
+
+    renderSettings()
+
+    expect(screen.getByText('Preferences')).toBeInTheDocument()
+    expect(screen.getByText('Admin-only settings are hidden for this account.')).toBeInTheDocument()
+    expect(screen.queryByText('API Keys')).not.toBeInTheDocument()
+    expect(screen.queryByText('Models')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -15,52 +15,103 @@ interface SettingsItem {
 
 const SECTIONS: { label: string; items: SettingsItem[] }[] = [
   {
+    label: 'Personal',
+    items: [
+      {
+        to: '/preferences',
+        label: 'Preferences',
+        sub: 'Theme, page size, and account settings',
+        icon: '👤',
+        hue: 'settings',
+      },
+    ],
+  },
+]
+
+const ADMIN_SECTIONS: { label: string; items: SettingsItem[] }[] = [
+  {
+    label: 'Integrations',
+    items: [
+      {
+        to: '/settings/integrations',
+        label: 'Integrations',
+        sub: 'MCP, CLI, and external AI tool setup',
+        icon: '🔌',
+        hue: 'research',
+      },
+    ],
+  },
+  {
     label: 'Access & identity',
     items: [
-      { to: '/admin/users', label: 'Users', sub: 'Manage accounts and roles', icon: '👥', hue: 'docs' },
-      { to: '/admin/keys', label: 'API Keys', sub: 'Create and revoke API keys', icon: '🔑', hue: 'research' },
+      { to: '/settings/users', label: 'Users', sub: 'Manage accounts and roles', icon: '👥', hue: 'docs' },
+      {
+        to: '/settings/api-keys',
+        label: 'API Keys',
+        sub: 'Create, scope, and revoke API keys',
+        icon: '🔑',
+        hue: 'research',
+      },
     ],
   },
   {
     label: 'Models & languages',
     items: [
-      { to: '/admin/models', label: 'Models', sub: 'Download and manage LLM models', icon: '🧠', hue: 'observatory' },
-      { to: '/admin/languages', label: 'Languages', sub: 'OCR & entity language packs', icon: '🌐', hue: 'explore' },
+      {
+        to: '/settings/models',
+        label: 'Models',
+        sub: 'Download and manage local AI models',
+        icon: '🧠',
+        hue: 'observatory',
+      },
+      {
+        to: '/settings/languages',
+        label: 'Languages',
+        sub: 'OCR and entity language packs',
+        icon: '🌐',
+        hue: 'explore',
+      },
     ],
   },
   {
     label: 'Behavior & limits',
     items: [
-      { to: '/admin/retrieval', label: 'Retrieval', sub: 'Chat & MCP search behavior', icon: '🔍', hue: 'search' },
-      { to: '/admin/rate-limits', label: 'Rate Limits', sub: 'Default API key rate limits', icon: '⏱', hue: 'ask' },
+      {
+        to: '/settings/retrieval',
+        label: 'Retrieval',
+        sub: 'Ask, Research, MCP, and search behavior',
+        icon: '🔍',
+        hue: 'search',
+      },
+      { to: '/settings/rate-limits', label: 'Rate Limits', sub: 'Default API key rate limits', icon: '⏱', hue: 'ask' },
     ],
   },
   {
     label: 'Operations',
     items: [
       {
-        to: '/admin/system/status',
-        label: 'System Status',
-        sub: 'Health checks and statistics',
+        to: '/settings/status',
+        label: 'Status',
+        sub: 'Readiness, service health, and mail account state',
         icon: '💚',
         hue: 'observatory',
       },
       {
-        to: '/admin/system/logs',
-        label: 'Service Logs',
-        sub: 'View log files and tail commands',
+        to: '/settings/diagnostics',
+        label: 'Diagnostics',
+        sub: 'Logs and advanced troubleshooting detail',
         icon: '📜',
         hue: 'settings',
       },
       {
-        to: '/admin/system/maintenance',
-        label: 'System Maintenance',
+        to: '/settings/maintenance',
+        label: 'Maintenance',
         sub: 'Purge, reaper, and cleanup',
         icon: '🧹',
         hue: 'ask',
       },
       {
-        to: '/admin/system/security',
+        to: '/settings/security',
         label: 'Security',
         sub: 'Encryption status and master key management',
         icon: '🔒',
@@ -71,20 +122,18 @@ const SECTIONS: { label: string; items: SettingsItem[] }[] = [
 ]
 
 export default function SystemSettingsPage() {
-  const { user } = useAuth()
-  if (user?.role !== 'admin') {
-    return (
-      <div className="mx-auto max-w-4xl px-4 py-8">
-        <PageHeader title="System Settings" />
-        <p className="text-sm text-(--color-text-secondary)">Admins only.</p>
-      </div>
-    )
-  }
+  const { isAdmin } = useAuth()
+  const sections = isAdmin ? [...SECTIONS, ...ADMIN_SECTIONS] : SECTIONS
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      <PageHeader title="System Settings" />
-      {SECTIONS.map((section) => (
+      <PageHeader title="Settings" subtitle="Preferences, integrations, models, status, and diagnostics." />
+      {!isAdmin && (
+        <p className="mb-5 rounded-lg bg-(--color-bg-secondary) px-3 py-2 text-sm text-(--color-text-secondary)">
+          Admin-only settings are hidden for this account.
+        </p>
+      )}
+      {sections.map((section) => (
         <div key={section.label} className="mb-6">
           <h2 className="mb-2 font-serif text-base font-semibold tracking-tight text-(--color-text-primary)">
             {section.label}

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -127,7 +127,12 @@ export default function SystemSettingsPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      <PageHeader title="Settings" subtitle="Preferences, integrations, models, status, and diagnostics." />
+      <PageHeader
+        title="Settings"
+        subtitle={
+          isAdmin ? 'Preferences, integrations, models, status, and diagnostics.' : 'Preferences and account settings.'
+        }
+      />
       {!isAdmin && (
         <p className="mb-5 rounded-lg bg-(--color-bg-secondary) px-3 py-2 text-sm text-(--color-text-secondary)">
           Admin-only settings are hidden for this account.

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -18,7 +18,7 @@ const SECTIONS: { label: string; items: SettingsItem[] }[] = [
     label: 'Personal',
     items: [
       {
-        to: '/preferences',
+        to: '/settings/preferences',
         label: 'Preferences',
         sub: 'Theme, page size, and account settings',
         icon: '👤',

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -96,8 +96,8 @@ export default function SystemStatusPage() {
   return (
     <div className="animate-slide-in">
       <PageHeader
-        title="System Status"
-        subtitle="Health checks and service statistics"
+        title="Status"
+        subtitle="System readiness, service health, and account state"
         actions={
           <button
             onClick={handleRefresh}
@@ -114,7 +114,7 @@ export default function SystemStatusPage() {
         </div>
       )}
 
-      <h2 className="mb-3 text-lg font-semibold">Health Checks</h2>
+      <h2 className="mb-3 text-lg font-semibold">Service Health</h2>
       {health && (
         <div className="mb-6 grid grid-cols-3 gap-4">
           <HealthCard


### PR DESCRIPTION
## Summary
- Reorders primary chrome around Search, Documents, Ask, Research, Folders, and Explore, with Observatory and Settings on the right.
- Adds `/settings` as a real settings hub available to all users, with admin-only settings cards shown only to admins.
- Adds `/settings/...` admin aliases while preserving existing `/admin/...` and `/integrations` routes.
- Renames the user-facing status surface from System Status/Health Checks toward Status/Service Health and updates model/API-key links to the Settings aliases.

## Tests
- `npm run test -- SystemSettingsPage.test.tsx HomePage.test.tsx --run`
- `npm run type-check`
- `npx eslint src/App.tsx src/components/Layout.tsx src/components/BackButton.tsx src/hooks/useAreaAccent.ts src/pages/SystemSettingsPage.tsx src/pages/SystemSettingsPage.test.tsx src/pages/SystemStatusPage.tsx src/pages/ChatPage.tsx src/pages/DocumentsPage.tsx src/pages/ResearchPage.tsx src/pages/ApiKeysPage.tsx src/pages/ApiKeyDashboardPage.tsx src/pages/IntegrationsPage.tsx src/components/OnboardingWizard.tsx src/components/SummaryChip.tsx` (existing SummaryChip fast-refresh warning only)
- `npx prettier --check src/App.tsx src/components/Layout.tsx src/components/BackButton.tsx src/hooks/useAreaAccent.ts src/pages/SystemSettingsPage.tsx src/pages/SystemSettingsPage.test.tsx src/pages/SystemStatusPage.tsx src/pages/ChatPage.tsx src/pages/DocumentsPage.tsx src/pages/ResearchPage.tsx src/pages/ApiKeysPage.tsx src/pages/ApiKeyDashboardPage.tsx src/pages/IntegrationsPage.tsx src/components/OnboardingWizard.tsx src/components/SummaryChip.tsx`
- `npm run build` (existing Vite chunk-size warning only)