### PR TITLE
Clarify skipped ingest and entity status states

### DIFF
--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -40,6 +40,7 @@ interface TestStatusSummary {
   state: 'ready' | 'processing' | 'needs_attention'
   counts: {
     processing_documents: number
+    stranded_documents?: number
     queued_jobs: number
     running_jobs: number
     failed_documents: number
@@ -60,6 +61,7 @@ const READY_SUMMARY: TestStatusSummary = {
   state: 'ready',
   counts: {
     processing_documents: 0,
+    stranded_documents: 0,
     queued_jobs: 0,
     running_jobs: 0,
     failed_documents: 0,
@@ -211,6 +213,37 @@ describe('GlobalStatusPill', () => {
     expect(await screen.findByRole('link', { name: 'Status: 2 processing' })).toHaveAttribute(
       'href',
       '/settings/status',
+    )
+  })
+
+  it('names stranded pipeline-state warnings as stale state', async () => {
+    mockPill({
+      summary: {
+        ...READY_SUMMARY,
+        state: 'needs_attention',
+        counts: {
+          ...READY_SUMMARY.counts,
+          stranded_documents: 7,
+        },
+        needs_attention: [
+          {
+            kind: 'stranded_pipeline_state',
+            severity: 'warning',
+            title: 'Some documents are marked processing without active jobs',
+            detail: '7 active documents have an in-progress pipeline state but no queued or running ingest job.',
+            count: 7,
+          },
+        ],
+      },
+    })
+
+    renderPill()
+
+    const link = await screen.findByRole('link', { name: 'Status: Stale state' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+    expect(link).toHaveAttribute(
+      'title',
+      '7 active documents have an in-progress pipeline state but no queued or running ingest job.',
     )
   })
 

--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -166,6 +166,34 @@ describe('GlobalStatusPill', () => {
     expect(link).toHaveAttribute('title', '3 active documents need review.')
   })
 
+  it('names entity-only warning as skipped entities', async () => {
+    mockPill({
+      summary: {
+        ...READY_SUMMARY,
+        state: 'needs_attention',
+        counts: {
+          ...READY_SUMMARY.counts,
+          ner_skipped_documents: 12,
+        },
+        needs_attention: [
+          {
+            kind: 'entity_extraction_skipped',
+            severity: 'warning',
+            title: 'Entity extraction skipped some documents',
+            detail: '12 documents need reprocessing before entity filters are complete.',
+            count: 12,
+          },
+        ],
+      },
+    })
+
+    renderPill()
+
+    const link = await screen.findByRole('link', { name: 'Status: Entities skipped' })
+    expect(link).toHaveAttribute('href', '/settings/status')
+    expect(link).toHaveAttribute('title', '12 documents need reprocessing before entity filters are complete.')
+  })
+
   it('shows document processing before local AI ready state', async () => {
     mockPill({
       summary: {

--- a/frontend/src/components/GlobalStatusPill.tsx
+++ b/frontend/src/components/GlobalStatusPill.tsx
@@ -86,7 +86,7 @@ function attentionView(summary: StatusSummary): PillView {
 
   if (firstIssue?.kind === 'entity_extraction_skipped') {
     return {
-      label: 'Entity check',
+      label: 'Entities skipped',
       glyph: '◐',
       state,
       title: firstIssue.detail,

--- a/frontend/src/components/GlobalStatusPill.tsx
+++ b/frontend/src/components/GlobalStatusPill.tsx
@@ -94,6 +94,16 @@ function attentionView(summary: StatusSummary): PillView {
     }
   }
 
+  if (firstIssue?.kind === 'stranded_pipeline_state') {
+    return {
+      label: 'Stale state',
+      glyph: '◐',
+      state,
+      title: firstIssue.detail,
+      to: '/settings/status',
+    }
+  }
+
   return {
     label: 'Needs attention',
     glyph: errorIssue ? '⚠' : '◐',

--- a/frontend/src/components/SummaryChip.test.tsx
+++ b/frontend/src/components/SummaryChip.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSummaryState } from './SummaryChip'
+
+describe('resolveSummaryState', () => {
+  it('prefers a persisted summary over stale summarize job status', () => {
+    expect(resolveSummaryState('A valid summary.', 'qwen3', 'queued')).toBe('summarized')
+    expect(resolveSummaryState('A valid summary.', 'qwen3', 'running')).toBe('summarized')
+    expect(resolveSummaryState('A valid summary.', 'qwen3', 'error')).toBe('summarized')
+  })
+
+  it('preserves the extractive label for persisted fallback summaries', () => {
+    expect(resolveSummaryState('A fallback summary.', 'extractive', 'queued')).toBe('extractive')
+  })
+
+  it('uses summarize job status when no summary has been saved', () => {
+    expect(resolveSummaryState(null, null, 'running')).toBe('generating')
+    expect(resolveSummaryState('', null, 'queued')).toBe('pending')
+    expect(resolveSummaryState(undefined, undefined, 'error')).toBe('failed')
+  })
+})

--- a/frontend/src/components/SummaryChip.tsx
+++ b/frontend/src/components/SummaryChip.tsx
@@ -95,20 +95,21 @@ export default function SummaryChip({ state, onRetry }: SummaryChipProps) {
 
 /**
  * Resolve the SummaryState from the doc's persisted fields + latest
- * job status. Order matters — running/queued/error take precedence
- * over terminal-state inferences from `summary` / `summary_model`.
+ * job status. Persisted summary text wins over job rows because
+ * reprocess/resummarize jobs can be stale while the existing summary is
+ * still valid and usable.
  */
 export function resolveSummaryState(
   summary: string | null | undefined,
   summary_model: string | null | undefined,
   summarize_job_status: string | null | undefined,
 ): SummaryState {
-  if (summarize_job_status === 'running') return 'generating'
-  if (summarize_job_status === 'queued') return 'pending'
-  if (summarize_job_status === 'error') return 'failed'
   if (summary && summary.trim()) {
     if (summary_model === 'extractive') return 'extractive'
     return 'summarized'
   }
+  if (summarize_job_status === 'running') return 'generating'
+  if (summarize_job_status === 'queued') return 'pending'
+  if (summarize_job_status === 'error') return 'failed'
   return 'none'
 }

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get, post, del } from '../api'
+import { useAuth } from '../auth'
+import { useJobEvents } from '../hooks/useJobEvents'
+import { useSystemConfig } from '../hooks/useSystemConfig'
+import DocumentDetailPage from './DocumentDetailPage'
+
+vi.mock('../api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+}))
+
+vi.mock('../auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+vi.mock('../hooks/useJobEvents', () => ({
+  useJobEvents: vi.fn(),
+}))
+
+vi.mock('../hooks/useSystemConfig', () => ({
+  useSystemConfig: vi.fn(),
+}))
+
+const getMock = vi.mocked(get)
+const postMock = vi.mocked(post)
+const delMock = vi.mocked(del)
+const useAuthMock = vi.mocked(useAuth)
+const useJobEventsMock = vi.mocked(useJobEvents)
+const useSystemConfigMock = vi.mocked(useSystemConfig)
+
+const READY_DOC = {
+  doc_id: 'doc-1',
+  title: 'Ready document',
+  canonical_filename: 'ready.pdf',
+  status: 'active',
+  pipeline_status: 'ready',
+  pipeline_seq: 1,
+  summary: null,
+  doc_type: null,
+  mime_type: 'application/pdf',
+  source_path: '/tmp/ready.pdf',
+  has_text_layer: true,
+  needs_ocr: false,
+  extracted_chars: 953,
+  size_bytes: 1024,
+  ocr_languages_used: null,
+  error: null,
+  created_at: '2026-06-04T12:00:00Z',
+  updated_at: '2026-06-04T12:30:00Z',
+  jobs: [
+    {
+      job_id: 'job-extract',
+      stage: 'extract',
+      status: 'done',
+      created_at: '2026-06-04T12:00:00Z',
+      finished_at: '2026-06-04T12:01:00Z',
+    },
+    {
+      job_id: 'job-ocr',
+      stage: 'ocr',
+      status: 'skipped',
+      error: null,
+      created_at: '2026-06-04T12:01:00Z',
+      finished_at: '2026-06-04T12:01:00Z',
+    },
+    {
+      job_id: 'job-entities',
+      stage: 'entities',
+      status: 'skipped',
+      error: 'spaCy NER models not available',
+      created_at: '2026-06-04T12:02:00Z',
+      finished_at: '2026-06-04T12:02:00Z',
+    },
+    {
+      job_id: 'job-summarize',
+      stage: 'summarize',
+      status: 'skipped',
+      error: null,
+      created_at: '2026-06-04T12:03:00Z',
+      finished_at: '2026-06-04T12:03:00Z',
+    },
+    {
+      job_id: 'job-embed',
+      stage: 'embed',
+      status: 'done',
+      progress_current: 2,
+      progress_total: 2,
+      created_at: '2026-06-04T12:04:00Z',
+      finished_at: '2026-06-04T12:04:00Z',
+    },
+    {
+      job_id: 'job-finalize',
+      stage: 'finalize',
+      status: 'done',
+      created_at: '2026-06-04T12:05:00Z',
+      finished_at: '2026-06-04T12:05:00Z',
+    },
+  ],
+}
+
+function renderDocumentDetail() {
+  render(
+    <MemoryRouter initialEntries={['/docs/doc-1']}>
+      <Routes>
+        <Route path="/docs/:id" element={<DocumentDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('DocumentDetailPage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    postMock.mockReset()
+    delMock.mockReset()
+    useAuthMock.mockReset()
+    useJobEventsMock.mockReset()
+    useSystemConfigMock.mockReset()
+
+    useAuthMock.mockReturnValue({
+      isAdmin: true,
+      user: { preferences: { page_size: 10, enabled_languages: ['en'] } },
+    } as ReturnType<typeof useAuth>)
+    useSystemConfigMock.mockReturnValue({
+      healthStatus: 'healthy',
+      allowSourceDownload: false,
+      enableCliAccess: false,
+      cliShimInstallStatus: null,
+      loaded: true,
+    })
+    useJobEventsMock.mockReturnValue(undefined)
+    getMock.mockImplementation((url) => {
+      if (url === '/api/docs/doc-1') return Promise.resolve(READY_DOC)
+      if (url === '/api/docs/doc-1/related') return Promise.resolve({ related: [] })
+      return Promise.reject(new Error(`Unexpected URL: ${url}`))
+    })
+  })
+
+  it('renders skipped ingestion stages as skipped instead of pending', async () => {
+    renderDocumentDetail()
+
+    expect(await screen.findByText('Ingestion complete')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Ingestion Jobs/ }))
+
+    expect(screen.getAllByText('skipped')).toHaveLength(3)
+    expect(screen.getByText('not needed')).toBeInTheDocument()
+    expect(screen.getByText('spaCy NER models not available')).toBeInTheDocument()
+    expect(screen.getByText('skipped by maintenance')).toBeInTheDocument()
+    expect(screen.queryByText('pending')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -152,4 +152,31 @@ describe('DocumentDetailPage', () => {
     expect(screen.getByText('skipped by maintenance')).toBeInTheDocument()
     expect(screen.queryByText('pending')).not.toBeInTheDocument()
   })
+
+  it('uses document artifacts over stale optional-stage pending jobs', async () => {
+    getMock.mockImplementation((url) => {
+      if (url === '/api/docs/doc-1') {
+        return Promise.resolve({
+          ...READY_DOC,
+          summary: 'A valid summary exists.',
+          jobs: READY_DOC.jobs.map((job) => {
+            if (job.stage === 'ocr') return { ...job, status: 'queued', finished_at: null }
+            if (job.stage === 'summarize') return { ...job, status: 'queued', finished_at: null }
+            return job
+          }),
+        })
+      }
+      if (url === '/api/docs/doc-1/related') return Promise.resolve({ related: [] })
+      return Promise.reject(new Error(`Unexpected URL: ${url}`))
+    })
+
+    renderDocumentDetail()
+
+    expect(await screen.findByText('Ingestion complete')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Ingestion Jobs/ }))
+
+    expect(screen.getByText('not needed')).toBeInTheDocument()
+    expect(screen.getByText('summary available')).toBeInTheDocument()
+    expect(screen.queryByText('pending')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -136,27 +136,47 @@ function jobPillState(status: string): PillState {
   return 'pending'
 }
 
-function jobProgressLabel(job: JobInfo): string {
+function hasPersistedSummary(doc: DocumentDetail): boolean {
+  return Boolean(doc.summary?.trim())
+}
+
+function effectiveJobStatus(job: JobInfo, doc: DocumentDetail): string {
+  if (job.stage === 'ocr' && doc.needs_ocr === false) return 'skipped'
+  if (job.stage === 'summarize' && hasPersistedSummary(doc)) return 'done'
+  return job.status
+}
+
+function jobProgressLabel(job: JobInfo, doc: DocumentDetail, status = effectiveJobStatus(job, doc)): string {
+  if (job.stage === 'summarize' && hasPersistedSummary(doc)) return 'summary available'
   if (job.progress_total) return `${job.progress_current || 0}/${job.progress_total}`
-  if (job.status !== 'skipped') return '—'
+  if (status !== 'skipped') return '—'
   if (job.error) return job.error
   if (job.stage === 'ocr') return 'not needed'
   if (job.stage === 'summarize') return 'skipped by maintenance'
   return 'skipped'
 }
 
-function jobTimeLabel(job: JobInfo): string {
+function jobTimeLabel(job: JobInfo, status = job.status): string {
   if (job.finished_at) return new Date(job.finished_at).toLocaleTimeString()
-  if (job.status === 'skipped') return 'skipped'
+  if (status === 'done') return 'complete'
+  if (status === 'skipped') return 'skipped'
   if (job.started_at) return 'running...'
   return 'queued'
 }
 
 function DocStatusBanner({ doc }: { doc: DocumentDetail }) {
   const hasJobs = doc.jobs.length > 0
-  const allDone = hasJobs && doc.jobs.every((j) => j.status === 'done' || j.status === 'skipped')
-  const hasError = doc.jobs.some((j) => j.status === 'error')
-  const runningJob = doc.jobs.find((j) => j.status === 'running' || j.status === 'queued')
+  const allDone =
+    hasJobs &&
+    doc.jobs.every((j) => {
+      const status = effectiveJobStatus(j, doc)
+      return status === 'done' || status === 'skipped'
+    })
+  const hasError = doc.jobs.some((j) => effectiveJobStatus(j, doc) === 'error')
+  const runningJob = doc.jobs.find((j) => {
+    const status = effectiveJobStatus(j, doc)
+    return status === 'running' || status === 'queued'
+  })
 
   if (doc.pipeline_status === 'ready' || allDone) {
     return (
@@ -183,7 +203,10 @@ function DocStatusBanner({ doc }: { doc: DocumentDetail }) {
   }
 
   if (runningJob) {
-    const doneCount = doc.jobs.filter((j) => j.status === 'done' || j.status === 'skipped').length
+    const doneCount = doc.jobs.filter((j) => {
+      const status = effectiveJobStatus(j, doc)
+      return status === 'done' || status === 'skipped'
+    }).length
     return (
       <div className="mb-3 flex items-center gap-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
         <div className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -878,13 +901,14 @@ export default function DocumentDetailPage() {
                 </thead>
                 <tbody>
                   {doc.jobs.map((j) => {
-                    const pillState = jobPillState(j.status)
-                    const progressLabel = jobProgressLabel(j)
+                    const status = effectiveJobStatus(j, doc)
+                    const pillState = jobPillState(status)
+                    const progressLabel = jobProgressLabel(j, doc, status)
                     return (
                       <tr key={j.job_id || j.stage} className="border-b border-gray-100 dark:border-gray-700">
                         <td className="py-1 pr-3 font-medium">{stageName(j.stage)}</td>
                         <td className="py-1 pr-3">
-                          <StatusPill state={pillState} label={j.status} />
+                          <StatusPill state={pillState} label={status} />
                         </td>
                         <td
                           className="py-1 pr-3 text-gray-500 dark:text-gray-400"
@@ -892,7 +916,7 @@ export default function DocumentDetailPage() {
                         >
                           {progressLabel}
                         </td>
-                        <td className="py-1 text-xs text-gray-400">{jobTimeLabel(j)}</td>
+                        <td className="py-1 text-xs text-gray-400">{jobTimeLabel(j, status)}</td>
                       </tr>
                     )
                   })}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -107,6 +107,51 @@ function JobStatusBadge({ status }: { status: string }) {
   return <span className={`rounded-md px-2 py-0.5 text-[11px] font-medium ${cls}`}>{status}</span>
 }
 
+function stageName(stage: string): string {
+  switch (stage) {
+    case 'extract':
+      return 'Extract'
+    case 'ocr':
+      return 'OCR'
+    case 'chunk':
+      return 'Chunk'
+    case 'entities':
+      return 'Entities'
+    case 'embed':
+      return 'Embed'
+    case 'summarize':
+      return 'Summarize'
+    case 'finalize':
+      return 'Finalize'
+    default:
+      return stage
+  }
+}
+
+function jobPillState(status: string): PillState {
+  if (status === 'done') return 'active'
+  if (status === 'running') return 'running'
+  if (status === 'error') return 'error'
+  if (status === 'skipped') return 'idle'
+  return 'pending'
+}
+
+function jobProgressLabel(job: JobInfo): string {
+  if (job.progress_total) return `${job.progress_current || 0}/${job.progress_total}`
+  if (job.status !== 'skipped') return '—'
+  if (job.error) return job.error
+  if (job.stage === 'ocr') return 'not needed'
+  if (job.stage === 'summarize') return 'skipped by maintenance'
+  return 'skipped'
+}
+
+function jobTimeLabel(job: JobInfo): string {
+  if (job.finished_at) return new Date(job.finished_at).toLocaleTimeString()
+  if (job.status === 'skipped') return 'skipped'
+  if (job.started_at) return 'running...'
+  return 'queued'
+}
+
 function DocStatusBanner({ doc }: { doc: DocumentDetail }) {
   const hasJobs = doc.jobs.length > 0
   const allDone = hasJobs && doc.jobs.every((j) => j.status === 'done' || j.status === 'skipped')
@@ -833,31 +878,21 @@ export default function DocumentDetailPage() {
                 </thead>
                 <tbody>
                   {doc.jobs.map((j) => {
-                    const pillState: PillState =
-                      j.status === 'done'
-                        ? 'active'
-                        : j.status === 'running'
-                          ? 'running'
-                          : j.status === 'error'
-                            ? 'error'
-                            : 'pending'
-                    const pillLabel = j.status === 'done' ? 'done' : j.status === 'queued' ? 'queued' : undefined
+                    const pillState = jobPillState(j.status)
+                    const progressLabel = jobProgressLabel(j)
                     return (
                       <tr key={j.job_id || j.stage} className="border-b border-gray-100 dark:border-gray-700">
-                        <td className="py-1 pr-3 font-medium">{j.stage}</td>
+                        <td className="py-1 pr-3 font-medium">{stageName(j.stage)}</td>
                         <td className="py-1 pr-3">
-                          <StatusPill state={pillState} label={pillLabel} />
+                          <StatusPill state={pillState} label={j.status} />
                         </td>
-                        <td className="py-1 pr-3 text-gray-500 dark:text-gray-400">
-                          {j.progress_total ? `${j.progress_current || 0}/${j.progress_total}` : '—'}
+                        <td
+                          className="py-1 pr-3 text-gray-500 dark:text-gray-400"
+                          title={progressLabel.length > 48 ? progressLabel : undefined}
+                        >
+                          {progressLabel}
                         </td>
-                        <td className="py-1 text-xs text-gray-400">
-                          {j.finished_at
-                            ? new Date(j.finished_at).toLocaleTimeString()
-                            : j.started_at
-                              ? 'running...'
-                              : 'queued'}
-                        </td>
+                        <td className="py-1 text-xs text-gray-400">{jobTimeLabel(j)}</td>
                       </tr>
                     )
                   })}

--- a/frontend/src/pages/SystemStatusPage.test.tsx
+++ b/frontend/src/pages/SystemStatusPage.test.tsx
@@ -40,6 +40,8 @@ const SUMMARY = {
     active_documents: 3,
     ready_documents: 1,
     processing_documents: 1,
+    pipeline_processing_documents: 1,
+    stranded_documents: 0,
     failed_documents: 1,
     queued_jobs: 2,
     running_jobs: 1,
@@ -84,6 +86,8 @@ const SUMMARY = {
       doc_id: 'doc-2',
       title: 'Still embedding',
       pipeline_status: 'embedding',
+      processing_stage: 'embed',
+      job_status: 'running',
       updated_at: '2026-06-04T12:01:00Z',
     },
   ],
@@ -149,6 +153,8 @@ describe('SystemStatusPage', () => {
       counts: {
         ...SUMMARY.counts,
         processing_documents: 0,
+        pipeline_processing_documents: 0,
+        stranded_documents: 0,
         failed_documents: 0,
         queued_jobs: 0,
         running_jobs: 0,
@@ -176,5 +182,42 @@ describe('SystemStatusPage', () => {
     expect(await screen.findByText('Entity extraction skipped some documents')).toBeInTheDocument()
     expect(screen.getAllByText('Review').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByRole('link', { name: 'Open maintenance' })).toHaveAttribute('href', '/settings/maintenance')
+  })
+
+  it('separates stale pipeline state from live processing', async () => {
+    mockRequests({
+      state: 'needs_attention',
+      counts: {
+        ...SUMMARY.counts,
+        processing_documents: 0,
+        pipeline_processing_documents: 12,
+        stranded_documents: 12,
+        failed_documents: 0,
+        queued_jobs: 0,
+        running_jobs: 0,
+        failed_jobs: 0,
+        stuck_jobs: 0,
+      },
+      needs_attention: [
+        {
+          kind: 'stranded_pipeline_state',
+          severity: 'warning',
+          title: 'Some documents are marked processing without active jobs',
+          detail: '12 active documents have an in-progress pipeline state but no queued or running ingest job.',
+          count: 12,
+          action_label: 'Open maintenance',
+          action_href: '/settings/maintenance',
+        },
+      ],
+      recent_failed_documents: [],
+      recent_processing_documents: [],
+    })
+
+    renderStatusPage()
+
+    expect(await screen.findByText('Some documents are marked processing without active jobs')).toBeInTheDocument()
+    expect(screen.getByText('Stale state')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.queryByText('Processing now')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/SystemStatusPage.test.tsx
+++ b/frontend/src/pages/SystemStatusPage.test.tsx
@@ -142,4 +142,39 @@ describe('SystemStatusPage', () => {
     await waitFor(() => expect(postMock).toHaveBeenCalledWith('/api/system/reaper-run'))
     expect(await screen.findByText('Recovered 1 stale job.')).toBeInTheDocument()
   })
+
+  it('shows warning-only entity issues as review items with maintenance CTA', async () => {
+    mockRequests({
+      state: 'needs_attention',
+      counts: {
+        ...SUMMARY.counts,
+        processing_documents: 0,
+        failed_documents: 0,
+        queued_jobs: 0,
+        running_jobs: 0,
+        failed_jobs: 0,
+        ner_skipped_documents: 12,
+        stuck_jobs: 0,
+      },
+      needs_attention: [
+        {
+          kind: 'entity_extraction_skipped',
+          severity: 'warning',
+          title: 'Entity extraction skipped some documents',
+          detail: '12 documents were processed while spaCy NER models were unavailable.',
+          count: 12,
+          action_label: 'Open maintenance',
+          action_href: '/settings/maintenance',
+        },
+      ],
+      recent_failed_documents: [],
+      recent_processing_documents: [],
+    })
+
+    renderStatusPage()
+
+    expect(await screen.findByText('Entity extraction skipped some documents')).toBeInTheDocument()
+    expect(screen.getAllByText('Review').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole('link', { name: 'Open maintenance' })).toHaveAttribute('href', '/settings/maintenance')
+  })
 })

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -43,6 +43,8 @@ interface StatusDoc {
   title: string
   canonical_filename?: string | null
   pipeline_status: string
+  processing_stage?: string | null
+  job_status?: string | null
   error?: string | null
   failed_stage?: string | null
   updated_at?: string | null
@@ -54,6 +56,8 @@ interface StatusSummary {
     active_documents: number
     ready_documents: number
     processing_documents: number
+    pipeline_processing_documents?: number
+    stranded_documents: number
     failed_documents: number
     queued_jobs: number
     running_jobs: number
@@ -93,7 +97,17 @@ function hasErrorIssue(items: StatusIssue[]): boolean {
 }
 
 function stateLabel(state: StatusSummary['state'] | undefined, attentionItems: StatusIssue[] = []): string {
-  if (state === 'needs_attention') return hasErrorIssue(attentionItems) ? 'Needs attention' : 'Review'
+  if (state === 'needs_attention') {
+    const errorItems = attentionItems.filter((item) => item.severity === 'error')
+    if (errorItems.length === 0) return 'Review'
+    if (errorItems.length > 1) return 'Action needed'
+    const issue = errorItems[0]
+    if (issue.kind === 'stuck_jobs') return issue.count === 1 ? 'Stuck job' : 'Stuck jobs'
+    if (issue.kind === 'failed_documents') return issue.count === 1 ? 'Failed doc' : 'Failed docs'
+    if (issue.kind === 'folder_access') return issue.count === 1 ? 'Folder issue' : 'Folder issues'
+    if (issue.kind === 'service_health') return 'Service issue'
+    return 'Action needed'
+  }
   if (state === 'processing') return 'Processing'
   return 'Ready'
 }
@@ -231,6 +245,7 @@ export default function SystemStatusPage() {
   const attentionItems = [...serviceIssues, ...(summary?.needs_attention ?? [])]
   const displayState: StatusSummary['state'] =
     attentionItems.length > 0 ? 'needs_attention' : summary?.state === 'processing' ? 'processing' : 'ready'
+  const attentionHeading = hasErrorIssue(attentionItems) ? 'Action needed' : 'Review'
 
   if (loading && !health && !summary) {
     return <div className="text-gray-500 dark:text-gray-400">Loading status...</div>
@@ -240,7 +255,7 @@ export default function SystemStatusPage() {
     <div className="animate-slide-in">
       <PageHeader
         title="Status"
-        subtitle="Readiness, needs-attention items, and recovery actions"
+        subtitle="Readiness, active processing, and recovery actions"
         actions={
           <button
             onClick={handleRefresh}
@@ -286,6 +301,9 @@ export default function SystemStatusPage() {
             <MetricTile label="Documents" value={summary?.counts.active_documents ?? 0} />
             <MetricTile label="Ready" value={summary?.counts.ready_documents ?? 0} />
             <MetricTile label="Processing" value={summary?.counts.processing_documents ?? 0} />
+            {(summary?.counts.stranded_documents ?? 0) > 0 && (
+              <MetricTile label="Stale state" value={summary?.counts.stranded_documents ?? 0} tone="warning" />
+            )}
             <MetricTile label="Failed" value={summary?.counts.failed_documents ?? 0} tone="error" />
             <MetricTile label="Queued jobs" value={summary?.counts.queued_jobs ?? 0} />
             <MetricTile label="Running jobs" value={summary?.counts.running_jobs ?? 0} />
@@ -295,7 +313,9 @@ export default function SystemStatusPage() {
 
       <section className="mb-6">
         <div className="mb-3 flex items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold text-(--color-text-primary)">Needs attention</h2>
+          <h2 className="text-lg font-semibold text-(--color-text-primary)">
+            {attentionItems.length > 0 ? attentionHeading : 'Action needed'}
+          </h2>
           {attentionItems.length > 0 && (
             <Link to="/settings/maintenance" className="text-sm text-(--color-accent) hover:underline">
               Advanced maintenance
@@ -308,7 +328,8 @@ export default function SystemStatusPage() {
             <div className="flex items-center gap-3">
               <StatusPill state="active" label="No action needed" />
               <p className="text-sm text-(--color-text-secondary)">
-                No failed documents, stuck jobs, unavailable folders, or degraded service checks are currently reported.
+                No failed documents, stuck jobs, stale pipeline states, unavailable folders, or degraded service checks
+                are currently reported.
               </p>
             </div>
           </Card>
@@ -373,7 +394,8 @@ function ReadinessChecklist({
   const healthOk = health ? Object.values(health.checks).every(serviceIsOk) : false
   const foldersReady = (summary?.counts.watched_folders ?? 0) > 0 && (summary?.counts.unavailable_folders ?? 0) === 0
   const docsOk = (summary?.counts.failed_documents ?? 0) === 0
-  const processing = (summary?.counts.processing_documents ?? 0) > 0 || (summary?.counts.running_jobs ?? 0) > 0
+  const activeJobs = (summary?.counts.queued_jobs ?? 0) + (summary?.counts.running_jobs ?? 0)
+  const processing = (summary?.counts.processing_documents ?? 0) > 0 || activeJobs > 0
   const localAiLabel =
     llmState === 'ready'
       ? 'ready'
@@ -417,7 +439,11 @@ function ReadinessChecklist({
       <CheckRow
         label="Ingestion"
         state={processing ? 'running' : 'active'}
-        detail={processing ? 'Documents are processing' : 'No active processing'}
+        detail={
+          processing
+            ? `${activeJobs.toLocaleString()} active job${activeJobs === 1 ? '' : 's'}`
+            : 'No active processing'
+        }
       />
       <CheckRow label="Local AI" state={localAiState} detail={localAiLabel} />
     </div>
@@ -436,14 +462,25 @@ function CheckRow({ label, state, detail }: { label: string; state: PillState; d
   )
 }
 
-function MetricTile({ label, value, tone = 'normal' }: { label: string; value: number; tone?: 'normal' | 'error' }) {
+function MetricTile({
+  label,
+  value,
+  tone = 'normal',
+}: {
+  label: string
+  value: number
+  tone?: 'normal' | 'error' | 'warning'
+}) {
+  const valueClass =
+    tone === 'error' && value > 0
+      ? 'text-red-600 dark:text-red-400'
+      : tone === 'warning' && value > 0
+        ? 'text-amber-600 dark:text-amber-400'
+        : ''
+
   return (
     <div className="rounded-lg bg-(--color-bg-secondary) px-3 py-3">
-      <div
-        className={`text-2xl font-semibold ${tone === 'error' && value > 0 ? 'text-red-600 dark:text-red-400' : ''}`}
-      >
-        {value.toLocaleString()}
-      </div>
+      <div className={`text-2xl font-semibold ${valueClass}`}>{value.toLocaleString()}</div>
       <div className="mt-1 text-xs text-(--color-text-secondary)">{label}</div>
     </div>
   )
@@ -513,7 +550,11 @@ function RecentActivity({ summary }: { summary: StatusSummary | null }) {
           <h2 className="mb-3 text-lg font-semibold text-(--color-text-primary)">Processing now</h2>
           <div className="space-y-2">
             {processing.map((doc) => (
-              <DocumentStatusRow key={doc.doc_id} doc={doc} tone="running" />
+              <DocumentStatusRow
+                key={`${doc.doc_id}-${doc.processing_stage ?? doc.pipeline_status}`}
+                doc={doc}
+                tone="running"
+              />
             ))}
           </div>
         </div>
@@ -523,6 +564,12 @@ function RecentActivity({ summary }: { summary: StatusSummary | null }) {
 }
 
 function DocumentStatusRow({ doc, tone }: { doc: StatusDoc; tone: 'error' | 'running' }) {
+  const processingDetail =
+    tone === 'running' && doc.processing_stage && doc.job_status
+      ? `${doc.processing_stage} ${doc.job_status}`
+      : doc.pipeline_status
+  const detail = tone === 'running' ? processingDetail : doc.error || doc.canonical_filename || doc.pipeline_status
+
   return (
     <Card interactive className="p-3">
       <div className="flex items-start justify-between gap-3">
@@ -532,10 +579,10 @@ function DocumentStatusRow({ doc, tone }: { doc: StatusDoc; tone: 'error' | 'run
           </Link>
           <div className="mt-0.5 truncate text-xs text-(--color-text-secondary)">
             {doc.failed_stage ? `${doc.failed_stage}: ` : ''}
-            {doc.error || doc.canonical_filename || doc.pipeline_status}
+            {detail}
           </div>
         </div>
-        <StatusPill state={tone === 'error' ? 'error' : 'running'} label={doc.pipeline_status} />
+        <StatusPill state={tone === 'error' ? 'error' : 'running'} label={doc.job_status ?? doc.pipeline_status} />
       </div>
     </Card>
   )

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -88,14 +88,18 @@ function formatStatValue(key: string, value: number | string | null | undefined)
   return value.toLocaleString()
 }
 
-function stateLabel(state?: StatusSummary['state']): string {
-  if (state === 'needs_attention') return 'Needs attention'
+function hasErrorIssue(items: StatusIssue[]): boolean {
+  return items.some((item) => item.severity === 'error')
+}
+
+function stateLabel(state: StatusSummary['state'] | undefined, attentionItems: StatusIssue[] = []): string {
+  if (state === 'needs_attention') return hasErrorIssue(attentionItems) ? 'Needs attention' : 'Review'
   if (state === 'processing') return 'Processing'
   return 'Ready'
 }
 
-function statePill(state?: StatusSummary['state']): PillState {
-  if (state === 'needs_attention') return 'error'
+function statePill(state: StatusSummary['state'] | undefined, attentionItems: StatusIssue[] = []): PillState {
+  if (state === 'needs_attention') return hasErrorIssue(attentionItems) ? 'error' : 'pending'
   if (state === 'processing') return 'running'
   return 'active'
 }
@@ -268,7 +272,10 @@ export default function SystemStatusPage() {
                 The short version of whether Harbor Clerk is ready to search, ingest, and answer.
               </p>
             </div>
-            <StatusPill state={statePill(displayState)} label={stateLabel(displayState)} />
+            <StatusPill
+              state={statePill(displayState, attentionItems)}
+              label={stateLabel(displayState, attentionItems)}
+            />
           </div>
           <ReadinessChecklist summary={summary} health={health} llmState={llmStatus.state} />
         </Card>

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -395,14 +395,16 @@ async def status_summary(
             {
                 "kind": "entity_extraction_skipped",
                 "severity": "warning",
-                "title": "Entity extraction was skipped",
+                "title": "Entity extraction skipped some documents",
                 "detail": (
                     f"{ner_skipped_documents} document{'s' if ner_skipped_documents != 1 else ''} "
-                    "were processed while spaCy NER models were unavailable."
+                    "were processed while spaCy NER models were unavailable. Search still works, "
+                    "but entity filters and Explore may be incomplete. If NER models are installed now, "
+                    "open Maintenance and reprocess to populate entities."
                 ),
                 "count": int(ner_skipped_documents),
-                "action_label": "Review diagnostics",
-                "action_href": "/settings/diagnostics",
+                "action_label": "Open maintenance",
+                "action_href": "/settings/maintenance",
             }
         )
 

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -234,7 +234,7 @@ async def status_summary(
     active_documents = sum(pipeline_counts.values())
     ready_documents = pipeline_counts.get(PipelineStatus.ready.value, 0)
     failed_documents = pipeline_counts.get(PipelineStatus.error.value, 0)
-    processing_documents = sum(pipeline_counts.get(status.value, 0) for status in _PROCESSING_STATUSES)
+    pipeline_processing_documents = sum(pipeline_counts.get(status.value, 0) for status in _PROCESSING_STATUSES)
 
     job_rows = (
         await session.execute(
@@ -249,6 +249,28 @@ async def status_summary(
         for row in job_rows
         if row[0] is not None
     }
+    live_processing_documents = (
+        await session.execute(
+            select(func.count(func.distinct(IngestionJob.doc_id)))
+            .join(Document, Document.doc_id == IngestionJob.doc_id)
+            .where(
+                Document.status == "active",
+                IngestionJob.status.in_((JobStatus.queued, JobStatus.running)),
+            )
+        )
+    ).scalar() or 0
+    live_job_doc_ids = (
+        select(IngestionJob.doc_id).where(IngestionJob.status.in_((JobStatus.queued, JobStatus.running))).distinct()
+    )
+    stranded_documents = (
+        await session.execute(
+            select(func.count(Document.doc_id)).where(
+                Document.status == "active",
+                Document.pipeline_status.in_(_PROCESSING_STATUSES),
+                Document.doc_id.not_in(live_job_doc_ids),
+            )
+        )
+    ).scalar() or 0
 
     folder_rows = (
         await session.execute(
@@ -332,25 +354,32 @@ async def status_summary(
         )
 
     processing_docs = (
-        (
-            await session.execute(
-                select(Document)
-                .where(Document.status == "active", Document.pipeline_status.in_(_PROCESSING_STATUSES))
-                .order_by(Document.updated_at.desc())
-                .limit(5)
+        await session.execute(
+            select(
+                Document,
+                IngestionJob.stage,
+                IngestionJob.status,
             )
+            .join(Document, Document.doc_id == IngestionJob.doc_id)
+            .where(
+                Document.status == "active",
+                IngestionJob.status.in_((JobStatus.queued, JobStatus.running)),
+            )
+            .order_by(IngestionJob.started_at.desc().nullslast(), IngestionJob.created_at.desc())
+            .limit(5)
         )
-        .scalars()
-        .all()
-    )
+    ).all()
     recent_processing_documents = [
         {
             "doc_id": str(doc.doc_id),
             "title": doc.title,
+            "canonical_filename": doc.canonical_filename,
             "pipeline_status": doc.pipeline_status.value,
+            "processing_stage": stage.value,
+            "job_status": status.value,
             "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
         }
-        for doc in processing_docs
+        for doc, stage, status in processing_docs
     ]
 
     needs_attention: list[dict[str, Any]] = []
@@ -390,6 +419,22 @@ async def status_summary(
                 "action_href": "/folders",
             }
         )
+    if stranded_documents:
+        needs_attention.append(
+            {
+                "kind": "stranded_pipeline_state",
+                "severity": "warning",
+                "title": "Some documents are marked processing without active jobs",
+                "detail": (
+                    f"{stranded_documents} active document{'s' if stranded_documents != 1 else ''} "
+                    "have an in-progress pipeline state but no queued or running ingest job. "
+                    "They may need reprocessing or cleanup if they do not clear after the current queue finishes."
+                ),
+                "count": int(stranded_documents),
+                "action_label": "Open maintenance",
+                "action_href": "/settings/maintenance",
+            }
+        )
     if ner_skipped_documents:
         needs_attention.append(
             {
@@ -412,7 +457,9 @@ async def status_summary(
     if needs_attention:
         state = "needs_attention"
     elif (
-        processing_documents or job_counts.get(JobStatus.queued.value, 0) or job_counts.get(JobStatus.running.value, 0)
+        live_processing_documents
+        or job_counts.get(JobStatus.queued.value, 0)
+        or job_counts.get(JobStatus.running.value, 0)
     ):
         state = "processing"
 
@@ -421,7 +468,9 @@ async def status_summary(
         "counts": {
             "active_documents": active_documents,
             "ready_documents": ready_documents,
-            "processing_documents": processing_documents,
+            "processing_documents": int(live_processing_documents),
+            "pipeline_processing_documents": pipeline_processing_documents,
+            "stranded_documents": int(stranded_documents),
             "failed_documents": failed_documents,
             "queued_jobs": job_counts.get(JobStatus.queued.value, 0),
             "running_jobs": job_counts.get(JobStatus.running.value, 0),

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -159,6 +159,11 @@ async def test_status_summary_surfaces_recovery_attention(client, admin_user, ad
         "folder_access",
         "entity_extraction_skipped",
     }.issubset(issue_kinds)
+    entity_issue = next(issue for issue in data["needs_attention"] if issue["kind"] == "entity_extraction_skipped")
+    assert entity_issue["title"] == "Entity extraction skipped some documents"
+    assert "open Maintenance and reprocess" in entity_issue["detail"]
+    assert entity_issue["action_label"] == "Open maintenance"
+    assert entity_issue["action_href"] == "/settings/maintenance"
     assert data["recent_failed_documents"][0]["title"] == "Broken scan"
     assert data["recent_failed_documents"][0]["failed_stage"] == "extract"
     assert data["recent_processing_documents"][0]["title"] == "Still embedding"

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -148,6 +148,8 @@ async def test_status_summary_surfaces_recovery_attention(client, admin_user, ad
     assert data["state"] == "needs_attention"
     assert data["counts"]["failed_documents"] == 1
     assert data["counts"]["processing_documents"] == 1
+    assert data["counts"]["pipeline_processing_documents"] == 1
+    assert data["counts"]["stranded_documents"] == 0
     assert data["counts"]["stuck_jobs"] == 1
     assert data["counts"]["unavailable_folders"] == 1
     assert data["counts"]["ner_skipped_documents"] == 1
@@ -167,6 +169,33 @@ async def test_status_summary_surfaces_recovery_attention(client, admin_user, ad
     assert data["recent_failed_documents"][0]["title"] == "Broken scan"
     assert data["recent_failed_documents"][0]["failed_stage"] == "extract"
     assert data["recent_processing_documents"][0]["title"] == "Still embedding"
+    assert data["recent_processing_documents"][0]["processing_stage"] == "embed"
+    assert data["recent_processing_documents"][0]["job_status"] == "running"
+
+
+async def test_status_summary_separates_stranded_pipeline_state(client, admin_user, admin_token, db_session):
+    stranded_doc = Document(
+        title="Marked chunking",
+        status="active",
+        sha256=b"s" * 32,
+        pipeline_status=PipelineStatus.chunking,
+    )
+    db_session.add(stranded_doc)
+    await db_session.flush()
+
+    resp = await client.get("/api/system/status-summary", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "needs_attention"
+    assert data["counts"]["processing_documents"] == 0
+    assert data["counts"]["pipeline_processing_documents"] == 1
+    assert data["counts"]["stranded_documents"] == 1
+    assert data["recent_processing_documents"] == []
+
+    issue = next(issue for issue in data["needs_attention"] if issue["kind"] == "stranded_pipeline_state")
+    assert issue["severity"] == "warning"
+    assert issue["count"] == 1
+    assert "no queued or running ingest job" in issue["detail"]
 
 
 async def test_status_summary_ready_when_no_attention_items(client, admin_user, admin_token, db_session):


### PR DESCRIPTION
## Summary
- render skipped ingestion stages as skipped instead of pending in document detail
- clarify warning-only status state as Review rather than red Needs attention
- rename the global entity warning to Entities skipped and point the Status CTA to Maintenance with explicit reprocess guidance

## Fresh-eyes review
- reviewed the final diff for status severity ambiguity, skipped-stage rendering regressions, and misleading recovery CTAs
- kept entity warnings above processing in the global pill, but changed the label so it names the concrete issue instead of a vague check

## Tests
- npm --prefix frontend test -- --run src/pages/DocumentDetailPage.test.tsx src/pages/SystemStatusPage.test.tsx src/components/GlobalStatusPill.test.tsx
- npm --prefix frontend run type-check
- npm --prefix frontend run lint (passes with existing warnings)
- npm --prefix frontend run format:check
- npm --prefix frontend test -- --run
- uv run pytest tests/test_api_system.py -q
- uv run ruff check src/harbor_clerk/api/routes/system.py tests/test_api_system.py
- uv run ruff format --check src/harbor_clerk/api/routes/system.py tests/test_api_system.py
