### PR TITLE
Handle Apple summary context overflows

### DIFF
--- a/src/harbor_clerk/llm/summarize.py
+++ b/src/harbor_clerk/llm/summarize.py
@@ -38,8 +38,16 @@ class AppleIntelligenceUnavailableError(RuntimeError):
     """Raised when forced Apple Intelligence summaries cannot be produced."""
 
 
-class AppleIntelligenceContentRejectedError(RuntimeError):
+class AppleIntelligenceDocumentError(RuntimeError):
+    """Raised when Apple Intelligence refuses a specific document/request."""
+
+
+class AppleIntelligenceContentRejectedError(AppleIntelligenceDocumentError):
     """Raised when Apple Intelligence refuses a specific document's content."""
+
+
+class AppleIntelligenceContextWindowError(AppleIntelligenceDocumentError):
+    """Raised when a document is too large for Apple Intelligence after shrinking."""
 
 
 class _Tier(Enum):
@@ -488,9 +496,20 @@ def _remember_apple_intelligence_failure(reason: str) -> None:
     _afm_last_failure_reason = reason
 
 
+def _clear_apple_intelligence_failure() -> None:
+    global _afm_last_failure_until_monotonic, _afm_last_failure_reason
+    _afm_last_failure_until_monotonic = 0.0
+    _afm_last_failure_reason = ""
+
+
 def _is_apple_intelligence_content_rejection(reason: str) -> bool:
     normalized = reason.lower()
     return "unsafe" in normalized or "safety" in normalized
+
+
+def _is_apple_intelligence_context_window_error(reason: str) -> bool:
+    normalized = reason.lower()
+    return "context window" in normalized or "context size" in normalized
 
 
 def _disable_apple_intelligence(reason: str) -> None:
@@ -647,6 +666,7 @@ def _apple_intelligence_call(text: str, mode: str, max_chars: int = 500) -> str 
     if not result:
         _remember_apple_intelligence_failure("helper returned an empty summary")
         return None
+    _clear_apple_intelligence_failure()
     logger.info("Apple Intelligence %s: %d chars", mode, len(result))
     return result
 
@@ -666,7 +686,15 @@ def _apple_intelligence_summary(chunks: list[str], max_chars: int) -> str | None
         sampled += chunks[-2:]
         text = "\n\n".join(sampled)
 
-    return _apple_intelligence_call(text, mode="summary", max_chars=max_chars)
+    for limit in (12_000, 8_000, 5_000, 3_000):
+        result = _apple_intelligence_call(text[:limit], mode="summary", max_chars=max_chars)
+        if result:
+            return result
+        reason = _recent_apple_intelligence_failure_reason() or ""
+        if not _is_apple_intelligence_context_window_error(reason):
+            return None
+        logger.info("Apple Intelligence summary exceeded context at %d chars; retrying with shorter input", limit)
+    return None
 
 
 def _apple_intelligence_doc_type(chunks: list[str]) -> str | None:
@@ -928,6 +956,14 @@ def generate_summary(
             )
             raise AppleIntelligenceContentRejectedError(
                 f"Apple Intelligence refused to summarize this document: {reason}"
+            )
+        if _is_apple_intelligence_context_window_error(reason):
+            logger.error(
+                "Apple Intelligence exceeded context for this document while forced; refusing extractive fallback (%s)",
+                reason,
+            )
+            raise AppleIntelligenceContextWindowError(
+                f"Apple Intelligence could not summarize this document within its context window: {reason}"
             )
         if _apple_intelligence_disabled_reason() is None:
             _disable_apple_intelligence(reason)

--- a/src/harbor_clerk/worker/stages/summarize.py
+++ b/src/harbor_clerk/worker/stages/summarize.py
@@ -10,7 +10,7 @@ from sqlalchemy import select, update
 from harbor_clerk.config import refresh_llm_settings
 from harbor_clerk.db_sync import get_sync_session
 from harbor_clerk.llm.summarize import (
-    AppleIntelligenceContentRejectedError,
+    AppleIntelligenceDocumentError,
     AppleIntelligenceUnavailableError,
     classify_doc_type,
     generate_summary,
@@ -142,8 +142,8 @@ def run_summarize(doc_id: uuid.UUID, *, worker_seq: int | None = None) -> None:
             except AppleIntelligenceUnavailableError:
                 logger.warning("Summary generation blocked for %s because Apple Intelligence is unavailable", doc_id)
                 raise
-            except AppleIntelligenceContentRejectedError:
-                logger.warning("Summary generation rejected for %s by Apple Intelligence safety checks", doc_id)
+            except AppleIntelligenceDocumentError:
+                logger.warning("Summary generation rejected for %s by Apple Intelligence", doc_id)
                 raise
             except Exception:
                 logger.warning("Summary generation failed for %s", doc_id, exc_info=True)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -7,6 +7,7 @@ import pytest
 
 from harbor_clerk.llm.summarize import (
     AppleIntelligenceContentRejectedError,
+    AppleIntelligenceContextWindowError,
     AppleIntelligenceUnavailableError,
     _compute_max_input_chars,
     _extractive_fallback,
@@ -566,6 +567,28 @@ class TestGenerateSummary:
             mock_call.assert_not_called()
             disable_afm.assert_not_called()
 
+    def test_force_afm_context_window_is_not_unavailable(self):
+        """A too-large AFM prompt should fail one document, not pause the whole queue."""
+        mock_call = MagicMock()
+        with (
+            patch(
+                "harbor_clerk.llm.summarize.get_settings",
+                return_value=_mock_settings(summary_force_apple_intelligence=True),
+            ),
+            patch("harbor_clerk.llm.summarize._call_llm", mock_call),
+            patch("harbor_clerk.llm.summarize._apple_intelligence_summary", return_value=None),
+            patch(
+                "harbor_clerk.llm.summarize._apple_intelligence_unavailable_reason",
+                return_value="Exceeded model context window size",
+            ),
+            patch("harbor_clerk.llm.summarize._disable_apple_intelligence") as disable_afm,
+        ):
+            chunks = ["A" * 100]
+            with pytest.raises(AppleIntelligenceContextWindowError, match="context window"):
+                generate_summary(chunks)
+            mock_call.assert_not_called()
+            disable_afm.assert_not_called()
+
 
 def test_summarize_long_calls_progress_callback_per_map_step(monkeypatch):
     """Map-reduce summarize must report progress between sub-calls so the
@@ -604,6 +627,26 @@ def test_summarize_long_calls_progress_callback_per_map_step(monkeypatch):
     n_total = totals.pop()
     assert n_total == len(progress_calls), f"expected total={len(progress_calls)} (groups+reduce), got {n_total}"
     assert currents[-1] == n_total - 1, "reduce step must fire as the final progress event"
+
+
+def test_apple_summary_retries_shorter_input_on_context_window(monkeypatch):
+    from harbor_clerk.llm import summarize as sum_mod
+
+    requested_lengths: list[int] = []
+
+    def fake_apple_call(text, *, mode, max_chars=500):
+        requested_lengths.append(len(text))
+        if len(requested_lengths) == 1:
+            sum_mod._remember_apple_intelligence_failure("Exceeded model context window size")
+            return None
+        return "Shorter AFM summary."
+
+    monkeypatch.setattr(sum_mod, "_apple_intelligence_call", fake_apple_call)
+
+    result = sum_mod._apple_intelligence_summary(["A" * 15_000], max_chars=500)
+
+    assert result == "Shorter AFM summary."
+    assert requested_lengths == [12_000, 8_000]
 
 
 class TestTruncateAtSentence:


### PR DESCRIPTION
## Summary\n- retry forced Apple summaries with shorter input when Foundation Models reports context-window overflow\n- treat remaining Apple document/request failures as per-document summary errors instead of global AFM outages\n- add regression coverage for context overflow classification and shorter-input retry\n\n## Tests\n- uv run ruff check src/harbor_clerk/llm/summarize.py src/harbor_clerk/worker/stages/summarize.py tests/test_summarize.py tests/test_pipeline.py src/harbor_clerk/worker/entry.py\n- uv run ruff format --check src/harbor_clerk/llm/summarize.py src/harbor_clerk/worker/stages/summarize.py tests/test_summarize.py tests/test_pipeline.py src/harbor_clerk/worker/entry.py\n- uv run pytest tests/test_summarize.py tests/test_pipeline.py tests/test_api_system.py tests/api/test_chat_models_status.py -q