### PR TITLE
feat(frontend): add global status pill

### DIFF
--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSystemConfig, type SystemConfig } from '../hooks/useSystemConfig'
+import { useLLMStatusContext } from './LLMStatusBanner'
+import GlobalStatusPill from './GlobalStatusPill'
+
+vi.mock('../hooks/useSystemConfig', () => ({
+  useSystemConfig: vi.fn(),
+}))
+
+vi.mock('./LLMStatusBanner', () => ({
+  useLLMStatusContext: vi.fn(),
+}))
+
+const useSystemConfigMock = vi.mocked(useSystemConfig)
+const useLLMStatusContextMock = vi.mocked(useLLMStatusContext)
+
+const READY_CONFIG: SystemConfig = {
+  healthStatus: 'healthy',
+  allowSourceDownload: false,
+  enableCliAccess: false,
+  cliShimInstallStatus: null,
+  loaded: true,
+}
+
+function mockPill({
+  config = READY_CONFIG,
+  llmState = 'ready',
+}: {
+  config?: SystemConfig
+  llmState?: 'deactivated' | 'loading' | 'ready' | 'unknown'
+}) {
+  useSystemConfigMock.mockReturnValue(config)
+  useLLMStatusContextMock.mockReturnValue({
+    status: {
+      state: llmState,
+      model_id: llmState === 'ready' ? 'qwen3' : null,
+      model_name: llmState === 'ready' ? 'Qwen3' : null,
+    },
+    markTransitioning: vi.fn(),
+  })
+}
+
+function renderPill() {
+  render(
+    <MemoryRouter>
+      <GlobalStatusPill />
+    </MemoryRouter>,
+  )
+}
+
+describe('GlobalStatusPill', () => {
+  beforeEach(() => {
+    useSystemConfigMock.mockReset()
+    useLLMStatusContextMock.mockReset()
+  })
+
+  it('links degraded system health to Status', () => {
+    mockPill({ config: { ...READY_CONFIG, healthStatus: 'degraded' } })
+
+    renderPill()
+
+    const link = screen.getByRole('link', { name: 'Status: Needs attention' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+    expect(screen.getByText('Needs attention')).toBeInTheDocument()
+  })
+
+  it('links inactive local AI to Models', () => {
+    mockPill({ llmState: 'deactivated' })
+
+    renderPill()
+
+    const link = screen.getByRole('link', { name: 'Status: Choose model' })
+    expect(link).toHaveAttribute('href', '/settings/models')
+  })
+
+  it('shows ready when system health and local AI are ready', () => {
+    mockPill({})
+
+    renderPill()
+
+    const link = screen.getByRole('link', { name: 'Status: Ready' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+  })
+})

--- a/frontend/src/components/GlobalStatusPill.tsx
+++ b/frontend/src/components/GlobalStatusPill.tsx
@@ -1,0 +1,97 @@
+import { Link } from 'react-router-dom'
+import { useSystemConfig } from '../hooks/useSystemConfig'
+import { useLLMStatusContext } from './LLMStatusBanner'
+import { StatusPill, type PillState } from './StatusPill'
+
+interface PillView {
+  label: string
+  glyph?: string
+  state: PillState
+  title: string
+  to: string
+}
+
+function statusView({
+  healthStatus,
+  loaded,
+  llmState,
+}: {
+  healthStatus: 'healthy' | 'degraded' | null
+  loaded: boolean
+  llmState: string
+}): PillView {
+  if (healthStatus === 'degraded') {
+    return {
+      label: 'Needs attention',
+      glyph: '⚠',
+      state: 'error',
+      title: 'System checks need attention',
+      to: '/settings/status',
+    }
+  }
+
+  if (!loaded) {
+    return {
+      label: 'Checking',
+      state: 'pending',
+      title: 'Checking system status',
+      to: '/settings/status',
+    }
+  }
+
+  if (llmState === 'loading') {
+    return {
+      label: 'AI loading',
+      state: 'running',
+      title: 'Local AI model is loading',
+      to: '/settings/models',
+    }
+  }
+
+  if (llmState === 'deactivated') {
+    return {
+      label: 'Choose model',
+      state: 'idle',
+      title: 'No local AI model is active',
+      to: '/settings/models',
+    }
+  }
+
+  if (llmState === 'unknown') {
+    return {
+      label: 'AI unknown',
+      state: 'pending',
+      title: 'Local AI status is unknown',
+      to: '/settings/models',
+    }
+  }
+
+  return {
+    label: 'Ready',
+    glyph: '●',
+    state: 'active',
+    title: 'System ready',
+    to: '/settings/status',
+  }
+}
+
+export default function GlobalStatusPill() {
+  const { status } = useLLMStatusContext()
+  const systemConfig = useSystemConfig()
+  const view = statusView({
+    healthStatus: systemConfig.healthStatus,
+    loaded: systemConfig.loaded,
+    llmState: status.state,
+  })
+
+  return (
+    <Link
+      to={view.to}
+      aria-label={`Status: ${view.label}`}
+      title={view.title}
+      className="inline-flex rounded-full transition-opacity hover:opacity-80 focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+    >
+      <StatusPill state={view.state} label={view.label} glyph={view.glyph} />
+    </Link>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { LLMStatusBanner, LLMStatusProvider } from './LLMStatusBanner'
 import { QueueTray } from './queue-tray'
 import CorpusEmptyBanner from './CorpusEmptyBanner'
 import OnboardingWizard from './OnboardingWizard'
+import GlobalStatusPill from './GlobalStatusPill'
 import { useCorpusBannerState } from '../hooks/useCorpusBannerState'
 import { useAreaAccent } from '../hooks/useAreaAccent'
 
@@ -94,101 +95,102 @@ export default function Layout() {
 
   return (
     <div data-layout-root className="min-h-screen bg-(--color-bg-primary)">
-      <nav className="sticky top-0 z-40 border-b border-(--color-border) bg-(--bg-vibrancy) backdrop-blur-xl">
-        <div className="mx-auto max-w-7xl px-4">
-          <div className="flex h-12 items-center justify-between">
-            <div className="flex items-center space-x-1">
-              <NavLink
-                to="/"
-                className="relative mr-2 flex items-center rounded-lg px-2 py-1 transition-colors text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6"
-                aria-label="Harbor Clerk home"
-              >
-                <img src="/favicon.svg" alt="" className="h-6 w-6" />
-              </NavLink>
-              <TabLink to="/search" icon="🔍">
-                Search
-              </TabLink>
-              <TabLink to="/docs" icon="📄">
-                Documents
-              </TabLink>
-              <TabLink to="/ask" icon="💬" activeWhen={(pathname) => pathname.startsWith('/c/')}>
-                Ask
-              </TabLink>
-              <TabLink to="/research" icon="🐙">
-                Research
-              </TabLink>
-              <TabLink to="/folders" icon="📁">
-                Folders
-              </TabLink>
-              <TabLink to="/explore" icon="🌍">
-                Explore
-              </TabLink>
-            </div>
-            <div className="flex items-center space-x-1">
-              <TabLink to="/stats" icon="📊">
-                Observatory
-              </TabLink>
-              <TabLink
-                to="/settings"
-                icon="⚙️"
-                activeWhen={(pathname) =>
-                  pathname.startsWith('/admin') ||
-                  pathname.startsWith('/integrations') ||
-                  pathname.startsWith('/preferences')
-                }
-              >
-                Settings
-              </TabLink>
-              <div className="relative ml-2" ref={menuRef}>
-                <button
-                  onClick={() => setMenuOpen(!menuOpen)}
-                  className="flex items-center space-x-1 rounded-lg px-2.5 py-1.5 text-[13px] text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 transition-colors"
+      <LLMStatusProvider>
+        <nav className="sticky top-0 z-40 border-b border-(--color-border) bg-(--bg-vibrancy) backdrop-blur-xl">
+          <div className="mx-auto max-w-7xl px-4">
+            <div className="flex h-12 items-center justify-between">
+              <div className="flex items-center space-x-1">
+                <NavLink
+                  to="/"
+                  className="relative mr-2 flex items-center rounded-lg px-2 py-1 transition-colors text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6"
+                  aria-label="Harbor Clerk home"
                 >
-                  <div className="flex flex-col items-end">
-                    <span>{user?.email}</span>
-                    {isAdmin && (
-                      <span className="text-[10px] leading-tight text-amber-600 dark:text-amber-400">admin</span>
-                    )}
-                  </div>
-                  <svg
-                    className={`h-3.5 w-3.5 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
+                  <img src="/favicon.svg" alt="" className="h-6 w-6" />
+                </NavLink>
+                <TabLink to="/search" icon="🔍">
+                  Search
+                </TabLink>
+                <TabLink to="/docs" icon="📄">
+                  Documents
+                </TabLink>
+                <TabLink to="/ask" icon="💬" activeWhen={(pathname) => pathname.startsWith('/c/')}>
+                  Ask
+                </TabLink>
+                <TabLink to="/research" icon="🐙">
+                  Research
+                </TabLink>
+                <TabLink to="/folders" icon="📁">
+                  Folders
+                </TabLink>
+                <TabLink to="/explore" icon="🌍">
+                  Explore
+                </TabLink>
+              </div>
+              <div className="flex items-center space-x-1">
+                <GlobalStatusPill />
+                <TabLink to="/stats" icon="📊">
+                  Observatory
+                </TabLink>
+                <TabLink
+                  to="/settings"
+                  icon="⚙️"
+                  activeWhen={(pathname) =>
+                    pathname.startsWith('/admin') ||
+                    pathname.startsWith('/integrations') ||
+                    pathname.startsWith('/preferences')
+                  }
+                >
+                  Settings
+                </TabLink>
+                <div className="relative ml-2" ref={menuRef}>
+                  <button
+                    onClick={() => setMenuOpen(!menuOpen)}
+                    className="flex items-center space-x-1 rounded-lg px-2.5 py-1.5 text-[13px] text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 transition-colors"
                   >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                  </svg>
-                </button>
-                {menuOpen && (
-                  <div className="absolute right-0 mt-1.5 w-48 rounded-xl bg-(--bg-vibrancy) backdrop-blur-xl py-1 shadow-mac-lg ring-1 ring-(--color-border) z-50">
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        navigate('/preferences')
-                      }}
-                      className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
+                    <div className="flex flex-col items-end">
+                      <span>{user?.email}</span>
+                      {isAdmin && (
+                        <span className="text-[10px] leading-tight text-amber-600 dark:text-amber-400">admin</span>
+                      )}
+                    </div>
+                    <svg
+                      className={`h-3.5 w-3.5 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
                     >
-                      Preferences
-                    </button>
-                    <div className="mx-3 my-1 border-t border-(--color-border)" />
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        logout()
-                      }}
-                      className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
-                    >
-                      Logout
-                    </button>
-                  </div>
-                )}
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                  {menuOpen && (
+                    <div className="absolute right-0 mt-1.5 w-48 rounded-xl bg-(--bg-vibrancy) backdrop-blur-xl py-1 shadow-mac-lg ring-1 ring-(--color-border) z-50">
+                      <button
+                        onClick={() => {
+                          setMenuOpen(false)
+                          navigate('/settings/preferences')
+                        }}
+                        className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
+                      >
+                        Preferences
+                      </button>
+                      <div className="mx-3 my-1 border-t border-(--color-border)" />
+                      <button
+                        onClick={() => {
+                          setMenuOpen(false)
+                          logout()
+                        }}
+                        className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
+                      >
+                        Logout
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </nav>
-      <LLMStatusProvider>
+        </nav>
         <main className="mx-auto max-w-7xl px-4 py-6">
           {showBanner && bannerState && <CorpusEmptyBanner state={bannerState} />}
           <BackButton />

--- a/frontend/src/hooks/useSystemConfig.ts
+++ b/frontend/src/hooks/useSystemConfig.ts
@@ -2,6 +2,11 @@ import { useEffect, useState } from 'react'
 
 export interface SystemConfig {
   /**
+   * Readiness status reported by /api/system/health. This is a coarse
+   * at-a-glance signal; the Status page remains the detailed diagnostic view.
+   */
+  healthStatus: 'healthy' | 'degraded' | null
+  /**
    * True when the backend is configured to serve original document bytes
    * over /api/docs/{doc_id}/download. Defaults to false on every deployment;
    * macOS native does not expose any toggle to flip this on (use Reveal in
@@ -29,6 +34,7 @@ export interface SystemConfig {
 }
 
 const FALLBACK: SystemConfig = {
+  healthStatus: null,
   allowSourceDownload: false,
   enableCliAccess: false,
   cliShimInstallStatus: null,
@@ -55,6 +61,7 @@ export function useSystemConfig(): SystemConfig {
       .then((data) => {
         if (cancelled || !data) return
         setConfig({
+          healthStatus: data.status === 'healthy' || data.status === 'degraded' ? data.status : null,
           allowSourceDownload: Boolean(data.allow_source_download),
           enableCliAccess: Boolean(data.enable_cli_access),
           cliShimInstallStatus: data.cli_shim_install_status ?? null,


### PR DESCRIPTION
## Summary
- Adds a compact global Status pill in the app chrome.
- Uses the existing LLMStatusProvider for local AI state and extends useSystemConfig to expose the coarse system health status already returned by `/api/system/health`.
- Links Needs attention and Ready states to Settings -> Status; links local AI setup/loading/unknown states to Settings -> Models.
- Moves LLMStatusProvider to wrap the chrome as well as main content, avoiding a second local-AI poller.

## Tests
- `npm run test -- GlobalStatusPill.test.tsx --run`
- `npm run type-check`
- `npx eslint src/components/GlobalStatusPill.tsx src/components/GlobalStatusPill.test.tsx src/components/Layout.tsx src/hooks/useSystemConfig.ts`
- `npx prettier --check src/components/GlobalStatusPill.tsx src/components/GlobalStatusPill.test.tsx src/components/Layout.tsx src/hooks/useSystemConfig.ts`
- `npm run build` (existing Vite chunk-size warning only)