### PR TITLE
Expose service and worker status diagnostics

### DIFF
--- a/frontend/src/pages/SystemStatusPage.test.tsx
+++ b/frontend/src/pages/SystemStatusPage.test.tsx
@@ -30,7 +30,30 @@ const HEALTHY = {
     postgres: 'ok',
     storage: 'ok',
     tika: 'ok',
+    embedder: 'ok',
     reranker: 'ok',
+  },
+}
+
+const STATS = {
+  postgres: {
+    db_size_mb: 12.4,
+    active_connections: 3,
+    cache_hit_ratio: 0.99,
+    total_chunks: 40,
+    dead_tuples: 0,
+  },
+  storage: {
+    object_count: 2,
+    total_size_mb: 5.5,
+  },
+  queues: {
+    io_queued: 2,
+    io_running: 1,
+    cpu_queued: 0,
+    cpu_running: 1,
+    llm_queued: 3,
+    llm_running: 1,
   },
 }
 
@@ -106,13 +129,18 @@ function mockRequests(summary = SUMMARY) {
   getMock.mockImplementation((url) => {
     if (url === '/api/system/health') return Promise.resolve(HEALTHY)
     if (url === '/api/system/status-summary') return Promise.resolve(summary)
-    if (url === '/api/system/stats') return Promise.resolve({})
+    if (url === '/api/system/stats') return Promise.resolve(STATS)
     return Promise.reject(new Error(`Unexpected URL: ${url}`))
   })
   postMock.mockResolvedValue({ reaped: 1 })
   listMailAccountsMock.mockResolvedValue([])
   useLLMStatusContextMock.mockReturnValue({
-    status: { state: 'ready', model_id: 'qwen3', model_name: 'Qwen3' },
+    status: {
+      state: 'ready',
+      model_id: 'qwen3',
+      model_name: 'Qwen3',
+      summarize: { backend: 'apple-intelligence', name: 'Apple Intelligence', state: 'ready' },
+    },
     markTransitioning: vi.fn(),
   })
 }
@@ -143,6 +171,23 @@ describe('SystemStatusPage', () => {
     expect(reviewLink).toHaveAttribute('href', '/docs?pipeline_status=error')
     expect(screen.getByText('Broken scan')).toBeInTheDocument()
     expect(screen.getByText('Still embedding')).toBeInTheDocument()
+  })
+
+  it('renders service and worker diagnostics', async () => {
+    mockRequests()
+
+    renderStatusPage()
+
+    expect(await screen.findByText('Diagnostics')).toBeInTheDocument()
+    expect(screen.getByText('Embedder')).toBeInTheDocument()
+    expect(screen.getAllByText('Local AI').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText('Workers / queues')).toBeInTheDocument()
+    expect(screen.getByText('Qwen3')).toBeInTheDocument()
+    expect(screen.getByText('Apple Intelligence')).toBeInTheDocument()
+    expect(screen.getByText('IO workers')).toBeInTheDocument()
+    expect(screen.getByText('2 queued, 1 running')).toBeInTheDocument()
+    expect(screen.getByText('LLM worker')).toBeInTheDocument()
+    expect(screen.getByText('3 queued, 1 running')).toBeInTheDocument()
   })
 
   it('runs the reaper action from a stuck-job issue', async () => {

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'
 import { StatusPill, type PillState } from '../components/StatusPill'
 import { useLLMStatusContext } from '../components/LLMStatusBanner'
+import type { LLMStatus } from '../hooks/useLLMStatus'
 
 interface HealthCheck {
   status: string
@@ -14,6 +15,7 @@ interface HealthCheck {
     postgres: string
     storage: string
     tika: string
+    embedder?: string
     reranker?: string
   }
 }
@@ -25,6 +27,7 @@ interface ServiceStats {
 interface StatsResponse {
   postgres?: ServiceStats
   storage?: ServiceStats
+  queues?: ServiceStats
 }
 
 interface StatusIssue {
@@ -87,8 +90,12 @@ const STAT_LABELS: Record<string, string> = {
   cache_hit_ratio: 'Cache Hit Ratio',
   total_chunks: 'Total Chunks',
   dead_tuples: 'Dead Tuples',
-  io_queue_depth: 'IO Queue',
-  cpu_queue_depth: 'CPU Queue',
+  io_queued: 'IO Queued',
+  io_running: 'IO Running',
+  cpu_queued: 'CPU Queued',
+  cpu_running: 'CPU Running',
+  llm_queued: 'LLM Queued',
+  llm_running: 'LLM Running',
   object_count: 'Objects',
   total_size_mb: 'Total Size',
 }
@@ -416,7 +423,7 @@ export default function SystemStatusPage() {
         </div>
 
         {health && (
-          <div className="mb-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="mb-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             <HealthCard
               name="PostgreSQL"
               status={health.checks.postgres}
@@ -430,7 +437,10 @@ export default function SystemStatusPage() {
               statsLoading={statsLoading}
             />
             <HealthCard name="Tika" status={health.checks.tika} statsLoading={false} />
+            <HealthCard name="Embedder" status={health.checks.embedder ?? 'unknown'} statsLoading={false} />
             <HealthCard name="Reranker" status={health.checks.reranker ?? 'not configured'} statsLoading={false} />
+            <LocalAICard status={llmStatus} />
+            <WorkerQueuesCard stats={stats?.queues} statsLoading={statsLoading} />
           </div>
         )}
       </section>
@@ -689,6 +699,96 @@ function HealthCard({
             <div key={key} className="flex justify-between gap-3 text-xs">
               <dt className="text-gray-500 dark:text-gray-400">{STAT_LABELS[key] || key}</dt>
               <dd className="font-medium text-gray-700 dark:text-gray-300">{formatStatValue(key, value)}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </Card>
+  )
+}
+
+function localAIState(state: string): PillState {
+  if (state === 'ready') return 'active'
+  if (state === 'loading') return 'running'
+  if (state === 'deactivated') return 'idle'
+  return 'pending'
+}
+
+function localAILabel(status: LLMStatus): string {
+  if (status.state === 'ready') return 'Ready'
+  if (status.state === 'loading') return 'Loading'
+  if (status.state === 'deactivated') return 'Not configured'
+  return 'Unknown'
+}
+
+function LocalAICard({ status }: { status: LLMStatus }) {
+  const summarize = status.summarize
+  const modelName = status.model_name || status.model_id || 'No active model'
+
+  return (
+    <Card className="p-4">
+      <div className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">Local AI</div>
+      <StatusPill state={localAIState(status.state)} label={localAILabel(status)} />
+      <dl className="mt-3 space-y-1 border-t border-gray-200 dark:border-gray-700 pt-2">
+        <div className="flex justify-between gap-3 text-xs">
+          <dt className="text-gray-500 dark:text-gray-400">Chat model</dt>
+          <dd className="max-w-[11rem] truncate font-medium text-gray-700 dark:text-gray-300">{modelName}</dd>
+        </div>
+        {summarize && (
+          <div className="flex justify-between gap-3 text-xs">
+            <dt className="text-gray-500 dark:text-gray-400">Summaries</dt>
+            <dd className="max-w-[11rem] truncate font-medium text-gray-700 dark:text-gray-300">
+              {summarize.name || summarize.backend}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </Card>
+  )
+}
+
+function statNumber(stats: ServiceStats | undefined, key: string): number {
+  const value = stats?.[key]
+  return typeof value === 'number' ? value : 0
+}
+
+function WorkerQueuesCard({ stats, statsLoading }: { stats?: ServiceStats; statsLoading: boolean }) {
+  const queueRows = [
+    {
+      label: 'IO workers',
+      queued: statNumber(stats, 'io_queued'),
+      running: statNumber(stats, 'io_running'),
+    },
+    {
+      label: 'CPU workers',
+      queued: statNumber(stats, 'cpu_queued'),
+      running: statNumber(stats, 'cpu_running'),
+    },
+    {
+      label: 'LLM worker',
+      queued: statNumber(stats, 'llm_queued'),
+      running: statNumber(stats, 'llm_running'),
+    },
+  ]
+  const activeCount = queueRows.reduce((total, row) => total + row.queued + row.running, 0)
+
+  return (
+    <Card className="p-4">
+      <div className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">Workers / queues</div>
+      <StatusPill
+        state={activeCount > 0 ? 'running' : 'active'}
+        label={activeCount > 0 ? `${activeCount.toLocaleString()} active` : 'Idle'}
+      />
+      {statsLoading && !stats && <div className="mt-2 text-xs text-gray-400">Loading stats...</div>}
+      {stats?.error && <div className="mt-2 text-xs text-red-500">{String(stats.error)}</div>}
+      {!stats?.error && (
+        <dl className="mt-3 space-y-1 border-t border-gray-200 dark:border-gray-700 pt-2">
+          {queueRows.map((row) => (
+            <div key={row.label} className="flex justify-between gap-3 text-xs">
+              <dt className="text-gray-500 dark:text-gray-400">{row.label}</dt>
+              <dd className="font-medium text-gray-700 dark:text-gray-300">
+                {row.queued.toLocaleString()} queued, {row.running.toLocaleString()} running
+              </dd>
             </div>
           ))}
         </dl>

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -144,9 +144,10 @@ async def health_check(
         logger.error("Storage health check failed: %s", e)
         checks["storage"] = f"error: {e}"
 
+    settings = get_settings()
+
     # Tika
     try:
-        settings = get_settings()
         async with httpx.AsyncClient() as client:
             r = await client.get(f"{settings.tika_url}/tika", timeout=5)
             checks["tika"] = "ok" if r.status_code == 200 else f"error: HTTP {r.status_code}"
@@ -154,8 +155,16 @@ async def health_check(
         logger.error("Tika health check failed: %s", e)
         checks["tika"] = f"error: {e}"
 
+    # Embedder
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(f"{settings.embedder_url}/health", timeout=5)
+            checks["embedder"] = "ok" if r.status_code == 200 else f"error: HTTP {r.status_code}"
+    except Exception as e:
+        logger.error("Embedder health check failed: %s", e)
+        checks["embedder"] = f"error: {e}"
+
     # Reranker — only probed when enabled; disabled is not a degraded state
-    settings = get_settings()
     if settings.reranker_enabled:
         try:
             async with httpx.AsyncClient() as client:
@@ -696,14 +705,36 @@ async def system_stats(
 
     # ── Queue stats (from ingestion_jobs table) ──
     try:
-        rows = await session.execute(
-            text("SELECT stage, count(*) FROM ingestion_jobs WHERE status = 'queued' GROUP BY stage")
-        )
-        queue_depths = {row[0]: row[1] for row in rows}
-        result["queues"] = {
-            "io_queued": sum(queue_depths.get(s, 0) for s in ("extract", "chunk", "finalize")),
-            "cpu_queued": sum(queue_depths.get(s, 0) for s in ("ocr", "embed")),
+        from harbor_clerk.worker.pipeline import STAGE_CONFIG
+
+        rows = (
+            await session.execute(
+                select(IngestionJob.stage, IngestionJob.status, func.count())
+                .join(Document, IngestionJob.doc_id == Document.doc_id)
+                .where(IngestionJob.status.in_((JobStatus.queued, JobStatus.running)))
+                .where(IngestionJob.pipeline_seq == Document.pipeline_seq)
+                .where(Document.status == "active")
+                .group_by(IngestionJob.stage, IngestionJob.status)
+            )
+        ).all()
+        queue_stats = {
+            "io_queued": 0,
+            "io_running": 0,
+            "cpu_queued": 0,
+            "cpu_running": 0,
+            "llm_queued": 0,
+            "llm_running": 0,
         }
+        for stage, status, count in rows:
+            stage_enum = stage if isinstance(stage, JobStage) else JobStage(str(stage))
+            status_key = status.value if isinstance(status, JobStatus) else str(status)
+            if status_key not in ("queued", "running"):
+                continue
+            queue_name = STAGE_CONFIG[stage_enum][0]
+            stat_key = f"{queue_name}_{status_key}"
+            if stat_key in queue_stats:
+                queue_stats[stat_key] += int(count)
+        result["queues"] = queue_stats
     except Exception as e:
         logger.error("Failed to collect queue stats: %s", e)
         result["queues"] = {"error": str(e)}

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -55,6 +55,24 @@ async def test_health_check(client):
     assert data["checks"]["postgres"] == "ok"
 
 
+async def test_health_check_reports_embedder(client, monkeypatch):
+    import httpx
+
+    real_get = httpx.AsyncClient.get
+
+    async def _selective_get(self, url, *args, **kwargs):
+        if str(url) == "http://embedder:8000/health":
+            return httpx.Response(200, json={"status": "ok"}, request=httpx.Request("GET", str(url)))
+        return await real_get(self, url, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _selective_get)
+
+    resp = await client.get("/api/system/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["checks"]["embedder"] == "ok"
+
+
 async def test_health_check_exposes_allow_source_download_default_false(client):
     """The health endpoint surfaces the allow_source_download capability so the
     frontend can decide whether to render the Download button. Default must be
@@ -362,6 +380,93 @@ async def test_status_summary_reports_summarize_backlog_separately(client, admin
     assert data["counts"]["total_queued_jobs"] == 1
     assert data["recent_processing_documents"] == []
     assert data["needs_attention"] == []
+
+
+async def test_system_stats_reports_worker_queue_rollups(client, admin_user, admin_token, db_session):
+    io_doc = Document(
+        title="IO queued",
+        status="active",
+        sha256=b"i" * 32,
+        pipeline_status=PipelineStatus.extracting,
+        pipeline_seq=1,
+    )
+    cpu_doc = Document(
+        title="CPU running",
+        status="active",
+        sha256=b"c" * 32,
+        pipeline_status=PipelineStatus.embedding,
+        pipeline_seq=1,
+    )
+    llm_doc = Document(
+        title="LLM queued",
+        status="active",
+        sha256=b"l" * 32,
+        pipeline_status=PipelineStatus.ready,
+        pipeline_seq=1,
+    )
+    stale_doc = Document(
+        title="Stale job",
+        status="active",
+        sha256=b"s" * 32,
+        pipeline_status=PipelineStatus.chunking,
+        pipeline_seq=2,
+    )
+    inactive_doc = Document(
+        title="Inactive job",
+        status="inactive",
+        sha256=b"x" * 32,
+        pipeline_status=PipelineStatus.ocr_running,
+        pipeline_seq=1,
+    )
+    db_session.add_all([io_doc, cpu_doc, llm_doc, stale_doc, inactive_doc])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            IngestionJob(
+                doc_id=io_doc.doc_id,
+                stage=JobStage.extract,
+                status=JobStatus.queued,
+                pipeline_seq=io_doc.pipeline_seq,
+            ),
+            IngestionJob(
+                doc_id=cpu_doc.doc_id,
+                stage=JobStage.embed,
+                status=JobStatus.running,
+                pipeline_seq=cpu_doc.pipeline_seq,
+            ),
+            IngestionJob(
+                doc_id=llm_doc.doc_id,
+                stage=JobStage.summarize,
+                status=JobStatus.queued,
+                pipeline_seq=llm_doc.pipeline_seq,
+            ),
+            IngestionJob(
+                doc_id=stale_doc.doc_id,
+                stage=JobStage.chunk,
+                status=JobStatus.queued,
+                pipeline_seq=1,
+            ),
+            IngestionJob(
+                doc_id=inactive_doc.doc_id,
+                stage=JobStage.ocr,
+                status=JobStatus.queued,
+                pipeline_seq=inactive_doc.pipeline_seq,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/system/stats", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    queues = resp.json()["queues"]
+    assert queues == {
+        "io_queued": 1,
+        "io_running": 0,
+        "cpu_queued": 0,
+        "cpu_running": 1,
+        "llm_queued": 1,
+        "llm_running": 0,
+    }
 
 
 async def test_status_summary_summarize_jobs_do_not_hide_completed_status_cleanup(


### PR DESCRIPTION
## Summary
- add embedder to the system health diagnostics
- expose current-generation IO/CPU/LLM queue rollups from /api/system/stats
- show Embedder, Local AI, and Workers / queues cards on the Status diagnostics page

## Fresh-eyes review
- reviewed the diff as a separate pass for queue-count mismatches and health semantics
- no blocking findings; queue stats use active current-generation jobs only, matching the queue tray snapshot contract

## Tests
- uv run pytest tests/test_api_system.py -q
- uv run ruff check src/harbor_clerk/api/routes/system.py tests/test_api_system.py
- uv run ruff format --check src/harbor_clerk/api/routes/system.py tests/test_api_system.py
- npm test -- --run src/pages/SystemStatusPage.test.tsx
- npm run type-check
- npm run lint
- npm run format:check

Note: npm run lint passes with existing warnings in unrelated files.