### PR TITLE
Polish agent memory integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ harbor-clerk --help                  # full subcommand list
 harbor-clerk search "termination clause" | jq '.hits[] | {title: .doc_title, pages, chunk_id}'
 ```
 
-A copy-pasteable agent skill for these harnesses is in **Settings → Integrations**.
+A copy-pasteable agent skill for these harnesses is in **Settings → Integrations**. See
+[Integrations](docs/integrations.md) for setup details and
+[Agent memory eval plan](docs/agent-memory-eval.md) for the evidence needed before stronger OpenClaw claims.
 
 ## Why Harbor Clerk?
 
@@ -270,7 +272,7 @@ Beyond basic search, Harbor Clerk builds a navigable knowledge graph:
 
 ### External LLM Connections
 
-Connect ChatGPT, Claude Desktop, Claude Code, Gemini CLI, OpenClaw, or any MCP-compatible tool. ChatGPT connects via OAuth (requires a public URL); all others use API key authentication. Connection guides are available in the Integrations settings page.
+Connect ChatGPT, Claude Desktop, Claude Code, Gemini CLI, OpenClaw, or any MCP-compatible tool. ChatGPT connects via OAuth (requires a public URL); all others use API key authentication. Connection guides are available in the Integrations settings page and in [docs/integrations.md](docs/integrations.md).
 
 **Scoped API keys** control what each external tool can access: permission tiers (search / read / full), document scope (by topic or watched folder), snippet size limits, tool overrides, and expiry dates.
 

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /frontend
 COPY frontend/package.json frontend/package-lock.json* frontend/.npmrc ./
 RUN npm ci
 COPY frontend/ .
+COPY skills/ /skills/
 RUN npm run build
 
 # ── Python build ──

--- a/docs/agent-memory-eval.md
+++ b/docs/agent-memory-eval.md
@@ -1,0 +1,155 @@
+# Agent Memory Eval Plan
+
+This plan defines what Harbor Clerk needs to test before making stronger public
+claims about agentic memory, especially with OpenClaw.
+
+Safe release claim today:
+
+> Harbor Clerk can act as a private, cited memory layer for agents through MCP
+> and CLI.
+
+Do not claim measurable productivity, success-rate, or quality improvement
+until the eval results support it.
+
+## Claim Ladder
+
+| Level | Public claim | Required evidence |
+| --- | --- | --- |
+| 0 | Harbor Clerk exposes your local archive to agents through MCP and CLI, with citations. | Tool parity, setup docs, citation consistency, and boundary disclosure. |
+| 1 | Harbor Clerk works with OpenClaw as a private, cited document memory layer. | Fresh setup test, at least one realistic task, successful source retrieval, troubleshooting notes. |
+| 2 | Harbor Clerk helps OpenClaw workflows find, cite, and reuse facts from local archives. | Multiple task types, correct citations, logged successes and failures. |
+| 3 | Harbor Clerk improves OpenClaw task success or reduces manual retrieval work. | With/without Harbor Clerk comparison, stable scoring, enough tasks to avoid anecdote. |
+
+Initial release should target Level 0 by default. Level 1 is achievable quickly
+if setup and smoke testing pass. Level 2 is the more valuable launch claim if
+wall time stays reasonable. Level 3 should wait.
+
+## Minimum Credible OpenClaw Eval
+
+Goal: decide whether Harbor Clerk can be described as a working OpenClaw memory
+layer, not whether it universally improves agent performance.
+
+Shape:
+
+- 10 to 15 tasks.
+- OpenClaw primary.
+- Codex and Claude Code secondary only if setup is fast.
+- Use at least two corpora, ideally one contract-heavy corpus and one email or
+  mixed-office corpus.
+- Capture traces, tool calls, final answers, cited sources, and operator
+  interventions.
+- Include both success and failure examples in the result note.
+
+Required task types:
+
+- Find all relevant documents matching a fact pattern.
+- Answer a contract question with cited passages.
+- Trace an email thread, sender, recipient, or attachment context.
+- Reuse local project or research memory across a multi-step task.
+- Diagnose missing expected sources by checking ingest or scope state.
+
+Scoring:
+
+- **Task success**: pass, partial, fail.
+- **Citation quality**: correct source, plausible but weak source, wrong or
+  missing source.
+- **Tool behavior**: chose useful Harbor Clerk tools, needed nudging, or ignored
+  available tools.
+- **Intervention count**: number of operator corrections required.
+- **Boundary quality**: no unexpected absolute paths or full-corpus exposure.
+
+Minimum pass criteria:
+
+- The agent retrieves relevant Harbor Clerk sources when the task requires
+  corpus facts.
+- Final answers cite the right documents or passages.
+- The workflow succeeds from documented setup steps.
+- Failures are captured honestly and are not hidden in summary copy.
+
+## Suggested Task Set
+
+| ID | Corpus | Task | Expected signal |
+| --- | --- | --- | --- |
+| OC-01 | CUAD/contracts | Find all agreements that mention renewal, extension, or termination notice terms. | Uses `find-all`; cites multiple documents. |
+| OC-02 | CUAD/contracts | Compare indemnification scope across three relevant contracts. | Searches, expands context, cites passages. |
+| OC-03 | CUAD/contracts | Identify a contract with a worldwide territory clause and cite it. | Finds exact supporting passage. |
+| OC-04 | Enron/email | Find messages involving a named person and summarize the thread with citations. | Uses email metadata and citations. |
+| OC-05 | Enron/email | Trace who received a specific topic update and cite the message. | Uses sender/recipient fields. |
+| OC-06 | Mixed synthetic | Find invoices or vendor notes related to a project and list source documents. | Enumerates matching docs. |
+| OC-07 | Mixed synthetic | Answer a bilingual or OCR-heavy document question. | Handles OCR/language variance. |
+| OC-08 | Project memory | Locate prior notes/specs for a feature and summarize open decisions. | Works as coding/research memory. |
+| OC-09 | Project memory | Given a stale claim, verify whether local docs contradict it. | Uses search plus read/expand. |
+| OC-10 | Scope/ingest | Explain why an expected document might not appear. | Checks scope or ingest status. |
+
+Add five more variations if the first ten are too easy or if failures cluster
+around one tool-selection pattern.
+
+## Wall-Time Estimate
+
+These are estimates until the first dry run is complete.
+
+| Eval size | Evidence level | Wall time | Operator time | Notes |
+| --- | --- | --- | --- | --- |
+| Setup smoke | Level 1 candidate | 2-4 hours | 1-2 hours | Fresh key, CLI/MCP setup, one OpenClaw task, troubleshooting notes. |
+| Minimum credible | Level 2 candidate | 1-2 days if corpora are already ingested; 2-3 days if ingestion must be rebuilt. | 6-10 hours | 10-15 OpenClaw tasks, trace capture, manual scoring. |
+| Fuller comparative | Stronger Level 2, maybe early Level 3 | 4-7 days | 18-30 hours | OpenClaw with/without Harbor Clerk, plus Codex or Claude Code secondary checks. |
+| Outcome claim | Level 3 | 7-14+ days | 30+ hours | More tasks, repeated runs, stronger scoring, and cleaner statistical caution. |
+
+If release timing is tight, run setup smoke plus the minimum credible eval and
+publish only the claim level the evidence supports.
+
+## Runbook
+
+1. Start with a clean Harbor Clerk build and a known corpus state.
+2. Create a dedicated OpenClaw API key with explicit scope, rate limits, and
+   expiry.
+3. Verify CLI access:
+
+```bash
+harbor-clerk search "contract renewal" --json
+harbor-clerk find-all "renewal" --presentation full --json
+```
+
+4. Copy `skills/harbor-clerk/SKILL.md` into the OpenClaw skill location.
+5. Run OC-01 as a dry run. Fix setup problems before scoring.
+6. Run tasks one at a time, saving:
+   - prompt,
+   - trace/tool log,
+   - final answer,
+   - cited sources,
+   - manual score,
+   - operator interventions,
+   - failure notes.
+7. Summarize results in a dated report with commit hash, corpus state, and
+   public-claim recommendation.
+
+## Result Template
+
+```markdown
+# Agent Memory Eval Results - YYYY-MM-DD
+
+- Harbor Clerk commit:
+- OpenClaw version:
+- Corpus:
+- API key scope:
+- Surface: CLI / MCP
+
+| Task | Success | Citation quality | Tool behavior | Interventions | Notes |
+| --- | --- | --- | --- | --- | --- |
+| OC-01 | pass/partial/fail | correct/weak/wrong | good/nudged/ignored | 0 | |
+
+## Supported Claim
+
+Recommended public claim:
+
+## Failures To Disclose
+
+## Follow-Ups
+```
+
+## Release Decision
+
+OpenClaw can be mentioned in release copy at Level 0 with current documented
+tool parity and setup guidance. Promote to Level 1 only after a clean smoke
+test. Promote to Level 2 only after the minimum credible eval produces multiple
+successful, cited traces across task types.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,199 @@
+# Harbor Clerk Integrations
+
+Harbor Clerk can expose a local document archive to external models and local
+agent harnesses through two surfaces:
+
+- **MCP** for cloud models and connector-style clients that can call structured
+  tools over HTTPS.
+- **CLI** for shell-first local agents such as Codex, Claude Code, OpenClaw,
+  and Aider.
+
+Both surfaces use the same scoped API key model, audit logging, citations, and
+tool contracts. Use MCP when a client speaks MCP natively. Use the CLI when an
+agent is better at composing shell commands than remote tool calls.
+
+## Data Boundary
+
+Harbor Clerk does not upload the full corpus to connected tools. External MCP
+clients receive only tool responses: retrieved snippets, citations, document
+titles, folder labels, relative paths, and structured metadata needed for the
+request. Cloud model providers may see that response content and the tool
+arguments they are asked to run.
+
+CLI usage stays on the local machine unless the agent harness itself sends
+command output to a cloud model. Treat local agent harnesses as capable
+operators: give them scoped keys, rate limits, and expiry dates just as you
+would for a cloud connector.
+
+By default, agent-visible paths should avoid absolute local filesystem paths.
+Use relative paths and folder aliases unless a local-only workflow explicitly
+needs more detail.
+
+## API Key Guidance
+
+Create a dedicated API key for each external tool or harness.
+
+- **Search**: search and enumerate documents.
+- **Read**: search plus passage reads, document metadata, outlines, identifier
+  verification, and date lookup.
+- **Full**: all read-only tools, including full document reads, entity tools,
+  related-document tools, and ingest-status checks.
+
+Recommended defaults:
+
+- Cloud connector: **Read**, folder-scoped when possible, snippet caps enabled.
+- Local agent harness: **Read** for normal citation workflows; **Full** only
+  when the agent needs full-document reads, entity tools, or ingest-status
+  checks.
+- Autonomous agent: rate limit and expire the key. Review usage in the audit
+  dashboard.
+
+The admin-only tools `kb_system_health` and `kb_reprocess` are never available
+to API keys.
+
+If a skill or harness tries a tool outside its key scope, treat that as a
+recoverable scope mismatch. The agent should continue with search and passage
+reads, then tell the operator which broader capability was denied.
+
+## MCP Setup
+
+Use MCP for ChatGPT, Claude Desktop, Gemini CLI, and any other client that can
+call remote MCP servers.
+
+1. Set a public HTTPS URL in **Settings -> Integrations** if the client is not
+   running on the same machine.
+2. Create a scoped API key in **Settings -> API Keys**.
+3. Use the MCP URL shown in the Integrations page.
+
+For clients that cannot attach bearer headers, Harbor Clerk supports the
+URL-token form:
+
+```text
+https://your-server.example.com/mcp?key=YOUR_API_KEY
+```
+
+Do not reuse a broad admin key for autonomous tools. Create a separate scoped
+key per connector.
+
+## CLI Setup
+
+Use the CLI for shell-first agent harnesses.
+
+1. Enable CLI access in **Harbor Clerk Server -> Preferences -> Network
+   Access**. Docker/Linux operators can set `ENABLE_CLI_ACCESS=true` and
+   restart the API service.
+2. Install the CLI shim from the same preferences panel if running the macOS
+   native app.
+3. Export connection settings in the shell where the agent runs:
+
+```bash
+export HARBOR_CLERK_URL="http://localhost:8100"
+export HARBOR_CLERK_API_KEY="YOUR_API_KEY"
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+4. Smoke test:
+
+```bash
+harbor-clerk search "contract renewal" --json
+harbor-clerk find-all "renewal" --presentation full --json
+```
+
+The CLI is audit-logged as `request_type="cli_tool"`, distinct from MCP
+traffic. Exit code 3 means CLI access is disabled by an admin.
+
+## OpenClaw
+
+Release-safe claim:
+
+> Harbor Clerk can act as a private, cited memory layer for OpenClaw through
+> MCP or CLI.
+
+Prefer CLI for local OpenClaw runs because it matches OpenClaw's shell-first
+workflow and lets the agent use the checked-in Harbor Clerk skill markdown.
+Use MCP when your OpenClaw setup is already configured for MCP servers.
+
+Minimum setup:
+
+1. Create a dedicated, scoped API key.
+2. Enable CLI access and install the CLI shim.
+3. Copy `skills/harbor-clerk/SKILL.md` into the OpenClaw skill location used by
+   your local setup.
+4. Run a smoke task that requires a cited source from the local archive.
+
+Suggested first task:
+
+```text
+Using Harbor Clerk, find the documents that mention renewal terms, cite the
+best passages, and tell me which source each passage came from.
+```
+
+Do not claim Harbor Clerk improves OpenClaw outcomes until the
+[agent-memory eval](agent-memory-eval.md) has been run and the results support
+that stronger claim.
+
+## Codex
+
+Codex is best treated as a CLI-orchestrating local agent.
+
+1. Create a scoped API key.
+2. Enable CLI access and install the CLI shim.
+3. Export `HARBOR_CLERK_URL` and `HARBOR_CLERK_API_KEY` in the shell where
+   Codex runs.
+4. Copy the Harbor Clerk skill markdown into your local Codex skill location.
+
+Useful first commands:
+
+```bash
+harbor-clerk search "topic or phrase" --json
+harbor-clerk expand-context CHUNK_ID -n 3 --json
+harbor-clerk find-all "literal or semantic query" --presentation full --json
+```
+
+## Claude Desktop and Claude Code
+
+Claude Desktop usually uses MCP:
+
+```json
+{
+  "mcpServers": {
+    "harbor-clerk": {
+      "url": "https://your-server.example.com/mcp?key=YOUR_API_KEY"
+    }
+  }
+}
+```
+
+Claude Code can use MCP if configured for it:
+
+```bash
+claude mcp add harbor-clerk "https://your-server.example.com/mcp?key=YOUR_API_KEY"
+```
+
+For shell-first coding sessions, the CLI path is often simpler. Enable CLI
+access, export the same environment variables shown above, and copy the Harbor
+Clerk skill markdown into the local skill directory.
+
+## ChatGPT and Other Cloud Connectors
+
+ChatGPT-style OAuth connectors require a public HTTPS URL and will authorize
+through the browser. Once connected, the cloud model calls Harbor Clerk tools
+and receives retrieved snippets with citations.
+
+Make the data boundary explicit when helping users set this up:
+
+- The corpus stays local.
+- Retrieved snippets and citation metadata can be sent to the provider.
+- API keys should be scoped.
+- Audit logs should be reviewed if an autonomous agent may call tools in loops.
+
+## Troubleshooting
+
+- **401 Unauthorized**: regenerate or re-copy the API key.
+- **403 CLI access disabled**: enable CLI access in Preferences or set
+  `ENABLE_CLI_ACCESS=true` for Docker/Linux.
+- **MCP client cannot attach headers**: use the URL-token form.
+- **Agent cannot find expected documents**: check ingestion status and key
+  document scope before changing prompts.
+- **Too many tool calls**: lower per-key rate limits or narrow the document
+  scope.

--- a/frontend/src/components/CliAccessCard.tsx
+++ b/frontend/src/components/CliAccessCard.tsx
@@ -1,30 +1,6 @@
 import { useState } from 'react'
 import { Card } from './Card'
-
-const SKILL_MARKDOWN = `---
-name: harbor-clerk
-description: Search and read documents from a local Harbor Clerk knowledge base. Use when the user references their personal documents, contracts, notes, emails, or asks "what did I store about X?"
----
-
-# Harbor Clerk — extended memory for agents
-
-Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-ready reads. This skill exposes it via the \`harbor-clerk\` CLI.
-
-## First step: discover the surface
-Run \`harbor-clerk --help\` for the full command list, then \`harbor-clerk <cmd> --help\` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
-
-## Four patterns you'll use most
-
-1. **Search → expand**: \`harbor-clerk search "..."\` then \`harbor-clerk expand-context <chunk_id> -n 3\` on the best hit.
-2. **Find every matching document**: \`harbor-clerk find-all "..." --text-contains "literal phrase" --presentation full\` when the task asks to list or enumerate.
-3. **Read a known document**: \`harbor-clerk read-document <doc_id>\` for full text with pagination.
-4. **Check ingest status before searching for new content**: \`harbor-clerk ingest-status <doc_id>\` returns per-stage state.
-
-## What you can trust
-- Search returns top-level \`.hits[]\`; Find All returns top-level \`.results[]\`. Result-bearing commands include \`source\`, \`citation\`, and \`chunk_id\` when available. Use those fields as the citation trail, then call \`read-passages\` when you need exact surrounding text.
-- \`possible_conflict: true\` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
-- The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.
-`
+import skillMarkdown from '../../../skills/harbor-clerk/SKILL.md?raw'
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
@@ -154,9 +130,9 @@ export function CliAccessCard({
       </h3>
       <div className="relative mt-1 rounded-lg bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) p-3 font-mono text-xs text-(--color-text-primary) overflow-x-auto">
         <div className="absolute top-2 right-2">
-          <CopyButton text={SKILL_MARKDOWN} />
+          <CopyButton text={skillMarkdown} />
         </div>
-        <pre className="whitespace-pre-wrap pr-16">{SKILL_MARKDOWN}</pre>
+        <pre className="whitespace-pre-wrap pr-16">{skillMarkdown}</pre>
       </div>
     </Card>
   )

--- a/frontend/src/pages/IntegrationsPage.test.tsx
+++ b/frontend/src/pages/IntegrationsPage.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { del, get, put } from '../api'
+import IntegrationsPage from './IntegrationsPage'
+
+vi.mock('../api', () => ({
+  del: vi.fn(),
+  get: vi.fn(),
+  put: vi.fn(),
+}))
+
+vi.mock('../hooks/useSystemConfig', () => ({
+  useSystemConfig: () => ({
+    enableCliAccess: true,
+    cliShimInstallStatus: 'installed',
+  }),
+}))
+
+const getMock = vi.mocked(get)
+const putMock = vi.mocked(put)
+const delMock = vi.mocked(del)
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <IntegrationsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('IntegrationsPage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    putMock.mockReset()
+    delMock.mockReset()
+    getMock.mockImplementation((path: string) => {
+      if (path === '/api/integrations/settings') {
+        return Promise.resolve({ public_url: '', oauth_refresh_token_days: 90 })
+      }
+      if (path === '/api/integrations/connections') {
+        return Promise.resolve([])
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+  })
+
+  it('surfaces Codex and OpenClaw CLI-first setup guidance', async () => {
+    renderPage()
+
+    expect(await screen.findByText('Choose a Surface')).toBeInTheDocument()
+    expect(screen.getByText('Data boundary')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Codex/ }))
+
+    expect(screen.getByText(/Codex works best with Harbor Clerk as a local CLI skill/)).toBeInTheDocument()
+    expect(screen.getByText(/export HARBOR_CLERK_URL=/)).toBeInTheDocument()
+    expect(screen.getByText(/harbor-clerk search "contract renewal" --json/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /OpenClaw/ }))
+
+    expect(screen.getByText(/Prefer the CLI skill for local/)).toBeInTheDocument()
+    expect(screen.getByText(/Full only for local runs/)).toBeInTheDocument()
+  })
+
+  it('renders the checked-in CLI skill markdown with find-all guidance', async () => {
+    renderPage()
+
+    expect(await screen.findByText('Skill markdown')).toBeInTheDocument()
+    expect(screen.getByText(/Find every matching document/)).toBeInTheDocument()
+    expect(screen.getByText(/harbor-clerk find-all/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -21,6 +21,21 @@ interface OAuthConnection {
 
 const TOKEN_LIFETIME_OPTIONS = [30, 60, 90, 120, 365]
 
+type GuideTab = 'chatgpt' | 'claude' | 'codex' | 'gemini' | 'openclaw'
+
+const GUIDE_TABS: Array<{
+  id: GuideTab
+  label: string
+  desc: string
+  icon: string
+}> = [
+  { id: 'chatgpt', label: 'ChatGPT', desc: 'OAuth · cloud MCP', icon: '🌐' },
+  { id: 'claude', label: 'Claude', desc: 'Desktop & Code', icon: '💻' },
+  { id: 'codex', label: 'Codex', desc: 'CLI skill · local', icon: '⌘' },
+  { id: 'gemini', label: 'Gemini CLI', desc: 'API key · terminal', icon: '⌨️' },
+  { id: 'openclaw', label: 'OpenClaw', desc: 'CLI or MCP · agentic', icon: '🧠' },
+]
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
 
@@ -59,7 +74,7 @@ export default function IntegrationsPage() {
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
   const [urlDraft, setUrlDraft] = useState('')
-  const [guideTab, setGuideTab] = useState<'chatgpt' | 'claude' | 'gemini' | 'openclaw'>('chatgpt')
+  const [guideTab, setGuideTab] = useState<GuideTab>('chatgpt')
 
   const loadData = useCallback(async () => {
     try {
@@ -119,6 +134,11 @@ export default function IntegrationsPage() {
   const mcpUrl = settings.public_url
     ? `${settings.public_url.replace(/\/$/, '')}/mcp`
     : 'https://your-server.example.com/mcp'
+  const appOrigin = typeof window !== 'undefined' ? window.location.origin : ''
+  const cliBaseUrl = settings.public_url || appOrigin || 'https://your-server.example.com'
+  const cliEnvBlock = `export HARBOR_CLERK_URL="${cliBaseUrl.replace(/\/$/, '')}"
+export HARBOR_CLERK_API_KEY="YOUR_API_KEY"
+export PATH="$HOME/.local/bin:$PATH"`
 
   if (loading) return <div className="text-gray-500 dark:text-gray-400">Loading...</div>
 
@@ -247,16 +267,31 @@ export default function IntegrationsPage() {
         </Card>
       )}
 
+      <Card className="p-6">
+        <h2 className="text-lg font-semibold mb-3">Choose a Surface</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-lg border border-(--color-border) bg-(--color-bg-secondary) p-4">
+            <p className="text-sm font-semibold text-(--color-text-primary)">MCP for cloud and connector clients</p>
+            <p className="mt-1 text-sm text-(--color-text-secondary)">
+              Use MCP when the tool can call structured remote tools directly. Cloud models receive retrieved snippets,
+              citations, and metadata from scoped tool calls, not the full archive.
+            </p>
+          </div>
+          <div className="rounded-lg border border-(--color-border) bg-(--color-bg-secondary) p-4">
+            <p className="text-sm font-semibold text-(--color-text-primary)">CLI for shell-first local agents</p>
+            <p className="mt-1 text-sm text-(--color-text-secondary)">
+              Use the <code className="rounded bg-(--color-bg-primary) px-1 py-0.5 text-xs">harbor-clerk</code> CLI for
+              Codex, Claude Code, OpenClaw, Aider, and other harnesses that compose shell commands.
+            </p>
+          </div>
+        </div>
+      </Card>
+
       {/* Connection Guides */}
       <Card className="p-6">
-        <div className="grid grid-cols-4 gap-3 mb-6">
-          {(['chatgpt', 'claude', 'gemini', 'openclaw'] as const).map((tab) => {
-            const info = {
-              chatgpt: { label: 'ChatGPT', desc: 'OAuth \u00b7 browser-based', icon: '\ud83c\udf10' },
-              claude: { label: 'Claude', desc: 'API key \u00b7 desktop & CLI', icon: '\ud83d\udcbb' },
-              gemini: { label: 'Gemini CLI', desc: 'API key \u00b7 terminal', icon: '\u2328\ufe0f' },
-              openclaw: { label: 'OpenClaw', desc: 'API key \u00b7 agentic', icon: '\ud83e\udde0' },
-            }[tab]
+        <div className="grid grid-cols-2 gap-3 mb-6 md:grid-cols-5">
+          {GUIDE_TABS.map((info) => {
+            const tab = info.id
             const active = guideTab === tab
             return (
               <button
@@ -278,6 +313,16 @@ export default function IntegrationsPage() {
               </button>
             )
           })}
+        </div>
+
+        <div className="mb-6 rounded-lg border border-(--color-border) bg-(--color-bg-secondary) px-4 py-3">
+          <p className="text-sm font-medium text-(--color-text-primary)">Data boundary</p>
+          <p className="mt-1 text-xs text-(--color-text-secondary)">
+            MCP and URL-token connector clients can send retrieved snippets, citations, titles, folder labels, relative
+            paths, and tool arguments to the model provider. CLI usage stays on this machine unless the agent harness
+            itself sends command output elsewhere. Use scoped API keys and review the audit dashboard for autonomous
+            agents.
+          </p>
         </div>
 
         {guideTab === 'chatgpt' && (
@@ -312,7 +357,8 @@ export default function IntegrationsPage() {
         {guideTab === 'claude' && (
           <>
             <p className="mb-3 text-sm text-(--color-text-primary)">
-              Claude Desktop and Claude Code use API key authentication instead of OAuth.
+              Claude Desktop is usually best through MCP. Claude Code can use MCP when configured for it, but the CLI
+              skill below is often simpler for shell-first coding workflows.
             </p>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
@@ -343,12 +389,45 @@ export default function IntegrationsPage() {
               )}
             </CodeBlock>
             <p className="mt-4 text-sm text-(--color-text-primary)">
-              For <strong>Claude Code</strong>, run:
+              For <strong>Claude Code</strong> MCP setup, run:
             </p>
             <CodeBlock>{`claude mcp add harbor-clerk "${mcpUrl}?key=YOUR_API_KEY"`}</CodeBlock>
+            <p className="mt-4 text-sm text-(--color-text-primary)">
+              For shell-first Claude Code sessions, enable the CLI below, export the environment variables, and copy the
+              Harbor Clerk skill markdown into your local skill directory.
+            </p>
+            <CodeBlock>{cliEnvBlock}</CodeBlock>
             <p className="mt-3 text-xs text-(--color-text-secondary)">
               Replace <code className="rounded bg-(--color-bg-secondary) px-1 py-0.5">YOUR_API_KEY</code> with the key
               you created.
+            </p>
+          </>
+        )}
+
+        {guideTab === 'codex' && (
+          <>
+            <p className="mb-3 text-sm text-(--color-text-primary)">
+              Codex works best with Harbor Clerk as a local CLI skill: the agent can search, enumerate, read passages,
+              and cite documents while staying inside the same shell workflow.
+            </p>
+            <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
+              <li>
+                <Link to="/settings/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
+                  Create a scoped API key
+                </Link>
+                . Use <strong>Read</strong> for search and passage access, or <strong>Full</strong> when the local agent
+                also needs full-document reads, entity tools, or ingest-status checks.
+              </li>
+              <li>Enable CLI access and install the CLI shim from Harbor Clerk Server Preferences.</li>
+              <li>Set these environment variables in the shell where Codex runs:</li>
+            </ol>
+            <CodeBlock>{cliEnvBlock}</CodeBlock>
+            <p className="mt-4 text-sm text-(--color-text-primary)">Smoke test from the same shell:</p>
+            <CodeBlock>{`harbor-clerk search "contract renewal" --json`}</CodeBlock>
+            <p className="mt-3 text-xs text-(--color-text-secondary)">
+              Copy the Harbor Clerk skill markdown below into the Codex skill location you use for local project skills.
+              The skill tells Codex when to call <code>search</code>, <code>find-all</code>, <code>read-passages</code>,
+              and <code>expand-context</code>.
             </p>
           </>
         )}
@@ -391,8 +470,9 @@ export default function IntegrationsPage() {
         {guideTab === 'openclaw' && (
           <>
             <p className="mb-3 text-sm text-(--color-text-primary)">
-              OpenClaw is an agentic AI harness that can autonomously browse, research, and act on your behalf. Because
-              it operates with significant autonomy, <strong>always use a scoped API key with rate limits</strong>.
+              OpenClaw is a strong fit for Harbor Clerk&apos;s cited memory layer. Prefer the CLI skill for local
+              shell-first OpenClaw runs; use MCP when your OpenClaw setup can call remote MCP tools directly. Because it
+              operates with significant autonomy, <strong>always use a scoped API key with rate limits</strong>.
             </p>
             <ol className="list-decimal list-inside space-y-3 text-sm text-(--color-text-primary)">
               <li>
@@ -402,7 +482,8 @@ export default function IntegrationsPage() {
                 with the following recommended settings:
                 <ul className="ml-6 mt-1 list-disc text-xs text-(--color-text-secondary) space-y-1">
                   <li>
-                    <strong>Permission tier:</strong> Read (not Full — OpenClaw doesn&apos;t need entity tools)
+                    <strong>Permission tier:</strong> Read for normal citation workflows; Full only for local runs that
+                    need <code>read-document</code>, entity tools, or ingest-status checks
                   </li>
                   <li>
                     <strong>Document scope:</strong> limit to relevant topic(s) or folder(s)
@@ -416,13 +497,14 @@ export default function IntegrationsPage() {
                 </ul>
               </li>
               <li>
-                Add Harbor Clerk as an MCP server in your OpenClaw config (
-                <code className="rounded bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs">
-                  ~/.openclaw/openclaw.json
-                </code>
-                ):
+                For local CLI mode, enable CLI access below, install the CLI shim, export the environment variables, and
+                copy the Harbor Clerk skill markdown into OpenClaw&apos;s local skills directory.
               </li>
             </ol>
+            <CodeBlock>{cliEnvBlock}</CodeBlock>
+            <p className="mt-4 text-sm text-(--color-text-primary)">
+              If your OpenClaw setup is using MCP instead, add Harbor Clerk as an MCP server in your OpenClaw config:
+            </p>
             <CodeBlock>
               {`openclaw mcp set harbor-clerk '${JSON.stringify({ url: `${mcpUrl}?key=YOUR_API_KEY` })}'`}
             </CodeBlock>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,19 @@
 /// <reference types="vitest" />
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+
+const frontendRoot = fileURLToPath(new URL('.', import.meta.url))
+const skillsRoot = fileURLToPath(new URL('../skills', import.meta.url))
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   server: {
     host: 'localhost',
+    fs: {
+      allow: [frontendRoot, skillsRoot],
+    },
     proxy: {
       '/api': 'http://localhost:8000',
       '/mcp': 'http://localhost:8000',

--- a/skills/harbor-clerk/SKILL.md
+++ b/skills/harbor-clerk/SKILL.md
@@ -3,20 +3,22 @@ name: harbor-clerk
 description: Search and read documents from a local Harbor Clerk knowledge base. Use when the user references their personal documents, contracts, notes, emails, or asks "what did I store about X?"
 ---
 
-# Harbor Clerk — extended memory for agents
+# Harbor Clerk - extended memory for agents
 
 Harbor Clerk is a local document corpus with hybrid FTS+vector search and citation-ready reads. This skill exposes it via the `harbor-clerk` CLI.
 
 ## First step: discover the surface
-Run `harbor-clerk --help` for the full command list, then `harbor-clerk <cmd> --help` for any specific command. The help is comprehensive — JSON return shapes, examples, common mistakes are all there.
+Run `harbor-clerk --help` for the full command list, then `harbor-clerk <cmd> --help` for any specific command. The help is comprehensive: JSON return shapes, examples, and common mistakes are all there.
 
-## Three patterns you'll use most
+## Four patterns you'll use most
 
 1. **Search → expand**: `harbor-clerk search "..."` then `harbor-clerk expand-context <chunk_id> -n 3` on the best hit.
-2. **Read a known document**: `harbor-clerk read-document <doc_id>` for full text with pagination.
-3. **Check ingest status before searching for new content**: `harbor-clerk ingest-status <doc_id>` returns per-stage state.
+2. **Find every matching document**: `harbor-clerk find-all "..." --text-contains "literal phrase" --presentation full` when the task asks to list or enumerate.
+3. **Read a known document**: `harbor-clerk read-document <doc_id>` for full text with pagination.
+4. **Check ingest status before searching for new content**: `harbor-clerk ingest-status <doc_id>` returns per-stage state.
 
 ## What you can trust
-- Search returns top-level `.hits[]`; each hit includes `doc_title`, `pages` when available, and `chunk_id`. Use those fields as the citation, then call `read-passages` when you need exact surrounding text.
+- Search returns top-level `.hits[]`; Find All returns top-level `.results[]`. Result-bearing commands include `source`, `citation`, and `chunk_id` when available. Use those fields as the citation trail, then call `read-passages` when you need exact surrounding text.
 - `possible_conflict: true` means top hits span multiple similarly scored documents; inspect the relevant sources before answering.
-- The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access — tell the user.
+- `ingest-status`, `read-document`, and entity commands may require a Full-tier API key. If access is denied, continue with search and passage reads, and tell the user the key may be scoped too narrowly for that command.
+- The CLI exits non-zero on failure. Exit code 3 specifically means an admin has disabled CLI access; tell the user.


### PR DESCRIPTION
## Summary
- Add first-class Integrations docs covering MCP vs CLI, data boundaries, API key scope guidance, OpenClaw, Codex, Claude Code, ChatGPT, and troubleshooting.
- Add an agent-memory eval plan with claim ladder, OpenClaw task set, scoring rubric, and wall-time estimates for smoke/minimum/full evals.
- Promote Codex and CLI-first OpenClaw guidance in the in-app Integrations page.
- Use the checked-in Harbor Clerk skill markdown as the Integrations page source of truth, with a focused UI test for find-all guidance.

## Fresh-eyes review
- Reviewed the staged diff for misleading integration claims, API-key scope drift, and unsupported OpenClaw performance claims.
- Fixed one scope-contract issue before opening: the CLI skill now warns that ingest-status/read-document/entity commands may require a Full-tier key and tells agents how to recover when denied.

## Verification
- `npm test -- IntegrationsPage.test.tsx CliAccessCard --run`
- `npm test -- --run`
- `npm run type-check`
- `npm run lint` (passes with existing warnings)
- `npm run format:check`
- `npm run build`
- `git diff --cached --check`

Browser smoke was not run because this session did not expose a callable in-app browser tool.