### PR TITLE
Add document summary state filters

### DIFF
--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get, post, del, downloadBlob } from '../api'
@@ -52,6 +52,7 @@ const SAVED_STATE = {
   entityInput: '',
   folderFilter: '',
   pipelineStatusFilter: '',
+  summaryStateFilter: '',
   sortField: 'updated',
   sortDir: 'desc',
   scrollY: 0,
@@ -148,5 +149,53 @@ describe('DocumentsPage', () => {
     expect(await screen.findByText('Expanded doc')).toBeInTheDocument()
     expect(await screen.findByText('Acme Corp')).toBeInTheDocument()
     expect(getMock).toHaveBeenCalledWith('/api/docs/doc-1/entities')
+  })
+
+  it('sends summary state filters to the documents endpoint', async () => {
+    const docsCalls: Array<Record<string, string | number> | undefined> = []
+    getMock.mockImplementation((url, params) => {
+      if (url === '/api/docs/filters') {
+        return Promise.resolve({ mime_types: [], doc_types: [], languages: [], entity_types: [] })
+      }
+      if (url === '/api/stats/topics') return Promise.resolve({ clusters: [] })
+      if (url === '/api/watch/folders') return Promise.resolve([])
+      if (url === '/api/docs') {
+        docsCalls.push(params)
+        return Promise.resolve({
+          items: [
+            {
+              doc_id: 'doc-1',
+              title: 'Missing summary doc',
+              canonical_filename: 'missing.pdf',
+              status: 'active',
+              pipeline_status: 'ready',
+              created_at: '2026-06-04T12:00:00Z',
+              updated_at: '2026-06-04T12:30:00Z',
+              summary: null,
+              summary_model: null,
+              summarize_job_status: 'error',
+              doc_type: 'contract',
+            },
+          ],
+          total: 1,
+          limit: 10,
+          offset: 0,
+        })
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`))
+    })
+
+    renderDocumentsPage()
+
+    expect(await screen.findByText('Missing summary doc')).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Summary state'), { target: { value: 'failed' } })
+
+    await waitFor(() => {
+      expect(docsCalls).toContainEqual(
+        expect.objectContaining({
+          summary_state: 'failed',
+        }),
+      )
+    })
   })
 })

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -26,6 +26,7 @@ interface SavedDocsState {
   entityInput: string
   folderFilter: string
   pipelineStatusFilter: string
+  summaryStateFilter: string
   sortField: 'updated' | 'created' | 'title'
   sortDir: 'asc' | 'desc'
   scrollY: number
@@ -216,7 +217,8 @@ export default function DocumentsPage() {
     searchParams.has('language') ||
     searchParams.has('doc_type') ||
     searchParams.has('entity_type') ||
-    searchParams.has('pipeline_status')
+    searchParams.has('pipeline_status') ||
+    searchParams.has('summary_state')
 
   // Helper: read a field from saved state or URL params
   function initField<K extends keyof SavedDocsState>(
@@ -258,6 +260,9 @@ export default function DocumentsPage() {
   const [folderFilter, setFolderFilter] = useState<string>(() => initField('folderFilter', '', 'folder'))
   const [pipelineStatusFilter, setPipelineStatusFilter] = useState<string>(() =>
     initField('pipelineStatusFilter', '', 'pipeline_status'),
+  )
+  const [summaryStateFilter, setSummaryStateFilter] = useState<string>(() =>
+    initField('summaryStateFilter', '', 'summary_state'),
   )
   const [folderOptions, setFolderOptions] = useState<
     { folder_id: string; display_name: string | null; path: string }[]
@@ -331,6 +336,7 @@ export default function DocumentsPage() {
       entityInput,
       folderFilter,
       pipelineStatusFilter,
+      summaryStateFilter,
       sortField,
       sortDir,
       scrollY: window.scrollY,
@@ -350,6 +356,7 @@ export default function DocumentsPage() {
     entityInput,
     folderFilter,
     pipelineStatusFilter,
+    summaryStateFilter,
     sortField,
     sortDir,
     expanded,
@@ -425,6 +432,7 @@ export default function DocumentsPage() {
       if (entityFilter) params.entity = entityFilter
       if (entityTypeFilter) params.entity_type = entityTypeFilter
       if (pipelineStatusFilter) params.pipeline_status = pipelineStatusFilter
+      if (summaryStateFilter) params.summary_state = summaryStateFilter
       return get<PaginatedDocs>('/api/docs', params)
         .then((data) => {
           setDocs(data.items)
@@ -440,7 +448,17 @@ export default function DocumentsPage() {
           }
         })
     },
-    [sortField, sortDir, mimeFilter, langFilter, docTypeFilter, entityFilter, entityTypeFilter, pipelineStatusFilter],
+    [
+      sortField,
+      sortDir,
+      mimeFilter,
+      langFilter,
+      docTypeFilter,
+      entityFilter,
+      entityTypeFilter,
+      pipelineStatusFilter,
+      summaryStateFilter,
+    ],
   )
 
   useEffect(() => {
@@ -630,7 +648,8 @@ export default function DocumentsPage() {
     entityFilter ||
     entityTypeFilter ||
     folderFilter ||
-    pipelineStatusFilter
+    pipelineStatusFilter ||
+    summaryStateFilter
   )
 
   let lastDoc: { doc_id: string; title: string } | null = null
@@ -696,6 +715,7 @@ export default function DocumentsPage() {
       {/* Filter bar */}
       {(total > 0 ||
         pipelineStatusFilter ||
+        summaryStateFilter ||
         filterOptions.mime_types.length > 0 ||
         filterOptions.doc_types.length > 0 ||
         filterOptions.languages.length > 0) && (
@@ -837,6 +857,22 @@ export default function DocumentsPage() {
             <option value="error">Failed</option>
           </select>
 
+          <select
+            value={summaryStateFilter}
+            onChange={(e) => {
+              setSummaryStateFilter(e.target.value)
+              setCurrentPage(1)
+            }}
+            aria-label="Summary state"
+            className="rounded-lg border-0 bg-(--color-bg-secondary) dark:bg-(--color-bg-tertiary) shadow-mac px-2 py-1 text-xs text-(--color-text-primary) focus:outline-hidden focus:ring-2 focus:ring-(--color-accent)/30"
+          >
+            <option value="">All summaries</option>
+            <option value="has">Has summary</option>
+            <option value="missing">Missing summary</option>
+            <option value="failed">Summary failed</option>
+            <option value="pending">Summary queued/running</option>
+          </select>
+
           {/* Sort controls */}
           <div className="ml-auto flex items-center gap-1 text-xs text-gray-400">
             <span>Sort:</span>
@@ -871,7 +907,8 @@ export default function DocumentsPage() {
             entityFilter ||
             entityTypeFilter ||
             folderFilter ||
-            pipelineStatusFilter) && (
+            pipelineStatusFilter ||
+            summaryStateFilter) && (
             <button
               onClick={() => {
                 setMimeFilter('')
@@ -879,6 +916,7 @@ export default function DocumentsPage() {
                 setDocTypeFilter('')
                 setFolderFilter('')
                 setPipelineStatusFilter('')
+                setSummaryStateFilter('')
                 clearEntityFilter()
                 setCurrentPage(1)
               }}

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -36,7 +36,7 @@ from harbor_clerk.models import (
     Entity,
     IngestionJob,
 )
-from harbor_clerk.models.enums import JobStage, PipelineStatus
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
 from harbor_clerk.models.watched import WatchedFile, WatchedFolder
 from harbor_clerk.sql_escape import escape_ilike
 from harbor_clerk.storage import get_storage
@@ -58,6 +58,10 @@ async def list_documents(
     doc_ids: str | None = Query(default=None, description="Comma-separated document IDs"),
     topic_id: int | None = Query(default=None, description="Filter by topic cluster ID"),
     pipeline_status: str | None = Query(default=None, description="Filter by pipeline status; comma-separated"),
+    summary_state: str | None = Query(
+        default=None,
+        description="Filter by summary state: has, missing, failed, or pending",
+    ),
     sort: str = Query(default="updated", pattern="^(updated|created|title)$"),
     sort_dir: str = Query(default="desc", pattern="^(asc|desc)$"),
     principal: Principal = Depends(require_read_access),
@@ -97,6 +101,28 @@ async def list_documents(
                 )
         if statuses:
             base = base.where(Document.pipeline_status.in_(statuses))
+
+    if summary_state:
+        if summary_state == "has":
+            base = base.where(func.length(func.trim(func.coalesce(Document.summary, ""))) > 0)
+        elif summary_state == "missing":
+            base = base.where(func.length(func.trim(func.coalesce(Document.summary, ""))) == 0)
+        elif summary_state in {"failed", "pending"}:
+            statuses = [JobStatus.error] if summary_state == "failed" else [JobStatus.queued, JobStatus.running]
+            summary_job_exists = (
+                select(IngestionJob.job_id)
+                .where(IngestionJob.doc_id == Document.doc_id)
+                .where(IngestionJob.stage == JobStage.summarize)
+                .where(IngestionJob.pipeline_seq == Document.pipeline_seq)
+                .where(IngestionJob.status.in_(statuses))
+                .exists()
+            )
+            base = base.where(summary_job_exists)
+        else:
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid summary_state. Expected one of: has, missing, failed, pending",
+            )
 
     if q:
         escaped = escape_ilike(q)

--- a/tests/test_api_documents.py
+++ b/tests/test_api_documents.py
@@ -95,6 +95,59 @@ async def test_list_documents_filter_pipeline_status_rejects_unknown(client, adm
     assert resp.status_code == 422
 
 
+async def test_list_documents_filter_summary_state(client, admin_user, admin_token, db_session):
+    has_summary = Document(title="Has Summary", status="active", summary="Brief summary.", **_DOC_DEFAULTS)
+    missing_summary = Document(title="Missing Summary", status="active", summary=None, **_DOC_DEFAULTS)
+    failed_summary = Document(title="Failed Summary", status="active", summary=None, **_DOC_DEFAULTS)
+    pending_summary = Document(title="Pending Summary", status="active", summary=None, **_DOC_DEFAULTS)
+    db_session.add_all([has_summary, missing_summary, failed_summary, pending_summary])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            IngestionJob(
+                doc_id=failed_summary.doc_id,
+                stage=JobStage.summarize,
+                status=JobStatus.error,
+                pipeline_seq=failed_summary.pipeline_seq,
+            ),
+            IngestionJob(
+                doc_id=pending_summary.doc_id,
+                stage=JobStage.summarize,
+                status=JobStatus.queued,
+                pipeline_seq=pending_summary.pipeline_seq,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/docs?summary_state=has", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["title"] == "Has Summary"
+
+    resp = await client.get("/api/docs?summary_state=missing", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert {item["title"] for item in resp.json()["items"]} == {
+        "Missing Summary",
+        "Failed Summary",
+        "Pending Summary",
+    }
+
+    resp = await client.get("/api/docs?summary_state=failed", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["title"] == "Failed Summary"
+
+    resp = await client.get("/api/docs?summary_state=pending", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["title"] == "Pending Summary"
+
+
+async def test_list_documents_filter_summary_state_rejects_unknown(client, admin_user, admin_token):
+    resp = await client.get("/api/docs?summary_state=wat", headers=auth_header(admin_token))
+    assert resp.status_code == 422
+
+
 async def test_list_documents_pagination(client, admin_user, admin_token, db_session):
     for i in range(5):
         db_session.add(Document(title=f"Doc {i}", status="active", **_DOC_DEFAULTS))


### PR DESCRIPTION
## Summary
- add `summary_state` filtering to `/api/docs` for `has`, `missing`, `failed`, and `pending`
- expose a Summary state dropdown in Documents alongside pipeline status filters
- persist and restore the summary filter with the rest of the Documents page state

## Fresh-eyes review
- Re-read the final diff before staging; no blockers found.
- Semantics are intentional: `missing` means no usable summary text, while `failed`/`pending` narrow to summarize job state for the current pipeline sequence.

## Tests
- uv run pytest tests/test_api_documents.py -q
- uv run ruff check .
- uv run ruff format --check .
- npm test -- DocumentsPage.test.tsx --run
- npm test -- --run
- npm run type-check
- npm run lint (existing warnings only)
- npm run format:check
- npm run build