### PR TITLE
Improve source citation filename display

### DIFF
--- a/frontend/src/components/SourceCitation.test.tsx
+++ b/frontend/src/components/SourceCitation.test.tsx
@@ -37,7 +37,9 @@ describe('SourceCitation', () => {
     )
 
     expect(screen.getByText('Contract, p. 4')).toBeInTheDocument()
-    expect(screen.getByText('Contracts')).toBeInTheDocument()
-    expect(screen.getByText('vendors/contract.pdf')).toBeInTheDocument()
+    expect(screen.getByText('Folder Contracts')).toBeInTheDocument()
+    expect(screen.getByText('Filename')).toBeInTheDocument()
+    expect(screen.getByText('contract.pdf')).toBeInTheDocument()
+    expect(screen.getByTitle('vendors/contract.pdf')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/SourceCitation.tsx
+++ b/frontend/src/components/SourceCitation.tsx
@@ -10,17 +10,36 @@ function citationText(source?: SourceRef | null, citation?: string | null): stri
   return source?.citation || citation || source?.source_label || null
 }
 
+function fileNameFromPath(path?: string | null): string | null {
+  if (!path) return null
+  const parts = path.split(/[\\/]/).filter(Boolean)
+  return parts[parts.length - 1] || path
+}
+
 export function SourceCitation({ source, citation, className = '' }: SourceCitationProps) {
   const text = citationText(source, citation)
+  const fileName = fileNameFromPath(source?.relative_path)
   if (!text && !source?.relative_path && !source?.folder_label) return null
 
   return (
-    <span className={`inline-flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 ${className}`}>
-      {text && <span className="font-medium text-(--color-text-secondary)">{text}</span>}
-      {source?.folder_label && <span>{source.folder_label}</span>}
-      {source?.relative_path && (
-        <span className="min-w-0 max-w-[32rem] truncate font-mono text-[11px]" title={source.relative_path}>
-          {source.relative_path}
+    <span className={`inline-flex min-w-0 max-w-full flex-col gap-1 ${className}`}>
+      {text && <span className="min-w-0 font-medium text-(--color-text-secondary)">{text}</span>}
+      {(fileName || source?.folder_label) && (
+        <span className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-1.5">
+          {fileName && (
+            <span
+              className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md border border-(--color-border) bg-(--color-bg-secondary) px-1.5 py-0.5"
+              title={source?.relative_path || fileName}
+            >
+              <span className="shrink-0 text-[10px] font-medium text-gray-500 dark:text-gray-400">Filename</span>
+              <span className="min-w-0 max-w-[32rem] truncate font-mono text-[11px] text-(--color-text-secondary)">
+                {fileName}
+              </span>
+            </span>
+          )}
+          {source?.folder_label && (
+            <span className="text-[11px] text-gray-500 dark:text-gray-400">Folder {source.folder_label}</span>
+          )}
         </span>
       )}
       {source?.chunk_id && <span className="sr-only">Chunk {source.chunk_id}</span>}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -758,7 +758,7 @@ export default function SearchPage() {
                       </div>
                     </div>
                     <p className="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{hit.chunk_text}</p>
-                    <div className="flex items-center space-x-3 text-xs text-gray-400">
+                    <div className="flex flex-wrap items-start gap-x-3 gap-y-1 text-xs text-gray-400">
                       <SourceCitation source={hit.source} citation={hit.citation} />
                       {hit.page_start != null && (
                         <span>
@@ -854,7 +854,7 @@ export default function SearchPage() {
                     {hit.top_chunk?.text && (
                       <p className="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{hit.top_chunk.text}</p>
                     )}
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
+                    <div className="flex flex-wrap items-start gap-x-3 gap-y-1 text-xs text-gray-400">
                       <SourceCitation source={hit.source} citation={hit.citation} />
                       {hit.page_range && <span>Pages {hit.page_range}</span>}
                       {hit.language && <span>Lang: {hit.language}</span>}


### PR DESCRIPTION
## Summary
- split SourceCitation into citation text plus a clearer file identity row
- show a labeled File chip with the basename while preserving the safe relative path in the title
- let Search result metadata rows wrap cleanly around the richer citation block

## Tests
- npm test -- SourceCitation.test.tsx --run
- npm run lint
- npm run type-check
- npm run format:check -- src/components/SourceCitation.tsx src/components/SourceCitation.test.tsx src/pages/SearchPage.tsx
- npm run build