### PR TITLE
Improve local AI setup prompts

### DIFF
--- a/frontend/src/components/LocalAISetupPrompt.test.tsx
+++ b/frontend/src/components/LocalAISetupPrompt.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { LocalAISetupPrompt } from './LocalAISetupPrompt'
+
+function renderPrompt(variant: 'ask' | 'research') {
+  render(
+    <MemoryRouter>
+      <LocalAISetupPrompt variant={variant} />
+    </MemoryRouter>,
+  )
+}
+
+describe('LocalAISetupPrompt', () => {
+  it('explains the Ask setup path and preserves search as the fallback', () => {
+    renderPrompt('ask')
+
+    expect(screen.getByRole('heading', { name: 'Set up local AI for Ask' })).toBeInTheDocument()
+    expect(screen.getByText(/Ask needs one downloaded and active local AI model/)).toBeInTheDocument()
+    expect(screen.getByText(/Search, Documents, and Folders still work/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Choose a model' })).toHaveAttribute('href', '/settings/models')
+    expect(screen.getByRole('link', { name: 'Use Search instead' })).toHaveAttribute('href', '/search')
+  })
+
+  it('uses research-specific guidance for Research', () => {
+    renderPrompt('research')
+
+    expect(screen.getByRole('heading', { name: 'Set up local AI for Research' })).toBeInTheDocument()
+    expect(screen.getByText(/Research drives a local AI model through repeated searches/)).toBeInTheDocument()
+    expect(screen.getByText(/Larger models are better for long synthesis/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/LocalAISetupPrompt.tsx
+++ b/frontend/src/components/LocalAISetupPrompt.tsx
@@ -1,0 +1,101 @@
+import { Link } from 'react-router-dom'
+
+type LocalAISetupVariant = 'ask' | 'research'
+
+interface LocalAISetupPromptProps {
+  variant: LocalAISetupVariant
+  compact?: boolean
+  className?: string
+}
+
+const COPY: Record<
+  LocalAISetupVariant,
+  {
+    title: string
+    description: string
+    guidance: string
+  }
+> = {
+  ask: {
+    title: 'Set up local AI for Ask',
+    description:
+      'Ask needs one downloaded and active local AI model before it can answer questions over your documents.',
+    guidance:
+      'Search, Documents, and Folders still work while you skip setup. Important answers should be checked against citations.',
+  },
+  research: {
+    title: 'Set up local AI for Research',
+    description:
+      'Research drives a local AI model through repeated searches and tool calls, so it needs an active model first.',
+    guidance:
+      'Larger models are better for long synthesis. Smaller models are useful for quick lookup, but citations remain the source of truth.',
+  },
+}
+
+export function LocalAISetupPrompt({ variant, compact = false, className = '' }: LocalAISetupPromptProps) {
+  const copy = COPY[variant]
+
+  return (
+    <div className={`mx-auto text-center empty-state-appear ${compact ? 'max-w-md' : 'max-w-lg'} ${className}`.trim()}>
+      {!compact && (
+        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-50 ring-1 ring-amber-200/60 dark:bg-amber-900/30 dark:ring-amber-700/40">
+          <svg
+            className="h-8 w-8 text-amber-500 dark:text-amber-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09zM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456z"
+            />
+          </svg>
+        </div>
+      )}
+
+      <h3 className={`${compact ? 'text-[15px]' : 'text-lg'} mb-2 font-semibold text-gray-800 dark:text-gray-200`}>
+        {copy.title}
+      </h3>
+      <p className="mb-3 text-[13px] leading-relaxed text-gray-500 dark:text-gray-400">{copy.description}</p>
+
+      <div className="mb-4 rounded-xl border border-gray-200 bg-gray-50/70 px-4 py-3 text-left text-[12px] text-gray-600 dark:border-gray-700 dark:bg-gray-800/40 dark:text-gray-300">
+        <div className="font-medium text-gray-800 dark:text-gray-100">Setup path</div>
+        <ol className="mt-2 list-decimal space-y-1 pl-4">
+          <li>Open Models.</li>
+          <li>Download a model that fits this Mac.</li>
+          <li>Activate it when the download completes.</li>
+        </ol>
+      </div>
+
+      <p className="mb-5 text-[13px] leading-relaxed text-gray-500 dark:text-gray-400">{copy.guidance}</p>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Link
+          to="/settings/models"
+          className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2 text-[13px] font-medium text-white shadow-xs transition-colors hover:bg-blue-700"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+            />
+          </svg>
+          Choose a model
+        </Link>
+        <Link
+          to="/search"
+          className="inline-flex items-center rounded-xl border border-gray-300 px-5 py-2 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+        >
+          Use Search instead
+        </Link>
+      </div>
+
+      <p className="mt-4 text-[11px] leading-relaxed text-gray-400 dark:text-gray-500">
+        Local AI runs on this machine. Cloud integrations are configured separately and disclose what leaves the device.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/OnboardingWizard.test.tsx
+++ b/frontend/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get } from '../api'
+import OnboardingWizard from './OnboardingWizard'
+
+vi.mock('../api', () => ({
+  ApiError: class ApiError extends Error {},
+  get: vi.fn(),
+  patch: vi.fn(),
+  post: vi.fn(),
+}))
+
+const getMock = vi.mocked(get)
+
+function renderWizard(onComplete = vi.fn()) {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<OnboardingWizard onComplete={onComplete} />} />
+        <Route path="/settings/models" element={<div>Models route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('OnboardingWizard', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    getMock.mockImplementation((path: string) => {
+      if (path === '/api/watch/system') {
+        return Promise.resolve({ platform: 'macos', picker: 'native', watch_root: null })
+      }
+      if (path === '/api/languages') {
+        return Promise.resolve({
+          languages: [{ code: 'en', display_name: 'English', built_in: true, enabled: true, tools: {} }],
+        })
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+  })
+
+  it('asks about local AI during startup and can route to Models', () => {
+    const onComplete = vi.fn()
+
+    renderWizard(onComplete)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next →' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    expect(screen.getByRole('heading', { name: 'Set up local AI (optional)' })).toBeInTheDocument()
+    expect(screen.getByText(/Ask and Research need one downloaded and active local AI model/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose a model' }))
+
+    expect(onComplete).toHaveBeenCalledOnce()
+    expect(screen.getByText('Models route')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { get, patch, post, ApiError } from '../api'
 import { Card } from './Card'
 
@@ -33,7 +34,7 @@ interface Props {
  * paths (X, Skip, backdrop click, Get Started) call onComplete, which
  * writes preferences.onboardingComplete = true via updatePreferences().
  *
- * Three pages, structured so adding more (with screenshots) is additive.
+ * Four pages, structured so adding more (with screenshots) is additive.
  *
  * Page 1: welcome + platform-aware folder CTA.
  *   - macOS: "Pick a folder to watch" → window.harborclerk.pickFolder() →
@@ -47,9 +48,11 @@ interface Props {
  * each) — selected ones get installed AND added to enabled_languages
  * preferences in one go. Skip-friendly.
  *
- * Page 3: where-to-watch-progress (menubar status window + Observatory tab).
+ * Page 3: optional local AI model setup prompt.
+ * Page 4: where-to-watch-progress (menubar status window + Observatory tab).
  */
 export default function OnboardingWizard({ onComplete }: Props) {
+  const navigate = useNavigate()
   const [page, setPage] = useState(1)
   const [system, setSystem] = useState<SystemInfo | null>(null)
   const [error, setError] = useState('')
@@ -130,6 +133,11 @@ export default function OnboardingWizard({ onComplete }: Props) {
 
     setPage(3)
   }, [selectedLangs, languages])
+
+  function openModelSettings() {
+    onComplete()
+    navigate('/settings/models')
+  }
 
   async function handlePickFolder() {
     if (system?.picker !== 'native' || !window.harborclerk) return
@@ -317,6 +325,52 @@ export default function OnboardingWizard({ onComplete }: Props) {
         {page === 3 && (
           <>
             <h2 id="onboarding-title" className="mb-3 text-lg font-bold">
+              Set up local AI (optional)
+            </h2>
+            <p className="mb-3 text-sm text-(--color-text-secondary)">
+              Ask and Research need one downloaded and active local AI model. Search, Documents, and Folders work
+              without a model, so you can skip this and come back later.
+            </p>
+            <div className="mb-5 border-l-2 border-blue-500/70 pl-3 text-sm text-(--color-text-secondary)">
+              <div className="font-medium text-(--color-text-primary)">Setup path</div>
+              <ol className="mt-2 list-decimal space-y-1 pl-4">
+                <li>Download a model that fits this Mac.</li>
+                <li>Activate it after the download completes.</li>
+                <li>Return to Ask or Research when the local AI status is ready.</li>
+              </ol>
+            </div>
+            <p className="mb-6 text-xs leading-relaxed text-(--color-text-secondary)">
+              Larger models are better for synthesis; smaller models are useful for quick lookup. Citations remain the
+              source of truth either way.
+            </p>
+            <div className="flex items-center justify-between">
+              <button
+                onClick={() => setPage(2)}
+                className="text-xs text-(--color-text-secondary) underline hover:no-underline"
+              >
+                ← Back
+              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setPage(4)}
+                  className="text-xs text-(--color-text-secondary) underline hover:no-underline"
+                >
+                  Skip
+                </button>
+                <button
+                  onClick={openModelSettings}
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-blue-700"
+                >
+                  Choose a model
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {page === 4 && (
+          <>
+            <h2 id="onboarding-title" className="mb-3 text-lg font-bold">
               Track ingestion progress
             </h2>
             <p className="mb-3 text-sm text-(--color-text-secondary)">
@@ -335,7 +389,7 @@ export default function OnboardingWizard({ onComplete }: Props) {
             </ul>
             <div className="flex items-center justify-between">
               <button
-                onClick={() => setPage(2)}
+                onClick={() => setPage(3)}
                 className="text-xs text-(--color-text-secondary) underline hover:no-underline"
               >
                 ← Back

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { IconTile } from '../components/IconTile'
 import { FolderPicker } from '../components/FolderPicker'
+import { LocalAISetupPrompt } from '../components/LocalAISetupPrompt'
 import { LocalModelChip } from '../components/LocalModelChip'
 import { ScopeChip } from '../components/ScopeChip'
 import { del, get, post } from '../api'
@@ -440,7 +441,9 @@ export default function ChatPage() {
         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto chat-messages-scroll">
           {messages.length === 0 ? (
             !hasActiveModel ? (
-              <ModelNudge />
+              <div className="flex h-full items-center justify-center p-8">
+                <LocalAISetupPrompt variant="ask" />
+              </div>
             ) : researchActive ? (
               <div className="flex h-full items-center justify-center p-8">
                 <div className="text-center max-w-md empty-state-appear">
@@ -569,54 +572,6 @@ export default function ChatPage() {
             </form>
           </div>
         </div>
-      </div>
-    </div>
-  )
-}
-
-/* ---- Model onboarding nudge ---- */
-
-function ModelNudge() {
-  return (
-    <div className="flex h-full items-center justify-center p-8">
-      <div className="text-center max-w-lg empty-state-appear">
-        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-50 dark:bg-amber-900/30 ring-1 ring-amber-200/60 dark:ring-amber-700/40">
-          <svg
-            className="h-8 w-8 text-amber-500 dark:text-amber-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={1.5}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
-            />
-          </svg>
-        </div>
-        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">Set up your local AI model</h3>
-        <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-2">
-          Harbor Clerk uses a local AI model to answer questions over your documents. Choose a model to get started —
-          everything stays on this machine.
-        </p>
-        <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-6">
-          Larger models are better for research and synthesis. Smaller models are useful for quick lookup, but important
-          answers should be checked against the citations.
-        </p>
-        <Link
-          to="/settings/models"
-          className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
-        >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-            />
-          </svg>
-          Choose a model
-        </Link>
       </div>
     </div>
   )

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -289,13 +289,24 @@ export default function ModelsPage() {
       )}
 
       <Card className="mb-4 p-4">
-        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
-          Local AI is useful, but model choice matters.
+        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">Download, then activate one model.</div>
+        <div className="mt-2 grid gap-3 text-xs leading-relaxed text-gray-500 dark:text-gray-400 md:grid-cols-[minmax(0,1fr)_minmax(220px,0.45fr)]">
+          <div className="space-y-2">
+            <p>
+              Ask and Research need one active local AI model. Larger models are better for research and synthesis;
+              smaller models are still useful for quick lookup.
+            </p>
+            <p>
+              You can skip this setup and still use Search, Documents, Folders, and Integrations. Important AI answers
+              should be checked against citations.
+            </p>
+          </div>
+          <ol className="space-y-1 border-l-2 border-blue-500/70 pl-4 text-gray-600 dark:text-gray-300">
+            <li>1. Pick a model for this Mac.</li>
+            <li>2. Download it.</li>
+            <li>3. Activate it when ready.</li>
+          </ol>
         </div>
-        <p className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-          Larger models are better for research and synthesis. Smaller models are still useful for quick lookup, but
-          important answers should be checked against the citations.
-        </p>
       </Card>
 
       <Card className="overflow-hidden">

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -1,7 +1,8 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { FolderPicker } from '../components/FolderPicker'
+import { LocalAISetupPrompt } from '../components/LocalAISetupPrompt'
 import { LocalModelChip } from '../components/LocalModelChip'
 import { PageHeader } from '../components/PageHeader'
 import { ScopeChip } from '../components/ScopeChip'
@@ -512,7 +513,7 @@ export default function ResearchPage() {
                 </p>
 
                 {!hasActiveModel ? (
-                  <ModelNudge />
+                  <LocalAISetupPrompt variant="research" compact />
                 ) : isRunning || chatStreaming ? (
                   <div className="max-w-md mx-auto rounded-xl border border-amber-200 dark:border-amber-800/40 bg-amber-50/50 dark:bg-amber-900/10 px-4 py-3 text-center">
                     <p className="text-[13px] text-amber-700 dark:text-amber-400">
@@ -989,50 +990,6 @@ function RoundLabel({ round }: { round: number }) {
       <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
         Round {round}
       </span>
-    </div>
-  )
-}
-
-/* ---- Model onboarding nudge (mirrors ChatPage.ModelNudge tone, retargeted) ---- */
-
-function ModelNudge() {
-  return (
-    <div className="max-w-md mx-auto text-center empty-state-appear">
-      <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-50 dark:bg-amber-900/30 ring-1 ring-amber-200/60 dark:ring-amber-700/40">
-        <svg
-          className="h-7 w-7 text-amber-500 dark:text-amber-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1.5}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
-          />
-        </svg>
-      </div>
-      <h3 className="text-[15px] font-semibold text-gray-800 dark:text-gray-200 mb-2">
-        Choose a model to research with
-      </h3>
-      <p className="text-[13px] text-gray-500 dark:text-gray-400 leading-relaxed mb-5">
-        Deep Research drives a local AI model through many tool calls. Larger models are better for long synthesis;
-        smaller models are best for quick lookup.
-      </p>
-      <Link
-        to="/settings/models"
-        className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2 text-[13px] font-medium text-white shadow-xs hover:bg-blue-700 transition-colors"
-      >
-        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-          />
-        </svg>
-        Choose a model
-      </Link>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a shared Local AI setup prompt for Ask and Research no-model states
- add a first-run onboarding step that routes users to Models or lets them skip
- clarify the Models page setup path and keep Search/Documents/Folders positioned as available without local AI

## Fresh-eyes review
- Re-read the staged diff as reviewer before commit; no blockers found.
- Main risk checked: onboarding completion plus route navigation follows the existing best-effort completion pattern and has route coverage in the new test.

## Tests
- npm test -- --run
- npm run type-check
- npm run lint (existing warnings only)
- npm run format:check
- npm run build
