### PR TITLE
feat(status): wire global pill to recovery summary

### DIFF
--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -1,9 +1,19 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get } from '../api'
+import { useAuth } from '../auth'
 import { useSystemConfig, type SystemConfig } from '../hooks/useSystemConfig'
 import { useLLMStatusContext } from './LLMStatusBanner'
 import GlobalStatusPill from './GlobalStatusPill'
+
+vi.mock('../api', () => ({
+  get: vi.fn(),
+}))
+
+vi.mock('../auth', () => ({
+  useAuth: vi.fn(),
+}))
 
 vi.mock('../hooks/useSystemConfig', () => ({
   useSystemConfig: vi.fn(),
@@ -13,6 +23,8 @@ vi.mock('./LLMStatusBanner', () => ({
   useLLMStatusContext: vi.fn(),
 }))
 
+const getMock = vi.mocked(get)
+const useAuthMock = vi.mocked(useAuth)
 const useSystemConfigMock = vi.mocked(useSystemConfig)
 const useLLMStatusContextMock = vi.mocked(useLLMStatusContext)
 
@@ -24,13 +36,52 @@ const READY_CONFIG: SystemConfig = {
   loaded: true,
 }
 
+interface TestStatusSummary {
+  state: 'ready' | 'processing' | 'needs_attention'
+  counts: {
+    processing_documents: number
+    queued_jobs: number
+    running_jobs: number
+    failed_documents: number
+    unavailable_folders: number
+    ner_skipped_documents: number
+    stuck_jobs: number
+  }
+  needs_attention: Array<{
+    kind: string
+    severity: 'error' | 'warning'
+    title: string
+    detail: string
+    count?: number
+  }>
+}
+
+const READY_SUMMARY: TestStatusSummary = {
+  state: 'ready',
+  counts: {
+    processing_documents: 0,
+    queued_jobs: 0,
+    running_jobs: 0,
+    failed_documents: 0,
+    unavailable_folders: 0,
+    ner_skipped_documents: 0,
+    stuck_jobs: 0,
+  },
+  needs_attention: [],
+}
+
 function mockPill({
   config = READY_CONFIG,
   llmState = 'ready',
+  isAdmin = true,
+  summary = READY_SUMMARY,
 }: {
   config?: SystemConfig
   llmState?: 'deactivated' | 'loading' | 'ready' | 'unknown'
+  isAdmin?: boolean
+  summary?: TestStatusSummary
 }) {
+  useAuthMock.mockReturnValue({ isAdmin } as ReturnType<typeof useAuth>)
   useSystemConfigMock.mockReturnValue(config)
   useLLMStatusContextMock.mockReturnValue({
     status: {
@@ -40,6 +91,7 @@ function mockPill({
     },
     markTransitioning: vi.fn(),
   })
+  getMock.mockResolvedValue(summary)
 }
 
 function renderPill() {
@@ -52,35 +104,94 @@ function renderPill() {
 
 describe('GlobalStatusPill', () => {
   beforeEach(() => {
+    getMock.mockReset()
+    useAuthMock.mockReset()
     useSystemConfigMock.mockReset()
     useLLMStatusContextMock.mockReset()
   })
 
-  it('links degraded system health to Status', () => {
+  it('links degraded system health to Status', async () => {
     mockPill({ config: { ...READY_CONFIG, healthStatus: 'degraded' } })
 
     renderPill()
 
-    const link = screen.getByRole('link', { name: 'Status: Needs attention' })
+    const link = await screen.findByRole('link', { name: 'Status: Needs attention' })
     expect(link).toHaveAttribute('href', '/settings/status')
     expect(screen.getByText('Needs attention')).toBeInTheDocument()
   })
 
-  it('links inactive local AI to Models', () => {
+  it('links inactive local AI to Models', async () => {
     mockPill({ llmState: 'deactivated' })
 
     renderPill()
 
-    const link = screen.getByRole('link', { name: 'Status: Choose model' })
+    const link = await screen.findByRole('link', { name: 'Status: Choose model' })
     expect(link).toHaveAttribute('href', '/settings/models')
   })
 
-  it('shows ready when system health and local AI are ready', () => {
+  it('shows ready when system health and local AI are ready', async () => {
     mockPill({})
 
     renderPill()
 
-    const link = screen.getByRole('link', { name: 'Status: Ready' })
+    const link = await screen.findByRole('link', { name: 'Status: Ready' })
     expect(link).toHaveAttribute('href', '/settings/status')
+  })
+
+  it('surfaces failed documents from the status summary', async () => {
+    mockPill({
+      summary: {
+        ...READY_SUMMARY,
+        state: 'needs_attention',
+        counts: {
+          ...READY_SUMMARY.counts,
+          failed_documents: 3,
+        },
+        needs_attention: [
+          {
+            kind: 'failed_documents',
+            severity: 'error',
+            title: 'Documents failed ingest',
+            detail: '3 active documents need review.',
+            count: 3,
+          },
+        ],
+      },
+    })
+
+    renderPill()
+
+    const link = await screen.findByRole('link', { name: 'Status: 3 failed docs' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+    expect(link).toHaveAttribute('title', '3 active documents need review.')
+  })
+
+  it('shows document processing before local AI ready state', async () => {
+    mockPill({
+      summary: {
+        ...READY_SUMMARY,
+        state: 'processing',
+        counts: {
+          ...READY_SUMMARY.counts,
+          processing_documents: 2,
+        },
+      },
+    })
+
+    renderPill()
+
+    expect(await screen.findByRole('link', { name: 'Status: 2 processing' })).toHaveAttribute(
+      'href',
+      '/settings/status',
+    )
+  })
+
+  it('does not request the admin-only summary for non-admin users', () => {
+    mockPill({ isAdmin: false, llmState: 'deactivated' })
+
+    renderPill()
+
+    expect(getMock).not.toHaveBeenCalledWith('/api/system/status-summary')
+    expect(screen.getByRole('link', { name: 'Status: Choose model' })).toHaveAttribute('href', '/settings/models')
   })
 })

--- a/frontend/src/components/GlobalStatusPill.tsx
+++ b/frontend/src/components/GlobalStatusPill.tsx
@@ -1,7 +1,30 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { get } from '../api'
+import { useAuth } from '../auth'
 import { useSystemConfig } from '../hooks/useSystemConfig'
 import { useLLMStatusContext } from './LLMStatusBanner'
 import { StatusPill, type PillState } from './StatusPill'
+
+interface StatusSummary {
+  state: 'ready' | 'processing' | 'needs_attention'
+  counts: {
+    processing_documents: number
+    queued_jobs: number
+    running_jobs: number
+    failed_documents: number
+    unavailable_folders: number
+    ner_skipped_documents: number
+    stuck_jobs: number
+  }
+  needs_attention: Array<{
+    kind: string
+    severity: 'error' | 'warning'
+    title: string
+    detail: string
+    count?: number
+  }>
+}
 
 interface PillView {
   label: string
@@ -11,15 +34,105 @@ interface PillView {
   to: string
 }
 
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return count === 1 ? `1 ${singular}` : `${count.toLocaleString()} ${pluralLabel}`
+}
+
+function attentionView(summary: StatusSummary): PillView {
+  const errorIssue = summary.needs_attention.find((issue) => issue.severity === 'error')
+  const firstIssue = errorIssue ?? summary.needs_attention[0]
+  const errorCount = summary.needs_attention.filter((issue) => issue.severity === 'error').length
+  const state: PillState = errorIssue ? 'error' : 'pending'
+
+  if (summary.needs_attention.length > 1) {
+    return {
+      label: errorCount > 0 ? plural(errorCount, 'issue') : plural(summary.needs_attention.length, 'notice'),
+      glyph: errorIssue ? '⚠' : '◐',
+      state,
+      title: 'Status needs attention',
+      to: '/settings/status',
+    }
+  }
+
+  if (firstIssue?.kind === 'failed_documents') {
+    return {
+      label: plural(summary.counts.failed_documents || firstIssue.count || 0, 'failed doc'),
+      glyph: '⚠',
+      state,
+      title: firstIssue.detail,
+      to: '/settings/status',
+    }
+  }
+
+  if (firstIssue?.kind === 'folder_access') {
+    return {
+      label: summary.counts.unavailable_folders === 1 ? 'Folder issue' : 'Folder issues',
+      glyph: '⚠',
+      state,
+      title: firstIssue.detail,
+      to: '/settings/status',
+    }
+  }
+
+  if (firstIssue?.kind === 'stuck_jobs') {
+    return {
+      label: summary.counts.stuck_jobs === 1 ? 'Stuck job' : 'Stuck jobs',
+      glyph: '⚠',
+      state,
+      title: firstIssue.detail,
+      to: '/settings/status',
+    }
+  }
+
+  if (firstIssue?.kind === 'entity_extraction_skipped') {
+    return {
+      label: 'Entity check',
+      glyph: '◐',
+      state,
+      title: firstIssue.detail,
+      to: '/settings/status',
+    }
+  }
+
+  return {
+    label: 'Needs attention',
+    glyph: errorIssue ? '⚠' : '◐',
+    state,
+    title: firstIssue?.title ?? 'Status needs attention',
+    to: '/settings/status',
+  }
+}
+
 function statusView({
   healthStatus,
   loaded,
   llmState,
+  summary,
+  summaryLoaded,
+  isAdmin,
 }: {
   healthStatus: 'healthy' | 'degraded' | null
   loaded: boolean
   llmState: string
+  summary: StatusSummary | null
+  summaryLoaded: boolean
+  isAdmin: boolean
 }): PillView {
+  const summaryHasError = summary?.needs_attention.some((issue) => issue.severity === 'error') ?? false
+
+  if ((isAdmin && !summaryLoaded) || (!loaded && !summary)) {
+    return {
+      label: 'Checking',
+      state: 'pending',
+      title: 'Checking system status',
+      to: '/settings/status',
+    }
+  }
+
+  if (summary?.state === 'needs_attention' && summaryHasError) {
+    return attentionView(summary)
+  }
+
   if (healthStatus === 'degraded') {
     return {
       label: 'Needs attention',
@@ -30,11 +143,16 @@ function statusView({
     }
   }
 
-  if (!loaded) {
+  if (summary?.state === 'needs_attention') {
+    return attentionView(summary)
+  }
+
+  if (summary?.state === 'processing') {
+    const count = summary.counts.processing_documents || summary.counts.running_jobs || summary.counts.queued_jobs || 0
     return {
-      label: 'Checking',
-      state: 'pending',
-      title: 'Checking system status',
+      label: count ? `${count.toLocaleString()} processing` : 'Processing',
+      state: 'running',
+      title: 'Documents are being processed',
       to: '/settings/status',
     }
   }
@@ -76,12 +194,46 @@ function statusView({
 }
 
 export default function GlobalStatusPill() {
+  const { isAdmin } = useAuth()
   const { status } = useLLMStatusContext()
   const systemConfig = useSystemConfig()
+  const [summary, setSummary] = useState<StatusSummary | null>(null)
+  const [summaryLoaded, setSummaryLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!isAdmin) return
+
+    let cancelled = false
+
+    async function loadSummary() {
+      try {
+        const data = await get<StatusSummary>('/api/system/status-summary')
+        if (!cancelled) setSummary(data)
+      } catch {
+        if (!cancelled) setSummary(null)
+      } finally {
+        if (!cancelled) setSummaryLoaded(true)
+      }
+    }
+
+    void loadSummary()
+    const interval = window.setInterval(() => {
+      void loadSummary()
+    }, 15000)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [isAdmin])
+
   const view = statusView({
     healthStatus: systemConfig.healthStatus,
     loaded: systemConfig.loaded,
     llmState: status.state,
+    summary,
+    summaryLoaded,
+    isAdmin,
   })
 
   return (


### PR DESCRIPTION
## Summary
- poll the admin status-summary endpoint from the global status pill
- surface failed documents, stuck/folder/entity issues, and processing state in the app chrome
- preserve existing local-AI status behavior and skip the admin-only summary fetch for non-admin users

## Fresh-eyes review
- Performed a separate reviewer pass after implementation.
- No blocking issues found.
- Residual pre-existing quirk: non-admin users can still see a ready pill that links to the admin-only Status route; this PR avoids adding admin-summary calls for non-admins.

## Tests
- npm --prefix frontend test -- --run src/components/GlobalStatusPill.test.tsx
- npm --prefix frontend test -- --run
- npm --prefix frontend run type-check
- npm --prefix frontend run lint
- npm --prefix frontend run format:check
- git diff --check