### PR TITLE
feat(frontend): add local model guidance labels

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,10 +52,14 @@ jobs:
         run: docker build -f docker/app.Dockerfile -t harborclerk-app:ci .
 
       - name: Build embedder image
-        run: docker build -f docker/embedder.Dockerfile -t harborclerk-embedder:ci .
+        # CI scans OS/dependency layers; model blobs are preloaded in normal
+        # builds but skipped here to avoid unauthenticated Hugging Face 429s.
+        run: docker build -f docker/embedder.Dockerfile --build-arg PRELOAD_MODEL=0 -t harborclerk-embedder:ci .
 
       - name: Build reranker image
-        run: docker build -f docker/reranker.Dockerfile -t harborclerk-reranker:ci .
+        # CI scans OS/dependency layers; model blobs are preloaded in normal
+        # builds but skipped here to avoid unauthenticated Hugging Face 429s.
+        run: docker build -f docker/reranker.Dockerfile --build-arg PRELOAD_MODEL=0 -t harborclerk-reranker:ci .
 
       - name: Install Trivy
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Harbor Clerk** — a single-tenant, watched-folder-first document archive for non-technical offices running on Mac mini/Studio. Local extraction, OCR (English/French), hybrid retrieval. Cloud LLMs query via MCP over HTTPS with read-only API keys, receiving only cited snippets (no full corpus upload). Local agent harnesses (OpenClaw, Claude Code, Codex, Aider) can use the `harbor-clerk` CLI as a parallel surface to MCP.
+**Harbor Clerk** — a single-tenant, watched-folder-first local document intelligence app for document-heavy small teams, independent operators, researchers, and privacy-focused individuals running on Mac mini/Studio or Docker. Local extraction, OCR (English/French), hybrid retrieval, local embeddings/reranking, cited local AI answers, and Research. Cloud LLMs query via MCP over HTTPS with read-only API keys, receiving only cited snippets (no full corpus upload). Local agent harnesses (OpenClaw, Claude Code, Codex, Aider) can use the `harbor-clerk` CLI as a parallel surface to MCP.
 
 Current state lives in this file plus `README.md` and `docs/architecture.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,12 +114,12 @@ Hybrid search: Postgres FTS (bilingual, queries both `fts_en` and `fts_fr` colum
 
 ## Key API Surface
 
-- REST: `/api/auth/login`, `/api/docs`, `/api/search`, `/api/passages/read`, `/api/system/health`
+- REST: `/api/auth/login`, `/api/docs`, `/api/search`, `/api/search/find-all`, `/api/passages/read`, `/api/system/health`
 - Watch: `/api/watch/system`, `/api/watch/folders` (CRUD; POST gated to macOS via `picker=ui`), `/api/watch/folders/{id}/progress`, `/api/watch/folders/stream`, `/api/watch/folders/{id}/rescan`, `/api/watch/ingest`, `/api/watch/remove`, `/api/watch/rename`, `/api/watch/allowed-extensions`
 - Source files: `/api/docs/{id}/download` (gated by `ALLOW_SOURCE_DOWNLOAD`, default off; macOS uses `window.harborclerk.revealInFinder` instead)
 - Legacy: `/api/uploads*` — endpoints retained for non-interactive ingest paths (planned email ingestion); no UI affordance
 - MCP: `POST /mcp` — 19 tools: `kb_search`, `kb_batch_search`, `kb_find_all`, `kb_read_passages`, `kb_expand_context`, `kb_get_document`, `kb_list_recent`, `kb_corpus_overview`, `kb_document_outline`, `kb_find_related`, `kb_entity_search`, `kb_entity_overview`, `kb_entity_cooccurrence`, `kb_read_document`, `kb_verify_identifier`, `kb_documents_by_date`, `kb_ingest_status`, `kb_reprocess`, `kb_system_health`
-- CLI: `harbor-clerk <command>` — 18 subcommands mirroring the MCP tools (all except `kb_find_all`), for CLI-orchestrating agent harnesses (OpenClaw, Claude Code, Codex, Aider). Off by default. macOS: toggle in **Harbor Clerk Server → Preferences** — `MCPAuthMiddleware` re-reads the config file on every CLI request, so the change takes effect in seconds without a service restart. Docker: set `ENABLE_CLI_ACCESS=true` in the env and restart the API service. Audit-logged as `request_type="cli_tool"`. Auth via `HARBOR_CLERK_API_KEY`. Skill markdown at `skills/harbor-clerk/SKILL.md`; Integrations page surfaces a copy-paste block.
+- CLI: `harbor-clerk <command>` — 19 subcommands mirroring the MCP tools, including `find-all` for document enumeration, for CLI-orchestrating agent harnesses (OpenClaw, Claude Code, Codex, Aider). Off by default. macOS: toggle in **Harbor Clerk Server → Preferences** — `MCPAuthMiddleware` re-reads the config file on every CLI request, so the change takes effect in seconds without a service restart. Docker: set `ENABLE_CLI_ACCESS=true` in the env and restart the API service. Audit-logged as `request_type="cli_tool"`. Auth via `HARBOR_CLERK_API_KEY`. Skill markdown at `skills/harbor-clerk/SKILL.md`; Integrations page surfaces a copy-paste block.
 - SSE: `GET /api/jobs/stream` — streams job progress events (server→client only)
 
 ## Database

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Harbor Clerk
 
-### Keep your data. Ask it anything.
+### Private document intelligence with search, citations, and local AI.
 
-Local-first document archive for non-technical offices. Point Harbor Clerk at a folder of PDFs, scans, notes, or research files; it OCRs, indexes, and lets you search, browse, and chat with everything — all on your own machine, all with citations.
+Harbor Clerk turns watched folders into a private, searchable document archive.
 
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Release](https://img.shields.io/badge/release-v0.9.1-blue)
@@ -15,13 +15,13 @@ Local-first document archive for non-technical offices. Point Harbor Clerk at a 
 
 ---
 
-Harbor Clerk is a safe harbor for your documents — and a capable clerk who knows where everything is. Tell it which folders to watch — contracts, scans, research, anything — and Harbor Clerk continuously reads what lands there and turns it into a searchable archive you can actually talk to.
+Harbor Clerk packages a serious local document intelligence stack into a Mac-native app: OCR for scans, hybrid lexical and semantic search, local embeddings and reranking, cited AI answers, and MCP/CLI access for agents. A technical operator could assemble pieces of this from open-source tools; Harbor Clerk makes that power available to small teams without turning document search into an infrastructure project.
 
 It reads your files in place, extracts text (including OCR for scanned documents), splits them into searchable passages, and indexes everything locally so you can search or ask questions across your entire collection. Results always come with clear citations so you can jump straight back to the original document and verify the source.
 
 Everything runs on your machine. No SaaS account. No background sync. No shared tenancy. Your originals never move — Harbor Clerk just reads them where they live.
 
-Harbor Clerk is designed for small offices, independent operators, and privacy-focused individuals. It runs comfortably on a Mac mini or similar hardware and includes a built-in chat assistant powered by a local LLM.
+Harbor Clerk is designed for document-heavy small teams, independent operators, researchers, and privacy-focused individuals. It runs comfortably on a Mac mini or similar hardware and includes cited answers powered by local AI models.
 
 If you want to connect external AI tools, Harbor Clerk exposes an MCP endpoint that allows them to search your knowledge base safely. They receive only the retrieved passages needed to answer a question — never your full documents.
 
@@ -34,7 +34,7 @@ It keeps your documents where they belong — and makes them useful.
 graph LR
     docs["Drop documents into a watched folder<br/>PDFs • Scans • Notes"]
     process["Harbor Clerk organizes them<br/>Text Extraction • OCR • Chunking • Hybrid Search + Embeddings"]
-    ask["Search or chat with your archive<br/>Answers include citations"]
+    ask["Search, ask, or research your archive<br/>Answers include citations"]
     docs --> process --> ask
 ```
 
@@ -46,7 +46,7 @@ External models can ask questions — they don't get your archive.
 graph LR
     subgraph local["Stays Local"]
         docs["Your Documents"]
-        harbor["Harbor Clerk<br/>OCR · Search · Chat"]
+        harbor["Harbor Clerk<br/>OCR · Search · Cited AI"]
     end
     subgraph external["Optional External Models"]
         models["Claude / GPT / other MCP clients"]
@@ -63,7 +63,7 @@ Once your documents are indexed, you can reach them three ways — pick whicheve
 ```mermaid
 graph LR
     corpus[("Your indexed corpus")]
-    web["Web UI<br/>Search · Chat · Research"]
+    web["Web UI<br/>Search · Ask · Research"]
     mcp["MCP endpoint<br/>Cloud LLMs · Claude · ChatGPT"]
     cli["harbor-clerk CLI<br/>Local agent harnesses<br/>OpenClaw · Claude Code · Codex · Aider"]
     web --> corpus
@@ -71,7 +71,7 @@ graph LR
     cli --> corpus
 ```
 
-**1. Web UI — search, chat, deep research.** Open Harbor Clerk in your browser (or the native Mac window) and search, browse, or chat with a local LLM. Deep Research runs structured plan→search→read→synthesize over the whole corpus and produces a cited report.
+**1. Web UI — search, cited answers, deep research.** Open Harbor Clerk in your browser (or the native Mac window) and search, browse, or ask questions with local AI models. Deep Research runs structured plan→search→read→synthesize over the whole corpus and produces a cited report.
 
 **2. MCP endpoint — for cloud LLMs.** Connect Claude, ChatGPT, Claude Desktop, Gemini CLI, or any MCP-compatible client. They authenticate with a scoped, read-only API key and receive only the cited snippets needed to answer a question — never your full corpus.
 
@@ -83,7 +83,7 @@ harbor-clerk --help                  # full subcommand list
 harbor-clerk search "termination clause" | jq '.hits[] | {title: .doc_title, pages, chunk_id}'
 ```
 
-A copy-pasteable agent skill for these harnesses is in **System Settings → Integrations**.
+A copy-pasteable agent skill for these harnesses is in **Settings → Integrations**.
 
 ## Why Harbor Clerk?
 
@@ -91,10 +91,10 @@ A copy-pasteable agent skill for these harnesses is in **System Settings → Int
 Everything runs locally. No uploads to SaaS services, no background syncing, and no shared infrastructure.
 
 **Your files become searchable knowledge**
-Harbor Clerk reads documents, performs OCR when needed, builds hybrid full-text and semantic search, and lets you explore everything through search or chat — always with citations.
+Harbor Clerk reads documents, performs OCR when needed, builds hybrid full-text and semantic search, and lets you explore everything through search, cited answers, or research — always with citations.
 
 **Use any model you trust**
-Chat locally with built-in models, connect external AI tools through MCP, or hand the CLI to a local agent harness. They see only the passages needed to answer a question — never your full corpus.
+Ask locally with built-in models, connect external AI tools through MCP, or hand the CLI to a local agent harness. They see only the passages needed to answer a question — never your full corpus.
 
 ## Quick Start (Mac)
 
@@ -104,7 +104,7 @@ Chat locally with built-in models, connect external AI tools through MCP, or han
 4. Click **Folders → Add Folder**, pick a directory full of documents, and let ingestion run
 5. Ask questions, browse the corpus, or kick off a deep research task
 
-That's it — everything runs locally. To wire in an external LLM or agent harness, head to **System Settings → Integrations** for MCP and CLI setup.
+That's it — everything runs locally. To wire in an external LLM or agent harness, head to **Settings → Integrations** for MCP and CLI setup.
 
 ## Quick Start (Docker)
 
@@ -122,7 +122,7 @@ To enable the `harbor-clerk` CLI for local agent harnesses, set `ENABLE_CLI_ACCE
 
 ## Who Harbor Clerk Is For
 
-- Small offices without a formal knowledge base
+- Document-heavy small teams without a formal knowledge base
 - Researchers with large document collections
 - Consultants, lawyers, and analysts managing private files
 - Anyone who wants LLM-style document search without uploading data to the cloud
@@ -151,7 +151,7 @@ Harbor Clerk can run in two ways:
 
 | | macOS Native | Docker Compose |
 |---|---|---|
-| **Best for** | Target audience — small offices with a Mac | DIY / Linux servers |
+| **Best for** | Small teams and independent operators with a Mac | DIY / Linux servers |
 | **Services** | Managed by menubar app as subprocesses | Eleven Docker containers |
 | **Folder picker** | Native folder picker in the UI | Operator mounts host paths into the watcher container |
 | **Originals** | Read in place from your filesystem | Read in place from bind-mounted volumes |
@@ -166,6 +166,8 @@ Both deployments use the same Python `watchdog`-based watcher under the hood (FS
 App data lives in `~/Library/Application Support/Harbor Clerk/` — PostgreSQL database, downloaded LLM models, logs, and settings. **Your source documents stay where you put them**; Harbor Clerk only references them by path.
 
 Open Preferences (Cmd+,) from the menubar to configure network access, worker preset, ports, and log level. Manage watched folders from the **Folders** tab in the web UI — the native folder picker dialog walks you through picking a directory, and macOS bookmark data keeps it tracked across renames and moves.
+
+For a basic backup, quit Harbor Clerk Server and copy `~/Library/Application Support/Harbor Clerk/` to backup storage. Keep the watched-folder source files backed up separately because Harbor Clerk reads those files in place. See [Backup and restore](docs/backup-and-restore.md) for the cautious initial guidance.
 
 ### Docker Compose
 
@@ -219,7 +221,7 @@ Drop a file into a watched folder and it flows through seven idempotent stages:
 6. **Summarize** — generate a document summary (local LLM, with extractive fallback)
 7. **Finalize** — mark ingestion complete
 
-Progress is streamed to the UI via server-sent events with a visual stage ring showing each step. Processing can be cancelled from the admin UI. Renames, edits, and deletions in the watched folder propagate automatically — Harbor Clerk reprocesses the file or soft-deletes the document, and a 30-day reaper purges originals that stay missing.
+Progress is streamed to the UI via server-sent events with a visual stage ring showing each step. Processing can be cancelled from the UI. Renames, edits, and deletions in the watched folder propagate automatically — Harbor Clerk reprocesses the file or soft-deletes the document, and a 30-day reaper purges originals that stay missing.
 
 ### Source Files: Reveal vs Download
 
@@ -238,11 +240,11 @@ The reason the download endpoint is locked down by default: it returns the *raw 
 
 Results combine PostgreSQL full-text search (bilingual English/French) and pgvector cosine similarity, normalized and merged into a single score with a small boost for higher-confidence OCR text. A cross-encoder re-ranking pass (`bge-reranker-v2-m3`, served by a dedicated `reranker` container/subprocess; on by default, gracefully degrades to merged-score ordering if unavailable) refines the top-K pool before returning results. All results include source citations with page numbers. Search supports filtering by document, date range, language, and MIME type, with faceted results grouping hits by document.
 
-### Local Chat
+### Local AI Answers
 
-A built-in chat assistant runs a local LLM (via llama-server) with access to the knowledge base through tool calls. Models can be downloaded and managed from the admin UI. No data leaves the machine.
+Ask runs a local AI model (via llama-server) with access to the knowledge base through tool calls. Models can be downloaded and managed from Settings. No data leaves the machine unless you deliberately connect an external model through MCP or another integration.
 
-The chat assistant uses tool calls to search, read passages, explore document structure, and query entities during the conversation. Results include source citations with page numbers so you can verify findings against the original documents.
+The local AI path uses tool calls to search, read passages, explore document structure, and query entities during the conversation. Results include source citations with page numbers so you can verify findings against the original documents.
 
 ### Deep Research
 
@@ -290,12 +292,12 @@ The `harbor-clerk` CLI mirrors the MCP tool surface as shell subcommands, includ
 **Auth:** the CLI talks to the same `/mcp` endpoint as MCP clients do, using the same API key:
 
 ```bash
-export HARBOR_CLERK_API_KEY=hc_...   # mint in System Settings → API Keys
+export HARBOR_CLERK_API_KEY=hc_...   # mint in Settings → API Keys
 harbor-clerk --help                  # full subcommand list
 harbor-clerk <command> --help        # man-page-class help with JSON return shape + examples
 ```
 
-**Audit:** CLI traffic is logged as `request_type="cli_tool"` (distinct from `mcp_tool`) so you can split per-key dashboards by surface. **System Settings → Integrations** has a copy-pasteable agent skill markdown for OpenClaw, Claude Code, and similar runtimes — drop it into the harness's skill directory and the agent learns the corpus.
+**Audit:** CLI traffic is logged as `request_type="cli_tool"` (distinct from `mcp_tool`) so you can split per-key dashboards by surface. **Settings → Integrations** has a copy-pasteable agent skill markdown for OpenClaw, Claude Code, and similar runtimes — drop it into the harness's skill directory and the agent learns the corpus.
 
 ### Auth
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Connect ChatGPT, Claude Desktop, Claude Code, Gemini CLI, OpenClaw, or any MCP-c
 
 ### Agentic CLI — full surface
 
-The `harbor-clerk` CLI mirrors 18 of the 19 MCP tools as shell subcommands. See the [Three ways to use Harbor Clerk](#three-ways-to-use-harbor-clerk) overview above for the framing; this section is the operator detail.
+The `harbor-clerk` CLI mirrors the MCP tool surface as shell subcommands, including `find-all` for document enumeration. See the [Three ways to use Harbor Clerk](#three-ways-to-use-harbor-clerk) overview above for the framing; this section is the operator detail.
 
 **Enabling it:**
 
@@ -337,6 +337,7 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 | `/api/stats/entity-network` | GET | Entity co-occurrence network graph |
 | `/api/docs/{id}/stats` | GET | Per-document statistics |
 | `/api/search` | POST | Hybrid search (with optional filtering and facets) |
+| `/api/search/find-all` | POST | Enumerate matching documents with filters and pagination |
 | `/api/passages/read` | POST | Read passages by chunk IDs |
 | `/api/chat/conversations` | GET/POST | List or create chat conversations |
 | `/api/chat/conversations/{id}/messages` | POST | Send a message (streamed response with RAG) |
@@ -356,13 +357,13 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 
 ### MCP
 
-`POST /mcp` — Streamable HTTP transport. Authenticate with `Authorization: Bearer <api_key>`. 19 tools available; the CLI mirrors all of them except `kb_find_all` (which is an enumeration shape that agents use less than search).
+`POST /mcp` — Streamable HTTP transport. Authenticate with `Authorization: Bearer <api_key>`. 19 tools available; the CLI mirrors the same practical tool surface, including `kb_find_all` via `harbor-clerk find-all`.
 
 | Tool | Description |
 |---|---|
 | `kb_search` | Hybrid search with pagination, detail modes, and optional filters |
 | `kb_batch_search` | Run up to 5 search queries in a single call |
-| `kb_find_all` | Unified enumeration: list, filter, and paginate documents without scoring (MCP-only) |
+| `kb_find_all` | Unified enumeration: list, filter, and paginate matching documents |
 | `kb_read_passages` | Read specific passages by chunk ID |
 | `kb_expand_context` | Get surrounding chunks for a given chunk |
 | `kb_get_document` | Document metadata and summary |

--- a/docker/download_hf_model.py
+++ b/docker/download_hf_model.py
@@ -1,0 +1,52 @@
+"""Download a Hugging Face model snapshot with retry/backoff for CI builds."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+import time
+from collections.abc import Sequence
+
+from huggingface_hub import snapshot_download
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--local-dir", required=True)
+    parser.add_argument("--ignore-pattern", action="append", default=[])
+    parser.add_argument("--attempts", type=int, default=6)
+    parser.add_argument("--base-delay", type=float, default=8.0)
+    return parser.parse_args()
+
+
+def download(args: argparse.Namespace) -> None:
+    ignore_patterns: Sequence[str] | None = args.ignore_pattern or None
+    for attempt in range(1, args.attempts + 1):
+        try:
+            snapshot_download(
+                repo_id=args.repo_id,
+                local_dir=args.local_dir,
+                ignore_patterns=ignore_patterns,
+            )
+            return
+        except Exception as exc:
+            if attempt >= args.attempts:
+                raise
+
+            delay = args.base_delay * (2 ** (attempt - 1)) + random.uniform(0, args.base_delay)
+            print(
+                f"Hugging Face download failed on attempt {attempt}/{args.attempts}: {exc.__class__.__name__}: {exc}",
+                file=sys.stderr,
+            )
+            print(f"Retrying in {delay:.1f}s...", file=sys.stderr)
+            time.sleep(delay)
+
+
+def main() -> None:
+    download(parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/embedder.Dockerfile
+++ b/docker/embedder.Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim AS builder
 
+ARG PRELOAD_MODEL=1
+
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
@@ -18,12 +20,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Pre-download the Granite-R2 weights at build time so the container
 # starts immediately. ~700 MB to image size; acceptable per project policy.
 COPY docker/download_hf_model.py /tmp/download_hf_model.py
-RUN /app/.venv/bin/python /tmp/download_hf_model.py \
-    --repo-id ibm-granite/granite-embedding-311m-multilingual-r2 \
-    --local-dir /models/granite-embedding-311m-multilingual-r2 \
-    --ignore-pattern 'onnx/*' \
-    --ignore-pattern 'openvino/*' \
-    --ignore-pattern 'openvino_model.*'
+RUN if [ "$PRELOAD_MODEL" = "1" ]; then \
+        /app/.venv/bin/python /tmp/download_hf_model.py \
+            --repo-id ibm-granite/granite-embedding-311m-multilingual-r2 \
+            --local-dir /models/granite-embedding-311m-multilingual-r2 \
+            --ignore-pattern 'onnx/*' \
+            --ignore-pattern 'openvino/*' \
+            --ignore-pattern 'openvino_model.*'; \
+    else \
+        mkdir -p /models/granite-embedding-311m-multilingual-r2; \
+    fi
 
 # ── Runtime ──
 FROM python:3.12-slim

--- a/docker/embedder.Dockerfile
+++ b/docker/embedder.Dockerfile
@@ -17,11 +17,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Pre-download the Granite-R2 weights at build time so the container
 # starts immediately. ~700 MB to image size; acceptable per project policy.
-RUN /app/.venv/bin/python -c "from huggingface_hub import snapshot_download; \
-  snapshot_download(repo_id='ibm-granite/granite-embedding-311m-multilingual-r2', \
-                    local_dir='/models/granite-embedding-311m-multilingual-r2', \
-                    local_dir_use_symlinks=False, \
-                    ignore_patterns=['onnx/*', 'openvino/*', 'openvino_model.*'])"
+COPY docker/download_hf_model.py /tmp/download_hf_model.py
+RUN /app/.venv/bin/python /tmp/download_hf_model.py \
+    --repo-id ibm-granite/granite-embedding-311m-multilingual-r2 \
+    --local-dir /models/granite-embedding-311m-multilingual-r2 \
+    --ignore-pattern 'onnx/*' \
+    --ignore-pattern 'openvino/*' \
+    --ignore-pattern 'openvino_model.*'
 
 # ── Runtime ──
 FROM python:3.12-slim

--- a/docker/reranker.Dockerfile
+++ b/docker/reranker.Dockerfile
@@ -3,6 +3,8 @@
 
 FROM python:3.12-slim
 
+ARG PRELOAD_MODEL=1
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -14,9 +16,13 @@ RUN pip install --no-cache-dir /app/embedder
 
 # Pre-download the reranker weights at build time. ~1.2 GB.
 COPY docker/download_hf_model.py /tmp/download_hf_model.py
-RUN python /tmp/download_hf_model.py \
-    --repo-id BAAI/bge-reranker-v2-m3 \
-    --local-dir /models/bge-reranker-v2-m3
+RUN if [ "$PRELOAD_MODEL" = "1" ]; then \
+        python /tmp/download_hf_model.py \
+            --repo-id BAAI/bge-reranker-v2-m3 \
+            --local-dir /models/bge-reranker-v2-m3; \
+    else \
+        mkdir -p /models/bge-reranker-v2-m3; \
+    fi
 ENV RERANKER_MODEL=/models/bge-reranker-v2-m3
 
 ENV HOST=0.0.0.0

--- a/docker/reranker.Dockerfile
+++ b/docker/reranker.Dockerfile
@@ -13,10 +13,10 @@ COPY embedder /app/embedder
 RUN pip install --no-cache-dir /app/embedder
 
 # Pre-download the reranker weights at build time. ~1.2 GB.
-RUN python -c "from huggingface_hub import snapshot_download; \
-  snapshot_download(repo_id='BAAI/bge-reranker-v2-m3', \
-                    local_dir='/models/bge-reranker-v2-m3', \
-                    local_dir_use_symlinks=False)"
+COPY docker/download_hf_model.py /tmp/download_hf_model.py
+RUN python /tmp/download_hf_model.py \
+    --repo-id BAAI/bge-reranker-v2-m3 \
+    --local-dir /models/bge-reranker-v2-m3
 ENV RERANKER_MODEL=/models/bge-reranker-v2-m3
 
 ENV HOST=0.0.0.0

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -1,0 +1,52 @@
+# Backup and restore
+
+This is cautious initial guidance, not a polished backup product flow. Harbor
+Clerk reads watched-folder source files in place, so a complete backup has two
+parts:
+
+1. Harbor Clerk application data.
+2. The original files in every watched folder.
+
+## macOS native app
+
+Harbor Clerk application data lives at:
+
+```text
+~/Library/Application Support/Harbor Clerk/
+```
+
+That directory contains the local database, downloaded models, logs, settings,
+and other app-managed state. Your source documents are not copied there; they
+stay in the folders you selected.
+
+Basic backup:
+
+1. Quit Harbor Clerk Server from the menubar app.
+2. Copy `~/Library/Application Support/Harbor Clerk/` to backup storage.
+3. Back up every watched-folder source directory separately.
+4. If you use mail ingestion or any future encrypted secrets, also preserve the
+   master key. See [Secrets and the master key](secrets-and-keys.md).
+
+Basic restore:
+
+1. Quit Harbor Clerk Server.
+2. Restore the saved `Harbor Clerk/` application-support directory to
+   `~/Library/Application Support/`.
+3. Restore the watched-folder source files to the same paths where possible.
+4. Launch Harbor Clerk Server and let the watcher reconcile changes.
+
+If source files moved, Harbor Clerk may need folder access repaired or watched
+folders re-added. Restore should be tested before relying on it for critical
+data recovery.
+
+## Docker Compose
+
+Docker deployments are operator-managed. Back up:
+
+- The Postgres data volume or a proper `pg_dump`.
+- Any object-storage volume if your deployment still uses legacy uploads.
+- The host directories mounted into the watcher.
+- `.env`, especially `SECRET_KEY` and `HARBOR_CLERK_MASTER_KEY` if configured.
+
+Do not treat `docker compose down -v` as a normal stop command; it deletes named
+volumes. Use `docker compose down` to stop while keeping data.

--- a/docs/secrets-and-keys.md
+++ b/docs/secrets-and-keys.md
@@ -14,7 +14,7 @@ lose it.
   identifies which key was used without revealing the key itself.
 - On decrypt, the fingerprint is compared to the active key's fingerprint
   before any decryption is attempted. A mismatch raises `KeyMismatch`, which
-  the application surfaces in System Status as "reconnect mail accounts".
+  the application surfaces in Status as "reconnect mail accounts".
 
 ## Where the master key lives
 
@@ -66,7 +66,7 @@ iCloud Keychain and cross-machine moves require manual export.
 
 ## What happens if you lose the master key
 
-You'll see "X mail accounts need reconnecting" in System Status. The encrypted
+You'll see "X mail accounts need reconnecting" in Status. The encrypted
 secrets are unrecoverable, but everything else is intact (documents, chunks,
 embeddings, search history, audit logs are all unencrypted).
 

--- a/docs/superpowers/plans/2026-06-03-source-ref-citation-contract.md
+++ b/docs/superpowers/plans/2026-06-03-source-ref-citation-contract.md
@@ -1,0 +1,730 @@
+# SourceRef and Citation Contract - Implementation Plan
+
+> **For agentic workers:** This is a detailed implementation plan. Execute task-by-task, preserving backwards-compatible response fields while adding the new `source` object and `citation` string. Do not remove legacy fields in this rollout.
+
+**Goal:** Add a central `SourceRef` builder and thread it through the highest-value REST, MCP, CLI, chat, and research citation paths so Harbor Clerk has one stable source/citation contract.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-source-ref-citation-contract-design.md`
+
+**Release plan:** `docs/superpowers/plans/2026-06-03-release-readiness-action-plan.md`
+
+**Architecture:** A new pure builder module formats document, email, attachment, page, section, folder-label, and relative-path information into a structured `SourceRef` object. Thin async context loaders bulk-fetch watched-folder and parent-email data so routes/tools do not N+1 query. Existing response shapes keep their legacy top-level fields, but gain `source` and `citation`. LLM citation extraction prefers `source` when present and falls back to legacy fields.
+
+**Non-goals for this plan:**
+
+- No path-disclosure API-key scope yet.
+- No absolute paths in MCP/CLI/cloud-visible payloads.
+- No removal of legacy `doc_id`, `doc_title`, `pages`, `page_start`, or `page_end` fields.
+- No full UI citation-chip rewrite beyond adding types/compatibility hooks if needed.
+- No verifier/citation-support UI.
+
+**Research/verifier decision:** Research citations normalize later, while preserving verifier compatibility. In practice: new research citation records may gain `source`, `citation`, and `pages`, but the existing `doc_title` and `page` fields must remain until the verifier loop is deliberately migrated. Do not break `_verify_citations` as part of the SourceRef rollout.
+
+---
+
+## Current State Snapshot
+
+- REST `POST /api/search` returns `SearchHitOut` with top-level `chunk_id`, `doc_id`, `doc_title`, `page_start`, `page_end`, and no citation string.
+- REST `POST /api/passages/read` returns `PassageDetail` with similar top-level fields and no `source`.
+- MCP builds result dicts inline in `src/harbor_clerk/mcp_server.py`.
+- CLI JSON passes MCP output through; text rendering builds its own title/page line.
+- `src/harbor_clerk/llm/citations.py` extracts best-effort citation records from several ad hoc tool-result shapes.
+- `tests/test_mcp_metadata_filter.py::test_kb_get_document_does_not_leak_source_path` already pins a no-host-path rule for MCP document metadata.
+- Watched-folder source identity lives in `watched_files.relative_path` plus `watched_folders.display_name`/`path`.
+- Email identity usually lives in `Document.email_*` columns. Tika fallback metadata may exist under `doc.doc_metadata["tika"]["email_*"]`. Attachments link to parent email via `Document.email_parent_doc_id`.
+
+---
+
+## Contract
+
+Every new `source` object should have this shape, omitting null values on JSON output where practical:
+
+```json
+{
+  "doc_id": "uuid",
+  "doc_title": "string",
+  "chunk_id": "uuid",
+  "pages": "4-5",
+  "section": "string",
+  "source_kind": "document",
+  "source_label": "string",
+  "folder_label": "string",
+  "relative_path": "string",
+  "citation": "Contract A, pp. 4-5"
+}
+```
+
+Accepted `source_kind` values:
+
+- `document`
+- `email`
+- `attachment`
+- `unknown`
+
+Compatibility rule:
+
+- Add top-level `citation` as an alias of `source.citation`.
+- Keep old top-level fields for now.
+
+Path rule:
+
+- Human REST document endpoints may keep existing local path fields.
+- MCP and CLI result payloads must not include absolute paths.
+- `folder_label` and `relative_path` are allowed by default.
+- Future path-disclosure scope handles filename-only/relative/absolute modes.
+
+---
+
+## Task 1: Pure SourceRef builder
+
+**Why:** Centralize citation formatting and source-policy decisions before touching any route/tool.
+
+**Files:**
+
+- Create: `src/harbor_clerk/source_ref.py`
+- Create: `tests/test_source_ref.py`
+
+### Step 1.1: Write builder tests first
+
+Cover:
+
+- Document citation with one page: `Contract A, p. 4`.
+- Document citation with range: `Contract A, pp. 4-5`.
+- Document citation without page: `Contract A`.
+- Missing title falls back to canonical filename, then `Untitled document`.
+- Email citation uses native metadata: `Email from Jane Doe, "Budget follow-up", Mar 7, 2025`.
+- Email citation with missing sender still includes subject/date when present.
+- `.eml` fallback uses Tika metadata if native `email_*` fields are missing.
+- `.eml` fallback uses file/title metadata if email parsing failed.
+- Attachment citation includes attachment filename/title and parent email identity.
+- `source_label` and `citation` both exist and can differ.
+- No field renders `"None"`, `"null"`, or empty quotes.
+- No absolute path appears in `source.to_dict()`.
+
+### Step 1.2: Add core dataclass and helpers
+
+Implement:
+
+```python
+@dataclass(frozen=True)
+class SourceRef:
+    doc_id: str
+    doc_title: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    source_kind: Literal["document", "email", "attachment", "unknown"] = "document"
+    source_label: str = ""
+    folder_label: str | None = None
+    relative_path: str | None = None
+    citation: str = ""
+
+    def to_dict(self) -> dict: ...
+```
+
+Helpers:
+
+- `format_pages(page_start, page_end) -> str | None`
+- `format_document_citation(title, pages) -> str`
+- `format_email_citation(...) -> str`
+- `format_attachment_citation(...) -> str`
+- `build_source_ref(...) -> SourceRef`
+
+Recommended `build_source_ref` signature:
+
+```python
+def build_source_ref(
+    *,
+    doc: Document | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+    watched_file: WatchedFile | None = None,
+    watched_folder: WatchedFolder | None = None,
+    parent_email_doc: Document | None = None,
+    include_relative_path: bool = True,
+) -> SourceRef:
+    ...
+```
+
+Do not let this function query the database. Keep it pure.
+
+### Step 1.3: Implement email fallback order
+
+For email docs:
+
+1. Native `Document.email_from_*`, `email_subject`, `email_date_sent`.
+2. Tika metadata fallback under `doc.doc_metadata["tika"]`:
+   - `email_from`
+   - `email_subject`
+   - `email_date`
+3. File/title fallback:
+   - `doc.title`
+   - `doc.canonical_filename`
+   - relative path leaf
+
+Email detection:
+
+- `doc.email_parent_doc_id is None` and any native email field exists.
+- `doc.mime_type == "message/rfc822"`.
+- `doc.canonical_filename` or `relative_path` ends with `.eml`.
+
+Attachment detection:
+
+- `doc.email_parent_doc_id is not None`.
+- Use `parent_email_doc` when available to build parent email citation.
+
+### Step 1.4: Implement path handling
+
+Folder label:
+
+- Prefer `WatchedFolder.display_name`.
+- Else basename of `WatchedFolder.path`.
+- Else `None`.
+
+Relative path:
+
+- Include `WatchedFile.relative_path` only when `include_relative_path=True`.
+- Never derive a relative path by slicing `Document.source_path`; use watched-folder data.
+- Never output `Document.source_path`.
+
+### Step 1.5: Run tests
+
+Run:
+
+```bash
+uv run pytest tests/test_source_ref.py -v
+```
+
+---
+
+## Task 2: Bulk SourceRef context loader
+
+**Why:** Routes/tools need watched-folder and parent-email context without repeating ad hoc joins.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/source_ref.py`
+- Create: `tests/test_source_ref_context.py`
+
+### Step 2.1: Add `SourceRefContext`
+
+Implement a small context object:
+
+```python
+@dataclass
+class SourceRefContext:
+    docs_by_id: dict[uuid.UUID, Document]
+    watched_files_by_doc: dict[uuid.UUID, WatchedFile]
+    watched_folders_by_id: dict[uuid.UUID, WatchedFolder]
+    parent_email_docs_by_id: dict[uuid.UUID, Document]
+
+    def ref_for_doc(...): ...
+```
+
+`ref_for_doc` should call the pure builder.
+
+### Step 2.2: Add async loader
+
+Implement:
+
+```python
+async def load_source_ref_context(
+    session: AsyncSession,
+    doc_ids: Iterable[uuid.UUID | str],
+) -> SourceRefContext:
+    ...
+```
+
+Behavior:
+
+- Load `Document` rows for `doc_ids`.
+- Load active `WatchedFile` rows for those docs.
+- Load `WatchedFolder` rows for those watched files.
+- Load parent email documents for any `doc.email_parent_doc_id`.
+- Do not raise if watched tables are absent or missing rows; return partial context.
+
+### Step 2.3: Add context tests
+
+Cover:
+
+- Folder display name and relative path included.
+- Parent email doc loaded for attachment citation.
+- Missing watched rows still produces a valid source.
+- No absolute path appears in `ref.to_dict()`.
+
+Run:
+
+```bash
+uv run pytest tests/test_source_ref.py tests/test_source_ref_context.py -v
+```
+
+---
+
+## Task 3: REST search and passages
+
+**Why:** Human Search is becoming the default surface and should get structured citations early.
+
+**Files:**
+
+- Create: `src/harbor_clerk/api/schemas/source_ref.py`
+- Modify: `src/harbor_clerk/api/schemas/search.py`
+- Modify: `src/harbor_clerk/api/routes/search.py`
+- Create: `tests/api/test_search_source_ref.py`
+
+### Step 3.1: Add Pydantic schema
+
+Create `SourceRefOut` mirroring the dataclass:
+
+```python
+class SourceRefOut(BaseModel):
+    doc_id: str
+    doc_title: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    source_kind: Literal["document", "email", "attachment", "unknown"]
+    source_label: str
+    folder_label: str | None = None
+    relative_path: str | None = None
+    citation: str
+```
+
+### Step 3.2: Extend search schemas compatibly
+
+Add optional fields:
+
+- `SearchHitOut.source: SourceRefOut | None = None`
+- `SearchHitOut.citation: str | None = None`
+- `PassageDetail.source: SourceRefOut | None = None`
+- `PassageDetail.citation: str | None = None`
+
+Do not remove existing fields.
+
+### Step 3.3: Enrich `POST /api/search`
+
+After `hybrid_search`, bulk-load source context for `result.hits` doc IDs.
+
+Update `_hit_to_out` to accept `source_ref`:
+
+- `pages = format_pages(h.page_start, h.page_end)`
+- `chunk_id = h.chunk_id`
+- `section = None` for first REST pass unless heading lookup is added.
+- `citation = source_ref.citation`
+
+### Step 3.4: Enrich `POST /api/passages/read`
+
+After loading chunks/docs, use `SourceRefContext.ref_for_doc` for each passage.
+
+The existing route already has chunk rows and doc rows; the only new DB work should be watched-folder/parent-email context.
+
+### Step 3.5: REST tests
+
+Cover:
+
+- Search hit includes `source` and top-level `citation`.
+- Legacy top-level fields still exist.
+- Passage includes `source` and `citation`.
+- Email search result has email-native citation.
+- Attachment passage includes parent email context when available.
+- MCP/cloud-visible path policy is not directly tested here, but REST search should still not add absolute paths to `source`.
+
+Run:
+
+```bash
+uv run pytest tests/api/test_search_source_ref.py -v
+```
+
+---
+
+## Task 4: MCP high-volume citation-bearing tools
+
+**Why:** MCP is the main cloud/agent interface. Search/read tools should get `source` early.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Modify/create tests in `tests/test_mcp_tools.py` or `tests/test_mcp_source_ref.py`
+
+### Step 4.1: Add source refs to `kb_search` and `kb_batch_search`
+
+Modify `_format_search_response` to accept a source-ref map keyed by `(doc_id, chunk_id)`.
+
+Each hit keeps:
+
+- `chunk_id`
+- `doc_id`
+- `doc_title`
+- `pages`
+- `section`
+- `score`
+- `language`
+- `text`
+
+Each hit gains:
+
+- `source`
+- `citation`
+
+Build the map in `kb_search` and each `kb_batch_search` query after `hybrid_search`.
+
+### Step 4.2: Add source refs to `kb_find_all`
+
+Each `results[]` row keeps current fields and gains:
+
+- `source`
+- `citation`
+
+For `presentation="full"`, the row source should include `top_chunk_id` and `page_range` when available. If no chunk exists, emit a document-level source.
+
+### Step 4.3: Add source refs to `kb_read_passages`
+
+Each `passages[]` row gains:
+
+- `doc_id` if not already present in the current MCP shape
+- `source`
+- `citation`
+
+This is a useful small compatibility improvement: `llm/citations.py` currently has to keep chunk-only records from `kb_read_passages` because the MCP passage shape omits `doc_id`.
+
+### Step 4.4: Add source refs to `kb_expand_context`
+
+Each `chunks[]` row gains:
+
+- `source`
+- `citation`
+
+The top-level document identity remains unchanged.
+
+### Step 4.5: MCP tests
+
+Cover:
+
+- `kb_search` hit includes `source.citation` and top-level `citation`.
+- `kb_batch_search` nested hits include source refs.
+- `kb_find_all` rows include source refs.
+- `kb_read_passages` includes `doc_id`, `source`, and `citation`.
+- `kb_expand_context` chunks include source refs.
+- No MCP response includes `Document.source_path`.
+- No MCP response includes `/Users/` when source path is seeded as `/Users/alex/private/foo.pdf`.
+
+Run targeted tests:
+
+```bash
+uv run pytest tests/test_mcp_tools.py tests/test_mcp_metadata_filter.py -k "source_ref or source_path or search or read_passages or find_all" -v
+```
+
+---
+
+## Task 5: MCP document-row tools
+
+**Why:** Agents often pivot from search to document-listing and document-metadata tools. Those rows should carry the same source identity.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/mcp_server.py`
+- Modify: `src/harbor_clerk/mcp_lookup_tools.py`
+- Modify/create tests in `tests/test_mcp_tools.py`, `tests/test_mcp_lookup_tools.py`, or `tests/test_mcp_source_ref.py`
+
+### Step 5.1: Add document-level source refs
+
+Add `source` and `citation` to document rows returned by:
+
+- `kb_get_document`
+- `kb_list_recent`
+- `kb_corpus_overview`
+- `kb_document_outline`
+- `kb_find_related`
+- `kb_documents_by_date`
+- `kb_verify_identifier` unique match and ambiguous candidates
+
+Keep all current fields.
+
+### Step 5.2: Consider `kb_entity_search`
+
+If `kb_entity_search` returns per-mention `doc_id` and `chunk_id`, add source refs there too. If this becomes messy, defer it explicitly in the PR description and follow-up list.
+
+### Step 5.3: Tests
+
+Cover at least:
+
+- `kb_get_document` includes `source` but still does not leak `source_path`.
+- `kb_documents_by_date` result includes `source` and `citation`.
+- `kb_verify_identifier` unique match includes `source`.
+- `kb_find_related` related rows include `source`.
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_lookup_tools.py tests/test_mcp_metadata_filter.py tests/test_mcp_tools.py -k "verify_identifier or documents_by_date or get_document or find_related or source_path" -v
+```
+
+---
+
+## Task 6: LLM citation extraction compatibility
+
+**Why:** Ask and Research already persist citations from tool results. Once tool results carry `source`, the extractor should preserve the richer object.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/llm/citations.py`
+- Modify: `tests/test_llm_citations.py`
+
+### Step 6.1: Prefer `source` objects
+
+In `_record`, if a result row has a dict `source`:
+
+- Copy the `source` dict into the citation record.
+- Populate legacy flattened keys from `source` when absent:
+  - `doc_id`
+  - `doc_title`
+  - `chunk_id`
+  - `pages`
+  - `citation`
+- Preserve numeric `score` from the result row.
+
+Do not mutate the parsed tool result.
+
+### Step 6.2: Keep legacy fallback
+
+The extractor must continue to pass all existing tests for old shapes.
+
+### Step 6.3: Add extractor tests
+
+Cover:
+
+- `kb_search` hit with `source` yields citation with nested `source` and flattened legacy keys.
+- Top-level `citation` is preserved.
+- Legacy hit without `source` still works.
+- Dedup keeps richer `source` record when replacing by higher score.
+- Chunk-only legacy records still survive.
+
+Run:
+
+```bash
+uv run pytest tests/test_llm_citations.py -v
+```
+
+---
+
+## Task 7: CLI output and help compatibility
+
+**Why:** CLI is the shell-first agent surface. JSON should preserve `source`; text should prefer the formatted citation when available.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/cli/output.py`
+- Modify: `src/harbor_clerk/cli/help/search.txt`
+- Modify: `src/harbor_clerk/cli/help/batch-search.txt`
+- Modify: `src/harbor_clerk/cli/help/read-passages.txt`
+- Modify/create tests in `tests/cli/test_output.py`
+
+### Step 7.1: Update text renderer
+
+For search text mode:
+
+- Prefer `r["citation"]`.
+- Else prefer `r["source"]["citation"]`.
+- Else fall back to `doc_title` + `pages`.
+
+Keep chunk id visible for agents/humans.
+
+### Step 7.2: Update CLI help
+
+Help should say JSON results include:
+
+- `source`
+- `citation`
+- legacy citation-ready fields
+
+Update any current "expecting a standalone citation field" caveats to reflect the new field.
+
+### Step 7.3: CLI tests
+
+Cover:
+
+- Text search output uses `citation` when present.
+- JSON rendering preserves nested `source`.
+- Legacy payload still renders.
+
+Run:
+
+```bash
+uv run pytest tests/cli/test_output.py tests/cli/test_commands_search.py -v
+```
+
+---
+
+## Task 8: Research citation normalization
+
+**Why:** Research citations currently persist as doc/page records built inside `_read_evidence`. They should converge toward SourceRef so future citation-support validation has structured inputs.
+
+**Memorialized decision:** Research citations normalize later, while preserving verifier compatibility. This task is intentionally late in the plan because the verifier currently consumes `doc_title` and `page`; SourceRef must enrich that shape, not replace it, until a separate verifier migration exists.
+
+**Files:**
+
+- Modify: `src/harbor_clerk/llm/research.py`
+- Modify: `src/harbor_clerk/api/routes/research.py` if read-time compatibility is needed
+- Modify: `src/harbor_clerk/api/schemas/research.py` only if adding typed source schema is low-risk
+- Modify: `tests/test_api_research_citations.py`
+- Modify: `tests/test_research_verifier.py` only if verifier input shape changes
+
+### Step 8.1: Update `_read_evidence`
+
+Where it currently appends:
+
+```python
+{"doc_id": ..., "doc_title": ..., "page": ...}
+```
+
+append a richer record:
+
+```python
+{
+  "doc_id": ...,
+  "doc_title": ...,
+  "page": ...,
+  "pages": ...,
+  "citation": source_ref.citation,
+  "source": source_ref.to_dict(),
+}
+```
+
+Keep `page` for verifier compatibility until that code is deliberately updated.
+
+### Step 8.2: Preserve old persisted citations
+
+`GET /api/research/{id}` must still handle old `research_state.citations` values that lack `source`.
+
+Either:
+
+- return old citations as-is, or
+- enrich old citations best-effort when `doc_id` is present.
+
+Prefer the simpler path unless UI needs the richer shape immediately.
+
+### Step 8.3: Verifier compatibility
+
+The verifier currently reads `doc_title` and `page`. Do not break it.
+
+If changing verifier input, update tests in `tests/test_research_verifier.py`.
+
+### Step 8.4: Research tests
+
+Cover:
+
+- New research citations can include `source` and `citation`.
+- Old citations still round-trip.
+- Dedupe does not drop `source`.
+
+Run:
+
+```bash
+uv run pytest tests/test_api_research_citations.py tests/test_research_verifier.py -v
+```
+
+---
+
+## Task 9: Frontend type hook, minimal
+
+**Why:** Even if full citation-chip rendering is a later UI task, frontend code should have a stable type to consume.
+
+**Files:**
+
+- Create or modify: `frontend/src/types/sourceRef.ts`
+- Modify: `frontend/src/pages/SearchPage.tsx` only if this PR updates REST search UI immediately
+- Modify: `frontend/src/components/CitedMarkdown.tsx` only if accepting structured citations is low-risk
+
+### Step 9.1: Add TypeScript type
+
+```ts
+export interface SourceRef {
+  doc_id: string
+  doc_title: string
+  chunk_id?: string | null
+  pages?: string | null
+  section?: string | null
+  source_kind: 'document' | 'email' | 'attachment' | 'unknown'
+  source_label: string
+  folder_label?: string | null
+  relative_path?: string | null
+  citation: string
+}
+```
+
+### Step 9.2: Minimal UI use
+
+If SearchPage is touched in this PR:
+
+- Add `source?: SourceRef | null` and `citation?: string | null` to `SearchHit`.
+- Render `hit.citation` where page/title citation text is currently assembled.
+- Keep links based on existing `doc_id`/page fields.
+
+If this makes the PR too broad, leave UI rendering to the Search Workbench plan and only add the type.
+
+---
+
+## Task 10: Full verification
+
+Run targeted tests first, then broader suites:
+
+```bash
+uv run pytest tests/test_source_ref.py tests/test_source_ref_context.py -v
+uv run pytest tests/api/test_search_source_ref.py tests/test_llm_citations.py -v
+uv run pytest tests/test_mcp_tools.py tests/test_mcp_lookup_tools.py tests/test_mcp_metadata_filter.py -k "source_ref or source_path or search or read_passages or find_all or documents_by_date or verify_identifier" -v
+uv run pytest tests/cli/test_output.py tests/cli/test_commands_search.py -v
+```
+
+If frontend files changed:
+
+```bash
+cd frontend && npm run type-check
+cd frontend && npm run lint
+```
+
+If the change touches many MCP response shapes, also run:
+
+```bash
+uv run pytest tests/test_mcp_tools.py tests/test_mcp_response_steering.py tests/test_llm_citations.py -v
+```
+
+---
+
+## Backwards Compatibility Checklist
+
+- Legacy top-level fields are still present.
+- `llm/citations.py` still parses old tool result JSON.
+- CLI text output still handles old payloads.
+- Existing tests that assert old fields continue to pass.
+- No existing endpoint requires clients to understand `source`.
+- No absolute paths appear in MCP/CLI `source` payloads.
+- `kb_get_document` still omits `source_path`.
+
+---
+
+## Suggested PR Boundaries
+
+If this becomes too large, split into:
+
+1. **PR 1:** Pure builder, context loader, tests.
+2. **PR 2:** REST search/passages SourceRef.
+3. **PR 3:** MCP search/read/find-all SourceRef plus citation extractor.
+4. **PR 4:** MCP document-row tools and CLI help/output.
+5. **PR 5:** Research citation normalization and minimal frontend type/rendering.
+
+PR 1 and PR 2 should land before Search Workbench implementation.
+
+---
+
+## Fresh-Eyes Review Triggers
+
+Require review before merge if any PR:
+
+- changes MCP or CLI response contracts;
+- changes API schemas;
+- changes path/source disclosure;
+- changes chat/research citation extraction;
+- changes verifier inputs;
+- touches more than three files.
+
+This work almost certainly triggers review.

--- a/docs/superpowers/specs/2026-06-03-source-ref-citation-contract-design.md
+++ b/docs/superpowers/specs/2026-06-03-source-ref-citation-contract-design.md
@@ -1,0 +1,223 @@
+# SourceRef and Citation Contract - Design Spec
+
+**Date:** 2026-06-03
+**Status:** Accepted for planning
+**Scope:** Common source/citation object across REST, MCP, CLI, local chat/research, and UI. This spec is about response contracts and citation policy, not retrieval ranking.
+
+## Overview
+
+Harbor Clerk's strongest product promise is that search and AI answers are grounded in inspectable sources. That promise gets weaker if each surface invents its own citation string, omits chunk identifiers, exposes filesystem paths inconsistently, or handles email differently from documents.
+
+This spec introduces a shared `SourceRef` contract: responses should include both a structured `source` object and a derived human-readable `citation` string. The structured object gives agents and UI code stable fields; the string gives cloud LLMs and humans a compact citation they can quote directly.
+
+## Goals
+
+- One citation/source schema used by REST search, MCP tools, CLI commands, local chat tools, Ask, Research, and document UI where practical.
+- Include `chunk_id` whenever the result is chunk-backed.
+- Include a derived `citation` string in tool/API responses, not only in UI rendering.
+- Give email and email attachments first-class citation formats.
+- Avoid exposing absolute local filesystem paths to MCP/cloud/agent responses.
+- Allow folder aliases/labels and relative paths to be exposed as contextual source identity when policy permits.
+- Make citation generation testable and centrally maintained.
+
+## Non-goals
+
+- No rewrite of the retrieval algorithm.
+- No guarantee that every legacy endpoint immediately returns the new object in the first PR.
+- No source-file download policy change.
+- No cryptographic citation verification.
+- No full provenance graph for derived summaries.
+
+## SourceRef schema
+
+Initial shape:
+
+```json
+{
+  "doc_id": "uuid",
+  "doc_title": "string",
+  "chunk_id": "uuid|null",
+  "pages": "4-5|null",
+  "section": "string|null",
+  "source_kind": "document|email|attachment|unknown",
+  "source_label": "string",
+  "folder_label": "string|null",
+  "relative_path": "string|null",
+  "citation": "string"
+}
+```
+
+Field semantics:
+
+- `doc_id`: stable Harbor Clerk document identifier.
+- `doc_title`: display title for the document.
+- `chunk_id`: stable chunk/passage identifier when the result is chunk-backed. Null for document-level results without a specific passage.
+- `pages`: normalized page or page range when known, such as `"4"` or `"4-5"`.
+- `section`: heading, email part label, or other structural context when known.
+- `source_kind`: broad source category.
+- `source_label`: concise human-readable source name. For normal documents this is usually the title. For email it may include sender/subject/date.
+- `folder_label`: watched-folder alias/name, not an absolute path.
+- `relative_path`: path relative to the watched-folder root when policy permits.
+- `citation`: human-readable citation derived from the same fields.
+
+## Citation formats
+
+### Documents
+
+- `Contract A, p. 4`
+- `Contract A, pp. 4-5`
+- `Contract A`
+
+Use `p.` for one page and `pp.` for a range. If pages are unknown, omit page text rather than inventing location.
+
+### Email bodies
+
+- `Email from Jane Doe, "Budget follow-up", Mar 7, 2025`
+- `Email from Jane Doe to Sam Lee, "Budget follow-up", Mar 7, 2025`
+
+The short form should prefer sender, subject, and date. Include recipient when it materially disambiguates or when email metadata is central to the result.
+
+For `.eml` files on disk, default to email-native metadata. If parsing failed or key email fields are missing, fall back to file metadata rather than producing a broken email citation. Example fallback order:
+
+1. Parsed email sender/subject/date.
+2. Document title plus whatever email metadata is available.
+3. File name or relative path plus page/section context if no usable email metadata exists.
+
+### Email attachments
+
+- `Attachment "invoice.pdf" to Email from Jane Doe, "Budget follow-up", Mar 7, 2025`
+- `Attachment "contract.pdf", p. 2, to Email from Jane Doe, "Budget follow-up", Mar 7, 2025`
+
+Attachments should keep both identities: the attachment as the retrieved document and the parent email as provenance.
+
+### Unknown or partial source data
+
+When metadata is missing, degrade gracefully:
+
+- `Untitled document`
+- `Email "Budget follow-up"`
+- `Attachment "invoice.pdf"`
+
+Do not emit placeholders like `None`, `unknown.pdf`, or `page null`.
+
+## Path and security policy
+
+Absolute paths are sensitive because MCP and cloud LLMs may receive them. They can reveal usernames, project names, client names, folder structure, or mounted-volume details.
+
+Policy:
+
+- MCP responses: no absolute paths.
+- CLI responses: no absolute paths by default. Provide an explicit local-only flag later if needed.
+- REST responses used by the web UI: may include source-path data only when the endpoint already requires human auth and the UI needs local reveal/open behavior.
+- Cloud LLM bridge, if built: no absolute paths in model-visible payloads.
+- Folder labels and relative paths may be exposed if they are deliberately user-facing. This is still mildly sensitive, so docs should state it clearly.
+
+For watched folders, prefer:
+
+```json
+{
+  "folder_label": "Enron-ingest",
+  "relative_path": "lay/2001/forwarded/foo.eml"
+}
+```
+
+over:
+
+```json
+{
+  "path": "/Users/alex/Documents/private-client/lay/2001/forwarded/foo.eml"
+}
+```
+
+### Fast-follow: path disclosure scope
+
+Path disclosure should become an explicit API-key/tool policy rather than a one-size-fits-all default. Some local-agent use cases may already grant an agent broad filesystem access, making absolute paths acceptable and useful. Cloud-facing keys should remain conservative.
+
+Possible enum:
+
+- `filename`: expose only source/file label.
+- `relative_path`: expose folder label plus path relative to the watched-folder root.
+- `absolute_path`: expose full local path.
+
+Default recommendation:
+
+- Cloud/MCP keys: `relative_path` at most, possibly `filename` for conservative setups.
+- CLI/local-agent keys: `relative_path` by default, `absolute_path` opt-in.
+- Human UI: can use absolute paths for local reveal/open affordances where already authenticated and expected.
+
+## Surface matrix
+
+### REST search
+
+Search hits should include:
+
+- `source`
+- top-level `citation` alias, if compatibility requires it
+- `chunk_id`
+- existing snippet/score fields
+
+The frontend should render citations from `source.citation` rather than recreating page strings ad hoc.
+
+### REST document detail
+
+Document detail can expose richer local metadata because it is a human-authenticated UI endpoint. It should still separate:
+
+- `source` fields safe for citations.
+- local file fields used for reveal/open/download affordances.
+
+### MCP
+
+Every result-bearing tool should use the same source shape where it returns passages or documents:
+
+- `kb_search`
+- `kb_batch_search`
+- `kb_find_all`
+- `kb_read_passages`
+- `kb_expand_context`
+- `kb_get_document`
+- `kb_document_outline`
+- `kb_find_related`
+- `kb_documents_by_date`
+- `kb_verify_identifier`
+
+Tools that return operational data, such as health or ingest status, do not need `SourceRef` unless they include document rows.
+
+### CLI
+
+CLI JSON output should preserve the same structure as MCP. Friendly/table output should render citation strings and keep full source objects available under `--json`.
+
+This is important for agent harnesses that shell out to CLI and parse output.
+
+### Ask and Research
+
+Local chat and research tool results should preserve `SourceRef` internally. Final answers should cite using `citation` strings and carry enough metadata for UI citation chips to open the correct document/chunk.
+
+### UI citation component
+
+`CitedMarkdown` and result components should accept normalized citation/source data instead of parsing strings wherever practical. String parsing is acceptable only as a backwards-compatibility shim.
+
+## Implementation notes
+
+- Add a central citation builder in Python.
+- Add a TypeScript type mirroring `SourceRef`.
+- Keep old fields temporarily if existing UI code depends on them.
+- Avoid a large single PR if the surface is too broad. Recommended order:
+  1. Shared backend type and builder.
+  2. REST search plus UI search result rendering.
+  3. MCP/CLI result normalization.
+  4. Ask/Research final answer citation chips.
+  5. Legacy cleanup.
+
+## Tests
+
+- Unit tests for citation string generation, including page ranges, missing pages, email, and attachments.
+- Contract tests for MCP/CLI JSON shape.
+- REST schema tests for search hits.
+- Frontend render tests for citation chips if existing test harness supports it.
+- Security regression test that MCP/CLI result payloads do not include absolute paths unless an explicitly local-only mode is introduced.
+
+## Open questions
+
+- Whether emails on disk (`.eml`) should get both a document citation and an email citation. Recommendation: the primary citation should be email-native; the source object can still include relative path and document title.
+- Whether `relative_path` should always be included in MCP payloads. Recommendation: include only when the folder label is user-facing and the path is useful for disambiguation; otherwise omit.
+- Whether `source_label` and `citation` are redundant. Decision: keep both. `source_label` is identity; `citation` is a formatted quote target. Extra source signal is worth preserving.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,7 +53,7 @@ export default function App() {
           <Route path="/chat" element={<Navigate to="/ask" replace />} />
           <Route path="/chat/:conversationId" element={<ChatRedirect />} />
           <Route path="/settings" element={<SystemSettingsPage />} />
-          <Route path="/settings/preferences" element={<Navigate to="/preferences" replace />} />
+          <Route path="/settings/preferences" element={<PreferencesPage />} />
           <Route path="/preferences" element={<PreferencesPage />} />
           <Route element={<AdminRoute />}>
             <Route path="/integrations" element={<IntegrationsPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ export default function App() {
       <Route element={<ProtectedRoute />}>
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/ask" element={<ChatPage />} />
           <Route path="/c/:conversationId" element={<ChatPage />} />
           <Route path="/folders" element={<FoldersPage />} />
           <Route path="/docs" element={<DocumentsPage />} />
@@ -49,7 +50,7 @@ export default function App() {
           <Route path="/explore" element={<ExplorePage />} />
           <Route path="/research/:researchId?" element={<ResearchPage />} />
           <Route path="/stats" element={<StatsPage />} />
-          <Route path="/chat" element={<Navigate to="/" replace />} />
+          <Route path="/chat" element={<Navigate to="/ask" replace />} />
           <Route path="/chat/:conversationId" element={<ChatRedirect />} />
           <Route path="/preferences" element={<PreferencesPage />} />
           <Route element={<AdminRoute />}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,9 +52,23 @@ export default function App() {
           <Route path="/stats" element={<StatsPage />} />
           <Route path="/chat" element={<Navigate to="/ask" replace />} />
           <Route path="/chat/:conversationId" element={<ChatRedirect />} />
+          <Route path="/settings" element={<SystemSettingsPage />} />
+          <Route path="/settings/preferences" element={<Navigate to="/preferences" replace />} />
           <Route path="/preferences" element={<PreferencesPage />} />
           <Route element={<AdminRoute />}>
             <Route path="/integrations" element={<IntegrationsPage />} />
+            <Route path="/settings/integrations" element={<IntegrationsPage />} />
+            <Route path="/settings/users" element={<UsersPage />} />
+            <Route path="/settings/api-keys" element={<ApiKeysPage />} />
+            <Route path="/settings/api-keys/:keyId" element={<ApiKeyDashboardPage />} />
+            <Route path="/settings/models" element={<ModelsPage />} />
+            <Route path="/settings/languages" element={<LanguagesPage />} />
+            <Route path="/settings/retrieval" element={<RetrievalSettingsPage />} />
+            <Route path="/settings/rate-limits" element={<RateLimitSettingsPage />} />
+            <Route path="/settings/status" element={<SystemStatusPage />} />
+            <Route path="/settings/diagnostics" element={<ServiceLogsPage />} />
+            <Route path="/settings/maintenance" element={<SystemMaintenancePage />} />
+            <Route path="/settings/security" element={<SecuritySettingsPage />} />
             <Route path="/admin" element={<SystemSettingsPage />} />
             <Route path="/admin/users" element={<UsersPage />} />
             <Route path="/admin/keys" element={<ApiKeysPage />} />

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -8,6 +8,7 @@ const TOP_LEVEL = new Set([
   '/explore',
   '/stats',
   '/admin',
+  '/settings',
   '/preferences',
   '/login',
   '/setup',

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -1,6 +1,17 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 
-const TOP_LEVEL = new Set(['/', '/docs', '/search', '/explore', '/stats', '/admin', '/preferences', '/login', '/setup'])
+const TOP_LEVEL = new Set([
+  '/',
+  '/ask',
+  '/docs',
+  '/search',
+  '/explore',
+  '/stats',
+  '/admin',
+  '/preferences',
+  '/login',
+  '/setup',
+])
 
 function isTopLevel(pathname: string): boolean {
   if (TOP_LEVEL.has(pathname)) return true

--- a/frontend/src/components/CliAccessCard.tsx
+++ b/frontend/src/components/CliAccessCard.tsx
@@ -13,14 +13,15 @@ Harbor Clerk is a local document corpus with hybrid FTS+vector search and citati
 ## First step: discover the surface
 Run \`harbor-clerk --help\` for the full command list, then \`harbor-clerk <cmd> --help\` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
 
-## Three patterns you'll use most
+## Four patterns you'll use most
 
 1. **Search → expand**: \`harbor-clerk search "..."\` then \`harbor-clerk expand-context <chunk_id> -n 3\` on the best hit.
-2. **Read a known document**: \`harbor-clerk read-document <doc_id>\` for full text with pagination.
-3. **Check ingest status before searching for new content**: \`harbor-clerk ingest-status <doc_id>\` returns per-stage state.
+2. **Find every matching document**: \`harbor-clerk find-all "..." --text-contains "literal phrase" --presentation full\` when the task asks to list or enumerate.
+3. **Read a known document**: \`harbor-clerk read-document <doc_id>\` for full text with pagination.
+4. **Check ingest status before searching for new content**: \`harbor-clerk ingest-status <doc_id>\` returns per-stage state.
 
 ## What you can trust
-- Search returns top-level \`.hits[]\`; each hit includes \`doc_title\`, \`pages\` when available, and \`chunk_id\`. Use those fields as the citation, then call \`read-passages\` when you need exact surrounding text.
+- Search returns top-level \`.hits[]\`; Find All returns top-level \`.results[]\`. Result-bearing commands include \`source\`, \`citation\`, and \`chunk_id\` when available. Use those fields as the citation trail, then call \`read-passages\` when you need exact surrounding text.
 - \`possible_conflict: true\` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
 - The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.
 `

--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSystemConfig, type SystemConfig } from '../hooks/useSystemConfig'
+import { useLLMStatusContext } from './LLMStatusBanner'
+import GlobalStatusPill from './GlobalStatusPill'
+
+vi.mock('../hooks/useSystemConfig', () => ({
+  useSystemConfig: vi.fn(),
+}))
+
+vi.mock('./LLMStatusBanner', () => ({
+  useLLMStatusContext: vi.fn(),
+}))
+
+const useSystemConfigMock = vi.mocked(useSystemConfig)
+const useLLMStatusContextMock = vi.mocked(useLLMStatusContext)
+
+const READY_CONFIG: SystemConfig = {
+  healthStatus: 'healthy',
+  allowSourceDownload: false,
+  enableCliAccess: false,
+  cliShimInstallStatus: null,
+  loaded: true,
+}
+
+function mockPill({
+  config = READY_CONFIG,
+  llmState = 'ready',
+}: {
+  config?: SystemConfig
+  llmState?: 'deactivated' | 'loading' | 'ready' | 'unknown'
+}) {
+  useSystemConfigMock.mockReturnValue(config)
+  useLLMStatusContextMock.mockReturnValue({
+    status: {
+      state: llmState,
+      model_id: llmState === 'ready' ? 'qwen3' : null,
+      model_name: llmState === 'ready' ? 'Qwen3' : null,
+    },
+    markTransitioning: vi.fn(),
+  })
+}
+
+function renderPill() {
+  render(
+    <MemoryRouter>
+      <GlobalStatusPill />
+    </MemoryRouter>,
+  )
+}
+
+describe('GlobalStatusPill', () => {
+  beforeEach(() => {
+    useSystemConfigMock.mockReset()
+    useLLMStatusContextMock.mockReset()
+  })
+
+  it('links degraded system health to Status', () => {
+    mockPill({ config: { ...READY_CONFIG, healthStatus: 'degraded' } })
+
+    renderPill()
+
+    const link = screen.getByRole('link', { name: 'Status: Needs attention' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+    expect(screen.getByText('Needs attention')).toBeInTheDocument()
+  })
+
+  it('links inactive local AI to Models', () => {
+    mockPill({ llmState: 'deactivated' })
+
+    renderPill()
+
+    const link = screen.getByRole('link', { name: 'Status: Choose model' })
+    expect(link).toHaveAttribute('href', '/settings/models')
+  })
+
+  it('shows ready when system health and local AI are ready', () => {
+    mockPill({})
+
+    renderPill()
+
+    const link = screen.getByRole('link', { name: 'Status: Ready' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+  })
+})

--- a/frontend/src/components/GlobalStatusPill.tsx
+++ b/frontend/src/components/GlobalStatusPill.tsx
@@ -1,0 +1,97 @@
+import { Link } from 'react-router-dom'
+import { useSystemConfig } from '../hooks/useSystemConfig'
+import { useLLMStatusContext } from './LLMStatusBanner'
+import { StatusPill, type PillState } from './StatusPill'
+
+interface PillView {
+  label: string
+  glyph?: string
+  state: PillState
+  title: string
+  to: string
+}
+
+function statusView({
+  healthStatus,
+  loaded,
+  llmState,
+}: {
+  healthStatus: 'healthy' | 'degraded' | null
+  loaded: boolean
+  llmState: string
+}): PillView {
+  if (healthStatus === 'degraded') {
+    return {
+      label: 'Needs attention',
+      glyph: '⚠',
+      state: 'error',
+      title: 'System checks need attention',
+      to: '/settings/status',
+    }
+  }
+
+  if (!loaded) {
+    return {
+      label: 'Checking',
+      state: 'pending',
+      title: 'Checking system status',
+      to: '/settings/status',
+    }
+  }
+
+  if (llmState === 'loading') {
+    return {
+      label: 'AI loading',
+      state: 'running',
+      title: 'Local AI model is loading',
+      to: '/settings/models',
+    }
+  }
+
+  if (llmState === 'deactivated') {
+    return {
+      label: 'Choose model',
+      state: 'idle',
+      title: 'No local AI model is active',
+      to: '/settings/models',
+    }
+  }
+
+  if (llmState === 'unknown') {
+    return {
+      label: 'AI unknown',
+      state: 'pending',
+      title: 'Local AI status is unknown',
+      to: '/settings/models',
+    }
+  }
+
+  return {
+    label: 'Ready',
+    glyph: '●',
+    state: 'active',
+    title: 'System ready',
+    to: '/settings/status',
+  }
+}
+
+export default function GlobalStatusPill() {
+  const { status } = useLLMStatusContext()
+  const systemConfig = useSystemConfig()
+  const view = statusView({
+    healthStatus: systemConfig.healthStatus,
+    loaded: systemConfig.loaded,
+    llmState: status.state,
+  })
+
+  return (
+    <Link
+      to={view.to}
+      aria-label={`Status: ${view.label}`}
+      title={view.title}
+      className="inline-flex rounded-full transition-opacity hover:opacity-80 focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+    >
+      <StatusPill state={view.state} label={view.label} glyph={view.glyph} />
+    </Link>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,20 +9,33 @@ import OnboardingWizard from './OnboardingWizard'
 import { useCorpusBannerState } from '../hooks/useCorpusBannerState'
 import { useAreaAccent } from '../hooks/useAreaAccent'
 
-function TabLink({ to, end, icon, children }: { to: string; end?: boolean; icon?: string; children: React.ReactNode }) {
+function TabLink({
+  to,
+  end,
+  icon,
+  activeWhen,
+  children,
+}: {
+  to: string
+  end?: boolean
+  icon?: string
+  activeWhen?: (pathname: string) => boolean
+  children: React.ReactNode
+}) {
+  const location = useLocation()
   return (
     <NavLink
       to={to}
       end={end}
       className={({ isActive }) =>
         `relative inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors ${
-          isActive
+          isActive || activeWhen?.(location.pathname)
             ? 'text-(--area-accent-text)'
             : 'text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 hover:text-(--color-text-primary)'
         }`
       }
       style={({ isActive }) =>
-        isActive
+        isActive || activeWhen?.(location.pathname)
           ? {
               backgroundColor: 'var(--area-accent-tint)',
               boxShadow: 'inset 0 0 0 1px var(--area-accent)',
@@ -98,7 +111,7 @@ export default function Layout() {
               <TabLink to="/docs" icon="📄">
                 Documents
               </TabLink>
-              <TabLink to="/ask" icon="💬">
+              <TabLink to="/ask" icon="💬" activeWhen={(pathname) => pathname.startsWith('/c/')}>
                 Ask
               </TabLink>
               <TabLink to="/research" icon="🐙">
@@ -115,7 +128,15 @@ export default function Layout() {
               <TabLink to="/stats" icon="📊">
                 Observatory
               </TabLink>
-              <TabLink to="/settings" icon="⚙️">
+              <TabLink
+                to="/settings"
+                icon="⚙️"
+                activeWhen={(pathname) =>
+                  pathname.startsWith('/admin') ||
+                  pathname.startsWith('/integrations') ||
+                  pathname.startsWith('/preferences')
+                }
+              >
                 Settings
               </TabLink>
               <div className="relative ml-2" ref={menuRef}>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { LLMStatusBanner, LLMStatusProvider } from './LLMStatusBanner'
 import { QueueTray } from './queue-tray'
 import CorpusEmptyBanner from './CorpusEmptyBanner'
 import OnboardingWizard from './OnboardingWizard'
+import GlobalStatusPill from './GlobalStatusPill'
 import { useCorpusBannerState } from '../hooks/useCorpusBannerState'
 import { useAreaAccent } from '../hooks/useAreaAccent'
 
@@ -94,101 +95,102 @@ export default function Layout() {
 
   return (
     <div data-layout-root className="min-h-screen bg-(--color-bg-primary)">
-      <nav className="sticky top-0 z-40 border-b border-(--color-border) bg-(--bg-vibrancy) backdrop-blur-xl">
-        <div className="mx-auto max-w-7xl px-4">
-          <div className="flex h-12 items-center justify-between">
-            <div className="flex items-center space-x-1">
-              <NavLink
-                to="/"
-                className="relative mr-2 flex items-center rounded-lg px-2 py-1 transition-colors text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6"
-                aria-label="Harbor Clerk home"
-              >
-                <img src="/favicon.svg" alt="" className="h-6 w-6" />
-              </NavLink>
-              <TabLink to="/search" icon="🔍">
-                Search
-              </TabLink>
-              <TabLink to="/docs" icon="📄">
-                Documents
-              </TabLink>
-              <TabLink to="/ask" icon="💬" activeWhen={(pathname) => pathname.startsWith('/c/')}>
-                Ask
-              </TabLink>
-              <TabLink to="/research" icon="🐙">
-                Research
-              </TabLink>
-              <TabLink to="/folders" icon="📁">
-                Folders
-              </TabLink>
-              <TabLink to="/explore" icon="🌍">
-                Explore
-              </TabLink>
-            </div>
-            <div className="flex items-center space-x-1">
-              <TabLink to="/stats" icon="📊">
-                Observatory
-              </TabLink>
-              <TabLink
-                to="/settings"
-                icon="⚙️"
-                activeWhen={(pathname) =>
-                  pathname.startsWith('/admin') ||
-                  pathname.startsWith('/integrations') ||
-                  pathname.startsWith('/preferences')
-                }
-              >
-                Settings
-              </TabLink>
-              <div className="relative ml-2" ref={menuRef}>
-                <button
-                  onClick={() => setMenuOpen(!menuOpen)}
-                  className="flex items-center space-x-1 rounded-lg px-2.5 py-1.5 text-[13px] text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 transition-colors"
+      <LLMStatusProvider>
+        <nav className="sticky top-0 z-40 border-b border-(--color-border) bg-(--bg-vibrancy) backdrop-blur-xl">
+          <div className="mx-auto max-w-7xl px-4">
+            <div className="flex h-12 items-center justify-between">
+              <div className="flex items-center space-x-1">
+                <NavLink
+                  to="/"
+                  className="relative mr-2 flex items-center rounded-lg px-2 py-1 transition-colors text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6"
+                  aria-label="Harbor Clerk home"
                 >
-                  <div className="flex flex-col items-end">
-                    <span>{user?.email}</span>
-                    {isAdmin && (
-                      <span className="text-[10px] leading-tight text-amber-600 dark:text-amber-400">admin</span>
-                    )}
-                  </div>
-                  <svg
-                    className={`h-3.5 w-3.5 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
+                  <img src="/favicon.svg" alt="" className="h-6 w-6" />
+                </NavLink>
+                <TabLink to="/search" icon="🔍">
+                  Search
+                </TabLink>
+                <TabLink to="/docs" icon="📄">
+                  Documents
+                </TabLink>
+                <TabLink to="/ask" icon="💬" activeWhen={(pathname) => pathname.startsWith('/c/')}>
+                  Ask
+                </TabLink>
+                <TabLink to="/research" icon="🐙">
+                  Research
+                </TabLink>
+                <TabLink to="/folders" icon="📁">
+                  Folders
+                </TabLink>
+                <TabLink to="/explore" icon="🌍">
+                  Explore
+                </TabLink>
+              </div>
+              <div className="flex items-center space-x-1">
+                <GlobalStatusPill />
+                <TabLink to="/stats" icon="📊">
+                  Observatory
+                </TabLink>
+                <TabLink
+                  to="/settings"
+                  icon="⚙️"
+                  activeWhen={(pathname) =>
+                    pathname.startsWith('/admin') ||
+                    pathname.startsWith('/integrations') ||
+                    pathname.startsWith('/preferences')
+                  }
+                >
+                  Settings
+                </TabLink>
+                <div className="relative ml-2" ref={menuRef}>
+                  <button
+                    onClick={() => setMenuOpen(!menuOpen)}
+                    className="flex items-center space-x-1 rounded-lg px-2.5 py-1.5 text-[13px] text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6 transition-colors"
                   >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                  </svg>
-                </button>
-                {menuOpen && (
-                  <div className="absolute right-0 mt-1.5 w-48 rounded-xl bg-(--bg-vibrancy) backdrop-blur-xl py-1 shadow-mac-lg ring-1 ring-(--color-border) z-50">
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        navigate('/preferences')
-                      }}
-                      className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
+                    <div className="flex flex-col items-end">
+                      <span>{user?.email}</span>
+                      {isAdmin && (
+                        <span className="text-[10px] leading-tight text-amber-600 dark:text-amber-400">admin</span>
+                      )}
+                    </div>
+                    <svg
+                      className={`h-3.5 w-3.5 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
                     >
-                      Preferences
-                    </button>
-                    <div className="mx-3 my-1 border-t border-(--color-border)" />
-                    <button
-                      onClick={() => {
-                        setMenuOpen(false)
-                        logout()
-                      }}
-                      className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
-                    >
-                      Logout
-                    </button>
-                  </div>
-                )}
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                  {menuOpen && (
+                    <div className="absolute right-0 mt-1.5 w-48 rounded-xl bg-(--bg-vibrancy) backdrop-blur-xl py-1 shadow-mac-lg ring-1 ring-(--color-border) z-50">
+                      <button
+                        onClick={() => {
+                          setMenuOpen(false)
+                          navigate('/settings/preferences')
+                        }}
+                        className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
+                      >
+                        Preferences
+                      </button>
+                      <div className="mx-3 my-1 border-t border-(--color-border)" />
+                      <button
+                        onClick={() => {
+                          setMenuOpen(false)
+                          logout()
+                        }}
+                        className="block w-full px-3.5 py-2 text-left text-[13px] text-(--color-text-primary) hover:bg-black/4 dark:hover:bg-white/6"
+                      >
+                        Logout
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </nav>
-      <LLMStatusProvider>
+        </nav>
         <main className="mx-auto max-w-7xl px-4 py-6">
           {showBanner && bannerState && <CorpusEmptyBanner state={bannerState} />}
           <BackButton />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -47,6 +47,7 @@ export default function Layout() {
   const bannerSuppressedPath =
     location.pathname === '/folders' ||
     location.pathname.startsWith('/admin') ||
+    location.pathname.startsWith('/settings') ||
     location.pathname.startsWith('/preferences')
   const showBanner = bannerState !== null && !bannerSuppressedPath
   const showWizard = !!user && !user.preferences?.onboardingComplete
@@ -85,48 +86,38 @@ export default function Layout() {
           <div className="flex h-12 items-center justify-between">
             <div className="flex items-center space-x-1">
               <NavLink
-                to="/ask"
-                className={({ isActive }) =>
-                  `relative mr-2 flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-semibold transition-colors ${
-                    isActive
-                      ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 ring-1 ring-amber-200/60 dark:ring-amber-700/40'
-                      : 'text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6'
-                  }`
-                }
+                to="/"
+                className="relative mr-2 flex items-center rounded-lg px-2 py-1 transition-colors text-(--color-text-secondary) hover:bg-black/4 dark:hover:bg-white/6"
+                aria-label="Harbor Clerk home"
               >
                 <img src="/favicon.svg" alt="" className="h-6 w-6" />
-                <span>Ask</span>
               </NavLink>
+              <TabLink to="/search" icon="🔍">
+                Search
+              </TabLink>
+              <TabLink to="/docs" icon="📄">
+                Documents
+              </TabLink>
+              <TabLink to="/ask" icon="💬">
+                Ask
+              </TabLink>
               <TabLink to="/research" icon="🐙">
                 Research
               </TabLink>
               <TabLink to="/folders" icon="📁">
                 Folders
               </TabLink>
-              <TabLink to="/docs" icon="📄">
-                Documents
-              </TabLink>
               <TabLink to="/explore" icon="🌍">
                 Explore
-              </TabLink>
-              <TabLink to="/search" icon="🔍">
-                Search
               </TabLink>
             </div>
             <div className="flex items-center space-x-1">
               <TabLink to="/stats" icon="📊">
                 Observatory
               </TabLink>
-              {isAdmin && (
-                <TabLink to="/integrations" icon="🔌">
-                  Integrations
-                </TabLink>
-              )}
-              {isAdmin && (
-                <TabLink to="/admin" icon="⚙️">
-                  System Settings
-                </TabLink>
-              )}
+              <TabLink to="/settings" icon="⚙️">
+                Settings
+              </TabLink>
               <div className="relative ml-2" ref={menuRef}>
                 <button
                   onClick={() => setMenuOpen(!menuOpen)}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -85,8 +85,7 @@ export default function Layout() {
           <div className="flex h-12 items-center justify-between">
             <div className="flex items-center space-x-1">
               <NavLink
-                to="/"
-                end
+                to="/ask"
                 className={({ isActive }) =>
                   `relative mr-2 flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-semibold transition-colors ${
                     isActive

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -111,7 +111,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
         await patch('/api/me/preferences', { enabled_languages: installed })
       } catch (e) {
         // Pref-save failed but packs are on disk. Surface so the
-        // operator can flip the toggle in System Settings → Languages.
+        // operator can flip the toggle in Settings → Languages.
         failures.push(`preferences save (${e instanceof Error ? e.message : 'unknown'})`)
       }
     }
@@ -121,7 +121,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
     if (failures.length > 0) {
       setError(
         `Some languages failed to install: ${failures.join(', ')}. ` +
-          `Successfully installed languages are still available — manage them under System Settings → Languages.`,
+          `Successfully installed languages are still available — manage them under Settings → Languages.`,
       )
       // Stay on this page so the user sees the error; they can click
       // Skip to advance once they've read it.

--- a/frontend/src/components/SummaryChip.tsx
+++ b/frontend/src/components/SummaryChip.tsx
@@ -24,7 +24,7 @@ const LABELS: Record<Exclude<SummaryState, 'none'>, string> = {
 
 const TOOLTIPS: Partial<Record<Exclude<SummaryState, 'none'>, string>> = {
   extractive:
-    'No language model was active when this summary was generated, so the system fell back to an extractive heuristic. Configure an LLM in System Settings → Models for higher-quality summaries on future documents.',
+    'No language model was active when this summary was generated, so the system fell back to an extractive heuristic. Configure a local AI model in Settings → Models for higher-quality summaries on future documents.',
   failed: 'The summarize stage errored. The document is otherwise fully ingested and searchable.',
 }
 

--- a/frontend/src/hooks/useAreaAccent.ts
+++ b/frontend/src/hooks/useAreaAccent.ts
@@ -13,7 +13,11 @@ const ROUTE_TO_AREA: { test: (path: string) => boolean; area: AreaHue }[] = [
   { test: (p) => p.startsWith('/search'), area: 'search' },
   { test: (p) => p.startsWith('/stats'), area: 'observatory' },
   {
-    test: (p) => p.startsWith('/admin') || p.startsWith('/integrations') || p.startsWith('/preferences'),
+    test: (p) =>
+      p.startsWith('/admin') ||
+      p.startsWith('/settings') ||
+      p.startsWith('/integrations') ||
+      p.startsWith('/preferences'),
     area: 'settings',
   },
   // Ask is the default — matches '/' and '/c/:conversationId'.

--- a/frontend/src/hooks/useSystemConfig.ts
+++ b/frontend/src/hooks/useSystemConfig.ts
@@ -2,6 +2,11 @@ import { useEffect, useState } from 'react'
 
 export interface SystemConfig {
   /**
+   * Readiness status reported by /api/system/health. This is a coarse
+   * at-a-glance signal; the Status page remains the detailed diagnostic view.
+   */
+  healthStatus: 'healthy' | 'degraded' | null
+  /**
    * True when the backend is configured to serve original document bytes
    * over /api/docs/{doc_id}/download. Defaults to false on every deployment;
    * macOS native does not expose any toggle to flip this on (use Reveal in
@@ -29,6 +34,7 @@ export interface SystemConfig {
 }
 
 const FALLBACK: SystemConfig = {
+  healthStatus: null,
   allowSourceDownload: false,
   enableCliAccess: false,
   cliShimInstallStatus: null,
@@ -55,6 +61,7 @@ export function useSystemConfig(): SystemConfig {
       .then((data) => {
         if (cancelled || !data) return
         setConfig({
+          healthStatus: data.status === 'healthy' || data.status === 'degraded' ? data.status : null,
           allowSourceDownload: Boolean(data.allow_source_download),
           enableCliAccess: Boolean(data.enable_cli_access),
           cliShimInstallStatus: data.cli_shim_install_status ?? null,

--- a/frontend/src/pages/ApiKeyDashboardPage.tsx
+++ b/frontend/src/pages/ApiKeyDashboardPage.tsx
@@ -185,7 +185,7 @@ export default function ApiKeyDashboardPage() {
   if (!keyInfo) {
     return (
       <div className="animate-slide-in">
-        <Link to="/admin/keys" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+        <Link to="/settings/api-keys" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
           &larr; API Keys
         </Link>
         <p className="mt-4 text-gray-500 dark:text-gray-400">API key not found.</p>
@@ -214,7 +214,10 @@ export default function ApiKeyDashboardPage() {
     <div className="animate-slide-in space-y-6">
       {/* Header */}
       <div>
-        <Link to="/admin/keys" className="mb-2 inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline">
+        <Link
+          to="/settings/api-keys"
+          className="mb-2 inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
           &larr; API Keys
         </Link>
         <PageHeader

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -47,13 +47,21 @@ interface ScopePreview {
 }
 
 // Mirrors src/harbor_clerk/api/scope.py — keep in sync
-const SEARCH_TIER_TOOLS = ['kb_search', 'kb_batch_search', 'kb_corpus_overview', 'kb_list_recent'] as const
+const SEARCH_TIER_TOOLS = [
+  'kb_search',
+  'kb_batch_search',
+  'kb_corpus_overview',
+  'kb_list_recent',
+  'kb_find_all',
+  'kb_documents_by_date',
+] as const
 const READ_TIER_TOOLS = [
   ...SEARCH_TIER_TOOLS,
   'kb_read_passages',
   'kb_expand_context',
   'kb_document_outline',
   'kb_get_document',
+  'kb_verify_identifier',
 ] as const
 const FULL_TIER_TOOLS = [
   ...READ_TIER_TOOLS,

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -317,7 +317,10 @@ export default function ApiKeysPage() {
             {keys.map((k) => (
               <tr key={k.key_id} className="hover:bg-black/3 dark:hover:bg-white/3">
                 <td className="px-4 py-3 text-sm font-medium">
-                  <Link to={`/admin/keys/${k.key_id}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                  <Link
+                    to={`/settings/api-keys/${k.key_id}`}
+                    className="text-blue-600 dark:text-blue-400 hover:underline"
+                  >
                     {k.name}
                   </Link>
                 </td>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -177,7 +177,7 @@ export default function ChatPage() {
         )
       })
       .catch(() => {
-        navigate('/')
+        navigate('/ask')
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId])
@@ -243,7 +243,7 @@ export default function ChatPage() {
   const handleNewChat = useCallback(() => {
     if (isStreaming) stopStreaming()
     loadMessages('', [])
-    navigate('/')
+    navigate('/ask')
     inputRef.current?.focus()
   }, [isStreaming, stopStreaming, loadMessages, navigate])
 
@@ -253,7 +253,7 @@ export default function ChatPage() {
       setConversations((prev) => prev.filter((c) => c.conversation_id !== convId))
       if (conversationId === convId) {
         loadMessages('', [])
-        navigate('/')
+        navigate('/ask')
       }
     },
     [conversationId, loadMessages, navigate],

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -597,7 +597,7 @@ function ModelNudge() {
           — strong reasoning, tool use, and bilingual support.
         </p>
         <Link
-          to="/admin/models"
+          to="/settings/models"
           className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
         >
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -640,10 +640,10 @@ export default function DocumentsPage() {
             summaries, activate a model.
           </span>
           <Link
-            to="/admin/models"
+            to="/settings/models"
             className="ml-3 shrink-0 rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700"
           >
-            System Settings → Models
+            Settings → Models
           </Link>
         </div>
       )}

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get } from '../api'
+import HomePage from './HomePage'
+
+vi.mock('../api', () => ({
+  get: vi.fn(),
+}))
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}))
+
+const getMock = vi.mocked(get)
+
+function renderHome() {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/folders" element={<div>Folders route</div>} />
+        <Route path="/search" element={<div>Search route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+  })
+
+  it('routes to folders when no watched folders exist', async () => {
+    getMock.mockResolvedValueOnce([]).mockResolvedValueOnce({ total: 0 })
+
+    renderHome()
+
+    expect(await screen.findByText('Folders route')).toBeInTheDocument()
+    expect(getMock).toHaveBeenCalledWith('/api/watch/folders')
+    expect(getMock).toHaveBeenCalledWith('/api/docs', { limit: 0 })
+  })
+
+  it('routes to folders when watched folders have no documents', async () => {
+    getMock.mockResolvedValueOnce([{ folder_id: 'folder-1' }]).mockResolvedValueOnce({ total: 0 })
+
+    renderHome()
+
+    expect(await screen.findByText('Folders route')).toBeInTheDocument()
+  })
+
+  it('routes to search when the corpus has documents', async () => {
+    getMock.mockResolvedValueOnce([{ folder_id: 'folder-1' }]).mockResolvedValueOnce({ total: 3 })
+
+    renderHome()
+
+    expect(await screen.findByText('Search route')).toBeInTheDocument()
+  })
+
+  it('falls back to search on routing probe failure', async () => {
+    getMock.mockRejectedValueOnce(new Error('network'))
+
+    renderHome()
+
+    await waitFor(() => expect(screen.getByText('Search route')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,14 +1,44 @@
-import ChatPage from './ChatPage'
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { get } from '../api'
+import { useAuth } from '../auth'
 
-/**
- * Home route ('/'). Renders the chat experience unconditionally; the
- * empty-corpus signaling is handled globally by Layout.tsx's
- * <CorpusEmptyBanner /> and the first-run <OnboardingWizard />.
- *
- * Stage 2 dropped the previous "redirect to /upload when doc count is
- * zero" behaviour — that route is gone, and yanking users off chat on
- * arrival was confusing once direct upload became internal-only.
- */
+interface FolderRow {
+  folder_id: string
+}
+
+interface DocsCount {
+  total: number
+}
+
 export default function HomePage() {
-  return <ChatPage />
+  const { token } = useAuth()
+  const [target, setTarget] = useState<'/folders' | '/search' | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+
+    let cancelled = false
+
+    async function chooseTarget() {
+      try {
+        const [folders, docs] = await Promise.all([
+          get<FolderRow[]>('/api/watch/folders'),
+          get<DocsCount>('/api/docs', { limit: 0 }),
+        ])
+        if (cancelled) return
+        setTarget(folders.length === 0 || docs.total === 0 ? '/folders' : '/search')
+      } catch {
+        if (!cancelled) setTarget('/search')
+      }
+    }
+
+    chooseTarget()
+    return () => {
+      cancelled = true
+    }
+  }, [token])
+
+  if (target) return <Navigate to={target} replace />
+  return <div className="text-sm text-(--color-text-secondary)">Loading...</div>
 }

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -316,7 +316,7 @@ export default function IntegrationsPage() {
             </p>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
-                <Link to="/admin/keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
                   Create an API key
                 </Link>{' '}
                 if you don&apos;t have one already.
@@ -357,7 +357,7 @@ export default function IntegrationsPage() {
           <>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
-                <Link to="/admin/keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
                   Create an API key
                 </Link>{' '}
                 if you don&apos;t have one already.
@@ -396,7 +396,7 @@ export default function IntegrationsPage() {
             </p>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
-                <Link to="/admin/keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
                   Create a scoped API key
                 </Link>{' '}
                 with the following recommended settings:
@@ -449,7 +449,10 @@ export default function IntegrationsPage() {
                 OpenClaw agents run autonomously and may make many tool calls in rapid succession. Always scope the API
                 key to only the documents and tools the agent needs, set rate limits to prevent runaway loops, and use
                 the{' '}
-                <Link to="/admin/keys" className="text-amber-800 dark:text-amber-200 underline hover:no-underline">
+                <Link
+                  to="/settings/api-keys"
+                  className="text-amber-800 dark:text-amber-200 underline hover:no-underline"
+                >
                   audit dashboard
                 </Link>{' '}
                 to monitor usage.

--- a/frontend/src/pages/ModelsPage.test.tsx
+++ b/frontend/src/pages/ModelsPage.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { modelGuidance } from '../utils/modelGuidance'
+
+describe('modelGuidance', () => {
+  it('labels curated models by intended use', () => {
+    expect(modelGuidance({ id: 'qwen36-35b-a3b', size_bytes: 22_000_000_000, supports_research: true }).label).toBe(
+      'Best local research',
+    )
+    expect(modelGuidance({ id: 'gpt-oss-20b', size_bytes: 11_600_000_000, supports_research: true }).label).toBe(
+      'Strong tables and comparisons',
+    )
+    expect(modelGuidance({ id: 'qwen3-4b', size_bytes: 2_500_000_000, supports_research: true }).warning).toContain(
+      'May miss details',
+    )
+  })
+
+  it('warns for small or non-research fallback models', () => {
+    const guidance = modelGuidance({ id: 'future-small', size_bytes: 3_000_000_000, supports_research: false })
+
+    expect(guidance.label).toBe('Quick lookup')
+    expect(guidance.warning).toBe('Not recommended for deep research.')
+  })
+})

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -5,6 +5,7 @@ import { useLLMStatusContext } from '../components/LLMStatusBanner'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'
 import { StatusPill } from '../components/StatusPill'
+import { modelGuidance } from '../utils/modelGuidance'
 
 interface ModelInfo {
   id: string
@@ -276,13 +277,26 @@ export default function ModelsPage() {
 
   return (
     <div className="animate-slide-in">
-      <PageHeader title="Models" subtitle="Download and manage local LLM models" />
+      <PageHeader
+        title="Models"
+        subtitle="Choose local AI models for cited answers, research, and document summaries."
+      />
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
           {error}
         </div>
       )}
+
+      <Card className="mb-4 p-4">
+        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          Local AI is useful, but model choice matters.
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+          Larger models are better for research and synthesis. Smaller models are still useful for quick lookup, but
+          important answers should be checked against the citations.
+        </p>
+      </Card>
 
       <Card className="overflow-hidden">
         <table className="w-full text-sm">
@@ -324,11 +338,23 @@ export default function ModelsPage() {
                   </tr>
                   {tier.items.map((model) => {
                     const progress = downloadProgress.get(model.id)
+                    const guidance = modelGuidance(model)
                     return (
                       <tr key={model.id} className="bg-white dark:bg-[#2c2c2e]">
                         <td className="px-4 py-3">
                           <div className="font-medium text-gray-900 dark:text-gray-100">{model.name}</div>
                           <div className="text-xs text-gray-500 dark:text-gray-400">{model.id}</div>
+                          <div className="mt-1.5 inline-flex rounded-md bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-700 dark:bg-blue-900/25 dark:text-blue-300">
+                            {guidance.label}
+                          </div>
+                          <div className="mt-1 max-w-xs text-xs leading-snug text-gray-500 dark:text-gray-400">
+                            {guidance.note}
+                          </div>
+                          {guidance.warning && (
+                            <div className="mt-1 max-w-xs text-[11px] leading-snug text-amber-700 dark:text-amber-400">
+                              {guidance.warning}
+                            </div>
+                          )}
                         </td>
                         <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{formatSize(model.size_bytes)}</td>
                         <td className="px-4 py-3 text-gray-700 dark:text-gray-300">

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -988,7 +988,7 @@ function ModelNudge() {
         Deep Research drives a local LLM through many tool calls — pick a model first.
       </p>
       <Link
-        to="/admin/models"
+        to="/settings/models"
         className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2 text-[13px] font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
       >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { post } from '../api'
+import SearchPage from './SearchPage'
+
+vi.mock('../api', () => ({
+  post: vi.fn(),
+}))
+
+vi.mock('../hooks/useWatchedFolders', () => ({
+  useWatchedFolders: () => ({
+    folders: [],
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    refetch: () => undefined,
+  }),
+}))
+
+const postMock = vi.mocked(post)
+
+function storageMock(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => store.delete(key),
+    setItem: (key: string, value: string) => store.set(key, value),
+  }
+}
+
+function resetStorage() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storageMock(),
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: storageMock(),
+    configurable: true,
+  })
+}
+
+function renderSearchPage() {
+  render(
+    <MemoryRouter>
+      <SearchPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SearchPage', () => {
+  beforeEach(() => {
+    resetStorage()
+    postMock.mockReset()
+  })
+
+  it('uses the search endpoint by default', async () => {
+    postMock.mockResolvedValueOnce({
+      hits: [],
+      total_candidates: 0,
+      has_more: false,
+      possible_conflict: false,
+      conflict_sources: [],
+    })
+
+    renderSearchPage()
+
+    const input = screen.getByPlaceholderText('Search documents...')
+    fireEvent.change(input, { target: { value: 'arbitration' } })
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search', {
+        query: 'arbitration',
+        k: 25,
+        offset: 0,
+      })
+    })
+    expect(await screen.findByText('No results found.')).toBeInTheDocument()
+  })
+
+  it('uses the find-all endpoint and renders document results', async () => {
+    postMock.mockResolvedValueOnce({
+      results: [
+        {
+          doc_id: 'doc-1',
+          doc_title: 'Vendor Contract',
+          mime_type: 'application/pdf',
+          language: 'en',
+          score: 0.87,
+          ingested_at: '2026-06-01T00:00:00Z',
+          page_range: '2',
+          top_chunk: {
+            chunk_id: 'chunk-1',
+            text: 'Force majeure clause excerpt.',
+            page: 2,
+            heading: 'Terms',
+          },
+          source: {
+            doc_id: 'doc-1',
+            doc_title: 'Vendor Contract',
+            chunk_id: 'chunk-1',
+            pages: '2',
+            section: 'Terms',
+            source_kind: 'document',
+            source_label: 'Vendor Contract',
+            folder_label: 'Contracts',
+            relative_path: 'vendors/contract.pdf',
+            citation: 'Vendor Contract, p. 2',
+          },
+          citation: 'Vendor Contract, p. 2',
+        },
+      ],
+      total_matches: 1,
+      returned: 1,
+      offset: 0,
+      truncated: false,
+      sort_by: 'relevance',
+      presentation: 'full',
+    })
+
+    renderSearchPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Find All mode' }))
+    const input = screen.getByPlaceholderText('Find all matching documents...')
+    fireEvent.change(input, { target: { value: 'force majeure' } })
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search/find-all', {
+        query: 'force majeure',
+        max_results: 25,
+        offset: 0,
+        presentation: 'full',
+        sort_by: 'relevance',
+      })
+    })
+    expect(await screen.findByText('Vendor Contract')).toBeInTheDocument()
+    expect(screen.getByText('Force majeure clause excerpt.')).toBeInTheDocument()
+    expect(screen.getByText('Vendor Contract, p. 2')).toBeInTheDocument()
+    expect(screen.getByText('vendors/contract.pdf')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -145,4 +145,48 @@ describe('SearchPage', () => {
     expect(screen.getByText('Vendor Contract, p. 2')).toBeInTheDocument()
     expect(screen.getByText('vendors/contract.pdf')).toBeInTheDocument()
   })
+
+  it('serializes friendly filters into search request fields', async () => {
+    postMock.mockResolvedValueOnce({
+      hits: [],
+      total_candidates: 0,
+      has_more: false,
+      possible_conflict: false,
+      conflict_sources: [],
+    })
+
+    renderSearchPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /Filters/ }))
+    fireEvent.change(screen.getByLabelText('Exact text'), { target: { value: 'force majeure' } })
+    fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'en' } })
+    fireEvent.change(screen.getByLabelText('MIME type'), { target: { value: 'application/pdf' } })
+    fireEvent.change(screen.getByLabelText('Email from'), { target: { value: 'alice@example.com' } })
+    fireEvent.change(screen.getByLabelText('Email subject'), { target: { value: 'invoice' } })
+
+    expect(screen.getByLabelText('Generated metadata JSON')).toHaveTextContent(
+      '"email.from_address": "alice@example.com"',
+    )
+    expect(screen.getByText('Text: force majeure')).toBeInTheDocument()
+    expect(screen.getByText('From: alice@example.com')).toBeInTheDocument()
+
+    const input = screen.getByPlaceholderText('Search documents...')
+    fireEvent.change(input, { target: { value: 'contract' } })
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search', {
+        query: 'contract',
+        k: 25,
+        offset: 0,
+        text_contains: 'force majeure',
+        language: 'en',
+        mime_type: 'application/pdf',
+        metadata_filter: {
+          'email.from_address': 'alice@example.com',
+          'email.subject_contains': 'invoice',
+        },
+      })
+    })
+  })
 })

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -6,6 +6,21 @@ import { FolderPicker } from '../components/FolderPicker'
 import { PageHeader } from '../components/PageHeader'
 import { useWatchedFolders } from '../hooks/useWatchedFolders'
 
+type SearchMode = 'search' | 'find_all'
+
+interface SourceRef {
+  doc_id: string
+  doc_title: string
+  chunk_id?: string
+  pages?: string
+  section?: string
+  source_kind: 'document' | 'email' | 'attachment' | 'unknown'
+  source_label: string
+  folder_label?: string
+  relative_path?: string
+  citation: string
+}
+
 interface SearchHit {
   chunk_id: string
   doc_id: string
@@ -18,6 +33,8 @@ interface SearchHit {
   ocr_confidence?: number
   score: number
   doc_title?: string
+  source?: SourceRef
+  citation?: string
 }
 
 interface ConflictSource {
@@ -33,14 +50,47 @@ interface SearchResponse {
   conflict_sources: ConflictSource[]
 }
 
+interface FindAllTopChunk {
+  chunk_id?: string
+  text?: string
+  page?: number
+  heading?: string
+}
+
+interface FindAllHit {
+  doc_id: string
+  doc_title: string
+  mime_type: string
+  language?: string
+  score: number
+  ingested_at?: string
+  page_range?: string
+  top_chunk?: FindAllTopChunk
+  source?: SourceRef
+  citation?: string
+}
+
+interface FindAllResponse {
+  results: FindAllHit[]
+  total_matches: number
+  returned: number
+  offset: number
+  truncated: boolean
+  sort_by: 'relevance' | 'date_desc' | 'date_asc'
+  presentation: 'brief' | 'full'
+}
+
+type SearchResults = SearchResponse | FindAllResponse
+
 const HISTORY_KEY = 'search_history'
 const STATE_KEY = 'search_state'
 const MAX_HISTORY = 10
 const PAGE_SIZES = [10, 25, 50]
 
 interface SearchState {
+  mode?: SearchMode
   query: string
-  results: SearchResponse | null
+  results: SearchResults | null
   currentPage: number
   pageSize: number
   lastQuery: string
@@ -85,6 +135,16 @@ function addToHistory(query: string) {
   const history = getHistory().filter((q) => q !== trimmed)
   history.unshift(trimmed)
   saveHistory(history.slice(0, MAX_HISTORY))
+}
+
+function isFindAllResponse(results: SearchResults | null): results is FindAllResponse {
+  return !!results && 'results' in results
+}
+
+function firstPageFromRange(pageRange?: string): number | null {
+  if (!pageRange) return null
+  const match = pageRange.match(/^\d+/)
+  return match ? Number(match[0]) : null
 }
 
 function Pagination({
@@ -146,8 +206,9 @@ function Pagination({
 
 export default function SearchPage() {
   const [initial] = useState(loadSearchState)
+  const [mode, setMode] = useState<SearchMode>(initial?.mode === 'find_all' ? 'find_all' : 'search')
   const [query, setQuery] = useState(initial?.query || '')
-  const [results, setResults] = useState<SearchResponse | null>(initial?.results || null)
+  const [results, setResults] = useState<SearchResults | null>(initial?.results || null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [history, setHistory] = useState<string[]>(getHistory)
@@ -161,8 +222,8 @@ export default function SearchPage() {
 
   // Persist search state to sessionStorage
   useEffect(() => {
-    saveSearchState({ query, results, currentPage, pageSize, lastQuery: lastQuery.current })
-  }, [query, results, currentPage, pageSize])
+    saveSearchState({ mode, query, results, currentPage, pageSize, lastQuery: lastQuery.current })
+  }, [mode, query, results, currentPage, pageSize])
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -175,7 +236,13 @@ export default function SearchPage() {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  async function doSearch(q: string, page: number, size: number, folderIds: string[] = scopeFolderIds) {
+  async function doSearch(
+    q: string,
+    page: number,
+    size: number,
+    folderIds: string[] = scopeFolderIds,
+    searchMode: SearchMode = mode,
+  ) {
     const trimmed = q.trim()
     if (!trimmed) return
     setError('')
@@ -185,15 +252,25 @@ export default function SearchPage() {
     lastQuery.current = trimmed
     try {
       const offset = (page - 1) * size
-      const data = await post<SearchResponse>('/api/search', {
-        query: trimmed,
-        k: size,
-        offset,
-        ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
-      })
+      const data =
+        searchMode === 'find_all'
+          ? await post<FindAllResponse>('/api/search/find-all', {
+              query: trimmed,
+              max_results: size,
+              offset,
+              presentation: 'full',
+              sort_by: 'relevance',
+              ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
+            })
+          : await post<SearchResponse>('/api/search', {
+              query: trimmed,
+              k: size,
+              offset,
+              ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
+            })
       setResults(data)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Search failed')
+      setError(e instanceof Error ? e.message : searchMode === 'find_all' ? 'Find All failed' : 'Search failed')
     } finally {
       setLoading(false)
     }
@@ -219,6 +296,14 @@ export default function SearchPage() {
     }
   }
 
+  function handleModeChange(nextMode: SearchMode) {
+    if (nextMode === mode) return
+    setMode(nextMode)
+    setResults(null)
+    setCurrentPage(1)
+    lastQuery.current = ''
+  }
+
   function selectHistoryItem(q: string) {
     setQuery(q)
     setShowHistory(false)
@@ -232,13 +317,44 @@ export default function SearchPage() {
     setShowHistory(false)
   }
 
-  const maxScore = results?.hits[0]?.score || 1
-  const totalPages = results ? Math.max(1, Math.ceil(results.total_candidates / pageSize)) : 1
+  const searchResults = mode === 'search' && results && !isFindAllResponse(results) ? results : null
+  const findAllResults = mode === 'find_all' && isFindAllResponse(results) ? results : null
+  const totalCount = findAllResults?.total_matches ?? searchResults?.total_candidates ?? 0
+  const maxScore = searchResults?.hits[0]?.score || findAllResults?.results[0]?.score || 1
+  const totalPages = results ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1
   const startIdx = (currentPage - 1) * pageSize
 
   return (
     <div>
       <PageHeader title="Search" subtitle="Hybrid lexical + semantic retrieval" />
+      <div className="mb-4 inline-flex rounded-lg bg-(--color-bg-secondary) p-0.5 shadow-mac ring-1 ring-(--color-border)">
+        <button
+          type="button"
+          aria-label="Search mode"
+          aria-pressed={mode === 'search'}
+          onClick={() => handleModeChange('search')}
+          className={`min-w-24 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            mode === 'search'
+              ? 'bg-white text-(--color-text-primary) shadow-mac dark:bg-[#3a3a3c]'
+              : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+          }`}
+        >
+          Search
+        </button>
+        <button
+          type="button"
+          aria-label="Find All mode"
+          aria-pressed={mode === 'find_all'}
+          onClick={() => handleModeChange('find_all')}
+          className={`min-w-24 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            mode === 'find_all'
+              ? 'bg-white text-(--color-text-primary) shadow-mac dark:bg-[#3a3a3c]'
+              : 'text-(--color-text-secondary) hover:text-(--color-text-primary)'
+          }`}
+        >
+          Find All
+        </button>
+      </div>
       <form onSubmit={handleSearch} className="mb-6 flex items-center gap-2">
         <div className="relative flex-1" ref={wrapperRef}>
           <input
@@ -249,7 +365,7 @@ export default function SearchPage() {
             onKeyDown={(e) => {
               if (e.key === 'Escape') setShowHistory(false)
             }}
-            placeholder="Search documents..."
+            placeholder={mode === 'find_all' ? 'Find all matching documents...' : 'Search documents...'}
             autoFocus
             className="w-full rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac focus:ring-2 focus:ring-(--color-accent)/30 px-4 py-2 text-sm"
           />
@@ -305,7 +421,13 @@ export default function SearchPage() {
             border: '1px solid var(--area-accent)',
           }}
         >
-          {loading ? 'Searching...' : 'Search'}
+          {loading
+            ? mode === 'find_all'
+              ? 'Finding...'
+              : 'Searching...'
+            : mode === 'find_all'
+              ? 'Find All'
+              : 'Search'}
         </button>
       </form>
 
@@ -315,12 +437,12 @@ export default function SearchPage() {
         </div>
       )}
 
-      {results && (
+      {searchResults && (
         <>
-          {results.possible_conflict && results.conflict_sources.length > 0 && (
+          {searchResults.possible_conflict && searchResults.conflict_sources.length > 0 && (
             <div className="mb-4 rounded-sm bg-amber-50 dark:bg-amber-900/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-400">
               <strong>Possible conflict:</strong> Similar content found across multiple sources:{' '}
-              {results.conflict_sources.map((s, i) => (
+              {searchResults.conflict_sources.map((s, i) => (
                 <span key={s.doc_id}>
                   {i > 0 && ', '}
                   <Link to={`/docs/${s.doc_id}`} className="font-medium text-amber-900 dark:text-amber-300 underline">
@@ -331,11 +453,11 @@ export default function SearchPage() {
             </div>
           )}
 
-          {results.hits.length === 0 && currentPage === 1 ? (
+          {searchResults.hits.length === 0 && currentPage === 1 ? (
             <p className="text-gray-500 dark:text-gray-400">No results found.</p>
           ) : (
             <div className="space-y-3">
-              {results.hits.map((hit) => {
+              {searchResults.hits.map((hit) => {
                 const linkTo =
                   hit.page_start != null
                     ? `/docs/${hit.doc_id}?showContent=true&page=${hit.page_start}`
@@ -370,6 +492,7 @@ export default function SearchPage() {
                     </div>
                     <p className="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{hit.chunk_text}</p>
                     <div className="flex items-center space-x-3 text-xs text-gray-400">
+                      {hit.citation && <span>{hit.citation}</span>}
                       {hit.page_start != null && (
                         <span>
                           Page {hit.page_start}
@@ -377,6 +500,7 @@ export default function SearchPage() {
                         </span>
                       )}
                       <span>Lang: {hit.language}</span>
+                      {hit.source?.relative_path && <span>{hit.source.relative_path}</span>}
                       {hit.ocr_used && (
                         <span className="rounded-md text-[11px] font-medium bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5">
                           OCR
@@ -391,8 +515,96 @@ export default function SearchPage() {
               <div className="flex items-center justify-between pt-2">
                 <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
                   <span>
-                    Showing {results.total_candidates === 0 ? 0 : startIdx + 1}&ndash;
-                    {Math.min(startIdx + pageSize, results.total_candidates)} of {results.total_candidates} results
+                    Showing {searchResults.total_candidates === 0 ? 0 : startIdx + 1}&ndash;
+                    {Math.min(startIdx + pageSize, searchResults.total_candidates)} of {searchResults.total_candidates}{' '}
+                    results
+                  </span>
+                  <select
+                    value={pageSize}
+                    onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+                    className="rounded-md border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) py-0.5 pl-2 pr-6 text-sm"
+                  >
+                    {PAGE_SIZES.map((s) => (
+                      <option key={s} value={s}>
+                        {s} / page
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {findAllResults && (
+        <>
+          {findAllResults.results.length === 0 && currentPage === 1 ? (
+            <p className="text-gray-500 dark:text-gray-400">No documents found.</p>
+          ) : (
+            <div className="space-y-3">
+              {findAllResults.results.map((hit) => {
+                const page = hit.top_chunk?.page ?? firstPageFromRange(hit.page_range)
+                const linkTo =
+                  page != null
+                    ? `/docs/${hit.doc_id}?showContent=true&page=${page}`
+                    : `/docs/${hit.doc_id}?showContent=true`
+                const linkState =
+                  hit.top_chunk?.text || hit.top_chunk?.chunk_id
+                    ? {
+                        highlightChunkText: hit.top_chunk?.text,
+                        highlightChunkId: hit.top_chunk?.chunk_id,
+                      }
+                    : undefined
+
+                return (
+                  <Card key={hit.doc_id} className="p-4">
+                    <div className="mb-2 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <Link
+                          to={linkTo}
+                          state={linkState}
+                          className="font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                        >
+                          {hit.doc_title || 'Untitled'}
+                        </Link>
+                        {hit.source?.folder_label && (
+                          <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{hit.source.folder_label}</div>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 items-center space-x-2">
+                        <div className="h-1.5 w-24 rounded-full bg-gray-200 dark:bg-gray-600">
+                          <div
+                            className="h-1.5 rounded-full bg-blue-500"
+                            style={{
+                              width: `${Math.round((hit.score / maxScore) * 100)}%`,
+                            }}
+                          />
+                        </div>
+                        <span className="text-xs text-gray-400">{hit.score.toFixed(3)}</span>
+                      </div>
+                    </div>
+                    {hit.top_chunk?.text && (
+                      <p className="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{hit.top_chunk.text}</p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
+                      {hit.citation && <span>{hit.citation}</span>}
+                      {hit.page_range && <span>Pages {hit.page_range}</span>}
+                      {hit.language && <span>Lang: {hit.language}</span>}
+                      {hit.mime_type && <span>{hit.mime_type}</span>}
+                      {hit.source?.relative_path && <span>{hit.source.relative_path}</span>}
+                    </div>
+                  </Card>
+                )
+              })}
+
+              <div className="flex items-center justify-between pt-2">
+                <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                  <span>
+                    Showing {findAllResults.total_matches === 0 ? 0 : startIdx + 1}&ndash;
+                    {Math.min(startIdx + pageSize, findAllResults.total_matches)} of {findAllResults.total_matches}{' '}
+                    documents
                   </span>
                   <select
                     value={pageSize}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -8,6 +8,18 @@ import { useWatchedFolders } from '../hooks/useWatchedFolders'
 
 type SearchMode = 'search' | 'find_all'
 
+interface SearchFilters {
+  textContains: string
+  after: string
+  before: string
+  language: string
+  mimeType: string
+  emailFrom: string
+  emailTo: string
+  emailCc: string
+  emailSubject: string
+}
+
 interface SourceRef {
   doc_id: string
   doc_title: string
@@ -86,6 +98,17 @@ const HISTORY_KEY = 'search_history'
 const STATE_KEY = 'search_state'
 const MAX_HISTORY = 10
 const PAGE_SIZES = [10, 25, 50]
+const EMPTY_FILTERS: SearchFilters = {
+  textContains: '',
+  after: '',
+  before: '',
+  language: '',
+  mimeType: '',
+  emailFrom: '',
+  emailTo: '',
+  emailCc: '',
+  emailSubject: '',
+}
 
 interface SearchState {
   mode?: SearchMode
@@ -94,6 +117,7 @@ interface SearchState {
   currentPage: number
   pageSize: number
   lastQuery: string
+  filters?: SearchFilters
 }
 
 function saveSearchState(state: SearchState) {
@@ -145,6 +169,49 @@ function firstPageFromRange(pageRange?: string): number | null {
   if (!pageRange) return null
   const match = pageRange.match(/^\d+/)
   return match ? Number(match[0]) : null
+}
+
+function normalizedFilters(filters?: Partial<SearchFilters>): SearchFilters {
+  return { ...EMPTY_FILTERS, ...filters }
+}
+
+function buildMetadataFilter(filters: SearchFilters): Record<string, string> {
+  const metadataFilter: Record<string, string> = {}
+  const emailFrom = filters.emailFrom.trim()
+  const emailTo = filters.emailTo.trim()
+  const emailCc = filters.emailCc.trim()
+  const emailSubject = filters.emailSubject.trim()
+  if (emailFrom) metadataFilter['email.from_address'] = emailFrom
+  if (emailTo) metadataFilter['email.to_addresses'] = emailTo
+  if (emailCc) metadataFilter['email.cc_addresses'] = emailCc
+  if (emailSubject) metadataFilter['email.subject_contains'] = emailSubject
+  return metadataFilter
+}
+
+function buildFilterPayload(filters: SearchFilters) {
+  const metadataFilter = buildMetadataFilter(filters)
+  return {
+    ...(filters.textContains.trim() && { text_contains: filters.textContains.trim() }),
+    ...(filters.after && { after: filters.after }),
+    ...(filters.before && { before: filters.before }),
+    ...(filters.language && { language: filters.language }),
+    ...(filters.mimeType.trim() && { mime_type: filters.mimeType.trim() }),
+    ...(Object.keys(metadataFilter).length > 0 && { metadata_filter: metadataFilter }),
+  }
+}
+
+function activeFilterLabels(filters: SearchFilters): string[] {
+  const labels: string[] = []
+  if (filters.textContains.trim()) labels.push(`Text: ${filters.textContains.trim()}`)
+  if (filters.after) labels.push(`After: ${filters.after}`)
+  if (filters.before) labels.push(`Before: ${filters.before}`)
+  if (filters.language) labels.push(`Language: ${filters.language}`)
+  if (filters.mimeType.trim()) labels.push(`Type: ${filters.mimeType.trim()}`)
+  if (filters.emailFrom.trim()) labels.push(`From: ${filters.emailFrom.trim()}`)
+  if (filters.emailTo.trim()) labels.push(`To: ${filters.emailTo.trim()}`)
+  if (filters.emailCc.trim()) labels.push(`Cc: ${filters.emailCc.trim()}`)
+  if (filters.emailSubject.trim()) labels.push(`Subject: ${filters.emailSubject.trim()}`)
+  return labels
 }
 
 function Pagination({
@@ -211,6 +278,8 @@ export default function SearchPage() {
   const [results, setResults] = useState<SearchResults | null>(initial?.results || null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const [filters, setFilters] = useState<SearchFilters>(() => normalizedFilters(initial?.filters))
+  const [filtersOpen, setFiltersOpen] = useState(false)
   const [history, setHistory] = useState<string[]>(getHistory)
   const [showHistory, setShowHistory] = useState(false)
   const [pageSize, setPageSize] = useState(initial?.pageSize || 25)
@@ -222,8 +291,8 @@ export default function SearchPage() {
 
   // Persist search state to sessionStorage
   useEffect(() => {
-    saveSearchState({ mode, query, results, currentPage, pageSize, lastQuery: lastQuery.current })
-  }, [mode, query, results, currentPage, pageSize])
+    saveSearchState({ mode, query, results, currentPage, pageSize, lastQuery: lastQuery.current, filters })
+  }, [mode, query, results, currentPage, pageSize, filters])
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -252,6 +321,7 @@ export default function SearchPage() {
     lastQuery.current = trimmed
     try {
       const offset = (page - 1) * size
+      const filterPayload = buildFilterPayload(filters)
       const data =
         searchMode === 'find_all'
           ? await post<FindAllResponse>('/api/search/find-all', {
@@ -260,12 +330,14 @@ export default function SearchPage() {
               offset,
               presentation: 'full',
               sort_by: 'relevance',
+              ...filterPayload,
               ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
             })
           : await post<SearchResponse>('/api/search', {
               query: trimmed,
               k: size,
               offset,
+              ...filterPayload,
               ...(folderIds.length > 0 && { scope: { folder_ids: folderIds } }),
             })
       setResults(data)
@@ -317,8 +389,19 @@ export default function SearchPage() {
     setShowHistory(false)
   }
 
+  function updateFilter(key: keyof SearchFilters, value: string) {
+    setFilters((current) => ({ ...current, [key]: value }))
+  }
+
+  function clearFilters() {
+    setFilters(EMPTY_FILTERS)
+  }
+
   const searchResults = mode === 'search' && results && !isFindAllResponse(results) ? results : null
   const findAllResults = mode === 'find_all' && isFindAllResponse(results) ? results : null
+  const metadataFilter = buildMetadataFilter(filters)
+  const activeFilters = activeFilterLabels(filters)
+  const activeFilterCount = activeFilters.length
   const totalCount = findAllResults?.total_matches ?? searchResults?.total_candidates ?? 0
   const maxScore = searchResults?.hits[0]?.score || findAllResults?.results[0]?.score || 1
   const totalPages = results ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1
@@ -412,6 +495,19 @@ export default function SearchPage() {
         </div>
         <FolderPicker value={scopeFolderIds} onChange={setScopeFolderIds} folders={folders} size="sm" />
         <button
+          type="button"
+          onClick={() => setFiltersOpen((open) => !open)}
+          aria-expanded={filtersOpen}
+          className="rounded-md border border-(--color-border) bg-(--color-bg-secondary) px-3 py-1.5 text-sm font-medium text-(--color-text-primary) hover:bg-(--color-bg-tertiary)"
+        >
+          Filters
+          {activeFilterCount > 0 && (
+            <span className="ml-1.5 rounded-full bg-(--area-accent) px-1.5 py-0.5 text-[10px] font-semibold text-white">
+              {activeFilterCount}
+            </span>
+          )}
+        </button>
+        <button
           type="submit"
           disabled={loading}
           className="rounded-md px-4 py-1.5 text-sm font-medium disabled:opacity-50"
@@ -430,6 +526,126 @@ export default function SearchPage() {
               : 'Search'}
         </button>
       </form>
+
+      {activeFilterCount > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {activeFilters.map((label) => (
+            <span
+              key={label}
+              className="rounded-md border border-(--color-border) bg-(--color-bg-secondary) px-2 py-1 text-xs font-medium text-(--color-text-primary)"
+            >
+              {label}
+            </span>
+          ))}
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="rounded-md px-2 py-1 text-xs font-medium text-(--color-text-secondary) hover:bg-(--color-bg-secondary) hover:text-(--color-text-primary)"
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
+
+      {filtersOpen && (
+        <Card className="mb-6 p-4">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Exact text</span>
+              <input
+                type="text"
+                value={filters.textContains}
+                onChange={(e) => updateFilter('textContains', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">After</span>
+              <input
+                type="date"
+                value={filters.after}
+                onChange={(e) => updateFilter('after', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Before</span>
+              <input
+                type="date"
+                value={filters.before}
+                onChange={(e) => updateFilter('before', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Language</span>
+              <select
+                value={filters.language}
+                onChange={(e) => updateFilter('language', e.target.value)}
+                className="input-base"
+              >
+                <option value="">Any</option>
+                <option value="en">English</option>
+                <option value="fr">French</option>
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">MIME type</span>
+              <input
+                type="text"
+                value={filters.mimeType}
+                onChange={(e) => updateFilter('mimeType', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Email from</span>
+              <input
+                type="text"
+                value={filters.emailFrom}
+                onChange={(e) => updateFilter('emailFrom', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Email to</span>
+              <input
+                type="text"
+                value={filters.emailTo}
+                onChange={(e) => updateFilter('emailTo', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Email cc</span>
+              <input
+                type="text"
+                value={filters.emailCc}
+                onChange={(e) => updateFilter('emailCc', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <label className="block md:col-span-2 xl:col-span-2">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Email subject</span>
+              <input
+                type="text"
+                value={filters.emailSubject}
+                onChange={(e) => updateFilter('emailSubject', e.target.value)}
+                className="input-base"
+              />
+            </label>
+            <div className="md:col-span-2 xl:col-span-2">
+              <div className="mb-1 text-xs font-medium text-(--color-text-secondary)">Metadata JSON</div>
+              <pre
+                aria-label="Generated metadata JSON"
+                className="min-h-[38px] overflow-x-auto rounded-md border border-(--color-border) bg-(--color-bg-secondary) px-2.5 py-2 text-xs text-(--color-text-primary)"
+              >
+                {JSON.stringify(metadataFilter, null, 2)}
+              </pre>
+            </div>
+          </div>
+        </Card>
+      )}
 
       {error && (
         <div className="mb-4 rounded-sm bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">

--- a/frontend/src/pages/SystemSettingsPage.test.tsx
+++ b/frontend/src/pages/SystemSettingsPage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuth } from '../auth'
+import SystemSettingsPage from './SystemSettingsPage'
+
+vi.mock('../auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+const useAuthMock = vi.mocked(useAuth)
+
+function mockAuth(isAdmin: boolean) {
+  useAuthMock.mockReturnValue({
+    user: {
+      user_id: 'user-1',
+      email: isAdmin ? 'admin@example.com' : 'user@example.com',
+      role: isAdmin ? 'admin' : 'user',
+      preferences: {},
+    },
+    token: 'test-token',
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    updatePreferences: vi.fn(),
+    isAdmin,
+  } as ReturnType<typeof useAuth>)
+}
+
+function renderSettings() {
+  render(
+    <MemoryRouter>
+      <SystemSettingsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SystemSettingsPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset()
+  })
+
+  it('shows the full settings hub for admins', () => {
+    mockAuth(true)
+
+    renderSettings()
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
+    expect(screen.getAllByText('Integrations').length).toBeGreaterThan(0)
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+    expect(screen.getByText('Models')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Diagnostics')).toBeInTheDocument()
+  })
+
+  it('keeps non-admin settings focused on preferences', () => {
+    mockAuth(false)
+
+    renderSettings()
+
+    expect(screen.getByText('Preferences')).toBeInTheDocument()
+    expect(screen.getByText('Admin-only settings are hidden for this account.')).toBeInTheDocument()
+    expect(screen.queryByText('API Keys')).not.toBeInTheDocument()
+    expect(screen.queryByText('Models')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -15,52 +15,103 @@ interface SettingsItem {
 
 const SECTIONS: { label: string; items: SettingsItem[] }[] = [
   {
+    label: 'Personal',
+    items: [
+      {
+        to: '/preferences',
+        label: 'Preferences',
+        sub: 'Theme, page size, and account settings',
+        icon: '👤',
+        hue: 'settings',
+      },
+    ],
+  },
+]
+
+const ADMIN_SECTIONS: { label: string; items: SettingsItem[] }[] = [
+  {
+    label: 'Integrations',
+    items: [
+      {
+        to: '/settings/integrations',
+        label: 'Integrations',
+        sub: 'MCP, CLI, and external AI tool setup',
+        icon: '🔌',
+        hue: 'research',
+      },
+    ],
+  },
+  {
     label: 'Access & identity',
     items: [
-      { to: '/admin/users', label: 'Users', sub: 'Manage accounts and roles', icon: '👥', hue: 'docs' },
-      { to: '/admin/keys', label: 'API Keys', sub: 'Create and revoke API keys', icon: '🔑', hue: 'research' },
+      { to: '/settings/users', label: 'Users', sub: 'Manage accounts and roles', icon: '👥', hue: 'docs' },
+      {
+        to: '/settings/api-keys',
+        label: 'API Keys',
+        sub: 'Create, scope, and revoke API keys',
+        icon: '🔑',
+        hue: 'research',
+      },
     ],
   },
   {
     label: 'Models & languages',
     items: [
-      { to: '/admin/models', label: 'Models', sub: 'Download and manage LLM models', icon: '🧠', hue: 'observatory' },
-      { to: '/admin/languages', label: 'Languages', sub: 'OCR & entity language packs', icon: '🌐', hue: 'explore' },
+      {
+        to: '/settings/models',
+        label: 'Models',
+        sub: 'Download and manage local AI models',
+        icon: '🧠',
+        hue: 'observatory',
+      },
+      {
+        to: '/settings/languages',
+        label: 'Languages',
+        sub: 'OCR and entity language packs',
+        icon: '🌐',
+        hue: 'explore',
+      },
     ],
   },
   {
     label: 'Behavior & limits',
     items: [
-      { to: '/admin/retrieval', label: 'Retrieval', sub: 'Chat & MCP search behavior', icon: '🔍', hue: 'search' },
-      { to: '/admin/rate-limits', label: 'Rate Limits', sub: 'Default API key rate limits', icon: '⏱', hue: 'ask' },
+      {
+        to: '/settings/retrieval',
+        label: 'Retrieval',
+        sub: 'Ask, Research, MCP, and search behavior',
+        icon: '🔍',
+        hue: 'search',
+      },
+      { to: '/settings/rate-limits', label: 'Rate Limits', sub: 'Default API key rate limits', icon: '⏱', hue: 'ask' },
     ],
   },
   {
     label: 'Operations',
     items: [
       {
-        to: '/admin/system/status',
-        label: 'System Status',
-        sub: 'Health checks and statistics',
+        to: '/settings/status',
+        label: 'Status',
+        sub: 'Readiness, service health, and mail account state',
         icon: '💚',
         hue: 'observatory',
       },
       {
-        to: '/admin/system/logs',
-        label: 'Service Logs',
-        sub: 'View log files and tail commands',
+        to: '/settings/diagnostics',
+        label: 'Diagnostics',
+        sub: 'Logs and advanced troubleshooting detail',
         icon: '📜',
         hue: 'settings',
       },
       {
-        to: '/admin/system/maintenance',
-        label: 'System Maintenance',
+        to: '/settings/maintenance',
+        label: 'Maintenance',
         sub: 'Purge, reaper, and cleanup',
         icon: '🧹',
         hue: 'ask',
       },
       {
-        to: '/admin/system/security',
+        to: '/settings/security',
         label: 'Security',
         sub: 'Encryption status and master key management',
         icon: '🔒',
@@ -71,20 +122,18 @@ const SECTIONS: { label: string; items: SettingsItem[] }[] = [
 ]
 
 export default function SystemSettingsPage() {
-  const { user } = useAuth()
-  if (user?.role !== 'admin') {
-    return (
-      <div className="mx-auto max-w-4xl px-4 py-8">
-        <PageHeader title="System Settings" />
-        <p className="text-sm text-(--color-text-secondary)">Admins only.</p>
-      </div>
-    )
-  }
+  const { isAdmin } = useAuth()
+  const sections = isAdmin ? [...SECTIONS, ...ADMIN_SECTIONS] : SECTIONS
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      <PageHeader title="System Settings" />
-      {SECTIONS.map((section) => (
+      <PageHeader title="Settings" subtitle="Preferences, integrations, models, status, and diagnostics." />
+      {!isAdmin && (
+        <p className="mb-5 rounded-lg bg-(--color-bg-secondary) px-3 py-2 text-sm text-(--color-text-secondary)">
+          Admin-only settings are hidden for this account.
+        </p>
+      )}
+      {sections.map((section) => (
         <div key={section.label} className="mb-6">
           <h2 className="mb-2 font-serif text-base font-semibold tracking-tight text-(--color-text-primary)">
             {section.label}

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -127,7 +127,12 @@ export default function SystemSettingsPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      <PageHeader title="Settings" subtitle="Preferences, integrations, models, status, and diagnostics." />
+      <PageHeader
+        title="Settings"
+        subtitle={
+          isAdmin ? 'Preferences, integrations, models, status, and diagnostics.' : 'Preferences and account settings.'
+        }
+      />
       {!isAdmin && (
         <p className="mb-5 rounded-lg bg-(--color-bg-secondary) px-3 py-2 text-sm text-(--color-text-secondary)">
           Admin-only settings are hidden for this account.

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -18,7 +18,7 @@ const SECTIONS: { label: string; items: SettingsItem[] }[] = [
     label: 'Personal',
     items: [
       {
-        to: '/preferences',
+        to: '/settings/preferences',
         label: 'Preferences',
         sub: 'Theme, page size, and account settings',
         icon: '👤',

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -96,8 +96,8 @@ export default function SystemStatusPage() {
   return (
     <div className="animate-slide-in">
       <PageHeader
-        title="System Status"
-        subtitle="Health checks and service statistics"
+        title="Status"
+        subtitle="System readiness, service health, and account state"
         actions={
           <button
             onClick={handleRefresh}
@@ -114,7 +114,7 @@ export default function SystemStatusPage() {
         </div>
       )}
 
-      <h2 className="mb-3 text-lg font-semibold">Health Checks</h2>
+      <h2 className="mb-3 text-lg font-semibold">Service Health</h2>
       {health && (
         <div className="mb-6 grid grid-cols-3 gap-4">
           <HealthCard

--- a/frontend/src/utils/modelGuidance.ts
+++ b/frontend/src/utils/modelGuidance.ts
@@ -1,0 +1,52 @@
+export interface ModelGuidance {
+  label: string
+  note: string
+  warning?: string
+}
+
+const MODEL_GUIDANCE: Record<string, ModelGuidance> = {
+  'qwen36-35b-a3b': {
+    label: 'Best local research',
+    note: 'Strongest choice for longer synthesis, timelines, and multi-document questions.',
+  },
+  'gemma4-26b-a4b': {
+    label: 'Balanced local research',
+    note: 'A steady larger model for cited answers and research when memory allows.',
+  },
+  'gpt-oss-20b': {
+    label: 'Strong tables and comparisons',
+    note: 'Good fit for structured answers, comparisons, and table-heavy work.',
+  },
+  'qwen3-8b': {
+    label: 'Lightweight lookup',
+    note: 'Good starting point for quick cited answers and everyday document lookup.',
+    warning: 'For longer research tasks, verify cited answers carefully.',
+  },
+  'qwen3-4b': {
+    label: 'Smallest usable model',
+    note: 'Best for compact Macs and quick lookup, not deep synthesis.',
+    warning: 'May miss details in long, messy, or multi-step questions.',
+  },
+}
+
+export function modelGuidance(model: { id: string; size_bytes: number; supports_research: boolean }): ModelGuidance {
+  const guidance = MODEL_GUIDANCE[model.id]
+  if (guidance) return guidance
+  if (!model.supports_research || model.size_bytes < 4_000_000_000) {
+    return {
+      label: 'Quick lookup',
+      note: 'Use for short cited answers; verify anything important from the sources.',
+      warning: 'Not recommended for deep research.',
+    }
+  }
+  if (model.size_bytes >= 12_000_000_000) {
+    return {
+      label: 'Research capable',
+      note: 'A larger local model suitable for cited answers and research workflows.',
+    }
+  }
+  return {
+    label: 'General purpose',
+    note: 'A mid-size local model for everyday cited answers.',
+  }
+}

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -130,18 +130,23 @@ async def search(
                 conflict_sources=[],
             )
 
-    result = await hybrid_search(
-        session,
-        body.query,
-        k=body.k,
-        doc_id=doc_id,
-        offset=body.offset,
-        doc_ids=doc_ids,
-        after=body.after,
-        before=body.before,
-        language=body.language,
-        mime_type=body.mime_type,
-    )
+    try:
+        result = await hybrid_search(
+            session,
+            body.query,
+            k=body.k,
+            doc_id=doc_id,
+            offset=body.offset,
+            doc_ids=doc_ids,
+            after=body.after,
+            before=body.before,
+            language=body.language,
+            mime_type=body.mime_type,
+            metadata_filter=body.metadata_filter,
+            text_contains=body.text_contains,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
 
     has_more = body.offset + body.k < result.total_candidates
     source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -12,6 +12,10 @@ from harbor_clerk.api.schemas.search import (
     ConflictSourceOut,
     FacetedDocGroup,
     FacetedSearchResponse,
+    FindAllHitOut,
+    FindAllRequest,
+    FindAllResponse,
+    FindAllTopChunkOut,
     PassageDetail,
     ReadPassagesRequest,
     ReadPassagesResponse,
@@ -21,10 +25,12 @@ from harbor_clerk.api.schemas.search import (
 )
 from harbor_clerk.api.scope import apply_folder_scope, apply_key_scope
 from harbor_clerk.api.scope_validation import validate_scope_folders
+from harbor_clerk.config import get_settings
 from harbor_clerk.db import get_session
 from harbor_clerk.models import Chunk, Document
-from harbor_clerk.search import hybrid_search
-from harbor_clerk.source_ref import SourceRef, format_pages, load_source_ref_context
+from harbor_clerk.search import find_all, hybrid_search
+from harbor_clerk.search_types import FindAllHit
+from harbor_clerk.source_ref import SourceRef, format_document_citation, format_pages, load_source_ref_context
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["search"])
@@ -45,6 +51,80 @@ def _hit_to_out(h, source_ref: SourceRef | None = None) -> SearchHitOut:
         doc_title=h.doc_title,
         source=source_ref.to_dict() if source_ref else None,
         citation=source_ref.citation if source_ref else None,
+    )
+
+
+def _fallback_source_ref(
+    *,
+    doc_id: str,
+    doc_title: str | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+) -> SourceRef:
+    title = doc_title or "Untitled document"
+    return SourceRef(
+        doc_id=doc_id,
+        doc_title=title,
+        chunk_id=chunk_id,
+        pages=pages,
+        section=section,
+        source_kind="unknown",
+        source_label=title,
+        citation=format_document_citation(title, pages),
+    )
+
+
+def _source_ref_for_find_all_hit(hit: FindAllHit, source_ref: SourceRef | None = None) -> SourceRef:
+    if source_ref is not None and source_ref.doc_id:
+        return source_ref
+    return _fallback_source_ref(
+        doc_id=hit.doc_id,
+        doc_title=hit.doc_title,
+        chunk_id=hit.top_chunk_id,
+        pages=hit.page_range,
+        section=hit.top_chunk_heading,
+    )
+
+
+def _find_all_hit_to_out(hit: FindAllHit, source_ref: SourceRef | None = None) -> FindAllHitOut:
+    resolved_source = _source_ref_for_find_all_hit(hit, source_ref)
+    top_chunk = None
+    if hit.top_chunk_id is not None or hit.top_chunk_text is not None:
+        top_chunk = FindAllTopChunkOut(
+            chunk_id=hit.top_chunk_id,
+            text=hit.top_chunk_text,
+            page=hit.top_chunk_page,
+            heading=hit.top_chunk_heading,
+        )
+    return FindAllHitOut(
+        doc_id=hit.doc_id,
+        doc_title=hit.doc_title,
+        mime_type=hit.mime_type,
+        language=hit.language,
+        score=hit.score,
+        ingested_at=hit.ingested_at,
+        page_range=hit.page_range,
+        top_chunk=top_chunk,
+        source=resolved_source.to_dict(),
+        citation=resolved_source.citation,
+    )
+
+
+def _empty_find_all_response(
+    *,
+    offset: int,
+    sort_by: str,
+    presentation: str,
+) -> FindAllResponse:
+    return FindAllResponse(
+        results=[],
+        total_matches=0,
+        returned=0,
+        offset=offset,
+        truncated=False,
+        sort_by=sort_by,
+        presentation=presentation,
     )
 
 
@@ -197,6 +277,121 @@ async def search(
             for cs in result.conflict_sources
         ],
         reranker_status=result.reranker_status,
+    )
+
+
+@router.post("/search/find-all", response_model=FindAllResponse)
+async def search_find_all(
+    body: FindAllRequest,
+    principal: Principal = Depends(require_read_access),
+    session: AsyncSession = Depends(get_session),
+):
+    await validate_scope_folders(body.scope, session)
+
+    doc_id = body.doc_id
+    doc_ids = list(body.doc_ids) if body.doc_ids else None
+    max_results = max(1, min(body.max_results, get_settings().find_all_max_results_cap))
+
+    # Per-API-key scope: intersect with visible doc_ids for scoped keys.
+    if principal.type == "api_key" and principal.key_scope is not None and not principal.key_scope.is_unrestricted:
+        visible_q = apply_key_scope(select(Document.doc_id), principal)
+        visible_ids = {row[0] for row in (await session.execute(visible_q)).all()}
+        if not visible_ids:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in visible_ids]
+            if not doc_ids:
+                return _empty_find_all_response(
+                    offset=body.offset,
+                    sort_by=body.sort_by,
+                    presentation=body.presentation,
+                )
+        elif doc_id is None:
+            doc_ids = list(visible_ids)
+        if doc_id is not None and doc_id not in visible_ids:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+
+    # Per-request user scope: intersect with visible doc_ids for the requested folders.
+    if body.scope is not None and body.scope.folder_ids:
+        scoped_q = apply_folder_scope(
+            select(Document.doc_id).where(Document.status == "active"),
+            list(body.scope.folder_ids),
+        )
+        scoped_visible = {row[0] for row in (await session.execute(scoped_q)).all()}
+        if not scoped_visible:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+        if doc_ids is not None:
+            doc_ids = [d for d in doc_ids if d in scoped_visible]
+            if not doc_ids:
+                return _empty_find_all_response(
+                    offset=body.offset,
+                    sort_by=body.sort_by,
+                    presentation=body.presentation,
+                )
+        elif doc_id is None:
+            doc_ids = list(scoped_visible)
+        if doc_id is not None and doc_id not in scoped_visible:
+            return _empty_find_all_response(
+                offset=body.offset,
+                sort_by=body.sort_by,
+                presentation=body.presentation,
+            )
+
+    try:
+        result = await find_all(
+            session,
+            body.query,
+            max_results=max_results,
+            offset=body.offset,
+            sort_by=body.sort_by,
+            text_contains=body.text_contains,
+            doc_id=doc_id,
+            doc_ids=doc_ids,
+            after=body.after,
+            before=body.before,
+            language=body.language,
+            mime_type=body.mime_type,
+            metadata_filter=body.metadata_filter,
+            presentation=body.presentation,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+
+    source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits]) if result.hits else None
+    results = []
+    for hit in result.hits:
+        source_ref = (
+            source_context.ref_for_doc(
+                hit.doc_id,
+                chunk_id=hit.top_chunk_id,
+                pages=hit.page_range,
+                section=hit.top_chunk_heading,
+            )
+            if source_context is not None
+            else None
+        )
+        results.append(_find_all_hit_to_out(hit, source_ref))
+
+    return FindAllResponse(
+        results=results,
+        total_matches=result.total_matches,
+        returned=len(results),
+        offset=result.offset,
+        truncated=result.truncated,
+        sort_by=result.sort_by,
+        presentation=result.presentation,
     )
 
 

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -24,12 +24,13 @@ from harbor_clerk.api.scope_validation import validate_scope_folders
 from harbor_clerk.db import get_session
 from harbor_clerk.models import Chunk, Document
 from harbor_clerk.search import hybrid_search
+from harbor_clerk.source_ref import SourceRef, format_pages, load_source_ref_context
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["search"])
 
 
-def _hit_to_out(h) -> SearchHitOut:
+def _hit_to_out(h, source_ref: SourceRef | None = None) -> SearchHitOut:
     return SearchHitOut(
         chunk_id=h.chunk_id,
         doc_id=h.doc_id,
@@ -42,6 +43,8 @@ def _hit_to_out(h) -> SearchHitOut:
         ocr_confidence=h.ocr_confidence,
         score=h.score,
         doc_title=h.doc_title,
+        source=source_ref.to_dict() if source_ref else None,
+        citation=source_ref.citation if source_ref else None,
     )
 
 
@@ -141,7 +144,18 @@ async def search(
     )
 
     has_more = body.offset + body.k < result.total_candidates
-    hits_out = [_hit_to_out(h) for h in result.hits]
+    source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])
+    hits_out = [
+        _hit_to_out(
+            h,
+            source_context.ref_for_doc(
+                h.doc_id,
+                chunk_id=h.chunk_id,
+                pages=format_pages(h.page_start, h.page_end),
+            ),
+        )
+        for h in result.hits
+    ]
 
     if body.faceted:
         groups: dict[str, list[SearchHitOut]] = {}
@@ -221,6 +235,7 @@ async def read_passages(
     doc_ids = {c.doc_id for c in chunks.values()}
     docs_result = await session.execute(select(Document).where(Document.doc_id.in_(list(doc_ids))))
     docs_by_id = {d.doc_id: d for d in docs_result.scalars().all()}
+    source_context = await load_source_ref_context(session, doc_ids)
 
     # Optionally load surrounding chunks for context
     context_before: dict[uuid.UUID, str] = {}
@@ -256,6 +271,11 @@ async def read_passages(
         if chunk is None:
             continue
         doc = docs_by_id.get(chunk.doc_id)
+        source_ref = source_context.ref_for_doc(
+            chunk.doc_id,
+            chunk_id=cid,
+            pages=format_pages(chunk.page_start, chunk.page_end),
+        )
         passages.append(
             PassageDetail(
                 chunk_id=str(cid),
@@ -270,6 +290,8 @@ async def read_passages(
                 doc_title=doc.title if doc else None,
                 context_before=context_before.get(cid),
                 context_after=context_after.get(cid),
+                source=source_ref.to_dict(),
+                citation=source_ref.citation,
             )
         )
 

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -6,6 +6,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, model_validator
 
 from harbor_clerk.api.schemas.scope import ScopeSpec
+from harbor_clerk.api.schemas.source_ref import SourceRefOut
 
 
 class SearchRequest(BaseModel):
@@ -53,6 +54,8 @@ class SearchHitOut(BaseModel):
     score: float
     doc_title: str | None = None
     score_breakdown: ScoreBreakdown | None = None
+    source: SourceRefOut | None = None
+    citation: str | None = None
 
 
 class SearchResponse(BaseModel):
@@ -96,6 +99,8 @@ class PassageDetail(BaseModel):
     doc_title: str | None = None
     context_before: str | None = None
     context_after: str | None = None
+    source: SourceRefOut | None = None
+    citation: str | None = None
 
 
 class ReadPassagesResponse(BaseModel):

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from typing import Any, Literal
+from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -67,6 +68,59 @@ class SearchResponse(BaseModel):
     possible_conflict: bool = False
     conflict_sources: list[ConflictSourceOut] = []
     reranker_status: Literal["ok", "disabled", "failed"] = "disabled"
+
+
+class FindAllRequest(BaseModel):
+    query: str
+    text_contains: str | None = None
+    max_results: int = Field(default=100, ge=1)
+    offset: int = Field(default=0, ge=0)
+    presentation: Literal["brief", "full"] = "brief"
+    sort_by: Literal["relevance", "date_desc", "date_asc"] = "relevance"
+    after: datetime | None = None
+    before: datetime | None = None
+    doc_id: UUID | None = None
+    doc_ids: list[UUID] | None = Field(default=None, max_length=50)
+    language: str | None = None
+    mime_type: str | None = None
+    metadata_filter: dict[str, Any] | None = None
+    scope: ScopeSpec | None = None
+
+    @model_validator(mode="after")
+    def check_doc_id_mutual_exclusion(self):
+        if self.doc_id is not None and self.doc_ids is not None:
+            raise ValueError("Cannot specify both doc_id and doc_ids")
+        return self
+
+
+class FindAllTopChunkOut(BaseModel):
+    chunk_id: str | None = None
+    text: str | None = None
+    page: int | None = None
+    heading: str | None = None
+
+
+class FindAllHitOut(BaseModel):
+    doc_id: str
+    doc_title: str
+    mime_type: str
+    language: str | None = None
+    score: float
+    ingested_at: datetime | None = None
+    page_range: str | None = None
+    top_chunk: FindAllTopChunkOut | None = None
+    source: SourceRefOut | None = None
+    citation: str | None = None
+
+
+class FindAllResponse(BaseModel):
+    results: list[FindAllHitOut]
+    total_matches: int = 0
+    returned: int = 0
+    offset: int = 0
+    truncated: bool = False
+    sort_by: Literal["relevance", "date_desc", "date_asc"] = "relevance"
+    presentation: Literal["brief", "full"] = "brief"
 
 
 class FacetedDocGroup(BaseModel):

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -1,7 +1,7 @@
 """Search and passage-reading schemas."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -19,6 +19,8 @@ class SearchRequest(BaseModel):
     before: datetime | None = None
     language: str | None = None
     mime_type: str | None = None
+    metadata_filter: dict[str, Any] | None = None
+    text_contains: str | None = None
     faceted: bool = False
     scope: ScopeSpec | None = None
 

--- a/src/harbor_clerk/api/schemas/source_ref.py
+++ b/src/harbor_clerk/api/schemas/source_ref.py
@@ -1,0 +1,18 @@
+"""Shared source/citation response schemas."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class SourceRefOut(BaseModel):
+    doc_id: str
+    doc_title: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    source_kind: Literal["document", "email", "attachment", "unknown"]
+    source_label: str
+    folder_label: str | None = None
+    relative_path: str | None = None
+    citation: str

--- a/src/harbor_clerk/cli/commands/__init__.py
+++ b/src/harbor_clerk/cli/commands/__init__.py
@@ -28,6 +28,7 @@ def _common_parser() -> argparse.ArgumentParser:
 
 _COMMAND_NAMES = [
     "search",
+    "find-all",
     "batch-search",
     "read-passages",
     "expand-context",

--- a/src/harbor_clerk/cli/commands/find_all.py
+++ b/src/harbor_clerk/cli/commands/find_all.py
@@ -1,0 +1,105 @@
+"""harbor-clerk find-all - enumerate matching documents."""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+
+from harbor_clerk.cli.client import McpHttpClient
+from harbor_clerk.cli.commands import _common_parser
+from harbor_clerk.cli.config import resolve_config
+from harbor_clerk.cli.help import load
+from harbor_clerk.cli.output import render, resolve_mode
+
+_LANGUAGE_ALIASES = {
+    "en": "english",
+    "fr": "french",
+    "english": "english",
+    "french": "french",
+}
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    description = load("find-all") or "Enumerate documents matching a query."
+    p = subparsers.add_parser(
+        "find-all",
+        help="Enumerate documents matching a query",
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common_parser()],
+    )
+    p.add_argument("query_arg", nargs="?", help="Relevance query")
+    p.add_argument("--query", dest="query", help="Relevance query; alternative to positional query")
+    p.add_argument("--text-contains", help="Require an exact substring in matching chunk text")
+    p.add_argument("--max-results", type=int, default=100, help="Max documents returned (default: 100)")
+    p.add_argument("-o", "--offset", type=int, default=0, help="Pagination offset (default: 0)")
+    p.add_argument("--presentation", choices=["brief", "full"], default="brief", help="Result detail (default: brief)")
+    p.add_argument(
+        "--sort-by",
+        choices=["relevance", "date_desc", "date_asc"],
+        default="relevance",
+        help="Sort order (default: relevance)",
+    )
+    p.add_argument("--doc-id", help="Restrict enumeration to one document UUID")
+    p.add_argument("--doc-ids", help="Comma-separated doc UUIDs")
+    p.add_argument("--after", help="YYYY-MM-DD or ISO 8601 datetime; only docs after this date")
+    p.add_argument("--before", help="YYYY-MM-DD or ISO 8601 datetime; only docs before this date")
+    p.add_argument("--language", choices=sorted(_LANGUAGE_ALIASES))
+    p.add_argument("--mime-type", help="Restrict by MIME type (e.g. application/pdf)")
+    p.add_argument(
+        "--metadata-filter-json",
+        "--metadata-filter",
+        dest="metadata_filter",
+        help='JSON string of {"namespace.key": value} pairs (e.g. \'{"email.from_address": "alice@example.com"}\')',
+    )
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    query = args.query or args.query_arg
+    if args.query and args.query_arg:
+        sys.stderr.write("harbor-clerk: provide query either positionally or with --query, not both\n")
+        return 1
+    if not query:
+        sys.stderr.write("harbor-clerk: find-all requires a query or --query\n")
+        return 1
+
+    arguments: dict = {
+        "query": query,
+        "max_results": args.max_results,
+        "offset": args.offset,
+        "presentation": args.presentation,
+        "sort_by": args.sort_by,
+    }
+    if args.text_contains:
+        arguments["text_contains"] = args.text_contains
+    if args.doc_id:
+        arguments["doc_id"] = args.doc_id
+    if args.doc_ids:
+        arguments["doc_ids"] = [d.strip() for d in args.doc_ids.split(",") if d.strip()]
+    if args.after:
+        arguments["after"] = args.after
+    if args.before:
+        arguments["before"] = args.before
+    if args.language:
+        arguments["language"] = _LANGUAGE_ALIASES[args.language]
+    if args.mime_type:
+        arguments["mime_type"] = args.mime_type
+    if args.metadata_filter:
+        try:
+            metadata_filter = _json.loads(args.metadata_filter)
+        except _json.JSONDecodeError as exc:
+            sys.stderr.write(f"harbor-clerk: --metadata-filter-json must be valid JSON: {exc}\n")
+            return 1
+        if not isinstance(metadata_filter, dict):
+            sys.stderr.write("harbor-clerk: --metadata-filter-json must be a JSON object\n")
+            return 1
+        arguments["metadata_filter"] = metadata_filter
+
+    cfg = resolve_config(url=args.url, api_key=args.api_key, insecure=args.insecure)
+    mode = resolve_mode(force_json=bool(args.json), fmt=args.format, isatty=sys.stdout.isatty())
+    with McpHttpClient(cfg) as client:
+        payload = client.call_tool("kb_find_all", arguments)
+    render(payload, mode=mode, command="find-all")
+    return 0

--- a/src/harbor_clerk/cli/help/batch-search.txt
+++ b/src/harbor_clerk/cli/help/batch-search.txt
@@ -3,6 +3,8 @@ harbor-clerk batch-search — run multiple searches in one call
 DESCRIPTION
   Runs up to 5 hybrid searches in a single round-trip. Each query gets its
   own result set with the same hybrid FTS + pgvector scoring as `search`.
+  Hits include the same `citation` and structured `source` object returned
+  by `search`.
   All filter flags are shared across every query in the batch.
 
   Use this for comparative analysis — "do any of these contract files mention
@@ -48,6 +50,8 @@ RETURNS (JSON)
             "doc_id":     "uuid",      // document identifier
             "doc_title":  "string",    // document title
             "pages":      "42",        // page or page range (omitted when unavailable)
+            "citation":   "Contract A, p. 42",
+            "source":     { "...": "same SourceRef object as search" },
             "text":       "string",    // matched chunk text; omitted with --detail=compact
             "score":      0.87,        // hybrid score, higher = better
             "language":   "english"    // "english" or "french"
@@ -93,8 +97,8 @@ COMMON MISTAKES
     offsets. Use individual `search` calls with --offset when you need page 2.
   - Using --detail=full on large -k across 5 queries: full detail can return
     several KB per hit, 5 × 10 = 50 chunks of text. default `brief` is safer.
-  - Expecting a standalone `citation` field; cite with doc_title + pages +
-    chunk_id, or call `read-passages` to verify exact context.
+  - Treating `citation` as proof without reading the passage: use
+    `read-passages` to verify exact context before making a specific claim.
 
 SEE ALSO
   search, read-passages, expand-context

--- a/src/harbor_clerk/cli/help/find-all.txt
+++ b/src/harbor_clerk/cli/help/find-all.txt
@@ -1,0 +1,79 @@
+harbor-clerk find-all - enumerate matching documents
+
+DESCRIPTION
+  Enumerates documents matching a query, deduped by document. Use this when
+  the task is to list every matching document rather than retrieve the single
+  best passage. This mirrors the MCP `kb_find_all` tool for shell-based agents.
+
+  Results preserve the MCP response shape in JSON, including `citation` and
+  structured `source` fields when available. Text output renders citations and,
+  with --presentation=full, the best matching chunk for each document.
+
+USAGE
+  harbor-clerk find-all <query> [options]
+  harbor-clerk find-all --query <query> [options]
+
+OPTIONS
+      --query TEXT             Relevance query; alternative to positional query
+      --text-contains TEXT     Require an exact substring in matching chunk text
+      --max-results INT        Max documents returned (default: 100)
+  -o, --offset INT             Pagination offset (default: 0)
+      --presentation brief|full
+                                brief omits chunk text; full includes best chunk
+      --sort-by relevance|date_desc|date_asc
+                                Sort order (default: relevance)
+      --doc-id UUID            Restrict to one document
+      --doc-ids UUID,UUID      Restrict to multiple documents
+      --after YYYY-MM-DD       Only docs after this date
+      --before YYYY-MM-DD      Only docs before this date
+      --language english|french|en|fr
+                                Restrict to one language
+      --mime-type MIME         Restrict by MIME type (e.g. application/pdf)
+      --metadata-filter-json JSON
+                                JSON metadata filter; --metadata-filter also works
+
+RETURNS (JSON)
+  {
+    "results": [
+      {
+        "doc_id": "uuid",
+        "doc_title": "Contract A",
+        "mime_type": "application/pdf",
+        "language": "english",
+        "score": 0.91,
+        "ingested_at": "2026-06-03T12:00:00+00:00",
+        "page_range": "4-5",
+        "citation": "Contract A, pp. 4-5",
+        "source": { "...": "SourceRef object" },
+        "top_chunk": {
+          "chunk_id": "uuid",
+          "text": "matching chunk text",
+          "page": 4,
+          "heading": "Termination"
+        }
+      }
+    ],
+    "total_matches": 42,
+    "returned": 25,
+    "offset": 0,
+    "truncated": true,
+    "sort_by": "relevance",
+    "presentation": "full"
+  }
+
+EXAMPLES
+  # Enumerate documents mentioning a concept
+  harbor-clerk find-all "force majeure"
+
+  # Require a literal phrase and include the best matching chunk
+  harbor-clerk find-all "contracts" \
+    --text-contains "termination for convenience" \
+    --presentation full
+
+  # Agent-friendly JSON with a raw metadata filter
+  harbor-clerk find-all --query "invoice" \
+    --metadata-filter-json '{"email.from_address": "alice@example.com"}' \
+    --json
+
+SEE ALSO
+  search, batch-search, read-passages, documents-by-date

--- a/src/harbor_clerk/cli/help/read-passages.txt
+++ b/src/harbor_clerk/cli/help/read-passages.txt
@@ -11,8 +11,9 @@ DESCRIPTION
   Returns passages in the same order as the input chunk_ids, skipping any
   that are not found or are outside the API key's document scope.
 
-  Each passage includes the document title and language. Page numbers are
-  included when available (PDFs and other paginated formats); plain-text
+  Each passage includes the document id, document title, language, a
+  human-readable `citation`, and a structured `source` object. Page numbers
+  are included when available (PDFs and other paginated formats); plain-text
   documents may omit the `pages` field.
 
   Pass --include-context to also receive the immediately preceding and following
@@ -33,7 +34,10 @@ RETURNS (JSON)
     "passages": [
       {
         "chunk_id":  "uuid",       // same UUID you passed in
+        "doc_id":    "uuid",       // containing document
         "doc_title": "string",     // title of the containing document
+        "citation":  "Contract A, pp. 12-13",
+        "source":    { "...": "SourceRef object with doc/chunk/page identity" },
         "text":      "string",     // full chunk text (≈1000 chars)
         "language":  "en" | "fr",
         "pages":     "12-13"       // page range (omitted for non-paginated docs)

--- a/src/harbor_clerk/cli/help/search.txt
+++ b/src/harbor_clerk/cli/help/search.txt
@@ -4,8 +4,9 @@ DESCRIPTION
   Runs a hybrid retrieval combining PostgreSQL full-text search (bilingual,
   English + French) and pgvector cosine similarity over the corpus. Scores
   are normalized and merged per-chunk with a small OCR-confidence boost.
-  Results include citation-ready fields (doc_id, doc_title, pages,
-  chunk_id) usable with `read-passages` and `expand-context`.
+  Results include `citation` and `source` fields alongside the legacy
+  doc_id, doc_title, pages, and chunk_id fields. Use `source` for structured
+  agent workflows and `citation` for human-readable output.
 
   If top hits have similar scores across multiple documents, the response
   includes `possible_conflict: true` and a `conflict_sources` array. Treat
@@ -42,6 +43,16 @@ RETURNS (JSON)
         "doc_title":  "string",      // document title
         "pages":      "42",          // page or page range (omitted when unavailable)
         "section":    "string",      // nearest heading, when available
+        "citation":   "Contract A, p. 42",
+        "source": {
+          "doc_id": "uuid",
+          "doc_title": "string",
+          "chunk_id": "uuid",
+          "pages": "42",
+          "source_kind": "document",
+          "source_label": "string",
+          "citation": "Contract A, p. 42"
+        },
         "text":       "string",      // matched chunk text; omitted with --detail=compact
         "score":      0.87,          // hybrid score, higher = better
         "language":   "english" | "french"
@@ -73,8 +84,8 @@ COMMON MISTAKES
   - Passing a chunk_id as --doc-id (chunk_id and doc_id are distinct UUIDs).
   - Forgetting --detail=brief on large k — default `full` returns the entire
     matching chunk text, which can be 1–2KB per result.
-  - Expecting a standalone `citation` field; cite with doc_title + pages +
-    chunk_id, or call `read-passages` to verify exact context.
+  - Treating `citation` as proof without reading the passage: use
+    `read-passages` to verify exact context before making a specific claim.
   - Using --after/--before with timestamps; only dates (YYYY-MM-DD) are accepted.
 
 SEE ALSO

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -52,6 +52,41 @@ def render(payload: Any, *, mode: OutputMode, command: str, stream: TextIO | Non
 # --- Search results pretty-printer ---
 
 
+def _source_obj(record: dict) -> dict:
+    source = record.get("source")
+    if not isinstance(source, dict):
+        source = record.get("source_ref")
+    return source if isinstance(source, dict) else {}
+
+
+def _citation(record: dict) -> str:
+    source = _source_obj(record)
+    citation = record.get("citation") or source.get("citation")
+    if citation:
+        return str(citation)
+    title = record.get("doc_title") or record.get("title") or source.get("doc_title") or ""
+    pages = record.get("pages") or record.get("page") or source.get("pages")
+    if title and pages:
+        prefix = "pp." if "-" in str(pages) else "p."
+        return f"{title}, {prefix} {pages}"
+    return str(title)
+
+
+def _render_hit_line(index: int, record: dict, stream: TextIO) -> None:
+    label = _citation(record)
+    score = record.get("score")
+    text = (record.get("text") or record.get("snippet") or "").strip().replace("\n", " ")
+    if len(text) > 200:
+        text = text[:200] + "..."
+    score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "?"
+    chunk_id = record.get("chunk_id") or _source_obj(record).get("chunk_id")
+    chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
+    stream.write(f"{index}. {label}  [{score_str}]{chunk_suffix}\n")
+    if text:
+        stream.write(f"   {text}\n")
+    stream.write("\n")
+
+
 @register_text_renderer("search")
 def _render_search(payload: Any, stream: TextIO) -> None:
     if not isinstance(payload, dict):
@@ -67,22 +102,57 @@ def _render_search(payload: Any, stream: TextIO) -> None:
     if not hits:
         stream.write("0 results\n")
     for i, r in enumerate(hits, 1):
-        title = r.get("doc_title") or r.get("title") or ""
-        score = r.get("score")
-        text = (r.get("text") or r.get("snippet") or "").strip().replace("\n", " ")
-        if len(text) > 200:
-            text = text[:200] + "..."
-        score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "?"
-        pages = r.get("pages") or r.get("page")
-        location = f" p. {pages}" if pages else ""
-        chunk_id = r.get("chunk_id")
-        chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
-        stream.write(f"{i}. {title}{location}  [{score_str}]{chunk_suffix}\n")
-        if text:
-            stream.write(f"   {text}\n")
-        stream.write("\n")
+        _render_hit_line(i, r, stream)
     if payload.get("possible_conflict"):
         stream.write("possible_conflict=true - top hits span multiple similarly scored documents\n")
+
+
+# --- Batch search pretty-printer ---
+
+
+@register_text_renderer("batch-search")
+def _render_batch_search(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+    for result in payload.get("results", []):
+        query = result.get("query") or ""
+        stream.write(f"query: {query}\n")
+        hits = result.get("hits") or []
+        if not hits:
+            stream.write("  0 results\n\n")
+            continue
+        for i, hit in enumerate(hits, 1):
+            stream.write("  ")
+            _render_hit_line(i, hit, stream)
+
+
+# --- Read passages pretty-printer ---
+
+
+@register_text_renderer("read-passages")
+def _render_read_passages(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+    passages = payload.get("passages") or []
+    if not passages:
+        stream.write("0 passages\n")
+        return
+    for i, passage in enumerate(passages, 1):
+        chunk_id = passage.get("chunk_id") or _source_obj(passage).get("chunk_id")
+        chunk_suffix = f"  chunk={chunk_id}" if chunk_id else ""
+        stream.write(f"{i}. {_citation(passage)}{chunk_suffix}\n")
+        text = (passage.get("text") or "").strip()
+        if text:
+            stream.write(f"{text}\n")
+        stream.write("\n")
 
 
 # --- Verify identifier pretty-printer ---
@@ -106,7 +176,7 @@ def _render_verify_identifier(payload: Any, stream: TextIO) -> None:
 
     if status == "unique":
         m = payload.get("match", {})
-        stream.write(f"unique: {m.get('title', '')}  [{m.get('doc_id', '')}]\n")
+        stream.write(f"unique: {_citation(m)}  [{m.get('doc_id', '')}]\n")
         if m.get("canonical_filename"):
             stream.write(f"  filename: {m['canonical_filename']}\n")
         return
@@ -116,7 +186,7 @@ def _render_verify_identifier(payload: Any, stream: TextIO) -> None:
         overflow = " (overflow)" if payload.get("overflow") else ""
         stream.write(f"ambiguous: {count} candidates{overflow}\n")
         for c in payload.get("candidates", []):
-            stream.write(f"  - {c.get('title', '')}  [{c.get('doc_id', '')}]\n")
+            stream.write(f"  - {_citation(c)}  [{c.get('doc_id', '')}]\n")
             for path, value in (c.get("discriminating_fields") or {}).items():
                 stream.write(f"      {path}={value!r}\n")
         suggestion = payload.get("suggestion")
@@ -150,6 +220,5 @@ def _render_documents_by_date(payload: Any, stream: TextIO) -> None:
         date = r.get("date") or ""
         date_short = date[:10] if isinstance(date, str) and len(date) >= 10 else date
         src = r.get("date_source") or ""
-        title = r.get("title") or ""
         doc_id = r.get("doc_id") or ""
-        stream.write(f"  {date_short} [{src}]  {title}  ({doc_id})\n")
+        stream.write(f"  {date_short} [{src}]  {_citation(r)}  ({doc_id})\n")

--- a/src/harbor_clerk/cli/output.py
+++ b/src/harbor_clerk/cli/output.py
@@ -107,6 +107,38 @@ def _render_search(payload: Any, stream: TextIO) -> None:
         stream.write("possible_conflict=true - top hits span multiple similarly scored documents\n")
 
 
+# --- Find all pretty-printer ---
+
+
+@register_text_renderer("find-all")
+def _render_find_all(payload: Any, stream: TextIO) -> None:
+    if not isinstance(payload, dict):
+        stream.write(repr(payload) + "\n")
+        return
+    if "error" in payload:
+        stream.write(f"error: {payload['error']}\n")
+        return
+    results = payload.get("results") or []
+    total = payload.get("total_matches", 0)
+    returned = payload.get("returned", len(results))
+    offset = payload.get("offset", 0)
+    truncated = " truncated" if payload.get("truncated") else ""
+    stream.write(f"{returned} of {total} matches (offset {offset}){truncated}\n")
+    if not results:
+        return
+    stream.write("\n")
+    for i, result in enumerate(results, 1):
+        record = dict(result)
+        top_chunk = record.get("top_chunk")
+        if isinstance(top_chunk, dict):
+            record.setdefault("chunk_id", top_chunk.get("chunk_id"))
+            record.setdefault("text", top_chunk.get("text"))
+            record.setdefault("page", top_chunk.get("page"))
+        if record.get("page_range") and not record.get("pages"):
+            record["pages"] = record["page_range"]
+        _render_hit_line(i, record, stream)
+
+
 # --- Batch search pretty-printer ---
 
 

--- a/src/harbor_clerk/llm/citations.py
+++ b/src/harbor_clerk/llm/citations.py
@@ -2,10 +2,10 @@
 
 The chat and research loops execute tools whose JSON output contains
 references back to corpus chunks and documents. This module pulls those
-references into a uniform ``{doc_id, doc_title?, chunk_id?, pages?, score?}``
-shape so that the chat ``done`` SSE event and ``ResearchDetail`` can expose a
-``citations`` list to clients (UI badges, test-harness ``citation_overlap``,
-etc.).
+references into a uniform ``{doc_id, doc_title?, chunk_id?, pages?, source?,
+citation?, score?}`` shape so that the chat ``done`` SSE event and
+``ResearchDetail`` can expose a ``citations`` list to clients (UI badges,
+test-harness ``citation_overlap``, etc.).
 
 The extractor is best-effort: tool results that don't look like citations
 (errors, status responses, free-form summaries) return an empty list. It
@@ -51,27 +51,35 @@ def extract_citations_from_tool_result(raw_result: str) -> list[dict]:
     parent_doc_title = data.get("doc_title") or data.get("title")
 
     def _record(d: dict, *, fallback_doc_id: Any = None, fallback_doc_title: Any = None) -> None:
-        doc_id = d.get("doc_id") or fallback_doc_id
+        source = _extract_source(d)
+        doc_id = d.get("doc_id") or (source.get("doc_id") if source else None) or fallback_doc_id
         if doc_id is None:
             # passages-only case: chunk_id present, no doc_id. Capture the
             # chunk so a chunk→doc join later can still resolve it; the
             # test harness will ignore entries with no doc_id when computing
             # citation_overlap.
-            if not d.get("chunk_id"):
+            if not (d.get("chunk_id") or (source.get("chunk_id") if source else None)):
                 return
             cite: dict = {}
         else:
             cite = {"doc_id": str(doc_id)}
 
-        title = d.get("doc_title") or d.get("title") or fallback_doc_title
+        if source:
+            cite["source"] = dict(source)
+
+        title = d.get("doc_title") or d.get("title") or (source.get("doc_title") if source else None)
+        title = title or fallback_doc_title
         if title:
             cite["doc_title"] = title
-        chunk_id = d.get("chunk_id")
+        chunk_id = d.get("chunk_id") or (source.get("chunk_id") if source else None)
         if chunk_id:
             cite["chunk_id"] = str(chunk_id)
-        pages = d.get("pages")
+        pages = d.get("pages") or (source.get("pages") if source else None)
         if pages:
             cite["pages"] = pages
+        citation = d.get("citation") or (source.get("citation") if source else None)
+        if citation:
+            cite["citation"] = citation
         score = d.get("score")
         if isinstance(score, (int, float)):
             cite["score"] = score
@@ -118,6 +126,17 @@ def extract_citations_from_tool_result(raw_result: str) -> list[dict]:
     return out
 
 
+def _extract_source(d: dict) -> dict | None:
+    """Return a copied SourceRef-like dict from a result row, if present."""
+    source = d.get("source")
+    if not isinstance(source, dict):
+        # kb_find_related already used "source" for linked/embedding before
+        # SourceRef existed, so that tool exposes the citation object under
+        # source_ref to preserve compatibility.
+        source = d.get("source_ref")
+    return dict(source) if isinstance(source, dict) else None
+
+
 def dedupe_citations(cites: list[dict]) -> list[dict]:
     """Dedupe by (doc_id, chunk_id), preserving first-seen order.
 
@@ -141,8 +160,19 @@ def dedupe_citations(cites: list[dict]) -> list[dict]:
             if isinstance(cur_score, (int, float)) and (
                 not isinstance(prev_score, (int, float)) or cur_score > prev_score
             ):
-                seen[key] = c
+                seen[key] = _merge_richer(prev, c)
+            else:
+                seen[key] = _merge_richer(c, prev)
         else:
             seen[key] = c
             order.append(key)
     return [seen[k] for k in order]
+
+
+def _merge_richer(old: dict, new: dict) -> dict:
+    """Prefer ``new`` while carrying rich source fields forward from ``old``."""
+    merged = dict(new)
+    for key in ("source", "citation", "doc_title", "pages"):
+        if key not in merged and key in old:
+            merged[key] = old[key]
+    return merged

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -33,7 +33,14 @@ from harbor_clerk.models import (
 )
 from harbor_clerk.models.enums import JobStage, PipelineStatus
 from harbor_clerk.oauth import validate_access_token as validate_oauth_access_token
-from harbor_clerk.search import FindAllResult, SearchHit, SearchResult, find_all, hybrid_search
+from harbor_clerk.search import FindAllHit, FindAllResult, SearchHit, SearchResult, find_all, hybrid_search
+from harbor_clerk.source_ref import (
+    SourceRef,
+    SourceRefContext,
+    format_document_citation,
+    format_pages,
+    load_source_ref_context,
+)
 from harbor_clerk.sql_escape import escape_ilike
 
 logger = logging.getLogger(__name__)
@@ -590,6 +597,7 @@ def _format_search_response(
     k: int,
     offset: int,
     heading_map: dict[tuple[str, int], str] | None = None,
+    source_context: SourceRefContext | None = None,
 ) -> dict:
     """Build the non-faceted search response dict from a SearchResult.
 
@@ -597,12 +605,15 @@ def _format_search_response(
     """
     hits = []
     for h in result.hits:
+        source_ref = _source_ref_for_search_hit(h, source_context, heading_map)
         hit: dict = {
             "chunk_id": h.chunk_id,
             "doc_id": h.doc_id,
             "doc_title": h.doc_title,
             "score": h.score,
             "language": h.language,
+            "source": source_ref.to_dict(),
+            "citation": source_ref.citation,
         }
         if h.page_start is not None:
             hit["pages"] = f"{h.page_start}-{h.page_end}" if h.page_end != h.page_start else str(h.page_start)
@@ -659,6 +670,68 @@ def _format_search_response(
         resp["possible_conflict"] = True
         resp["conflict_sources"] = [{"doc_id": cs.doc_id, "title": cs.title} for cs in result.conflict_sources]
     return resp
+
+
+def _fallback_source_ref(
+    *,
+    doc_id: str,
+    doc_title: str | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+) -> SourceRef:
+    title = doc_title or "Untitled document"
+    return SourceRef(
+        doc_id=doc_id,
+        doc_title=title,
+        chunk_id=chunk_id,
+        pages=pages,
+        section=section,
+        source_kind="unknown",
+        source_label=title,
+        citation=format_document_citation(title, pages),
+    )
+
+
+def _source_ref_for_search_hit(
+    hit: SearchHit,
+    source_context: SourceRefContext | None,
+    heading_map: dict[tuple[str, int], str] | None = None,
+) -> SourceRef:
+    pages = format_pages(hit.page_start, hit.page_end)
+    section = None
+    if heading_map and hit.page_start is not None:
+        section = heading_map.get((hit.doc_id, hit.page_start))
+    if source_context is not None:
+        source_ref = source_context.ref_for_doc(hit.doc_id, chunk_id=hit.chunk_id, pages=pages, section=section)
+        if source_ref.doc_id:
+            return source_ref
+    return _fallback_source_ref(
+        doc_id=hit.doc_id,
+        doc_title=hit.doc_title,
+        chunk_id=hit.chunk_id,
+        pages=pages,
+        section=section,
+    )
+
+
+def _source_ref_for_find_all_hit(hit: FindAllHit, source_context: SourceRefContext | None) -> SourceRef:
+    if source_context is not None:
+        source_ref = source_context.ref_for_doc(
+            hit.doc_id,
+            chunk_id=hit.top_chunk_id,
+            pages=hit.page_range,
+            section=hit.top_chunk_heading,
+        )
+        if source_ref.doc_id:
+            return source_ref
+    return _fallback_source_ref(
+        doc_id=hit.doc_id,
+        doc_title=hit.doc_title,
+        chunk_id=hit.top_chunk_id,
+        pages=hit.page_range,
+        section=hit.top_chunk_heading,
+    )
 
 
 @mcp.tool()
@@ -844,6 +917,7 @@ async def kb_search(
             text_contains=text_contains,
         )
         heading_map = await _resolve_headings(session, result.hits)
+        source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])
         # Compute discriminator_hint if applicable. Cheap post-processing:
         # one indexed SELECT for top-K candidate docs' metadata. Skips when
         # fewer than 2 hits.
@@ -852,7 +926,15 @@ async def kb_search(
     # Resolve brief_chars for brief mode
     effective_brief_chars = brief_chars if brief_chars > 0 else settings.mcp_brief_chars
 
-    base_resp = _format_search_response(result, detail, effective_brief_chars, k, offset, heading_map)
+    base_resp = _format_search_response(
+        result,
+        detail,
+        effective_brief_chars,
+        k,
+        offset,
+        heading_map,
+        source_context,
+    )
 
     if faceted:
         # Group hits by doc_id
@@ -1118,10 +1200,12 @@ async def kb_find_all(
             metadata_filter=metadata_filter,
             presentation=presentation,
         )
+        source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])
 
     # Build per-hit response dicts
     results = []
     for h in result.hits:
+        source_ref = _source_ref_for_find_all_hit(h, source_context)
         hit: dict = {
             "doc_id": h.doc_id,
             "doc_title": h.doc_title,
@@ -1130,6 +1214,8 @@ async def kb_find_all(
             "score": round(h.score, 4),
             "ingested_at": h.ingested_at.isoformat() if h.ingested_at is not None else None,
             "page_range": h.page_range,
+            "source": source_ref.to_dict(),
+            "citation": source_ref.citation,
         }
         if presentation == "full":
             hit["top_chunk"] = {
@@ -1287,7 +1373,16 @@ async def kb_batch_search(
                 metadata_filter=metadata_filter,
             )
             heading_map = await _resolve_headings(session, result.hits)
-            resp = _format_search_response(result, detail, effective_brief_chars, k, 0, heading_map)
+            source_context = await load_source_ref_context(session, [h.doc_id for h in result.hits])
+            resp = _format_search_response(
+                result,
+                detail,
+                effective_brief_chars,
+                k,
+                0,
+                heading_map,
+                source_context,
+            )
             resp["query"] = query
             hint = await _compute_discriminator_hint(result.hits, session)
             if hint is not None:
@@ -1364,6 +1459,7 @@ async def kb_read_passages(
         doc_ids = {c.doc_id for c in chunks.values()}
         docs_result = await session.execute(select(Document).where(Document.doc_id.in_(list(doc_ids))))
         docs = {d.doc_id: d for d in docs_result.scalars().all()}
+        source_context = await load_source_ref_context(session, doc_ids)
 
         # Snippet truncation limit from key scope, if any
         snippet_limit: int | None = None
@@ -1381,6 +1477,7 @@ async def kb_read_passages(
                 text = text[:snippet_limit]
             p: dict = {
                 "chunk_id": str(cid),
+                "doc_id": str(chunk.doc_id),
                 "doc_title": doc.title if doc else None,
                 "text": text,
                 "language": chunk.language,
@@ -1391,6 +1488,13 @@ async def kb_read_passages(
                     if chunk.page_end != chunk.page_start
                     else str(chunk.page_start)
                 )
+            source_ref = source_context.ref_for_doc(
+                chunk.doc_id,
+                chunk_id=cid,
+                pages=format_pages(chunk.page_start, chunk.page_end),
+            )
+            p["source"] = source_ref.to_dict()
+            p["citation"] = source_ref.citation
 
             if include_context:
                 prev = await session.execute(
@@ -1463,6 +1567,7 @@ async def kb_expand_context(chunk_id: str, n: int = 2) -> str:
         neighbours = result.scalars().all()
 
         doc = (await session.execute(select(Document).where(Document.doc_id == target.doc_id))).scalar_one_or_none()
+        source_context = await load_source_ref_context(session, [target.doc_id])
 
         # Snippet truncation limit from key scope, if any
         snippet_limit: int | None = None
@@ -1482,6 +1587,13 @@ async def kb_expand_context(chunk_id: str, n: int = 2) -> str:
             }
             if c.page_start is not None:
                 entry["pages"] = f"{c.page_start}-{c.page_end}" if c.page_end != c.page_start else str(c.page_start)
+            source_ref = source_context.ref_for_doc(
+                c.doc_id,
+                chunk_id=c.chunk_id,
+                pages=format_pages(c.page_start, c.page_end),
+            )
+            entry["source"] = source_ref.to_dict()
+            entry["citation"] = source_ref.citation
             if c.chunk_id == target_id:
                 entry["is_target"] = True
             chunks.append(entry)

--- a/src/harbor_clerk/mcp_server.py
+++ b/src/harbor_clerk/mcp_server.py
@@ -734,6 +734,51 @@ def _source_ref_for_find_all_hit(hit: FindAllHit, source_context: SourceRefConte
     )
 
 
+def _valid_doc_ids_from_payloads(payloads: list[dict]) -> list[str]:
+    doc_ids = []
+    for payload in payloads:
+        doc_id = payload.get("doc_id")
+        if doc_id is None:
+            continue
+        try:
+            uuid.UUID(str(doc_id))
+        except ValueError:
+            continue
+        doc_ids.append(str(doc_id))
+    return doc_ids
+
+
+def _source_ref_for_doc_payload(payload: dict, source_context: SourceRefContext | None) -> SourceRef | None:
+    doc_id = payload.get("doc_id")
+    if doc_id is None:
+        return None
+    doc_id_text = str(doc_id)
+    if source_context is not None:
+        try:
+            source_ref = source_context.ref_for_doc(doc_id_text)
+        except ValueError:
+            source_ref = None
+        if source_ref is not None and source_ref.doc_id:
+            return source_ref
+    return _fallback_source_ref(
+        doc_id=doc_id_text,
+        doc_title=payload.get("title") or payload.get("doc_title") or payload.get("canonical_filename"),
+    )
+
+
+def _enrich_doc_payload_with_source(
+    payload: dict,
+    source_context: SourceRefContext | None,
+    *,
+    source_key: str = "source",
+) -> None:
+    source_ref = _source_ref_for_doc_payload(payload, source_context)
+    if source_ref is None:
+        return
+    payload[source_key] = source_ref.to_dict()
+    payload["citation"] = source_ref.citation
+
+
 @mcp.tool()
 async def kb_search(
     query: str,
@@ -1652,23 +1697,24 @@ async def kb_get_document(doc_id: str) -> str:
         jobs = [
             {"stage": j.stage.value, "status": j.status.value, "error": j.error} for j in jobs_result.scalars().all()
         ]
+        source_context = await load_source_ref_context(session, [did])
 
-    return json.dumps(
-        {
-            "doc_id": str(doc.doc_id),
-            "title": doc.title,
-            "status": doc.status,
-            "pipeline_status": doc.pipeline_status.value if doc.pipeline_status else None,
-            "summary": doc.summary,
-            "mime_type": doc.mime_type,
-            "size_bytes": doc.size_bytes,
-            "extracted_chars": doc.extracted_chars,
-            "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
-            "metadata": doc.doc_metadata,
-            "jobs": jobs,
-        },
-        indent=2,
-    )
+    payload = {
+        "doc_id": str(doc.doc_id),
+        "title": doc.title,
+        "status": doc.status,
+        "pipeline_status": doc.pipeline_status.value if doc.pipeline_status else None,
+        "summary": doc.summary,
+        "mime_type": doc.mime_type,
+        "size_bytes": doc.size_bytes,
+        "extracted_chars": doc.extracted_chars,
+        "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+        "metadata": doc.doc_metadata,
+        "jobs": jobs,
+    }
+    _enrich_doc_payload_with_source(payload, source_context)
+
+    return json.dumps(payload, indent=2)
 
 
 @mcp.tool()
@@ -1706,19 +1752,20 @@ async def kb_list_recent(limit: int = 20) -> str:
 
         result = await session.execute(list_q)
         docs = result.scalars().all()
+        source_context = await load_source_ref_context(session, [doc.doc_id for doc in docs])
 
     items = []
     for doc in docs:
-        items.append(
-            {
-                "doc_id": str(doc.doc_id),
-                "title": doc.title,
-                "summary": doc.summary,
-                "status": doc.status,
-                "pipeline_status": doc.pipeline_status.value if doc.pipeline_status else None,
-                "updated_at": doc.updated_at.isoformat(),
-            }
-        )
+        item = {
+            "doc_id": str(doc.doc_id),
+            "title": doc.title,
+            "summary": doc.summary,
+            "status": doc.status,
+            "pipeline_status": doc.pipeline_status.value if doc.pipeline_status else None,
+            "updated_at": doc.updated_at.isoformat(),
+        }
+        _enrich_doc_payload_with_source(item, source_context)
+        items.append(item)
 
     return json.dumps(
         {"total_count": total_count, "truncated": total_count > len(items), "documents": items},
@@ -1850,18 +1897,19 @@ async def kb_corpus_overview(limit: int = 50) -> str:
             list_q = list_q.where(Document.doc_id.in_(visible_ids))
         result = await session.execute(list_q)
         docs = result.scalars().all()
+        source_context = await load_source_ref_context(session, [doc.doc_id for doc in docs])
 
     items = []
     for doc in docs:
-        items.append(
-            {
-                "doc_id": str(doc.doc_id),
-                "title": doc.title,
-                "summary": doc.summary,
-                "pipeline_status": doc.pipeline_status.value if doc.pipeline_status else None,
-                "updated_at": doc.updated_at.isoformat(),
-            }
-        )
+        item = {
+            "doc_id": str(doc.doc_id),
+            "title": doc.title,
+            "summary": doc.summary,
+            "pipeline_status": doc.pipeline_status.value if doc.pipeline_status else None,
+            "updated_at": doc.updated_at.isoformat(),
+        }
+        _enrich_doc_payload_with_source(item, source_context)
+        items.append(item)
 
     return json.dumps(
         {
@@ -2009,24 +2057,25 @@ async def kb_document_outline(doc_id: str) -> str:
         chunk_count = (
             await session.execute(select(func.count()).select_from(Chunk).where(Chunk.doc_id == did))
         ).scalar_one()
+        source_context = await load_source_ref_context(session, [did])
 
-    return json.dumps(
-        {
-            "doc_id": str(doc.doc_id),
-            "title": doc.title,
-            "page_count": page_count,
-            "chunk_count": chunk_count,
-            "headings": [
-                {
-                    "level": h.level,
-                    "title": h.title,
-                    "page_num": h.page_num,
-                }
-                for h in headings
-            ],
-        },
-        indent=2,
-    )
+    payload = {
+        "doc_id": str(doc.doc_id),
+        "title": doc.title,
+        "page_count": page_count,
+        "chunk_count": chunk_count,
+        "headings": [
+            {
+                "level": h.level,
+                "title": h.title,
+                "page_num": h.page_num,
+            }
+            for h in headings
+        ],
+    }
+    _enrich_doc_payload_with_source(payload, source_context)
+
+    return json.dumps(payload, indent=2)
 
 
 @mcp.tool()
@@ -2157,6 +2206,7 @@ async def kb_find_related(doc_id: str, k: int = 5) -> str:
             select(Document).where(Document.doc_id.in_(merged_ids), Document.status == "active")
         )
         related_docs = {d.doc_id: d for d in docs_result.scalars().all()}
+        source_context = await load_source_ref_context(session, merged_ids)
 
     items = []
     for rid in merged_ids:
@@ -2169,18 +2219,18 @@ async def kb_find_related(doc_id: str, k: int = 5) -> str:
         else:
             similarity = round(1.0 - distances[rid], 4)
             source = "embedding"
-        items.append(
-            {
-                "doc_id": str(rid),
-                "title": rdoc.title,
-                "summary": rdoc.summary,
-                "similarity": similarity,
-                "source": source,
-                "doc_type": rdoc.doc_type,
-                "mime_type": rdoc.mime_type,
-                "canonical_filename": rdoc.canonical_filename,
-            }
-        )
+        item = {
+            "doc_id": str(rid),
+            "title": rdoc.title,
+            "summary": rdoc.summary,
+            "similarity": similarity,
+            "source": source,
+            "doc_type": rdoc.doc_type,
+            "mime_type": rdoc.mime_type,
+            "canonical_filename": rdoc.canonical_filename,
+        }
+        _enrich_doc_payload_with_source(item, source_context, source_key="source_ref")
+        items.append(item)
 
     return json.dumps(
         {"doc_id": doc_id, "related": items},
@@ -2715,6 +2765,16 @@ async def kb_verify_identifier(identifier: str) -> str:
     """
     async with async_session_factory() as session:
         result = await _verify_identifier_impl(session, identifier)
+        payloads: list[dict] = []
+        if isinstance(result, dict):
+            if isinstance(result.get("match"), dict):
+                payloads.append(result["match"])
+            candidates = result.get("candidates")
+            if isinstance(candidates, list):
+                payloads.extend(candidate for candidate in candidates if isinstance(candidate, dict))
+        source_context = await load_source_ref_context(session, _valid_doc_ids_from_payloads(payloads))
+        for payload in payloads:
+            _enrich_doc_payload_with_source(payload, source_context)
     # Response-level anti-hedge directive for the not_found case. The docstring
     # already says "do NOT fall back to closest match", but the BEFORE/AFTER on
     # PR-J showed frontier models reproduce the exact padding the docstring
@@ -2807,6 +2867,15 @@ async def kb_documents_by_date(
             date_field=date_field,
             limit=limit,
         )
+        rows = result.get("results") if isinstance(result, dict) else None
+        if isinstance(rows, list):
+            source_context = await load_source_ref_context(
+                session,
+                _valid_doc_ids_from_payloads([row for row in rows if isinstance(row, dict)]),
+            )
+            for row in rows:
+                if isinstance(row, dict):
+                    _enrich_doc_payload_with_source(row, source_context)
     return json.dumps(result, default=str)
 
 

--- a/src/harbor_clerk/source_ref.py
+++ b/src/harbor_clerk/source_ref.py
@@ -138,20 +138,23 @@ async def load_source_ref_context(
     watched_files_by_doc: dict[uuid.UUID, WatchedFile] = {}
     watched_folders_by_id: dict[uuid.UUID, WatchedFolder] = {}
     try:
-        wf_result = await session.execute(
-            select(WatchedFile).where(
-                WatchedFile.doc_id.in_(unique_ids),
-                WatchedFile.status == WatchedFileStatus.active,
+        async with session.begin_nested():
+            wf_result = await session.execute(
+                select(WatchedFile).where(
+                    WatchedFile.doc_id.in_(unique_ids),
+                    WatchedFile.status == WatchedFileStatus.active,
+                )
             )
-        )
-        for watched_file in wf_result.scalars().all():
-            if watched_file.doc_id is not None and watched_file.doc_id not in watched_files_by_doc:
-                watched_files_by_doc[watched_file.doc_id] = watched_file
+            for watched_file in wf_result.scalars().all():
+                if watched_file.doc_id is not None and watched_file.doc_id not in watched_files_by_doc:
+                    watched_files_by_doc[watched_file.doc_id] = watched_file
 
-        folder_ids = list({wf.folder_id for wf in watched_files_by_doc.values()})
-        if folder_ids:
-            folder_result = await session.execute(select(WatchedFolder).where(WatchedFolder.folder_id.in_(folder_ids)))
-            watched_folders_by_id = {folder.folder_id: folder for folder in folder_result.scalars().all()}
+            folder_ids = list({wf.folder_id for wf in watched_files_by_doc.values()})
+            if folder_ids:
+                folder_result = await session.execute(
+                    select(WatchedFolder).where(WatchedFolder.folder_id.in_(folder_ids))
+                )
+                watched_folders_by_id = {folder.folder_id: folder for folder in folder_result.scalars().all()}
     except (sa_exc.OperationalError, sa_exc.ProgrammingError):
         logger.debug("Failed to load watched-folder context for SourceRef", exc_info=True)
 
@@ -310,7 +313,13 @@ def _safe_relative_path(relative_path: str | None) -> str | None:
     normalized = clean.replace("\\", "/")
     if posixpath.isabs(normalized):
         return posixpath.basename(normalized)
+    if _looks_windows_drive_path(normalized):
+        return posixpath.basename(normalized[2:].lstrip("/")) or None
     return normalized
+
+
+def _looks_windows_drive_path(path: str) -> bool:
+    return len(path) >= 2 and path[0].isalpha() and path[1] == ":"
 
 
 def _page_label(pages: str | None) -> str | None:

--- a/src/harbor_clerk/source_ref.py
+++ b/src/harbor_clerk/source_ref.py
@@ -1,0 +1,390 @@
+"""Structured source references and citation formatting.
+
+This module is intentionally small and mostly pure. The builder never queries
+the database; callers that need watched-folder or parent-email context should
+load it up front with ``load_source_ref_context`` and then call into the pure
+builder.
+"""
+
+from __future__ import annotations
+
+import logging
+import posixpath
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from email.utils import parsedate_to_datetime
+from typing import Any, Literal
+
+from sqlalchemy import exc as sa_exc
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+
+logger = logging.getLogger(__name__)
+
+SourceKind = Literal["document", "email", "attachment", "unknown"]
+
+
+@dataclass(frozen=True)
+class SourceRef:
+    """A stable source/citation object for API, MCP, CLI, and UI payloads."""
+
+    doc_id: str
+    doc_title: str
+    source_kind: SourceKind
+    source_label: str
+    citation: str
+    chunk_id: str | None = None
+    pages: str | None = None
+    section: str | None = None
+    folder_label: str | None = None
+    relative_path: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-ready dict, omitting absent optional fields."""
+        out = {
+            "doc_id": self.doc_id,
+            "doc_title": self.doc_title,
+            "source_kind": self.source_kind,
+            "source_label": self.source_label,
+            "citation": self.citation,
+        }
+        if self.chunk_id:
+            out["chunk_id"] = self.chunk_id
+        if self.pages:
+            out["pages"] = self.pages
+        if self.section:
+            out["section"] = self.section
+        if self.folder_label:
+            out["folder_label"] = self.folder_label
+        if self.relative_path:
+            out["relative_path"] = self.relative_path
+        return out
+
+
+@dataclass
+class SourceRefContext:
+    """Bulk-loaded context for building SourceRefs without N+1 queries."""
+
+    docs_by_id: dict[uuid.UUID, Document]
+    watched_files_by_doc: dict[uuid.UUID, WatchedFile]
+    watched_folders_by_id: dict[uuid.UUID, WatchedFolder]
+    parent_email_docs_by_id: dict[uuid.UUID, Document]
+
+    def ref_for_doc(
+        self,
+        doc_or_id: Document | uuid.UUID | str,
+        *,
+        chunk_id: str | uuid.UUID | None = None,
+        pages: str | None = None,
+        section: str | None = None,
+        include_relative_path: bool = True,
+    ) -> SourceRef:
+        """Build a SourceRef for a loaded document or document id."""
+        if isinstance(doc_or_id, Document):
+            doc = doc_or_id
+            doc_id = doc.doc_id
+        else:
+            doc_id = _coerce_uuid(doc_or_id)
+            doc = self.docs_by_id.get(doc_id)
+
+        watched_file = self.watched_files_by_doc.get(doc_id)
+        watched_folder = self.watched_folders_by_id.get(watched_file.folder_id) if watched_file else None
+        parent_email_doc = None
+        if doc is not None and doc.email_parent_doc_id is not None:
+            parent_email_doc = self.parent_email_docs_by_id.get(doc.email_parent_doc_id)
+
+        return build_source_ref(
+            doc=doc,
+            chunk_id=str(chunk_id) if chunk_id else None,
+            pages=pages,
+            section=section,
+            watched_file=watched_file,
+            watched_folder=watched_folder,
+            parent_email_doc=parent_email_doc,
+            include_relative_path=include_relative_path,
+        )
+
+
+async def load_source_ref_context(
+    session: AsyncSession,
+    doc_ids: Iterable[uuid.UUID | str],
+) -> SourceRefContext:
+    """Bulk-load source context for the given document ids."""
+    normalized_ids = [_coerce_uuid(doc_id) for doc_id in doc_ids]
+    unique_ids = list(dict.fromkeys(normalized_ids))
+    if not unique_ids:
+        return SourceRefContext({}, {}, {}, {})
+
+    docs_result = await session.execute(select(Document).where(Document.doc_id.in_(unique_ids)))
+    docs_by_id = {doc.doc_id: doc for doc in docs_result.scalars().all()}
+
+    parent_ids = list(
+        {
+            doc.email_parent_doc_id
+            for doc in docs_by_id.values()
+            if doc.email_parent_doc_id is not None and doc.email_parent_doc_id not in docs_by_id
+        }
+    )
+    parent_email_docs_by_id: dict[uuid.UUID, Document] = {}
+    if parent_ids:
+        parent_result = await session.execute(select(Document).where(Document.doc_id.in_(parent_ids)))
+        parent_email_docs_by_id = {doc.doc_id: doc for doc in parent_result.scalars().all()}
+
+    watched_files_by_doc: dict[uuid.UUID, WatchedFile] = {}
+    watched_folders_by_id: dict[uuid.UUID, WatchedFolder] = {}
+    try:
+        wf_result = await session.execute(
+            select(WatchedFile).where(
+                WatchedFile.doc_id.in_(unique_ids),
+                WatchedFile.status == WatchedFileStatus.active,
+            )
+        )
+        for watched_file in wf_result.scalars().all():
+            if watched_file.doc_id is not None and watched_file.doc_id not in watched_files_by_doc:
+                watched_files_by_doc[watched_file.doc_id] = watched_file
+
+        folder_ids = list({wf.folder_id for wf in watched_files_by_doc.values()})
+        if folder_ids:
+            folder_result = await session.execute(select(WatchedFolder).where(WatchedFolder.folder_id.in_(folder_ids)))
+            watched_folders_by_id = {folder.folder_id: folder for folder in folder_result.scalars().all()}
+    except (sa_exc.OperationalError, sa_exc.ProgrammingError):
+        logger.debug("Failed to load watched-folder context for SourceRef", exc_info=True)
+
+    return SourceRefContext(
+        docs_by_id=docs_by_id,
+        watched_files_by_doc=watched_files_by_doc,
+        watched_folders_by_id=watched_folders_by_id,
+        parent_email_docs_by_id=parent_email_docs_by_id,
+    )
+
+
+def format_pages(page_start: int | None, page_end: int | None = None) -> str | None:
+    """Format a page or page range as ``"4"`` or ``"4-5"``."""
+    if page_start is None:
+        return None
+    if page_end is None or page_end == page_start:
+        return str(page_start)
+    return f"{page_start}-{page_end}"
+
+
+def format_document_citation(title: str, pages: str | None = None) -> str:
+    """Format a document citation."""
+    title = _clean(title) or "Untitled document"
+    page_label = _page_label(pages)
+    return f"{title}, {page_label}" if page_label else title
+
+
+def format_email_citation(
+    *,
+    from_name: str | None = None,
+    from_address: str | None = None,
+    subject: str | None = None,
+    date_sent: datetime | date | str | None = None,
+) -> str:
+    """Format an email-native citation from the available metadata."""
+    sender = _display_sender(from_name=from_name, from_address=from_address)
+    pieces = [f"Email from {sender}" if sender else "Email"]
+    clean_subject = _clean(subject)
+    if clean_subject:
+        pieces.append(f'"{clean_subject}"')
+    formatted_date = _format_date(date_sent)
+    if formatted_date:
+        pieces.append(formatted_date)
+    return ", ".join(pieces)
+
+
+def format_attachment_citation(
+    *,
+    attachment_label: str,
+    pages: str | None = None,
+    parent_email_doc: Document | None = None,
+) -> str:
+    """Format an attachment citation, including parent email context when available."""
+    label = _clean(attachment_label) or "attachment"
+    base = f'Attachment "{label}"'
+    page_label = _page_label(pages)
+    if page_label:
+        base = f"{base}, {page_label}"
+    if parent_email_doc is None:
+        return base
+    return f"{base}, to {_email_citation_for_doc(parent_email_doc)}"
+
+
+def build_source_ref(
+    *,
+    doc: Document | None,
+    chunk_id: str | None = None,
+    pages: str | None = None,
+    section: str | None = None,
+    watched_file: WatchedFile | None = None,
+    watched_folder: WatchedFolder | None = None,
+    parent_email_doc: Document | None = None,
+    include_relative_path: bool = True,
+) -> SourceRef:
+    """Build a SourceRef from preloaded document/source context."""
+    doc_id = str(doc.doc_id) if doc is not None and doc.doc_id is not None else ""
+    relative_path = _safe_relative_path(watched_file.relative_path if watched_file else None)
+    doc_title = _document_title(doc, relative_path)
+    folder_label = _folder_label(watched_folder)
+
+    if doc is None:
+        source_kind: SourceKind = "unknown"
+        source_label = doc_title
+        citation = format_document_citation(doc_title, pages)
+    elif _is_attachment_doc(doc):
+        source_kind = "attachment"
+        source_label = _clean(doc.title) or _clean(doc.canonical_filename) or _leaf(relative_path) or "attachment"
+        citation = format_attachment_citation(
+            attachment_label=source_label,
+            pages=pages,
+            parent_email_doc=parent_email_doc,
+        )
+    elif _is_email_doc(doc, relative_path):
+        source_kind = "email"
+        email_fields = _email_fields_for_doc(doc)
+        citation = format_email_citation(**email_fields)
+        source_label = citation
+        if citation == "Email":
+            source_label = doc_title
+            citation = format_document_citation(doc_title, pages)
+    else:
+        source_kind = "document"
+        source_label = doc_title
+        citation = format_document_citation(doc_title, pages)
+
+    return SourceRef(
+        doc_id=doc_id,
+        doc_title=doc_title,
+        chunk_id=chunk_id,
+        pages=_clean(pages),
+        section=_clean(section),
+        source_kind=source_kind,
+        source_label=source_label,
+        folder_label=folder_label,
+        relative_path=relative_path if include_relative_path else None,
+        citation=citation,
+    )
+
+
+def _coerce_uuid(value: uuid.UUID | str) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
+
+
+def _clean(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _leaf(path: str | None) -> str | None:
+    clean = _clean(path)
+    if not clean:
+        return None
+    return posixpath.basename(clean)
+
+
+def _document_title(doc: Document | None, relative_path: str | None) -> str:
+    if doc is None:
+        return _leaf(relative_path) or "Untitled document"
+    return _clean(doc.title) or _clean(doc.canonical_filename) or _leaf(relative_path) or "Untitled document"
+
+
+def _folder_label(folder: WatchedFolder | None) -> str | None:
+    if folder is None:
+        return None
+    return _clean(folder.display_name) or _leaf(folder.path)
+
+
+def _safe_relative_path(relative_path: str | None) -> str | None:
+    clean = _clean(relative_path)
+    if not clean:
+        return None
+    normalized = clean.replace("\\", "/")
+    if posixpath.isabs(normalized):
+        return posixpath.basename(normalized)
+    return normalized
+
+
+def _page_label(pages: str | None) -> str | None:
+    clean = _clean(pages)
+    if not clean:
+        return None
+    return f"pp. {clean}" if "-" in clean else f"p. {clean}"
+
+
+def _display_sender(*, from_name: str | None, from_address: str | None) -> str | None:
+    return _clean(from_name) or _clean(from_address)
+
+
+def _format_date(value: datetime | date | str | None) -> str | None:
+    parsed = _parse_date(value)
+    if parsed is None:
+        return None
+    return f"{parsed.strftime('%b')} {parsed.day}, {parsed.year}"
+
+
+def _parse_date(value: datetime | date | str | None) -> datetime | date | None:
+    if isinstance(value, datetime | date):
+        return value
+    text = _clean(value)
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+    try:
+        return parsedate_to_datetime(text)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+
+
+def _is_attachment_doc(doc: Document) -> bool:
+    return doc.email_parent_doc_id is not None
+
+
+def _is_email_doc(doc: Document, relative_path: str | None) -> bool:
+    if any(
+        _clean(v)
+        for v in (
+            doc.email_message_id,
+            doc.email_from_address,
+            doc.email_from_name,
+            doc.email_subject,
+        )
+    ):
+        return True
+    if doc.email_date_sent is not None:
+        return True
+    if _clean(doc.mime_type) == "message/rfc822":
+        return True
+    filename = (_clean(doc.canonical_filename) or _leaf(relative_path) or "").lower()
+    return filename.endswith(".eml")
+
+
+def _email_fields_for_doc(doc: Document) -> dict[str, str | datetime | date | None]:
+    tika = doc.doc_metadata.get("tika") if isinstance(doc.doc_metadata, dict) else None
+    if not isinstance(tika, dict):
+        tika = {}
+    return {
+        "from_name": doc.email_from_name,
+        "from_address": doc.email_from_address or _clean(tika.get("email_from")),
+        "subject": doc.email_subject or _clean(tika.get("email_subject")),
+        "date_sent": doc.email_date_sent or _clean(tika.get("email_date")),
+    }
+
+
+def _email_citation_for_doc(doc: Document) -> str:
+    fields = _email_fields_for_doc(doc)
+    citation = format_email_citation(**fields)
+    if citation != "Email":
+        return citation
+    return format_document_citation(_document_title(doc, None))

--- a/tests/api/test_find_all_route.py
+++ b/tests/api/test_find_all_route.py
@@ -1,0 +1,186 @@
+"""REST Find All route contract tests."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.routes import search as search_route
+from harbor_clerk.api.schemas.search import FindAllRequest, FindAllResponse
+from harbor_clerk.search_types import FindAllHit, FindAllResult
+from harbor_clerk.source_ref import SourceRef
+
+
+def test_search_find_all_route_is_registered() -> None:
+    assert any(
+        getattr(route, "path", None) == "/search/find-all" and "POST" in getattr(route, "methods", set())
+        for route in search_route.router.routes
+    )
+
+
+@pytest.mark.anyio
+async def test_search_find_all_forwards_filters_and_returns_sources(monkeypatch) -> None:
+    doc_id = uuid4()
+    chunk_id = uuid4()
+    captured: dict[str, object] = {}
+
+    async def fake_find_all(session, query, **kwargs):
+        captured["session"] = session
+        captured["query"] = query
+        captured.update(kwargs)
+        return FindAllResult(
+            hits=[
+                FindAllHit(
+                    doc_id=str(doc_id),
+                    doc_title="Vendor Contract",
+                    mime_type="application/pdf",
+                    language="en",
+                    score=0.87,
+                    ingested_at=datetime(2026, 6, 1, tzinfo=UTC),
+                    page_range="2",
+                    top_chunk_id=str(chunk_id),
+                    top_chunk_text="Force majeure clause excerpt.",
+                    top_chunk_page=2,
+                    top_chunk_heading="Terms",
+                )
+            ],
+            total_matches=1,
+            offset=5,
+            truncated=False,
+            sort_by="date_desc",
+            presentation="full",
+        )
+
+    class SourceContext:
+        def ref_for_doc(self, doc_or_id, *, chunk_id=None, pages=None, section=None, include_relative_path=True):
+            return SourceRef(
+                doc_id=str(doc_or_id),
+                doc_title="Vendor Contract",
+                chunk_id=str(chunk_id),
+                pages=pages,
+                section=section,
+                source_kind="document",
+                source_label="Vendor Contract",
+                folder_label="Contracts",
+                relative_path="vendors/contract.pdf",
+                citation="Vendor Contract, p. 2",
+            )
+
+    async def fake_load_source_ref_context(session, doc_ids):
+        captured["source_doc_ids"] = list(doc_ids)
+        return SourceContext()
+
+    monkeypatch.setattr(search_route, "find_all", fake_find_all)
+    monkeypatch.setattr(search_route, "load_source_ref_context", fake_load_source_ref_context)
+
+    session = object()
+    response = await search_route.search_find_all(
+        FindAllRequest(
+            query="vendor contract",
+            text_contains="force majeure",
+            max_results=10,
+            offset=5,
+            presentation="full",
+            sort_by="date_desc",
+            doc_ids=[doc_id],
+            language="en",
+            mime_type="application/pdf",
+            metadata_filter={"sidecar.vendor": "Pinnacle"},
+        ),
+        principal=Principal(type="user", id=uuid4(), role="admin"),
+        session=session,
+    )
+
+    assert isinstance(response, FindAllResponse)
+    assert captured["session"] is session
+    assert captured["query"] == "vendor contract"
+    assert captured["max_results"] == 10
+    assert captured["offset"] == 5
+    assert captured["presentation"] == "full"
+    assert captured["sort_by"] == "date_desc"
+    assert captured["text_contains"] == "force majeure"
+    assert captured["doc_ids"] == [doc_id]
+    assert captured["language"] == "en"
+    assert captured["mime_type"] == "application/pdf"
+    assert captured["metadata_filter"] == {"sidecar.vendor": "Pinnacle"}
+    assert captured["source_doc_ids"] == [str(doc_id)]
+
+    assert response.total_matches == 1
+    assert response.returned == 1
+    hit = response.results[0]
+    assert hit.doc_id == str(doc_id)
+    assert hit.citation == "Vendor Contract, p. 2"
+    assert hit.source is not None
+    assert hit.source.folder_label == "Contracts"
+    assert hit.source.relative_path == "vendors/contract.pdf"
+    assert hit.top_chunk is not None
+    assert hit.top_chunk.chunk_id == str(chunk_id)
+    assert hit.top_chunk.text == "Force majeure clause excerpt."
+
+
+@pytest.mark.anyio
+async def test_search_find_all_clamps_max_results(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Settings:
+        find_all_max_results_cap = 25
+
+    async def fake_find_all(session, query, **kwargs):
+        captured.update(kwargs)
+        return FindAllResult(
+            hits=[],
+            total_matches=0,
+            offset=0,
+            truncated=False,
+            sort_by="relevance",
+            presentation="brief",
+        )
+
+    async def fake_load_source_ref_context(session, doc_ids):
+        raise AssertionError("empty find-all results should not need source context")
+
+    monkeypatch.setattr(search_route, "get_settings", lambda: Settings())
+    monkeypatch.setattr(search_route, "find_all", fake_find_all)
+    monkeypatch.setattr(search_route, "load_source_ref_context", fake_load_source_ref_context)
+
+    response = await search_route.search_find_all(
+        FindAllRequest(query="vendor contract", max_results=999),
+        principal=Principal(type="user", id=uuid4(), role="admin"),
+        session=object(),
+    )
+
+    assert response.results == []
+    assert captured["max_results"] == 25
+
+
+@pytest.mark.anyio
+async def test_search_find_all_returns_422_for_invalid_filter(monkeypatch) -> None:
+    async def fake_find_all(*args, **kwargs):
+        raise ValueError("metadata_filter keys must be exactly 'namespace.key'")
+
+    monkeypatch.setattr(search_route, "find_all", fake_find_all)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await search_route.search_find_all(
+            FindAllRequest(query="vendor contract", metadata_filter={"too.many.dots": "x"}),
+            principal=Principal(type="user", id=uuid4(), role="admin"),
+            session=object(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "metadata_filter keys" in exc_info.value.detail
+
+
+def test_find_all_request_rejects_doc_id_and_doc_ids() -> None:
+    doc_id = uuid4()
+    with pytest.raises(ValidationError):
+        FindAllRequest.model_validate(
+            {
+                "query": "vendor contract",
+                "doc_id": str(doc_id),
+                "doc_ids": [str(doc_id)],
+            }
+        )

--- a/tests/api/test_search_filter_parity.py
+++ b/tests/api/test_search_filter_parity.py
@@ -1,0 +1,75 @@
+"""REST search filter parity tests."""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.api.routes import search as search_route
+from harbor_clerk.api.schemas.search import SearchRequest, SearchResponse
+from harbor_clerk.search_types import SearchResult
+
+
+@pytest.mark.anyio
+async def test_rest_search_forwards_metadata_filter_and_text_contains(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_hybrid_search(session, query, **kwargs):
+        captured["session"] = session
+        captured["query"] = query
+        captured.update(kwargs)
+        return SearchResult(hits=[], total_candidates=0, reranker_status="disabled")
+
+    monkeypatch.setattr(search_route, "hybrid_search", fake_hybrid_search)
+
+    session = object()
+    principal = Principal(type="user", id=uuid4(), role="admin")
+    request = SearchRequest(
+        query="vendor contract",
+        metadata_filter={
+            "email.from_address": "alice@example.com",
+            "sidecar.vendor": "Pinnacle Tech Solutions",
+        },
+        text_contains="force majeure",
+    )
+
+    response = await search_route.search(request, principal=principal, session=session)
+
+    assert isinstance(response, SearchResponse)
+    assert captured["session"] is session
+    assert captured["query"] == "vendor contract"
+    assert captured["metadata_filter"] == {
+        "email.from_address": "alice@example.com",
+        "sidecar.vendor": "Pinnacle Tech Solutions",
+    }
+    assert captured["text_contains"] == "force majeure"
+
+
+@pytest.mark.anyio
+async def test_rest_search_returns_422_for_invalid_filter(monkeypatch) -> None:
+    async def fake_hybrid_search(*args, **kwargs):
+        raise ValueError("metadata_filter keys must be exactly 'namespace.key'")
+
+    monkeypatch.setattr(search_route, "hybrid_search", fake_hybrid_search)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await search_route.search(
+            SearchRequest(query="vendor contract", metadata_filter={"too.many.dots": "x"}),
+            principal=Principal(type="user", id=uuid4(), role="admin"),
+            session=object(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "metadata_filter keys" in exc_info.value.detail
+
+
+def test_search_request_rejects_non_object_metadata_filter() -> None:
+    with pytest.raises(ValidationError):
+        SearchRequest.model_validate(
+            {
+                "query": "vendor contract",
+                "metadata_filter": ["email.from_address", "alice@example.com"],
+            }
+        )

--- a/tests/api/test_search_source_ref.py
+++ b/tests/api/test_search_source_ref.py
@@ -1,0 +1,208 @@
+"""REST search and passage SourceRef contract tests."""
+
+from uuid import uuid4
+
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+from harbor_clerk.search_types import SearchHit, SearchResult
+from tests.conftest import auth_header
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "title": "NDA",
+        "canonical_filename": "nda.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "source_path": "/Users/alex/private/contracts/client-a/nda.pdf",
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+async def _add_watched_doc(db_session, *, doc: Document, relative_path: str = "client-a/nda.pdf") -> WatchedFolder:
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    db_session.add(folder)
+    await db_session.flush()
+
+    db_session.add(doc)
+    await db_session.flush()
+
+    db_session.add(
+        WatchedFile(
+            folder_id=folder.folder_id,
+            relative_path=relative_path,
+            bookmark_data=b"",
+            sha256=doc.sha256,
+            doc_id=doc.doc_id,
+            status=WatchedFileStatus.active,
+        )
+    )
+    await db_session.commit()
+    return folder
+
+
+async def test_search_hit_includes_source_and_citation(client, admin_token, db_session, monkeypatch) -> None:
+    doc = _doc()
+    await _add_watched_doc(db_session, doc=doc)
+    chunk_id = uuid4()
+
+    async def fake_hybrid_search(*args, **kwargs):
+        return SearchResult(
+            hits=[
+                SearchHit(
+                    chunk_id=str(chunk_id),
+                    doc_id=str(doc.doc_id),
+                    chunk_num=0,
+                    chunk_text="The NDA terminates on written notice.",
+                    page_start=4,
+                    page_end=5,
+                    language="en",
+                    ocr_used=False,
+                    ocr_confidence=None,
+                    score=0.91,
+                    doc_title="NDA",
+                )
+            ],
+            total_candidates=1,
+            reranker_status="disabled",
+        )
+
+    monkeypatch.setattr("harbor_clerk.api.routes.search.hybrid_search", fake_hybrid_search)
+
+    resp = await client.post(
+        "/api/search",
+        json={"query": "termination"},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    hit = resp.json()["hits"][0]
+    assert hit["doc_id"] == str(doc.doc_id)
+    assert hit["doc_title"] == "NDA"
+    assert hit["page_start"] == 4
+    assert hit["page_end"] == 5
+    assert hit["citation"] == "NDA, pp. 4-5"
+    assert hit["source"]["doc_id"] == str(doc.doc_id)
+    assert hit["source"]["chunk_id"] == str(chunk_id)
+    assert hit["source"]["source_kind"] == "document"
+    assert hit["source"]["folder_label"] == "Contracts"
+    assert hit["source"]["relative_path"] == "client-a/nda.pdf"
+    assert hit["source"]["citation"] == "NDA, pp. 4-5"
+    assert "/Users/alex" not in str(hit["source"])
+
+
+async def test_faceted_search_hit_includes_source(client, admin_token, db_session, monkeypatch) -> None:
+    doc = _doc(title="Policy")
+    await _add_watched_doc(db_session, doc=doc, relative_path="policy.pdf")
+    chunk_id = uuid4()
+
+    async def fake_hybrid_search(*args, **kwargs):
+        return SearchResult(
+            hits=[
+                SearchHit(
+                    chunk_id=str(chunk_id),
+                    doc_id=str(doc.doc_id),
+                    chunk_num=0,
+                    chunk_text="Policy excerpt",
+                    page_start=1,
+                    page_end=1,
+                    language="en",
+                    ocr_used=False,
+                    ocr_confidence=None,
+                    score=0.72,
+                    doc_title="Policy",
+                )
+            ],
+            total_candidates=1,
+            reranker_status="disabled",
+        )
+
+    monkeypatch.setattr("harbor_clerk.api.routes.search.hybrid_search", fake_hybrid_search)
+
+    resp = await client.post(
+        "/api/search",
+        json={"query": "policy", "faceted": True},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    hit = resp.json()["documents"][0]["hits"][0]
+    assert hit["citation"] == "Policy, p. 1"
+    assert hit["source"]["citation"] == "Policy, p. 1"
+
+
+async def test_read_passages_includes_source_and_citation(client, admin_token, db_session) -> None:
+    doc = _doc(title="Operations Manual", canonical_filename="ops.pdf")
+    await _add_watched_doc(db_session, doc=doc, relative_path="manuals/ops.pdf")
+    chunk = Chunk(
+        doc_id=doc.doc_id,
+        chunk_num=0,
+        chunk_text="Use the lockout checklist before maintenance.",
+        page_start=2,
+        page_end=2,
+        language="en",
+        ocr_used=False,
+    )
+    db_session.add(chunk)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/passages/read",
+        json={"chunk_ids": [str(chunk.chunk_id)]},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    passage = resp.json()["passages"][0]
+    assert passage["doc_id"] == str(doc.doc_id)
+    assert passage["citation"] == "Operations Manual, p. 2"
+    assert passage["source"]["chunk_id"] == str(chunk.chunk_id)
+    assert passage["source"]["relative_path"] == "manuals/ops.pdf"
+    assert passage["source"]["citation"] == "Operations Manual, p. 2"
+    assert "/Users/alex" not in str(passage["source"])
+
+
+async def test_read_passages_attachment_source_uses_parent_email(client, admin_token, db_session) -> None:
+    parent = _doc(
+        title="Budget follow-up",
+        canonical_filename="budget-follow-up.eml",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_subject="Budget follow-up",
+    )
+    db_session.add(parent)
+    await db_session.flush()
+
+    attachment = _doc(
+        title="invoice.pdf",
+        canonical_filename="invoice.pdf",
+        mime_type="application/pdf",
+        email_parent_doc_id=parent.doc_id,
+    )
+    await _add_watched_doc(db_session, doc=attachment, relative_path="mail/attachments/invoice.pdf")
+    chunk = Chunk(
+        doc_id=attachment.doc_id,
+        chunk_num=0,
+        chunk_text="Invoice total is due on receipt.",
+        page_start=2,
+        page_end=2,
+        language="en",
+        ocr_used=False,
+    )
+    db_session.add(chunk)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/passages/read",
+        json={"chunk_ids": [str(chunk.chunk_id)]},
+        headers=auth_header(admin_token),
+    )
+
+    assert resp.status_code == 200, resp.text
+    passage = resp.json()["passages"][0]
+    assert passage["source"]["source_kind"] == "attachment"
+    assert passage["citation"] == 'Attachment "invoice.pdf", p. 2, to Email from Jane Doe, "Budget follow-up"'

--- a/tests/cli/test_commands_find_all.py
+++ b/tests/cli/test_commands_find_all.py
@@ -1,0 +1,153 @@
+"""CLI tests for harbor-clerk find-all."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from harbor_clerk.cli import main as cli_main
+
+
+def _run(args, mock_response):
+    """Invoke CLI in-process with a mocked McpHttpClient."""
+    with (
+        patch("harbor_clerk.cli.commands.find_all.McpHttpClient") as MockClient,
+        patch("harbor_clerk.cli.commands.find_all.resolve_config") as MockResolve,
+    ):
+        instance = MagicMock()
+        instance.call_tool.return_value = mock_response
+        instance.__enter__.return_value = instance
+        instance.__exit__.return_value = False
+        MockClient.return_value = instance
+        MockResolve.return_value = MagicMock(url="https://test", api_key="hc_t", insecure=False)
+        rc = cli_main.main(args)
+        return rc, instance
+
+
+_EMPTY = {
+    "results": [],
+    "total_matches": 0,
+    "returned": 0,
+    "offset": 0,
+    "truncated": False,
+    "sort_by": "relevance",
+    "presentation": "brief",
+}
+
+
+def test_find_all_defaults_with_positional_query(capsys):
+    rc, client = _run(["find-all", "termination", "--json"], _EMPTY)
+    assert rc == 0
+    client.call_tool.assert_called_once_with(
+        "kb_find_all",
+        {
+            "query": "termination",
+            "max_results": 100,
+            "offset": 0,
+            "presentation": "brief",
+            "sort_by": "relevance",
+        },
+    )
+    assert json.loads(capsys.readouterr().out) == _EMPTY
+
+
+def test_find_all_query_flag_and_filters_forwarded():
+    rc, client = _run(
+        [
+            "find-all",
+            "--query",
+            "invoice",
+            "--text-contains",
+            "total due",
+            "--max-results",
+            "25",
+            "--offset",
+            "50",
+            "--presentation",
+            "full",
+            "--sort-by",
+            "date_desc",
+            "--doc-ids",
+            "d1,d2",
+            "--after",
+            "2026-01-01",
+            "--before",
+            "2026-02-01",
+            "--language",
+            "fr",
+            "--mime-type",
+            "message/rfc822",
+            "--metadata-filter-json",
+            '{"email.from_address": "alice@example.com"}',
+            "--json",
+        ],
+        _EMPTY,
+    )
+    assert rc == 0
+    args = client.call_tool.call_args.args[1]
+    assert args == {
+        "query": "invoice",
+        "text_contains": "total due",
+        "max_results": 25,
+        "offset": 50,
+        "presentation": "full",
+        "sort_by": "date_desc",
+        "doc_ids": ["d1", "d2"],
+        "after": "2026-01-01",
+        "before": "2026-02-01",
+        "language": "french",
+        "mime_type": "message/rfc822",
+        "metadata_filter": {"email.from_address": "alice@example.com"},
+    }
+
+
+def test_find_all_rejects_missing_query(capsys):
+    rc, client = _run(["find-all", "--json"], _EMPTY)
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "requires a query" in capsys.readouterr().err
+
+
+def test_find_all_rejects_duplicate_query(capsys):
+    rc, client = _run(["find-all", "foo", "--query", "bar", "--json"], _EMPTY)
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "not both" in capsys.readouterr().err
+
+
+def test_find_all_invalid_metadata_filter_exits_1(capsys):
+    rc, client = _run(["find-all", "foo", "--metadata-filter-json", "not-json", "--json"], _EMPTY)
+    assert rc == 1
+    client.call_tool.assert_not_called()
+    assert "--metadata-filter-json must be valid JSON" in capsys.readouterr().err
+
+
+def test_find_all_text_mode_renders_citation_and_top_chunk(capsys):
+    payload = {
+        "results": [
+            {
+                "doc_id": "d1",
+                "doc_title": "Contract A",
+                "citation": "Contract A, p. 4",
+                "score": 0.87,
+                "page_range": "4",
+                "top_chunk": {
+                    "chunk_id": "c1",
+                    "text": "shall terminate",
+                    "page": 4,
+                    "heading": "Termination",
+                },
+            }
+        ],
+        "total_matches": 1,
+        "returned": 1,
+        "offset": 0,
+        "truncated": False,
+        "sort_by": "relevance",
+        "presentation": "full",
+    }
+    rc, _client = _run(["find-all", "terminate", "--format", "text"], payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 of 1 matches" in out
+    assert "Contract A, p. 4" in out
+    assert "chunk=c1" in out
+    assert "shall terminate" in out

--- a/tests/cli/test_e2e.py
+++ b/tests/cli/test_e2e.py
@@ -291,6 +291,19 @@ def test_documents_by_date_help_loads(capsys):
     assert "earliest" in out and "latest" in out
 
 
+def test_find_all_help_loads(capsys):
+    """Test that find-all --help loads correctly from the .txt file."""
+    from harbor_clerk.cli import main as cli_main
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["find-all", "--help"])
+    assert exc.value.code == 0
+
+    out = capsys.readouterr().out
+    assert "find-all" in out
+    assert "Enumerate" in out or "enumerate" in out
+
+
 # ---------------------------------------------------------------------------
 # Test: top-level --help lists new commands
 # ---------------------------------------------------------------------------
@@ -305,5 +318,6 @@ def test_top_level_help_lists_new_commands(capsys):
     assert exc.value.code == 0
 
     out = capsys.readouterr().out
+    assert "find-all" in out
     assert "verify-identifier" in out
     assert "documents-by-date" in out

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -19,11 +19,12 @@ def test_cli_version_flag():
     assert "harbor-clerk-cli/" in out
 
 
-def test_cli_help_flag_lists_all_18_commands():
+def test_cli_help_flag_lists_all_19_commands():
     out, _err, rc = run_cli("--help")
     assert rc == 0
     for cmd in [
         "search",
+        "find-all",
         "batch-search",
         "read-passages",
         "expand-context",

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -53,6 +53,109 @@ def test_render_text_search_results_uses_pretty_printer():
     assert "0.9" in out or "0.90" in out
 
 
+def test_render_text_search_prefers_citation():
+    buf = io.StringIO()
+    payload = {
+        "hits": [
+            {
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "doc_title": "Doc A",
+                "pages": "1",
+                "citation": "Doc A, p. 1",
+                "text": "hello world",
+                "score": 0.9,
+            },
+        ]
+    }
+    render(payload, mode=OutputMode.TEXT, command="search", stream=buf)
+    out = buf.getvalue()
+    assert "Doc A, p. 1" in out
+    assert "chunk=c1" in out
+
+
+def test_render_text_batch_search_uses_citations():
+    buf = io.StringIO()
+    payload = {
+        "results": [
+            {
+                "query": "termination",
+                "hits": [
+                    {
+                        "doc_id": "d1",
+                        "chunk_id": "c1",
+                        "citation": "Contract A, p. 4",
+                        "text": "shall terminate",
+                        "score": 0.87,
+                    }
+                ],
+            }
+        ]
+    }
+    render(payload, mode=OutputMode.TEXT, command="batch-search", stream=buf)
+    out = buf.getvalue()
+    assert "query: termination" in out
+    assert "Contract A, p. 4" in out
+    assert "shall terminate" in out
+
+
+def test_render_text_read_passages_uses_citations():
+    buf = io.StringIO()
+    payload = {
+        "passages": [
+            {
+                "chunk_id": "c1",
+                "doc_id": "d1",
+                "citation": "Manual, p. 2",
+                "text": "Use the lockout checklist.",
+            }
+        ]
+    }
+    render(payload, mode=OutputMode.TEXT, command="read-passages", stream=buf)
+    out = buf.getvalue()
+    assert "Manual, p. 2" in out
+    assert "chunk=c1" in out
+    assert "Use the lockout checklist." in out
+
+
+def test_render_text_verify_identifier_uses_citation():
+    buf = io.StringIO()
+    payload = {
+        "status": "unique",
+        "match": {
+            "doc_id": "d1",
+            "title": "Contract A",
+            "citation": "Contract A",
+            "canonical_filename": "contract-a.pdf",
+        },
+    }
+    render(payload, mode=OutputMode.TEXT, command="verify-identifier", stream=buf)
+    out = buf.getvalue()
+    assert "unique: Contract A" in out
+    assert "filename: contract-a.pdf" in out
+
+
+def test_render_text_documents_by_date_uses_citation():
+    buf = io.StringIO()
+    payload = {
+        "direction": "earliest",
+        "count": 1,
+        "results": [
+            {
+                "doc_id": "d1",
+                "title": "Email title",
+                "citation": 'Email from Jane Doe, "Budget", Mar 7, 2025',
+                "date": "2025-03-07T12:00:00+00:00",
+                "date_source": "tika.created_at",
+            }
+        ],
+    }
+    render(payload, mode=OutputMode.TEXT, command="documents-by-date", stream=buf)
+    out = buf.getvalue()
+    assert 'Email from Jane Doe, "Budget", Mar 7, 2025' in out
+    assert "2025-03-07" in out
+
+
 def test_render_text_search_error_prints_error():
     buf = io.StringIO()
     render({"error": "Cannot specify both doc_id and doc_ids"}, mode=OutputMode.TEXT, command="search", stream=buf)

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -74,6 +74,32 @@ def test_render_text_search_prefers_citation():
     assert "chunk=c1" in out
 
 
+def test_render_text_find_all_uses_citations_and_top_chunk():
+    buf = io.StringIO()
+    payload = {
+        "results": [
+            {
+                "doc_id": "d1",
+                "doc_title": "Contract A",
+                "citation": "Contract A, p. 4",
+                "score": 0.87,
+                "page_range": "4",
+                "top_chunk": {"chunk_id": "c1", "text": "shall terminate"},
+            }
+        ],
+        "total_matches": 1,
+        "returned": 1,
+        "offset": 0,
+        "truncated": False,
+    }
+    render(payload, mode=OutputMode.TEXT, command="find-all", stream=buf)
+    out = buf.getvalue()
+    assert "1 of 1 matches" in out
+    assert "Contract A, p. 4" in out
+    assert "chunk=c1" in out
+    assert "shall terminate" in out
+
+
 def test_render_text_batch_search_uses_citations():
     buf = io.StringIO()
     payload = {

--- a/tests/test_llm_citations.py
+++ b/tests/test_llm_citations.py
@@ -42,6 +42,70 @@ def test_extract_from_kb_search_hits() -> None:
     assert "pages" not in cites[1]
 
 
+def test_extract_from_kb_search_hit_with_source_ref_object() -> None:
+    raw = json.dumps(
+        {
+            "hits": [
+                {
+                    "score": 0.82,
+                    "source": {
+                        "doc_id": "22222222-2222-2222-2222-222222222222",
+                        "doc_title": "Vendor Agreement v3",
+                        "chunk_id": "11111111-1111-1111-1111-111111111111",
+                        "pages": "3-4",
+                        "source_kind": "document",
+                        "source_label": "Vendor Agreement v3",
+                        "citation": "Vendor Agreement v3, pp. 3-4",
+                    },
+                }
+            ]
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert cites == [
+        {
+            "doc_id": "22222222-2222-2222-2222-222222222222",
+            "source": {
+                "doc_id": "22222222-2222-2222-2222-222222222222",
+                "doc_title": "Vendor Agreement v3",
+                "chunk_id": "11111111-1111-1111-1111-111111111111",
+                "pages": "3-4",
+                "source_kind": "document",
+                "source_label": "Vendor Agreement v3",
+                "citation": "Vendor Agreement v3, pp. 3-4",
+            },
+            "doc_title": "Vendor Agreement v3",
+            "chunk_id": "11111111-1111-1111-1111-111111111111",
+            "pages": "3-4",
+            "citation": "Vendor Agreement v3, pp. 3-4",
+            "score": 0.82,
+        }
+    ]
+
+
+def test_extract_preserves_top_level_citation_when_source_also_has_citation() -> None:
+    raw = json.dumps(
+        {
+            "hits": [
+                {
+                    "doc_id": "d1",
+                    "citation": "Top level citation",
+                    "source": {
+                        "doc_id": "d1",
+                        "doc_title": "Doc 1",
+                        "source_kind": "document",
+                        "source_label": "Doc 1",
+                        "citation": "Source citation",
+                    },
+                }
+            ]
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert cites[0]["citation"] == "Top level citation"
+    assert cites[0]["source"]["citation"] == "Source citation"
+
+
 def test_extract_from_kb_batch_search() -> None:
     raw = json.dumps(
         {
@@ -124,6 +188,31 @@ def test_extract_from_kb_find_related() -> None:
     assert [c["doc_id"] for c in cites] == ["r1", "r2"]
 
 
+def test_extract_from_kb_find_related_source_ref_compat_field() -> None:
+    raw = json.dumps(
+        {
+            "doc_id": "ROOT",
+            "related": [
+                {
+                    "doc_id": "r1",
+                    "title": "Related 1",
+                    "source": "linked",
+                    "source_ref": {
+                        "doc_id": "r1",
+                        "doc_title": "Related 1",
+                        "source_kind": "document",
+                        "source_label": "Related 1",
+                        "citation": "Related 1",
+                    },
+                }
+            ],
+        }
+    )
+    cites = extract_citations_from_tool_result(raw)
+    assert cites[0]["source"]["doc_id"] == "r1"
+    assert cites[0]["citation"] == "Related 1"
+
+
 def test_extract_from_kb_get_document() -> None:
     raw = json.dumps(
         {
@@ -199,6 +288,31 @@ def test_dedupe_keeps_highest_score() -> None:
     out = dedupe_citations(cites)
     assert len(out) == 1
     assert out[0]["score"] == 0.9
+
+
+def test_dedupe_keeps_richer_source_when_higher_score_lacks_it() -> None:
+    cites = [
+        {
+            "doc_id": "a",
+            "chunk_id": "x",
+            "score": 0.5,
+            "source": {
+                "doc_id": "a",
+                "doc_title": "A",
+                "chunk_id": "x",
+                "source_kind": "document",
+                "source_label": "A",
+                "citation": "A",
+            },
+            "citation": "A",
+        },
+        {"doc_id": "a", "chunk_id": "x", "score": 0.9},
+    ]
+    out = dedupe_citations(cites)
+    assert len(out) == 1
+    assert out[0]["score"] == 0.9
+    assert out[0]["source"]["doc_id"] == "a"
+    assert out[0]["citation"] == "A"
 
 
 def test_dedupe_doc_only_vs_chunk() -> None:

--- a/tests/test_mcp_source_ref.py
+++ b/tests/test_mcp_source_ref.py
@@ -1,0 +1,224 @@
+"""MCP SourceRef contract tests for high-volume result tools."""
+
+import json
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harbor_clerk.api.deps import Principal
+from harbor_clerk.mcp_server import (
+    _mcp_principal,
+    kb_batch_search,
+    kb_expand_context,
+    kb_find_all,
+    kb_read_passages,
+    kb_search,
+)
+from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+from harbor_clerk.search import FindAllHit, FindAllResult, SearchHit, SearchResult
+
+
+@pytest.fixture
+def mcp_principal(admin_user):
+    token = _mcp_principal.set(Principal(type="user", id=admin_user.user_id, role="admin"))
+    yield
+    _mcp_principal.reset(token)
+
+
+@pytest.fixture
+async def mock_session_factory(db_session: AsyncSession, _engine, monkeypatch):
+    conn = await db_session.connection()
+
+    @asynccontextmanager
+    async def _factory():
+        session = AsyncSession(bind=conn, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.async_session_factory", _factory)
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "title": "NDA",
+        "canonical_filename": "nda.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "mime_type": "application/pdf",
+        "source_path": "/Users/alex/private/contracts/client-a/nda.pdf",
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+async def _add_watched_doc(db_session: AsyncSession, doc: Document, relative_path: str = "client-a/nda.pdf") -> None:
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    db_session.add(folder)
+    await db_session.flush()
+
+    db_session.add(doc)
+    await db_session.flush()
+
+    db_session.add(
+        WatchedFile(
+            folder_id=folder.folder_id,
+            relative_path=relative_path,
+            bookmark_data=b"",
+            sha256=doc.sha256,
+            doc_id=doc.doc_id,
+            status=WatchedFileStatus.active,
+        )
+    )
+    await db_session.flush()
+
+
+def _search_hit(doc: Document, *, chunk_id: uuid.UUID | None = None) -> SearchHit:
+    return SearchHit(
+        chunk_id=str(chunk_id or uuid.uuid4()),
+        doc_id=str(doc.doc_id),
+        chunk_num=0,
+        chunk_text="The NDA terminates on written notice.",
+        page_start=4,
+        page_end=5,
+        language="en",
+        ocr_used=False,
+        ocr_confidence=None,
+        score=0.91,
+        doc_title=doc.title,
+    )
+
+
+async def test_kb_search_hit_includes_source_ref(db_session, mcp_principal, mock_session_factory, monkeypatch) -> None:
+    doc = _doc()
+    await _add_watched_doc(db_session, doc)
+    hit = _search_hit(doc)
+
+    async def fake_hybrid_search(*args, **kwargs):
+        return SearchResult(hits=[hit], total_candidates=1)
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.hybrid_search", fake_hybrid_search)
+
+    payload = json.loads(await kb_search("termination"))
+    result_hit = payload["hits"][0]
+
+    assert result_hit["citation"] == "NDA, pp. 4-5"
+    assert result_hit["source"]["doc_id"] == str(doc.doc_id)
+    assert result_hit["source"]["chunk_id"] == hit.chunk_id
+    assert result_hit["source"]["folder_label"] == "Contracts"
+    assert result_hit["source"]["relative_path"] == "client-a/nda.pdf"
+    assert "/Users/alex" not in json.dumps(result_hit)
+
+
+async def test_kb_batch_search_hits_include_source_ref(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+    monkeypatch,
+) -> None:
+    doc = _doc(title="Policy")
+    await _add_watched_doc(db_session, doc, relative_path="policies/policy.pdf")
+    hit = _search_hit(doc)
+
+    async def fake_hybrid_search(*args, **kwargs):
+        return SearchResult(hits=[hit], total_candidates=1)
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.hybrid_search", fake_hybrid_search)
+
+    payload = json.loads(await kb_batch_search(["policy"]))
+    result_hit = payload["results"][0]["hits"][0]
+
+    assert result_hit["citation"] == "Policy, pp. 4-5"
+    assert result_hit["source"]["relative_path"] == "policies/policy.pdf"
+    assert "/Users/alex" not in json.dumps(result_hit)
+
+
+async def test_kb_find_all_result_includes_source_ref(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+    monkeypatch,
+) -> None:
+    doc = _doc(title="Operations Manual")
+    await _add_watched_doc(db_session, doc, relative_path="manuals/ops.pdf")
+
+    async def fake_find_all(*args, **kwargs):
+        return FindAllResult(
+            hits=[
+                FindAllHit(
+                    doc_id=str(doc.doc_id),
+                    doc_title="Operations Manual",
+                    mime_type="application/pdf",
+                    language="en",
+                    score=0.88,
+                    ingested_at=datetime(2026, 6, 3, tzinfo=UTC),
+                    page_range="2",
+                    top_chunk_id=str(uuid.uuid4()),
+                    top_chunk_text="Use the lockout checklist before maintenance.",
+                    top_chunk_page=2,
+                    top_chunk_heading="Safety",
+                )
+            ],
+            total_matches=1,
+            offset=0,
+            truncated=False,
+            sort_by="relevance",
+            presentation="full",
+        )
+
+    monkeypatch.setattr("harbor_clerk.mcp_server.find_all", fake_find_all)
+
+    payload = json.loads(await kb_find_all("lockout", presentation="full"))
+    result = payload["results"][0]
+
+    assert result["citation"] == "Operations Manual, p. 2"
+    assert result["source"]["section"] == "Safety"
+    assert result["source"]["relative_path"] == "manuals/ops.pdf"
+    assert result["top_chunk"]["heading"] == "Safety"
+    assert "/Users/alex" not in json.dumps(result)
+
+
+async def test_kb_read_passages_and_expand_context_include_source_refs(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+) -> None:
+    doc = _doc(title="Runbook")
+    await _add_watched_doc(db_session, doc, relative_path="runbooks/main.pdf")
+    chunks = []
+    for i in range(3):
+        chunk = Chunk(
+            doc_id=doc.doc_id,
+            chunk_num=i,
+            chunk_text=f"Runbook chunk {i}",
+            page_start=i + 1,
+            page_end=i + 1,
+            language="en",
+            ocr_used=False,
+        )
+        db_session.add(chunk)
+        chunks.append(chunk)
+    await db_session.flush()
+
+    read_payload = json.loads(await kb_read_passages([str(chunks[1].chunk_id)]))
+    passage = read_payload["passages"][0]
+    assert passage["doc_id"] == str(doc.doc_id)
+    assert passage["citation"] == "Runbook, p. 2"
+    assert passage["source"]["chunk_id"] == str(chunks[1].chunk_id)
+    assert passage["source"]["relative_path"] == "runbooks/main.pdf"
+
+    expand_payload = json.loads(await kb_expand_context(str(chunks[1].chunk_id), n=1))
+    target = next(chunk for chunk in expand_payload["chunks"] if chunk.get("is_target"))
+    assert target["citation"] == "Runbook, p. 2"
+    assert target["source"]["chunk_id"] == str(chunks[1].chunk_id)
+    assert target["source"]["relative_path"] == "runbooks/main.pdf"
+    assert "/Users/alex" not in json.dumps(read_payload)
+    assert "/Users/alex" not in json.dumps(expand_payload)

--- a/tests/test_mcp_source_ref.py
+++ b/tests/test_mcp_source_ref.py
@@ -12,12 +12,19 @@ from harbor_clerk.api.deps import Principal
 from harbor_clerk.mcp_server import (
     _mcp_principal,
     kb_batch_search,
+    kb_corpus_overview,
+    kb_document_outline,
+    kb_documents_by_date,
     kb_expand_context,
     kb_find_all,
+    kb_find_related,
+    kb_get_document,
+    kb_list_recent,
     kb_read_passages,
     kb_search,
+    kb_verify_identifier,
 )
-from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models import Chunk, Document, DocumentLink
 from harbor_clerk.models.enums import PipelineStatus
 from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
 from harbor_clerk.search import FindAllHit, FindAllResult, SearchHit, SearchResult
@@ -222,3 +229,109 @@ async def test_kb_read_passages_and_expand_context_include_source_refs(
     assert target["source"]["relative_path"] == "runbooks/main.pdf"
     assert "/Users/alex" not in json.dumps(read_payload)
     assert "/Users/alex" not in json.dumps(expand_payload)
+
+
+async def test_kb_get_document_includes_source_ref(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+) -> None:
+    doc = _doc(title="Board Packet")
+    await _add_watched_doc(db_session, doc, relative_path="board/packet.pdf")
+
+    payload = json.loads(await kb_get_document(str(doc.doc_id)))
+
+    assert payload["citation"] == "Board Packet"
+    assert payload["source"]["doc_id"] == str(doc.doc_id)
+    assert payload["source"]["relative_path"] == "board/packet.pdf"
+    assert "source_path" not in payload
+    assert "/Users/alex" not in json.dumps(payload)
+
+
+async def test_kb_list_recent_and_corpus_overview_document_rows_include_source_refs(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+) -> None:
+    doc = _doc(title="Recent Contract")
+    await _add_watched_doc(db_session, doc, relative_path="recent/contract.pdf")
+
+    recent = json.loads(await kb_list_recent(limit=5))
+    recent_row = next(row for row in recent["documents"] if row["doc_id"] == str(doc.doc_id))
+    assert recent_row["citation"] == "Recent Contract"
+    assert recent_row["source"]["relative_path"] == "recent/contract.pdf"
+
+    overview = json.loads(await kb_corpus_overview(limit=5))
+    overview_row = next(row for row in overview["documents"] if row["doc_id"] == str(doc.doc_id))
+    assert overview_row["citation"] == "Recent Contract"
+    assert overview_row["source"]["relative_path"] == "recent/contract.pdf"
+    assert "/Users/alex" not in json.dumps(overview_row)
+
+
+async def test_kb_document_outline_includes_source_ref(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+) -> None:
+    doc = _doc(title="Manual")
+    await _add_watched_doc(db_session, doc, relative_path="manuals/main.pdf")
+
+    payload = json.loads(await kb_document_outline(str(doc.doc_id)))
+
+    assert payload["citation"] == "Manual"
+    assert payload["source"]["relative_path"] == "manuals/main.pdf"
+
+
+async def test_kb_find_related_preserves_legacy_source_and_adds_source_ref(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+) -> None:
+    source_doc = _doc(title="Source")
+    related_doc = _doc(title="Related", sha256=b"y" * 32)
+    await _add_watched_doc(db_session, source_doc, relative_path="source.pdf")
+    await _add_watched_doc(db_session, related_doc, relative_path="related.pdf")
+    db_session.add(
+        DocumentLink(
+            src_doc_id=source_doc.doc_id,
+            target_doc_id=related_doc.doc_id,
+            link_text="Related",
+            target_title="related",
+            resolved=True,
+        )
+    )
+    await db_session.flush()
+
+    payload = json.loads(await kb_find_related(str(source_doc.doc_id)))
+    related = payload["related"][0]
+
+    assert related["source"] == "linked"
+    assert related["citation"] == "Related"
+    assert related["source_ref"]["doc_id"] == str(related_doc.doc_id)
+    assert related["source_ref"]["relative_path"] == "related.pdf"
+
+
+async def test_kb_verify_identifier_and_documents_by_date_rows_include_source_refs(
+    db_session,
+    mcp_principal,
+    mock_session_factory,
+) -> None:
+    doc = _doc(
+        title="Pinnacle Contract",
+        canonical_filename="pinnacle.pdf",
+        doc_metadata={"tika": {"created_at": "2024-01-01T00:00:00Z"}},
+    )
+    await _add_watched_doc(db_session, doc, relative_path="contracts/pinnacle.pdf")
+    db_session.add(Chunk(doc_id=doc.doc_id, chunk_num=0, chunk_text="California contract", language="english"))
+    await db_session.flush()
+
+    verified = json.loads(await kb_verify_identifier("Pinnacle Contract"))
+    assert verified["status"] == "unique"
+    assert verified["match"]["citation"] == "Pinnacle Contract"
+    assert verified["match"]["source"]["relative_path"] == "contracts/pinnacle.pdf"
+
+    by_date = json.loads(await kb_documents_by_date(direction="earliest", query="California", limit=5))
+    row = next(row for row in by_date["results"] if row["doc_id"] == str(doc.doc_id))
+    assert row["citation"] == "Pinnacle Contract"
+    assert row["source"]["relative_path"] == "contracts/pinnacle.pdf"
+    assert "/Users/alex" not in json.dumps(row)

--- a/tests/test_source_ref.py
+++ b/tests/test_source_ref.py
@@ -1,0 +1,189 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFolder
+from harbor_clerk.source_ref import (
+    build_source_ref,
+    format_document_citation,
+    format_email_citation,
+    format_pages,
+)
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "doc_id": uuid4(),
+        "title": "Contract A",
+        "canonical_filename": "contract-a.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+def test_format_pages() -> None:
+    assert format_pages(None) is None
+    assert format_pages(4) == "4"
+    assert format_pages(4, 4) == "4"
+    assert format_pages(4, 5) == "4-5"
+
+
+def test_format_document_citation_single_page_and_range() -> None:
+    assert format_document_citation("Contract A", "4") == "Contract A, p. 4"
+    assert format_document_citation("Contract A", "4-5") == "Contract A, pp. 4-5"
+    assert format_document_citation("Contract A") == "Contract A"
+
+
+def test_document_source_ref() -> None:
+    doc = _doc(title="Contract A")
+    ref = build_source_ref(doc=doc, chunk_id=str(uuid4()), pages="4-5", section="Termination")
+
+    payload = ref.to_dict()
+    assert payload["doc_id"] == str(doc.doc_id)
+    assert payload["doc_title"] == "Contract A"
+    assert payload["source_kind"] == "document"
+    assert payload["source_label"] == "Contract A"
+    assert payload["citation"] == "Contract A, pp. 4-5"
+    assert payload["pages"] == "4-5"
+    assert payload["section"] == "Termination"
+
+
+def test_document_title_falls_back_to_filename_then_untitled() -> None:
+    with_filename = _doc(title="", canonical_filename="fallback.pdf")
+    assert build_source_ref(doc=with_filename).citation == "fallback.pdf"
+
+    untitled = _doc(title="", canonical_filename=None)
+    assert build_source_ref(doc=untitled).citation == "Untitled document"
+
+
+def test_email_citation_uses_native_metadata() -> None:
+    sent = datetime(2025, 3, 7, 14, 30, tzinfo=UTC)
+    doc = _doc(
+        title="Budget follow-up",
+        canonical_filename="budget-follow-up.eml",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_from_address="jane@example.com",
+        email_subject="Budget follow-up",
+        email_date_sent=sent,
+    )
+
+    ref = build_source_ref(doc=doc)
+
+    assert ref.source_kind == "email"
+    assert ref.citation == 'Email from Jane Doe, "Budget follow-up", Mar 7, 2025'
+    assert ref.source_label == ref.citation
+
+
+def test_email_citation_handles_missing_sender() -> None:
+    assert (
+        format_email_citation(subject="Budget follow-up", date_sent="2025-03-07T00:00:00+00:00")
+        == 'Email, "Budget follow-up", Mar 7, 2025'
+    )
+
+
+def test_email_source_ref_falls_back_to_tika_metadata() -> None:
+    doc = _doc(
+        title="legacy",
+        canonical_filename="legacy.eml",
+        mime_type="message/rfc822",
+        email_subject=None,
+        doc_metadata={
+            "tika": {
+                "email_from": "alice@example.com",
+                "email_subject": "Legacy email",
+                "email_date": "Wed, 28 May 2026 12:00:00 +0000",
+            }
+        },
+    )
+
+    ref = build_source_ref(doc=doc)
+
+    assert ref.source_kind == "email"
+    assert ref.citation == 'Email from alice@example.com, "Legacy email", May 28, 2026'
+
+
+def test_eml_with_unparsed_metadata_falls_back_to_file_metadata() -> None:
+    doc = _doc(
+        title="legacy",
+        canonical_filename="legacy.eml",
+        mime_type="message/rfc822",
+        email_subject=None,
+        doc_metadata={},
+    )
+
+    ref = build_source_ref(doc=doc)
+
+    assert ref.source_kind == "email"
+    assert ref.citation == "legacy"
+
+
+def test_attachment_citation_includes_parent_email() -> None:
+    parent = _doc(
+        title="Budget follow-up",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_subject="Budget follow-up",
+        email_date_sent=datetime(2025, 3, 7, tzinfo=UTC),
+    )
+    child = _doc(
+        title="invoice.pdf",
+        canonical_filename="invoice.pdf",
+        mime_type="application/pdf",
+        email_parent_doc_id=parent.doc_id,
+    )
+
+    ref = build_source_ref(doc=child, pages="2", parent_email_doc=parent)
+
+    assert ref.source_kind == "attachment"
+    assert ref.source_label == "invoice.pdf"
+    assert ref.citation == 'Attachment "invoice.pdf", p. 2, to Email from Jane Doe, "Budget follow-up", Mar 7, 2025'
+
+
+def test_folder_label_and_relative_path_are_included_without_absolute_path() -> None:
+    doc = _doc(title="NDA")
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    watched_file = WatchedFile(
+        folder_id=uuid4(),
+        relative_path="client-a/nda.pdf",
+        bookmark_data=b"",
+        sha256=b"x" * 32,
+        doc_id=doc.doc_id,
+    )
+
+    payload = build_source_ref(doc=doc, watched_file=watched_file, watched_folder=folder).to_dict()
+
+    assert payload["folder_label"] == "Contracts"
+    assert payload["relative_path"] == "client-a/nda.pdf"
+    assert "/Users/alex" not in str(payload)
+
+
+def test_absolute_relative_path_degrades_to_filename() -> None:
+    doc = _doc(title="")
+    watched_file = WatchedFile(
+        folder_id=uuid4(),
+        relative_path="/Users/alex/private/secret.pdf",
+        bookmark_data=b"",
+        sha256=b"x" * 32,
+        doc_id=doc.doc_id,
+    )
+
+    payload = build_source_ref(doc=doc, watched_file=watched_file).to_dict()
+
+    assert payload["relative_path"] == "secret.pdf"
+    assert "/Users/alex" not in str(payload)
+
+
+def test_to_dict_omits_empty_optional_fields() -> None:
+    payload = build_source_ref(doc=_doc()).to_dict()
+
+    assert "chunk_id" not in payload
+    assert "pages" not in payload
+    assert "section" not in payload
+    assert "None" not in str(payload)
+    assert "null" not in str(payload)

--- a/tests/test_source_ref.py
+++ b/tests/test_source_ref.py
@@ -179,6 +179,23 @@ def test_absolute_relative_path_degrades_to_filename() -> None:
     assert "/Users/alex" not in str(payload)
 
 
+def test_windows_absolute_relative_path_degrades_to_filename() -> None:
+    doc = _doc(title="")
+    watched_file = WatchedFile(
+        folder_id=uuid4(),
+        relative_path=r"C:\Users\alex\private\secret.pdf",
+        bookmark_data=b"",
+        sha256=b"x" * 32,
+        doc_id=doc.doc_id,
+    )
+
+    payload = build_source_ref(doc=doc, watched_file=watched_file).to_dict()
+
+    assert payload["relative_path"] == "secret.pdf"
+    assert "C:" not in str(payload)
+    assert "Users" not in str(payload)
+
+
 def test_to_dict_omits_empty_optional_fields() -> None:
     payload = build_source_ref(doc=_doc()).to_dict()
 

--- a/tests/test_source_ref_context.py
+++ b/tests/test_source_ref_context.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from harbor_clerk.models.document import Document
 from harbor_clerk.models.enums import PipelineStatus
@@ -96,6 +97,27 @@ async def test_context_handles_missing_watched_rows(db_session) -> None:
     assert payload["citation"] == "Loose Document"
     assert "folder_label" not in payload
     assert "relative_path" not in payload
+
+
+@pytest.mark.asyncio
+async def test_context_soft_fails_watched_lookup_without_poisoning_session(db_session) -> None:
+    doc = _doc(title="Loose Document")
+    db_session.add(doc)
+    await db_session.flush()
+
+    original_name = WatchedFile.__table__.name
+    WatchedFile.__table__.name = "watched_files_missing_for_source_ref_test"
+    try:
+        ctx = await load_source_ref_context(db_session, [doc.doc_id])
+        ref = ctx.ref_for_doc(doc.doc_id)
+
+        assert ref.citation == "Loose Document"
+        # The optional watched-folder lookup failed, but the caller's session
+        # must remain usable for later route/tool queries.
+        loaded_doc_id = await db_session.scalar(select(Document.doc_id).where(Document.doc_id == doc.doc_id))
+        assert loaded_doc_id == doc.doc_id
+    finally:
+        WatchedFile.__table__.name = original_name
 
 
 @pytest.mark.asyncio

--- a/tests/test_source_ref_context.py
+++ b/tests/test_source_ref_context.py
@@ -1,0 +1,111 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from harbor_clerk.models.document import Document
+from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models.watched import WatchedFile, WatchedFileStatus, WatchedFolder
+from harbor_clerk.source_ref import load_source_ref_context
+
+
+def _doc(**kwargs) -> Document:
+    defaults = {
+        "title": "Contract A",
+        "canonical_filename": "contract-a.pdf",
+        "status": "active",
+        "sha256": b"x" * 32,
+        "pipeline_status": PipelineStatus.ready,
+        "doc_metadata": {},
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_context_loads_folder_label_and_relative_path(db_session) -> None:
+    folder = WatchedFolder(path="/Users/alex/private/contracts", display_name="Contracts")
+    db_session.add(folder)
+    await db_session.flush()
+
+    doc = _doc(title="NDA", source_path="/Users/alex/private/contracts/client-a/nda.pdf")
+    db_session.add(doc)
+    await db_session.flush()
+
+    db_session.add(
+        WatchedFile(
+            folder_id=folder.folder_id,
+            relative_path="client-a/nda.pdf",
+            bookmark_data=b"",
+            sha256=doc.sha256,
+            doc_id=doc.doc_id,
+            status=WatchedFileStatus.active,
+        )
+    )
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [doc.doc_id])
+    ref = ctx.ref_for_doc(doc.doc_id)
+    payload = ref.to_dict()
+
+    assert payload["folder_label"] == "Contracts"
+    assert payload["relative_path"] == "client-a/nda.pdf"
+    assert payload["citation"] == "NDA"
+    assert "/Users/alex" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_context_loads_parent_email_for_attachment(db_session) -> None:
+    parent = _doc(
+        title="Budget follow-up",
+        canonical_filename="budget-follow-up.eml",
+        mime_type="message/rfc822",
+        email_from_name="Jane Doe",
+        email_subject="Budget follow-up",
+        email_date_sent=datetime(2025, 3, 7, tzinfo=UTC),
+    )
+    db_session.add(parent)
+    await db_session.flush()
+
+    attachment = _doc(
+        title="invoice.pdf",
+        canonical_filename="invoice.pdf",
+        mime_type="application/pdf",
+        email_parent_doc_id=parent.doc_id,
+    )
+    db_session.add(attachment)
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [attachment.doc_id])
+    ref = ctx.ref_for_doc(attachment.doc_id, pages="2")
+
+    assert ref.source_kind == "attachment"
+    assert ref.citation == 'Attachment "invoice.pdf", p. 2, to Email from Jane Doe, "Budget follow-up", Mar 7, 2025'
+
+
+@pytest.mark.asyncio
+async def test_context_handles_missing_watched_rows(db_session) -> None:
+    doc = _doc(title="Loose Document")
+    db_session.add(doc)
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [doc.doc_id])
+    ref = ctx.ref_for_doc(doc.doc_id)
+    payload = ref.to_dict()
+
+    assert payload["citation"] == "Loose Document"
+    assert "folder_label" not in payload
+    assert "relative_path" not in payload
+
+
+@pytest.mark.asyncio
+async def test_context_accepts_string_doc_ids(db_session) -> None:
+    doc = _doc(title="String id")
+    db_session.add(doc)
+    await db_session.flush()
+
+    ctx = await load_source_ref_context(db_session, [str(doc.doc_id)])
+    ref = ctx.ref_for_doc(str(doc.doc_id), chunk_id=uuid4(), pages="1")
+
+    assert ref.doc_id == str(doc.doc_id)
+    assert ref.citation == "String id, p. 1"


### PR DESCRIPTION
## Summary
- Adds qualitative guidance labels for curated local models on the Models page.
- Adds short notes and caution copy for smaller models so users understand quick lookup vs research/synthesis tradeoffs.
- Updates the Models page intro copy to frame local AI as useful while emphasizing citation verification.
- Adds a small utility/test for model guidance labels and fallback behavior.

## Tests
- `npm run test -- ModelsPage.test.tsx --run`
- `npm run type-check`
- `npx eslint src/pages/ModelsPage.tsx src/pages/ModelsPage.test.tsx src/utils/modelGuidance.ts`
- `npx prettier --check src/pages/ModelsPage.tsx src/pages/ModelsPage.test.tsx src/utils/modelGuidance.ts`
- `npm run build` (existing Vite chunk-size warning only)