### PR TITLE
feat(models): surface local model labels in ask and research

### DIFF
--- a/frontend/src/components/LocalModelChip.test.tsx
+++ b/frontend/src/components/LocalModelChip.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { LocalModelChip } from './LocalModelChip'
+
+function renderChip(model: ComponentProps<typeof LocalModelChip>['model']) {
+  render(
+    <MemoryRouter>
+      <LocalModelChip model={model} />
+    </MemoryRouter>,
+  )
+}
+
+describe('LocalModelChip', () => {
+  it('shows the active model and qualitative guidance', () => {
+    renderChip({ id: 'qwen36-35b-a3b', name: 'Qwen 35B', size_bytes: 22_000_000_000, supports_research: true })
+
+    const link = screen.getByRole('link', { name: /Local AI.*Qwen 35B.*Best local research/ })
+    expect(link).toHaveAttribute('href', '/settings/models')
+    expect(link).toHaveAttribute('title', expect.stringContaining('Strongest choice'))
+  })
+
+  it('marks smaller models with a warning', () => {
+    renderChip({ id: 'qwen3-4b', name: 'Qwen 4B', size_bytes: 2_500_000_000, supports_research: true })
+
+    expect(screen.getByLabelText('May miss details in long, messy, or multi-step questions.')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/LocalModelChip.tsx
+++ b/frontend/src/components/LocalModelChip.tsx
@@ -1,0 +1,55 @@
+import { Link } from 'react-router-dom'
+import { modelGuidance } from '../utils/modelGuidance'
+
+interface LocalModelChipModel {
+  id: string
+  name?: string | null
+  size_bytes?: number
+  supports_research?: boolean
+}
+
+interface LocalModelChipProps {
+  model: LocalModelChipModel
+  label?: string
+}
+
+export function LocalModelChip({ model, label = 'Local AI' }: LocalModelChipProps) {
+  const guidance =
+    typeof model.size_bytes === 'number' && typeof model.supports_research === 'boolean'
+      ? modelGuidance({ id: model.id, size_bytes: model.size_bytes, supports_research: model.supports_research })
+      : null
+  const modelName = model.name || model.id
+  const title = guidance
+    ? `${modelName}: ${guidance.label}. ${guidance.note}${guidance.warning ? ` ${guidance.warning}` : ''}`
+    : `${modelName}: active local AI model`
+
+  return (
+    <Link
+      to="/settings/models"
+      title={title}
+      className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-gray-200 bg-white/70 px-2.5 py-1 text-[11px] text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-700 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-200"
+    >
+      <span className="shrink-0 font-medium text-gray-600 dark:text-gray-300">{label}</span>
+      <span aria-hidden className="text-gray-300 dark:text-gray-600">
+        ·
+      </span>
+      <span className="min-w-0 truncate">{modelName}</span>
+      {guidance && (
+        <>
+          <span aria-hidden className="text-gray-300 dark:text-gray-600">
+            ·
+          </span>
+          <span className="shrink-0 text-gray-400 dark:text-gray-500">{guidance.label}</span>
+          {guidance.warning && (
+            <span
+              aria-label={guidance.warning}
+              className="shrink-0 rounded-full bg-amber-100 px-1 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+            >
+              !
+            </span>
+          )}
+        </>
+      )}
+    </Link>
+  )
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { IconTile } from '../components/IconTile'
 import { FolderPicker } from '../components/FolderPicker'
+import { LocalModelChip } from '../components/LocalModelChip'
 import { ScopeChip } from '../components/ScopeChip'
 import { del, get, post } from '../api'
 import { useAuth } from '../auth'
@@ -43,6 +44,7 @@ interface ModelInfo {
   active: boolean
   downloaded: boolean
   size_bytes: number
+  supports_research: boolean
 }
 
 export default function ChatPage() {
@@ -77,6 +79,7 @@ export default function ChatPage() {
   const [modelNames, setModelNames] = useState<Record<string, string>>({})
   const [hasActiveModel, setHasActiveModel] = useState(true) // optimistic default
   const [activeModelId, setActiveModelId] = useState<string | null>(null)
+  const [activeModel, setActiveModel] = useState<ModelInfo | null>(null)
   const [researchActive, setResearchActive] = useState(false)
   // Folder scope for next new conversation (reset when conversation is created)
   const [newConvFolderIds, setNewConvFolderIds] = useState<string[]>([])
@@ -115,12 +118,17 @@ export default function ChatPage() {
       .then((models) => {
         const map: Record<string, string> = {}
         let activeId: string | null = null
+        let active: ModelInfo | null = null
         for (const m of models) {
           map[m.id] = m.name
-          if (m.active) activeId = m.id
+          if (m.active) {
+            activeId = m.id
+            active = m
+          }
         }
         setModelNames(map)
         setActiveModelId(activeId)
+        setActiveModel(active)
         setHasActiveModel(activeId !== null)
       })
       .catch(() => {})
@@ -486,12 +494,12 @@ export default function ChatPage() {
         <div className="border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
           <div className="mx-auto px-6 py-3" style={{ maxWidth: 'min(100%, 72rem)' }}>
             <form onSubmit={handleSubmit} className="relative">
+              {activeModel && (
+                <div className="mb-2 flex justify-end">
+                  <LocalModelChip model={activeModel} />
+                </div>
+              )}
               <div className="chat-input-container relative rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/50 shadow-xs focus-within:shadow-md focus-within:border-gray-300 dark:focus-within:border-gray-600 transition-all duration-200">
-                {activeModelId && modelNames[activeModelId] && (
-                  <div className="absolute top-1.5 right-3 text-[10px] text-gray-300 dark:text-gray-600 select-none pointer-events-none">
-                    {modelNames[activeModelId]}
-                  </div>
-                )}
                 <textarea
                   ref={inputRef}
                   value={input}
@@ -499,7 +507,7 @@ export default function ChatPage() {
                   onKeyDown={handleKeyDown}
                   placeholder={
                     !hasActiveModel
-                      ? 'Download and activate a model to start chatting'
+                      ? 'Choose a local AI model to ask questions'
                       : contextFull
                         ? 'Context is nearly full — start a new conversation'
                         : researchActive
@@ -589,12 +597,12 @@ function ModelNudge() {
         </div>
         <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">Set up your local AI model</h3>
         <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-2">
-          Harbor Clerk runs a local LLM to chat with your documents. Download a model to get started — everything stays
-          on this machine.
+          Harbor Clerk uses a local AI model to answer questions over your documents. Choose a model to get started —
+          everything stays on this machine.
         </p>
         <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-6">
-          We recommend <strong className="text-gray-700 dark:text-gray-300">Qwen3 8B</strong> as a great starting point
-          — strong reasoning, tool use, and bilingual support.
+          Larger models are better for research and synthesis. Smaller models are useful for quick lookup, but important
+          answers should be checked against the citations.
         </p>
         <Link
           to="/settings/models"
@@ -632,7 +640,7 @@ function EmptyState() {
             Ask your documents
           </h2>
           <p className="mt-2 text-sm text-(--color-text-secondary)">
-            Start a conversation to search, read, and reason over your library using a local LLM.
+            Start a conversation to search, read, and reason over your library using local AI.
           </p>
         </div>
         <div className="flex flex-wrap justify-center gap-2">

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { FolderPicker } from '../components/FolderPicker'
+import { LocalModelChip } from '../components/LocalModelChip'
 import { PageHeader } from '../components/PageHeader'
 import { ScopeChip } from '../components/ScopeChip'
 import ToolResultDisplay from '../components/ToolResultDisplay'
@@ -44,6 +45,13 @@ interface ResearchDetail extends ResearchSummary {
   report: string | null
   model_id: string | null
   messages?: ResearchMessage[]
+}
+
+interface ModelInfo {
+  id: string
+  name: string
+  size_bytes: number
+  supports_research: boolean
 }
 
 /**
@@ -110,6 +118,7 @@ export default function ResearchPage() {
   const hasActiveModel = llmStatus.state === 'ready' && llmStatus.model_id !== null
   const { folders } = useWatchedFolders()
   const [history, setHistory] = useState<ResearchSummary[]>([])
+  const [models, setModels] = useState<ModelInfo[]>([])
   const [selectedTask, setSelectedTask] = useState<ResearchDetail | null>(null)
   const [question, setQuestionRaw] = useState(() => sessionStorage.getItem('research_draft') ?? '')
   const setQuestion = useCallback((v: string) => {
@@ -161,6 +170,12 @@ export default function ResearchPage() {
   useEffect(() => {
     fetchHistory()
   }, [fetchHistory])
+
+  useEffect(() => {
+    get<ModelInfo[]>('/api/chat/models')
+      .then(setModels)
+      .catch(() => {})
+  }, [])
 
   // Load task detail when researchId changes
   useEffect(() => {
@@ -330,6 +345,17 @@ export default function ResearchPage() {
     (selectedTask?.status === 'completed' || (!selectedTask && !!report && !!conversationId))
   const isViewingInterrupted = !isRunning && !showNewForm && selectedTask?.status === 'interrupted'
   const isIdle = (!isRunning && !selectedTask && !error && !isViewingCompleted) || (showNewForm && !error)
+  const activeModel =
+    llmStatus.model_id === null
+      ? null
+      : (models.find((model) => model.id === llmStatus.model_id) ?? {
+          id: llmStatus.model_id,
+          name: llmStatus.model_name ?? llmStatus.model_id,
+        })
+
+  function modelLabel(modelId: string): string {
+    return models.find((model) => model.id === modelId)?.name ?? modelId
+  }
 
   return (
     <div className="flex h-[calc(100vh-3.5rem)] -mx-4 -my-6 overflow-hidden">
@@ -497,6 +523,12 @@ export default function ResearchPage() {
                   </div>
                 ) : (
                   <div className="max-w-md mx-auto space-y-4">
+                    {activeModel && (
+                      <div className="flex justify-center">
+                        <LocalModelChip model={activeModel} />
+                      </div>
+                    )}
+
                     <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/50 shadow-xs focus-within:shadow-md focus-within:border-gray-300 dark:focus-within:border-gray-600 transition-all duration-200">
                       <textarea
                         value={question}
@@ -742,7 +774,7 @@ export default function ResearchPage() {
               {/* Metadata */}
               {selectedTask && (
                 <div className="mt-4 flex flex-wrap items-center gap-3 text-[11px] text-gray-400 dark:text-gray-500">
-                  {selectedTask.model_id && <span>Model: {selectedTask.model_id}</span>}
+                  {selectedTask.model_id && <span>Model: {modelLabel(selectedTask.model_id)}</span>}
                   <span className="capitalize">Strategy: {selectedTask.strategy}</span>
                   {selectedTask.depth && <span className="capitalize">Depth: {selectedTask.depth}</span>}
                   <span>Rounds: {selectedTask.current_round}</span>
@@ -985,7 +1017,8 @@ function ModelNudge() {
         Choose a model to research with
       </h3>
       <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-5">
-        Deep Research drives a local LLM through many tool calls — pick a model first.
+        Deep Research drives a local AI model through many tool calls. Larger models are better for long synthesis;
+        smaller models are best for quick lookup.
       </p>
       <Link
         to="/settings/models"


### PR DESCRIPTION
## Summary
- add a reusable LocalModelChip that shows the active local AI model plus qualitative guidance labels
- show the model chip in Ask and Research where users start model-backed work
- soften stale LLM/assistant-style copy in Ask/Research no-model states
- show friendly model names in completed Research metadata when the catalog is available

## Fresh-eyes review
- Performed a separate review pass after implementation.
- No blocking issues found.
- Residual pre-existing behavior: Ask loads the model catalog on page mount, so a menubar-side model switch while Ask remains open may not immediately update the chip; handling that cleanly should derive Ask send state from the global LLM status in a separate PR.

## Tests
- npm --prefix frontend test -- --run src/components/LocalModelChip.test.tsx
- npm --prefix frontend test -- --run
- npm --prefix frontend run type-check
- npm --prefix frontend run lint
- npm --prefix frontend run format:check
- git diff --check