### PR TITLE
feat(status): add recovery summary surface

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -25,6 +25,7 @@ interface SavedDocsState {
   entityTypeFilter: string
   entityInput: string
   folderFilter: string
+  pipelineStatusFilter: string
   sortField: 'updated' | 'created' | 'title'
   sortDir: 'asc' | 'desc'
   scrollY: number
@@ -208,7 +209,8 @@ export default function DocumentsPage() {
     searchParams.has('mime_type') ||
     searchParams.has('language') ||
     searchParams.has('doc_type') ||
-    searchParams.has('entity_type')
+    searchParams.has('entity_type') ||
+    searchParams.has('pipeline_status')
 
   // Helper: read a field from saved state or URL params
   function initField<K extends keyof SavedDocsState>(
@@ -248,6 +250,9 @@ export default function DocumentsPage() {
   const [entityFilter, setEntityFilter] = useState(() => initField('entityFilter', '', 'entity'))
   const [entityTypeFilter, setEntityTypeFilter] = useState(() => initField('entityTypeFilter', '', 'entity_type'))
   const [folderFilter, setFolderFilter] = useState<string>(() => initField('folderFilter', '', 'folder'))
+  const [pipelineStatusFilter, setPipelineStatusFilter] = useState<string>(() =>
+    initField('pipelineStatusFilter', '', 'pipeline_status'),
+  )
   const [folderOptions, setFolderOptions] = useState<
     { folder_id: string; display_name: string | null; path: string }[]
   >([])
@@ -319,6 +324,7 @@ export default function DocumentsPage() {
       entityTypeFilter,
       entityInput,
       folderFilter,
+      pipelineStatusFilter,
       sortField,
       sortDir,
       scrollY: window.scrollY,
@@ -337,6 +343,7 @@ export default function DocumentsPage() {
     entityTypeFilter,
     entityInput,
     folderFilter,
+    pipelineStatusFilter,
     sortField,
     sortDir,
     expanded,
@@ -411,6 +418,7 @@ export default function DocumentsPage() {
       if (docTypeFilter) params.doc_type = docTypeFilter
       if (entityFilter) params.entity = entityFilter
       if (entityTypeFilter) params.entity_type = entityTypeFilter
+      if (pipelineStatusFilter) params.pipeline_status = pipelineStatusFilter
       return get<PaginatedDocs>('/api/docs', params)
         .then((data) => {
           setDocs(data.items)
@@ -426,7 +434,7 @@ export default function DocumentsPage() {
           }
         })
     },
-    [sortField, sortDir, mimeFilter, langFilter, docTypeFilter, entityFilter, entityTypeFilter],
+    [sortField, sortDir, mimeFilter, langFilter, docTypeFilter, entityFilter, entityTypeFilter, pipelineStatusFilter],
   )
 
   useEffect(() => {
@@ -585,7 +593,16 @@ export default function DocumentsPage() {
   const visibleDocs = folderFilter ? docs.filter((d) => d.folder_name === folderFilter) : docs
   const visibleDocIds = new Set(visibleDocs.map((d) => d.doc_id))
   const startIdx = (currentPage - 1) * pageSize
-  const hasFilters = !!(filter || mimeFilter || langFilter || docTypeFilter || entityFilter)
+  const hasFilters = !!(
+    filter ||
+    mimeFilter ||
+    langFilter ||
+    docTypeFilter ||
+    entityFilter ||
+    entityTypeFilter ||
+    folderFilter ||
+    pipelineStatusFilter
+  )
 
   let lastDoc: { doc_id: string; title: string } | null = null
   try {
@@ -648,7 +665,9 @@ export default function DocumentsPage() {
         </div>
       )}
       {/* Filter bar */}
-      {(filterOptions.mime_types.length > 0 ||
+      {(total > 0 ||
+        pipelineStatusFilter ||
+        filterOptions.mime_types.length > 0 ||
         filterOptions.doc_types.length > 0 ||
         filterOptions.languages.length > 0) && (
         <div className="mb-3 flex flex-wrap items-center gap-2">
@@ -773,6 +792,22 @@ export default function DocumentsPage() {
             </select>
           )}
 
+          <select
+            value={pipelineStatusFilter}
+            onChange={(e) => {
+              setPipelineStatusFilter(e.target.value)
+              setCurrentPage(1)
+            }}
+            className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+          >
+            <option value="">All statuses</option>
+            <option value="ready">Ready</option>
+            <option value="queued,extracting,extracted,ocr_running,ocr_done,chunking,chunked,extracting_entities,entities_done,embedding,embedded,summarizing,summarized,finalizing">
+              Processing
+            </option>
+            <option value="error">Failed</option>
+          </select>
+
           {/* Sort controls */}
           <div className="ml-auto flex items-center gap-1 text-xs text-gray-400">
             <span>Sort:</span>
@@ -801,13 +836,20 @@ export default function DocumentsPage() {
           </div>
 
           {/* Clear all filters */}
-          {(mimeFilter || langFilter || docTypeFilter || entityFilter || entityTypeFilter || folderFilter) && (
+          {(mimeFilter ||
+            langFilter ||
+            docTypeFilter ||
+            entityFilter ||
+            entityTypeFilter ||
+            folderFilter ||
+            pipelineStatusFilter) && (
             <button
               onClick={() => {
                 setMimeFilter('')
                 setLangFilter('')
                 setDocTypeFilter('')
                 setFolderFilter('')
+                setPipelineStatusFilter('')
                 clearEntityFilter()
                 setCurrentPage(1)
               }}

--- a/frontend/src/pages/SystemStatusPage.test.tsx
+++ b/frontend/src/pages/SystemStatusPage.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get, post } from '../api'
+import { listMailAccounts } from '../api/mail'
+import { useLLMStatusContext } from '../components/LLMStatusBanner'
+import SystemStatusPage from './SystemStatusPage'
+
+vi.mock('../api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+vi.mock('../api/mail', () => ({
+  listMailAccounts: vi.fn(),
+}))
+
+vi.mock('../components/LLMStatusBanner', () => ({
+  useLLMStatusContext: vi.fn(),
+}))
+
+const getMock = vi.mocked(get)
+const postMock = vi.mocked(post)
+const listMailAccountsMock = vi.mocked(listMailAccounts)
+const useLLMStatusContextMock = vi.mocked(useLLMStatusContext)
+
+const HEALTHY = {
+  status: 'healthy',
+  checks: {
+    postgres: 'ok',
+    storage: 'ok',
+    tika: 'ok',
+    reranker: 'ok',
+  },
+}
+
+const SUMMARY = {
+  state: 'needs_attention',
+  counts: {
+    active_documents: 3,
+    ready_documents: 1,
+    processing_documents: 1,
+    failed_documents: 1,
+    queued_jobs: 2,
+    running_jobs: 1,
+    failed_jobs: 1,
+    watched_folders: 1,
+    unavailable_folders: 0,
+    ner_skipped_documents: 0,
+    stuck_jobs: 1,
+  },
+  needs_attention: [
+    {
+      kind: 'failed_documents',
+      severity: 'error',
+      title: 'Documents failed ingest',
+      detail: '1 active document needs review.',
+      count: 1,
+      action_label: 'Review failed documents',
+      action_href: '/docs?pipeline_status=error',
+    },
+    {
+      kind: 'stuck_jobs',
+      severity: 'error',
+      title: 'Processing jobs may be stuck',
+      detail: '1 running job appears stale.',
+      count: 1,
+      action_label: 'Recover stuck jobs',
+      action_kind: 'reaper',
+    },
+  ],
+  recent_failed_documents: [
+    {
+      doc_id: 'doc-1',
+      title: 'Broken scan',
+      pipeline_status: 'error',
+      error: 'Tika failed',
+      failed_stage: 'extract',
+      updated_at: '2026-06-04T12:00:00Z',
+    },
+  ],
+  recent_processing_documents: [
+    {
+      doc_id: 'doc-2',
+      title: 'Still embedding',
+      pipeline_status: 'embedding',
+      updated_at: '2026-06-04T12:01:00Z',
+    },
+  ],
+}
+
+function mockRequests(summary = SUMMARY) {
+  getMock.mockImplementation((url) => {
+    if (url === '/api/system/health') return Promise.resolve(HEALTHY)
+    if (url === '/api/system/status-summary') return Promise.resolve(summary)
+    if (url === '/api/system/stats') return Promise.resolve({})
+    return Promise.reject(new Error(`Unexpected URL: ${url}`))
+  })
+  postMock.mockResolvedValue({ reaped: 1 })
+  listMailAccountsMock.mockResolvedValue([])
+  useLLMStatusContextMock.mockReturnValue({
+    status: { state: 'ready', model_id: 'qwen3', model_name: 'Qwen3' },
+    markTransitioning: vi.fn(),
+  })
+}
+
+function renderStatusPage() {
+  render(
+    <MemoryRouter>
+      <SystemStatusPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SystemStatusPage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    postMock.mockReset()
+    listMailAccountsMock.mockReset()
+    useLLMStatusContextMock.mockReset()
+  })
+
+  it('renders needs-attention recovery actions and failed document links', async () => {
+    mockRequests()
+
+    renderStatusPage()
+
+    expect(await screen.findByText('Documents failed ingest')).toBeInTheDocument()
+    const reviewLink = screen.getByRole('link', { name: 'Review failed documents' })
+    expect(reviewLink).toHaveAttribute('href', '/docs?pipeline_status=error')
+    expect(screen.getByText('Broken scan')).toBeInTheDocument()
+    expect(screen.getByText('Still embedding')).toBeInTheDocument()
+  })
+
+  it('runs the reaper action from a stuck-job issue', async () => {
+    mockRequests()
+
+    renderStatusPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Recover stuck jobs' }))
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledWith('/api/system/reaper-run'))
+    expect(await screen.findByText('Recovered 1 stale job.')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from 'react'
-import { get } from '../api'
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { get, post } from '../api'
 import { listMailAccounts } from '../api/mail'
 import type { MailAccountResponse } from '../types/mail'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'
-import { StatusPill } from '../components/StatusPill'
+import { StatusPill, type PillState } from '../components/StatusPill'
+import { useLLMStatusContext } from '../components/LLMStatusBanner'
 
 interface HealthCheck {
   status: string
@@ -25,6 +27,47 @@ interface StatsResponse {
   storage?: ServiceStats
 }
 
+interface StatusIssue {
+  kind: string
+  severity: 'error' | 'warning'
+  title: string
+  detail: string
+  count?: number
+  action_label?: string
+  action_href?: string
+  action_kind?: 'reaper'
+}
+
+interface StatusDoc {
+  doc_id: string
+  title: string
+  canonical_filename?: string | null
+  pipeline_status: string
+  error?: string | null
+  failed_stage?: string | null
+  updated_at?: string | null
+}
+
+interface StatusSummary {
+  state: 'ready' | 'processing' | 'needs_attention'
+  counts: {
+    active_documents: number
+    ready_documents: number
+    processing_documents: number
+    failed_documents: number
+    queued_jobs: number
+    running_jobs: number
+    failed_jobs: number
+    watched_folders: number
+    unavailable_folders: number
+    ner_skipped_documents: number
+    stuck_jobs: number
+  }
+  needs_attention: StatusIssue[]
+  recent_failed_documents: StatusDoc[]
+  recent_processing_documents: StatusDoc[]
+}
+
 const STAT_LABELS: Record<string, string> = {
   db_size_mb: 'DB Size',
   active_connections: 'Connections',
@@ -38,19 +81,40 @@ const STAT_LABELS: Record<string, string> = {
 }
 
 function formatStatValue(key: string, value: number | string | null | undefined): string {
-  if (value == null) return '\u2014'
+  if (value == null) return '-'
   if (typeof value === 'string') return value
   if (key.endsWith('_mb')) return `${value} MB`
   if (key === 'cache_hit_ratio') return `${(value * 100).toFixed(1)}%`
   return value.toLocaleString()
 }
 
+function stateLabel(state?: StatusSummary['state']): string {
+  if (state === 'needs_attention') return 'Needs attention'
+  if (state === 'processing') return 'Processing'
+  return 'Ready'
+}
+
+function statePill(state?: StatusSummary['state']): PillState {
+  if (state === 'needs_attention') return 'error'
+  if (state === 'processing') return 'running'
+  return 'active'
+}
+
+function serviceIsOk(status?: string): boolean {
+  return status === 'ok' || status === 'disabled'
+}
+
 export default function SystemStatusPage() {
+  const { status: llmStatus } = useLLMStatusContext()
   const [health, setHealth] = useState<HealthCheck | null>(null)
   const [stats, setStats] = useState<StatsResponse | null>(null)
+  const [summary, setSummary] = useState<StatusSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [statsLoading, setStatsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [actionResult, setActionResult] = useState('')
+  const [reaperRunning, setReaperRunning] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   async function loadHealth() {
     try {
@@ -58,8 +122,15 @@ export default function SystemStatusPage() {
       setHealth(data)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load health')
-    } finally {
-      setLoading(false)
+    }
+  }
+
+  async function loadSummary() {
+    try {
+      const data = await get<StatusSummary>('/api/system/status-summary')
+      setSummary(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load status')
     }
   }
 
@@ -69,35 +140,103 @@ export default function SystemStatusPage() {
       const data = await get<StatsResponse>('/api/system/stats')
       setStats(data)
     } catch {
-      // Stats are non-critical; silently ignore (user may not be admin)
+      // Stats are diagnostic-only; status recovery should still render.
     } finally {
       setStatsLoading(false)
     }
   }
 
+  async function reloadStatusData() {
+    await Promise.all([loadHealth(), loadSummary(), loadStats()])
+    setLoading(false)
+  }
+
   useEffect(() => {
-    async function run() {
-      await loadHealth()
-      await loadStats()
+    let cancelled = false
+    Promise.allSettled([
+      get<HealthCheck>('/api/system/health'),
+      get<StatusSummary>('/api/system/status-summary'),
+      get<StatsResponse>('/api/system/stats'),
+    ]).then(([healthResult, summaryResult, statsResult]) => {
+      if (cancelled) return
+
+      if (healthResult.status === 'fulfilled') {
+        setHealth(healthResult.value)
+      } else {
+        setError(healthResult.reason instanceof Error ? healthResult.reason.message : 'Failed to load health')
+      }
+
+      if (summaryResult.status === 'fulfilled') {
+        setSummary(summaryResult.value)
+      } else {
+        setError(summaryResult.reason instanceof Error ? summaryResult.reason.message : 'Failed to load status')
+      }
+
+      if (statsResult.status === 'fulfilled') {
+        setStats(statsResult.value)
+      }
+      setStatsLoading(false)
+      setLoading(false)
+    })
+
+    return () => {
+      cancelled = true
     }
-    run()
   }, [])
 
-  const [refreshKey, setRefreshKey] = useState(0)
-
   function handleRefresh() {
-    loadHealth()
-    loadStats()
+    setError('')
+    setActionResult('')
+    setLoading(true)
+    void reloadStatusData()
     setRefreshKey((k) => k + 1)
   }
 
-  if (loading) return <div className="text-gray-500 dark:text-gray-400">Loading...</div>
+  async function handleReaperRun() {
+    setError('')
+    setActionResult('')
+    setReaperRunning(true)
+    try {
+      const data = await post<{ reaped: number }>('/api/system/reaper-run')
+      setActionResult(`Recovered ${data.reaped} stale job${data.reaped === 1 ? '' : 's'}.`)
+      await loadSummary()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to recover stale jobs')
+    } finally {
+      setReaperRunning(false)
+    }
+  }
+
+  const serviceIssues = useMemo<StatusIssue[]>(() => {
+    if (!health) return []
+    const failed = Object.entries(health.checks).filter(([, status]) => !serviceIsOk(status))
+    if (failed.length === 0) return []
+    return [
+      {
+        kind: 'service_health',
+        severity: 'error',
+        title: 'Search services need attention',
+        detail: failed.map(([name, status]) => `${name}: ${status}`).join('; '),
+        count: failed.length,
+        action_label: 'Open diagnostics',
+        action_href: '/settings/diagnostics',
+      },
+    ]
+  }, [health])
+
+  const attentionItems = [...serviceIssues, ...(summary?.needs_attention ?? [])]
+  const displayState: StatusSummary['state'] =
+    attentionItems.length > 0 ? 'needs_attention' : summary?.state === 'processing' ? 'processing' : 'ready'
+
+  if (loading && !health && !summary) {
+    return <div className="text-gray-500 dark:text-gray-400">Loading status...</div>
+  }
 
   return (
     <div className="animate-slide-in">
       <PageHeader
         title="Status"
-        subtitle="System readiness, service health, and account state"
+        subtitle="Readiness, needs-attention items, and recovery actions"
         actions={
           <button
             onClick={handleRefresh}
@@ -114,35 +253,284 @@ export default function SystemStatusPage() {
         </div>
       )}
 
-      <h2 className="mb-3 text-lg font-semibold">Service Health</h2>
-      {health && (
-        <div className="mb-6 grid grid-cols-3 gap-4">
-          <HealthCard
-            name="PostgreSQL"
-            status={health.checks.postgres}
-            stats={stats?.postgres}
-            statsLoading={statsLoading}
-          />
-          <HealthCard
-            name="Storage"
-            status={health.checks.storage}
-            stats={stats?.storage}
-            statsLoading={statsLoading}
-          />
-          <HealthCard name="Tika" status={health.checks.tika} statsLoading={false} />
-          <HealthCard name="Reranker" status={health.checks.reranker ?? 'not configured'} statsLoading={false} />
+      {actionResult && (
+        <div className="mb-4 rounded-sm bg-green-50 dark:bg-green-900/20 px-3 py-2 text-sm text-green-700 dark:text-green-400">
+          {actionResult}
         </div>
       )}
 
-      {health && (
-        <div className="mb-6 flex items-center gap-2">
-          <span className="text-sm text-(--color-text-secondary)">Overall:</span>
-          <StatusPill state={health.status === 'healthy' ? 'active' : 'error'} label={health.status} />
+      <section className="mb-6 grid gap-4 lg:grid-cols-[1.1fr_1fr]">
+        <Card className="p-5">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-(--color-text-primary)">System state</h2>
+              <p className="mt-1 text-sm text-(--color-text-secondary)">
+                The short version of whether Harbor Clerk is ready to search, ingest, and answer.
+              </p>
+            </div>
+            <StatusPill state={statePill(displayState)} label={stateLabel(displayState)} />
+          </div>
+          <ReadinessChecklist summary={summary} health={health} llmState={llmStatus.state} />
+        </Card>
+
+        <Card className="p-5">
+          <h2 className="text-lg font-semibold text-(--color-text-primary)">At a glance</h2>
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <MetricTile label="Documents" value={summary?.counts.active_documents ?? 0} />
+            <MetricTile label="Ready" value={summary?.counts.ready_documents ?? 0} />
+            <MetricTile label="Processing" value={summary?.counts.processing_documents ?? 0} />
+            <MetricTile label="Failed" value={summary?.counts.failed_documents ?? 0} tone="error" />
+            <MetricTile label="Queued jobs" value={summary?.counts.queued_jobs ?? 0} />
+            <MetricTile label="Running jobs" value={summary?.counts.running_jobs ?? 0} />
+          </div>
+        </Card>
+      </section>
+
+      <section className="mb-6">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-(--color-text-primary)">Needs attention</h2>
+          {attentionItems.length > 0 && (
+            <Link to="/settings/maintenance" className="text-sm text-(--color-accent) hover:underline">
+              Advanced maintenance
+            </Link>
+          )}
         </div>
-      )}
+
+        {attentionItems.length === 0 ? (
+          <Card className="p-4">
+            <div className="flex items-center gap-3">
+              <StatusPill state="active" label="No action needed" />
+              <p className="text-sm text-(--color-text-secondary)">
+                No failed documents, stuck jobs, unavailable folders, or degraded service checks are currently reported.
+              </p>
+            </div>
+          </Card>
+        ) : (
+          <div className="grid gap-3">
+            {attentionItems.map((issue) => (
+              <IssueCard key={issue.kind} issue={issue} reaperRunning={reaperRunning} onRunReaper={handleReaperRun} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <RecentActivity summary={summary} />
+
+      <section className="mb-6">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-(--color-text-primary)">Diagnostics</h2>
+          <div className="flex items-center gap-3 text-sm">
+            <Link to="/settings/diagnostics" className="text-(--color-accent) hover:underline">
+              Logs
+            </Link>
+            <Link to="/settings/maintenance" className="text-(--color-accent) hover:underline">
+              Maintenance
+            </Link>
+          </div>
+        </div>
+
+        {health && (
+          <div className="mb-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <HealthCard
+              name="PostgreSQL"
+              status={health.checks.postgres}
+              stats={stats?.postgres}
+              statsLoading={statsLoading}
+            />
+            <HealthCard
+              name="Storage"
+              status={health.checks.storage}
+              stats={stats?.storage}
+              statsLoading={statsLoading}
+            />
+            <HealthCard name="Tika" status={health.checks.tika} statsLoading={false} />
+            <HealthCard name="Reranker" status={health.checks.reranker ?? 'not configured'} statsLoading={false} />
+          </div>
+        )}
+      </section>
 
       <MailAccountsStatus refreshKey={refreshKey} />
     </div>
+  )
+}
+
+function ReadinessChecklist({
+  summary,
+  health,
+  llmState,
+}: {
+  summary: StatusSummary | null
+  health: HealthCheck | null
+  llmState: string
+}) {
+  const healthOk = health ? Object.values(health.checks).every(serviceIsOk) : false
+  const foldersReady = (summary?.counts.watched_folders ?? 0) > 0 && (summary?.counts.unavailable_folders ?? 0) === 0
+  const docsOk = (summary?.counts.failed_documents ?? 0) === 0
+  const processing = (summary?.counts.processing_documents ?? 0) > 0 || (summary?.counts.running_jobs ?? 0) > 0
+  const localAiLabel =
+    llmState === 'ready'
+      ? 'ready'
+      : llmState === 'loading'
+        ? 'loading'
+        : llmState === 'deactivated'
+          ? 'not configured'
+          : 'unknown'
+  const localAiState: PillState =
+    llmState === 'ready'
+      ? 'active'
+      : llmState === 'loading'
+        ? 'running'
+        : llmState === 'deactivated'
+          ? 'idle'
+          : 'pending'
+
+  return (
+    <div className="space-y-3">
+      <CheckRow
+        label="Search services"
+        state={healthOk ? 'active' : 'error'}
+        detail={healthOk ? 'Ready' : 'Open diagnostics'}
+      />
+      <CheckRow
+        label="Watched folders"
+        state={foldersReady ? 'active' : summary?.counts.unavailable_folders ? 'error' : 'idle'}
+        detail={
+          foldersReady
+            ? `${summary?.counts.watched_folders ?? 0} folder${summary?.counts.watched_folders === 1 ? '' : 's'} watching`
+            : summary?.counts.unavailable_folders
+              ? 'Folder access issue'
+              : 'No folders configured'
+        }
+      />
+      <CheckRow
+        label="Documents"
+        state={docsOk ? 'active' : 'error'}
+        detail={docsOk ? 'No ingest failures' : 'Failures need review'}
+      />
+      <CheckRow
+        label="Ingestion"
+        state={processing ? 'running' : 'active'}
+        detail={processing ? 'Documents are processing' : 'No active processing'}
+      />
+      <CheckRow label="Local AI" state={localAiState} detail={localAiLabel} />
+    </div>
+  )
+}
+
+function CheckRow({ label, state, detail }: { label: string; state: PillState; detail: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-(--color-border) pb-2 last:border-0 last:pb-0">
+      <span className="text-sm font-medium text-(--color-text-primary)">{label}</span>
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-(--color-text-secondary)">{detail}</span>
+        <StatusPill state={state} label={state === 'active' ? 'OK' : state} />
+      </div>
+    </div>
+  )
+}
+
+function MetricTile({ label, value, tone = 'normal' }: { label: string; value: number; tone?: 'normal' | 'error' }) {
+  return (
+    <div className="rounded-lg bg-(--color-bg-secondary) px-3 py-3">
+      <div
+        className={`text-2xl font-semibold ${tone === 'error' && value > 0 ? 'text-red-600 dark:text-red-400' : ''}`}
+      >
+        {value.toLocaleString()}
+      </div>
+      <div className="mt-1 text-xs text-(--color-text-secondary)">{label}</div>
+    </div>
+  )
+}
+
+function IssueCard({
+  issue,
+  reaperRunning,
+  onRunReaper,
+}: {
+  issue: StatusIssue
+  reaperRunning: boolean
+  onRunReaper: () => void
+}) {
+  const pillState: PillState = issue.severity === 'error' ? 'error' : 'pending'
+  return (
+    <Card className="p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="mb-1 flex items-center gap-2">
+            <StatusPill state={pillState} label={issue.severity === 'error' ? 'Action needed' : 'Review'} />
+            <h3 className="font-medium text-(--color-text-primary)">{issue.title}</h3>
+          </div>
+          <p className="text-sm text-(--color-text-secondary)">{issue.detail}</p>
+        </div>
+        {issue.action_kind === 'reaper' ? (
+          <button
+            onClick={onRunReaper}
+            disabled={reaperRunning}
+            className="rounded-lg bg-(--color-accent) px-3 py-1.5 text-sm font-medium text-white disabled:opacity-60"
+          >
+            {reaperRunning ? 'Recovering...' : issue.action_label || 'Recover'}
+          </button>
+        ) : issue.action_href && issue.action_label ? (
+          <Link
+            to={issue.action_href}
+            className="rounded-lg bg-(--color-bg-tertiary) px-3 py-1.5 text-sm font-medium text-(--color-text-primary) hover:bg-gray-200 dark:hover:bg-gray-600"
+          >
+            {issue.action_label}
+          </Link>
+        ) : null}
+      </div>
+    </Card>
+  )
+}
+
+function RecentActivity({ summary }: { summary: StatusSummary | null }) {
+  const failed = summary?.recent_failed_documents ?? []
+  const processing = summary?.recent_processing_documents ?? []
+
+  if (failed.length === 0 && processing.length === 0) return null
+
+  return (
+    <section className="mb-6 grid gap-4 lg:grid-cols-2">
+      {failed.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-(--color-text-primary)">Failed documents</h2>
+          <div className="space-y-2">
+            {failed.map((doc) => (
+              <DocumentStatusRow key={doc.doc_id} doc={doc} tone="error" />
+            ))}
+          </div>
+        </div>
+      )}
+      {processing.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-(--color-text-primary)">Processing now</h2>
+          <div className="space-y-2">
+            {processing.map((doc) => (
+              <DocumentStatusRow key={doc.doc_id} doc={doc} tone="running" />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function DocumentStatusRow({ doc, tone }: { doc: StatusDoc; tone: 'error' | 'running' }) {
+  return (
+    <Card interactive className="p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Link to={`/docs/${doc.doc_id}`} className="font-medium text-blue-600 dark:text-blue-400 hover:underline">
+            {doc.title}
+          </Link>
+          <div className="mt-0.5 truncate text-xs text-(--color-text-secondary)">
+            {doc.failed_stage ? `${doc.failed_stage}: ` : ''}
+            {doc.error || doc.canonical_filename || doc.pipeline_status}
+          </div>
+        </div>
+        <StatusPill state={tone === 'error' ? 'error' : 'running'} label={doc.pipeline_status} />
+      </div>
+    </Card>
   )
 }
 
@@ -157,7 +545,7 @@ function HealthCard({
   stats?: ServiceStats
   statsLoading: boolean
 }) {
-  const ok = status === 'ok'
+  const ok = serviceIsOk(status)
   const statEntries = stats ? Object.entries(stats).filter(([k]) => k !== 'error') : []
 
   return (
@@ -169,7 +557,7 @@ function HealthCard({
       {statEntries.length > 0 && (
         <dl className="mt-3 space-y-1 border-t border-gray-200 dark:border-gray-700 pt-2">
           {statEntries.map(([key, value]) => (
-            <div key={key} className="flex justify-between text-xs">
+            <div key={key} className="flex justify-between gap-3 text-xs">
               <dt className="text-gray-500 dark:text-gray-400">{STAT_LABELS[key] || key}</dt>
               <dd className="font-medium text-gray-700 dark:text-gray-300">{formatStatValue(key, value)}</dd>
             </div>
@@ -218,7 +606,7 @@ function MailAccountsStatus({ refreshKey }: { refreshKey: number }) {
     return (
       <section className="mb-6">
         <h2 className="text-base font-medium mb-2">Mail Accounts</h2>
-        <p className="text-sm text-(--color-text-secondary)">Loading…</p>
+        <p className="text-sm text-(--color-text-secondary)">Loading...</p>
       </section>
     )
   }
@@ -229,9 +617,9 @@ function MailAccountsStatus({ refreshKey }: { refreshKey: number }) {
         <h2 className="text-base font-medium mb-2">Mail Accounts</h2>
         <p className="text-sm text-(--color-text-secondary)">
           No mail accounts connected. Add one from{' '}
-          <a href="/folders" className="text-(--color-accent) hover:underline">
+          <Link to="/folders" className="text-(--color-accent) hover:underline">
             Folders
-          </a>
+          </Link>
           .
         </p>
       </section>

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -139,10 +139,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusWindowItem.target = self
         menu.addItem(statusWindowItem)
 
-        let consoleItem = NSMenuItem(title: "View Logs in Console...", action: #selector(openConsole), keyEquivalent: "l")
-        consoleItem.target = self
-        menu.addItem(consoleItem)
-
         let preferencesItem = NSMenuItem(title: "Preferences...", action: #selector(showPreferences), keyEquivalent: ",")
         preferencesItem.target = self
         menu.addItem(preferencesItem)
@@ -316,14 +312,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusWindowController?.showWindow(nil)
         statusWindowController?.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-    }
-
-    @objc private func openConsole() {
-        if let consoleURL = NSWorkspace.shared.urlForApplication(
-            withBundleIdentifier: "com.apple.Console"
-        ) {
-            NSWorkspace.shared.openApplication(at: consoleURL, configuration: .init())
-        }
     }
 
     @objc private func showPreferences() {

--- a/macos/HarborClerkServer/HarborClerkServer/StatusWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/StatusWindow.swift
@@ -197,18 +197,6 @@ struct StatusWindow: View {
             .buttonStyle(.bordered)
 
             Spacer()
-
-            Button {
-                if let url = NSWorkspace.shared.urlForApplication(
-                    withBundleIdentifier: "com.apple.Console"
-                ) {
-                    NSWorkspace.shared.openApplication(at: url, configuration: .init())
-                }
-            } label: {
-                Label("View Logs in Console", systemImage: "terminal")
-            }
-            .controlSize(.large)
-            .buttonStyle(.bordered)
         }
     }
 

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -57,6 +57,7 @@ async def list_documents(
     doc_type: str | None = Query(default=None, description="Filter by doc type"),
     doc_ids: str | None = Query(default=None, description="Comma-separated document IDs"),
     topic_id: int | None = Query(default=None, description="Filter by topic cluster ID"),
+    pipeline_status: str | None = Query(default=None, description="Filter by pipeline status; comma-separated"),
     sort: str = Query(default="updated", pattern="^(updated|created|title)$"),
     sort_dir: str = Query(default="desc", pattern="^(asc|desc)$"),
     principal: Principal = Depends(require_read_access),
@@ -79,6 +80,23 @@ async def list_documents(
 
     if topic_id is not None:
         base = base.where(Document.topic_id == topic_id)
+
+    if pipeline_status:
+        statuses: list[PipelineStatus] = []
+        for raw_status in pipeline_status.split(","):
+            value = raw_status.strip()
+            if not value:
+                continue
+            try:
+                statuses.append(PipelineStatus(value))
+            except ValueError:
+                allowed = ", ".join(s.value for s in PipelineStatus)
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid pipeline_status {value!r}. Expected one of: {allowed}",
+                )
+        if statuses:
+            base = base.where(Document.pipeline_status.in_(statuses))
 
     if q:
         escaped = escape_ilike(q)

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -28,6 +28,7 @@ from harbor_clerk.models import (
     User,
 )
 from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
+from harbor_clerk.models.watched import WatchedFolder
 from harbor_clerk.storage import get_storage
 
 logger = logging.getLogger(__name__)
@@ -183,6 +184,254 @@ async def health_check(
         # (None → omitted by frontend) on Docker/Linux where the shim concept
         # doesn't apply.
         "cli_shim_install_status": _cli_shim_install_status(),
+    }
+
+
+_PROCESSING_STATUSES: tuple[PipelineStatus, ...] = tuple(
+    status for status in PipelineStatus if status not in (PipelineStatus.ready, PipelineStatus.error)
+)
+
+
+def _job_age_seconds(now: datetime, job: IngestionJob) -> float | None:
+    started_at = job.started_at or job.created_at
+    if started_at is None:
+        return None
+    return (now - started_at).total_seconds()
+
+
+def _is_stuck_running_job(now: datetime, job: IngestionJob) -> bool:
+    if job.heartbeat_at is not None:
+        return (now - job.heartbeat_at).total_seconds() >= 90
+
+    from harbor_clerk.worker.pipeline import STAGE_CONFIG
+
+    _, timeout, _ = STAGE_CONFIG.get(job.stage, ("io", 600, PipelineStatus.error))
+    age = _job_age_seconds(now, job)
+    return age is not None and age >= timeout * 2
+
+
+@router.get("/system/status-summary")
+async def status_summary(
+    _admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    """User-facing readiness and recovery summary for the Status page.
+
+    This endpoint intentionally stays one layer above raw service diagnostics.
+    It answers: what needs attention, what is processing, and where should the
+    operator go next?
+    """
+    status_rows = (
+        await session.execute(
+            select(Document.pipeline_status, func.count())
+            .where(Document.status == "active")
+            .group_by(Document.pipeline_status)
+        )
+    ).all()
+    pipeline_counts = {
+        (row[0].value if isinstance(row[0], PipelineStatus) else str(row[0])): int(row[1]) for row in status_rows
+    }
+    active_documents = sum(pipeline_counts.values())
+    ready_documents = pipeline_counts.get(PipelineStatus.ready.value, 0)
+    failed_documents = pipeline_counts.get(PipelineStatus.error.value, 0)
+    processing_documents = sum(pipeline_counts.get(status.value, 0) for status in _PROCESSING_STATUSES)
+
+    job_rows = (
+        await session.execute(
+            select(IngestionJob.status, func.count())
+            .join(Document, Document.doc_id == IngestionJob.doc_id)
+            .where(Document.status == "active")
+            .group_by(IngestionJob.status)
+        )
+    ).all()
+    job_counts = {
+        (row[0].value if isinstance(row[0], JobStatus) else str(row[0])): int(row[1])
+        for row in job_rows
+        if row[0] is not None
+    }
+
+    folder_rows = (
+        await session.execute(
+            select(
+                func.count(WatchedFolder.folder_id),
+                func.count(WatchedFolder.folder_id).filter(WatchedFolder.unavailable_reason.is_not(None)),
+            )
+        )
+    ).one()
+    watched_folders = int(folder_rows[0] or 0)
+    unavailable_folders = int(folder_rows[1] or 0)
+
+    ner_skipped_documents = (
+        await session.execute(
+            select(func.count(func.distinct(IngestionJob.doc_id)))
+            .join(Document, Document.doc_id == IngestionJob.doc_id)
+            .where(
+                Document.status == "active",
+                IngestionJob.stage == JobStage.entities,
+                IngestionJob.metrics["reason"].astext == "spacy_unavailable",
+            )
+        )
+    ).scalar() or 0
+
+    now = datetime.now(UTC)
+    running_jobs = (
+        (
+            await session.execute(
+                select(IngestionJob)
+                .join(Document, Document.doc_id == IngestionJob.doc_id)
+                .where(Document.status == "active", IngestionJob.status == JobStatus.running)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stuck_jobs = [job for job in running_jobs if _is_stuck_running_job(now, job)]
+
+    failed_docs = (
+        (
+            await session.execute(
+                select(Document)
+                .where(Document.status == "active", Document.pipeline_status == PipelineStatus.error)
+                .order_by(Document.updated_at.desc())
+                .limit(8)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    failed_doc_ids = [doc.doc_id for doc in failed_docs]
+    failed_jobs_by_doc: dict[uuid.UUID, IngestionJob] = {}
+    if failed_doc_ids:
+        error_jobs = (
+            (
+                await session.execute(
+                    select(IngestionJob)
+                    .where(IngestionJob.doc_id.in_(failed_doc_ids), IngestionJob.status == JobStatus.error)
+                    .order_by(IngestionJob.created_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for job in error_jobs:
+            failed_jobs_by_doc.setdefault(job.doc_id, job)
+
+    recent_failed_documents = []
+    for doc in failed_docs:
+        failed_job = failed_jobs_by_doc.get(doc.doc_id)
+        recent_failed_documents.append(
+            {
+                "doc_id": str(doc.doc_id),
+                "title": doc.title,
+                "canonical_filename": doc.canonical_filename,
+                "pipeline_status": doc.pipeline_status.value,
+                "error": doc.error or (failed_job.error if failed_job else None),
+                "failed_stage": failed_job.stage.value if failed_job else None,
+                "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+            }
+        )
+
+    processing_docs = (
+        (
+            await session.execute(
+                select(Document)
+                .where(Document.status == "active", Document.pipeline_status.in_(_PROCESSING_STATUSES))
+                .order_by(Document.updated_at.desc())
+                .limit(5)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    recent_processing_documents = [
+        {
+            "doc_id": str(doc.doc_id),
+            "title": doc.title,
+            "pipeline_status": doc.pipeline_status.value,
+            "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+        }
+        for doc in processing_docs
+    ]
+
+    needs_attention: list[dict[str, Any]] = []
+    if failed_documents:
+        needs_attention.append(
+            {
+                "kind": "failed_documents",
+                "severity": "error",
+                "title": "Documents failed ingest",
+                "detail": f"{failed_documents} active document{'s' if failed_documents != 1 else ''} need review.",
+                "count": failed_documents,
+                "action_label": "Review failed documents",
+                "action_href": "/docs?pipeline_status=error",
+            }
+        )
+    if stuck_jobs:
+        needs_attention.append(
+            {
+                "kind": "stuck_jobs",
+                "severity": "error",
+                "title": "Processing jobs may be stuck",
+                "detail": f"{len(stuck_jobs)} running job{'s' if len(stuck_jobs) != 1 else ''} appear stale.",
+                "count": len(stuck_jobs),
+                "action_label": "Recover stuck jobs",
+                "action_kind": "reaper",
+            }
+        )
+    if unavailable_folders:
+        needs_attention.append(
+            {
+                "kind": "folder_access",
+                "severity": "error",
+                "title": "Folder access needs repair",
+                "detail": f"{unavailable_folders} watched folder{'s' if unavailable_folders != 1 else ''} are unavailable.",
+                "count": unavailable_folders,
+                "action_label": "Open Folders",
+                "action_href": "/folders",
+            }
+        )
+    if ner_skipped_documents:
+        needs_attention.append(
+            {
+                "kind": "entity_extraction_skipped",
+                "severity": "warning",
+                "title": "Entity extraction was skipped",
+                "detail": (
+                    f"{ner_skipped_documents} document{'s' if ner_skipped_documents != 1 else ''} "
+                    "were processed while spaCy NER models were unavailable."
+                ),
+                "count": int(ner_skipped_documents),
+                "action_label": "Review diagnostics",
+                "action_href": "/settings/diagnostics",
+            }
+        )
+
+    state = "ready"
+    if needs_attention:
+        state = "needs_attention"
+    elif (
+        processing_documents or job_counts.get(JobStatus.queued.value, 0) or job_counts.get(JobStatus.running.value, 0)
+    ):
+        state = "processing"
+
+    return {
+        "state": state,
+        "counts": {
+            "active_documents": active_documents,
+            "ready_documents": ready_documents,
+            "processing_documents": processing_documents,
+            "failed_documents": failed_documents,
+            "queued_jobs": job_counts.get(JobStatus.queued.value, 0),
+            "running_jobs": job_counts.get(JobStatus.running.value, 0),
+            "failed_jobs": job_counts.get(JobStatus.error.value, 0),
+            "watched_folders": watched_folders,
+            "unavailable_folders": unavailable_folders,
+            "ner_skipped_documents": int(ner_skipped_documents),
+            "stuck_jobs": len(stuck_jobs),
+        },
+        "needs_attention": needs_attention,
+        "recent_failed_documents": recent_failed_documents,
+        "recent_processing_documents": recent_processing_documents,
     }
 
 

--- a/tests/test_api_documents.py
+++ b/tests/test_api_documents.py
@@ -74,6 +74,27 @@ async def test_list_documents_filter(client, admin_user, admin_token, db_session
     assert data["items"][0]["title"] == "Budget Report 2024"
 
 
+async def test_list_documents_filter_pipeline_status(client, admin_user, admin_token, db_session):
+    db_session.add_all(
+        [
+            Document(title="Ready Doc", status="active", pipeline_status=PipelineStatus.ready, sha256=b"r" * 32),
+            Document(title="Failed Doc", status="active", pipeline_status=PipelineStatus.error, sha256=b"f" * 32),
+        ]
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/docs?pipeline_status=error", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["title"] == "Failed Doc"
+
+
+async def test_list_documents_filter_pipeline_status_rejects_unknown(client, admin_user, admin_token):
+    resp = await client.get("/api/docs?pipeline_status=made_up", headers=auth_header(admin_token))
+    assert resp.status_code == 422
+
+
 async def test_list_documents_pagination(client, admin_user, admin_token, db_session):
     for i in range(5):
         db_session.add(Document(title=f"Doc {i}", status="active", **_DOC_DEFAULTS))

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -1,5 +1,10 @@
 """Tests for /api/system/* endpoints."""
 
+from datetime import UTC, datetime, timedelta
+
+from harbor_clerk.models import Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
+from harbor_clerk.models.watched import WatchedFolder
 from tests.conftest import auth_header
 
 
@@ -86,6 +91,113 @@ async def test_health_check_cli_shim_absent_on_docker(client):
         assert data.get("cli_shim_install_status") is None
     finally:
         s.native_config_file = original
+
+
+async def test_status_summary_surfaces_recovery_attention(client, admin_user, admin_token, db_session):
+    now = datetime.now(UTC)
+    failed_doc = Document(
+        title="Broken scan",
+        status="active",
+        sha256=b"f" * 32,
+        pipeline_status=PipelineStatus.error,
+        error="Tika failed",
+    )
+    processing_doc = Document(
+        title="Still embedding",
+        status="active",
+        sha256=b"p" * 32,
+        pipeline_status=PipelineStatus.embedding,
+    )
+    ner_doc = Document(
+        title="No entities",
+        status="active",
+        sha256=b"n" * 32,
+        pipeline_status=PipelineStatus.ready,
+    )
+    db_session.add_all([failed_doc, processing_doc, ner_doc])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            IngestionJob(
+                doc_id=failed_doc.doc_id,
+                stage=JobStage.extract,
+                status=JobStatus.error,
+                error="Tika failed",
+            ),
+            IngestionJob(
+                doc_id=processing_doc.doc_id,
+                stage=JobStage.embed,
+                status=JobStatus.running,
+                started_at=now - timedelta(hours=3),
+            ),
+            IngestionJob(
+                doc_id=ner_doc.doc_id,
+                stage=JobStage.entities,
+                status=JobStatus.done,
+                metrics={"skipped": True, "reason": "spacy_unavailable"},
+            ),
+        ]
+    )
+    db_session.add(WatchedFolder(path="/missing", unavailable_reason="permission denied"))
+    await db_session.flush()
+
+    resp = await client.get("/api/system/status-summary", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "needs_attention"
+    assert data["counts"]["failed_documents"] == 1
+    assert data["counts"]["processing_documents"] == 1
+    assert data["counts"]["stuck_jobs"] == 1
+    assert data["counts"]["unavailable_folders"] == 1
+    assert data["counts"]["ner_skipped_documents"] == 1
+
+    issue_kinds = {issue["kind"] for issue in data["needs_attention"]}
+    assert {
+        "failed_documents",
+        "stuck_jobs",
+        "folder_access",
+        "entity_extraction_skipped",
+    }.issubset(issue_kinds)
+    assert data["recent_failed_documents"][0]["title"] == "Broken scan"
+    assert data["recent_failed_documents"][0]["failed_stage"] == "extract"
+    assert data["recent_processing_documents"][0]["title"] == "Still embedding"
+
+
+async def test_status_summary_ready_when_no_attention_items(client, admin_user, admin_token, db_session):
+    ready_doc = Document(
+        title="Ready",
+        status="active",
+        sha256=b"r" * 32,
+        pipeline_status=PipelineStatus.ready,
+    )
+    deleted_failed_doc = Document(
+        title="Deleted failure",
+        status="deleted",
+        sha256=b"d" * 32,
+        pipeline_status=PipelineStatus.error,
+    )
+    db_session.add_all([ready_doc, deleted_failed_doc])
+    db_session.add(WatchedFolder(path="/docs"))
+    await db_session.flush()
+    db_session.add(
+        IngestionJob(
+            doc_id=deleted_failed_doc.doc_id,
+            stage=JobStage.extract,
+            status=JobStatus.error,
+            error="old failure",
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/system/status-summary", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "ready"
+    assert data["counts"]["ready_documents"] == 1
+    assert data["counts"]["failed_documents"] == 0
+    assert data["counts"]["failed_jobs"] == 0
+    assert data["needs_attention"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an admin status-summary API that reports readiness, failed docs, stale jobs, folder access issues, skipped NER, and recent failed/processing docs
- redesign Settings -> Status around readiness, needs-attention items, recovery links/actions, and secondary diagnostics
- add a Documents pipeline-status filter so Status can deep-link to failed documents
- remove stale macOS "View Logs in Console" controls from the menubar and status window

## Tests
- uv run pytest tests/test_api_system.py tests/test_api_documents.py -q
- uv run ruff check src/harbor_clerk/api/routes/system.py src/harbor_clerk/api/routes/documents.py tests/test_api_system.py tests/test_api_documents.py
- npm --prefix frontend test -- --run
- npm --prefix frontend run lint (passes with existing warnings)
- npm --prefix frontend run type-check
- npm --prefix frontend run format:check
- xcodebuild -project macos/HarborClerkServer/HarborClerkServer.xcodeproj -scheme HarborClerkServer -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO