### PR TITLE
Fix MCP token URL examples

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -65,11 +65,12 @@ call remote MCP servers.
 2. Create a scoped API key in **Settings -> API Keys**.
 3. Use the MCP URL shown in the Integrations page.
 
-For clients that cannot attach bearer headers, Harbor Clerk supports the
-URL-token form:
+Use `/mcp` for OAuth or clients that can send `Authorization: Bearer
+YOUR_API_KEY`. For clients that cannot attach bearer headers, Harbor Clerk
+supports the URL-token path form:
 
 ```text
-https://your-server.example.com/mcp?key=YOUR_API_KEY
+https://your-server.example.com/t/YOUR_API_KEY
 ```
 
 Do not reuse a broad admin key for autonomous tools. Create a separate scoped
@@ -158,7 +159,7 @@ Claude Desktop usually uses MCP:
 {
   "mcpServers": {
     "harbor-clerk": {
-      "url": "https://your-server.example.com/mcp?key=YOUR_API_KEY"
+      "url": "https://your-server.example.com/t/YOUR_API_KEY"
     }
   }
 }
@@ -167,7 +168,7 @@ Claude Desktop usually uses MCP:
 Claude Code can use MCP if configured for it:
 
 ```bash
-claude mcp add harbor-clerk "https://your-server.example.com/mcp?key=YOUR_API_KEY"
+claude mcp add harbor-clerk "https://your-server.example.com/t/YOUR_API_KEY"
 ```
 
 For shell-first coding sessions, the CLI path is often simpler. Enable CLI

--- a/frontend/src/pages/IntegrationsPage.test.tsx
+++ b/frontend/src/pages/IntegrationsPage.test.tsx
@@ -29,6 +29,14 @@ function renderPage() {
   )
 }
 
+function expectPreContains(text: string) {
+  expect(
+    screen.getByText((content, element) => {
+      return element?.tagName.toLowerCase() === 'pre' && content.includes(text)
+    }),
+  ).toBeInTheDocument()
+}
+
 describe('IntegrationsPage', () => {
   beforeEach(() => {
     getMock.mockReset()
@@ -69,5 +77,32 @@ describe('IntegrationsPage', () => {
     expect(await screen.findByText('Skill markdown')).toBeInTheDocument()
     expect(screen.getByText(/Find every matching document/)).toBeInTheDocument()
     expect(screen.getByText(/harbor-clerk find-all/)).toBeInTheDocument()
+  })
+
+  it('renders authless MCP examples with token-path URLs', async () => {
+    getMock.mockImplementation((path: string) => {
+      if (path === '/api/integrations/settings') {
+        return Promise.resolve({ public_url: 'https://clerk.example/', oauth_refresh_token_days: 90 })
+      }
+      if (path === '/api/integrations/connections') {
+        return Promise.resolve([])
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Choose a Surface')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Claude/ }))
+    expectPreContains('"url": "https://clerk.example/t/YOUR_API_KEY"')
+    expectPreContains('claude mcp add harbor-clerk "https://clerk.example/t/YOUR_API_KEY"')
+
+    fireEvent.click(screen.getByRole('button', { name: /Gemini/ }))
+    expectPreContains('"uri": "https://clerk.example/t/YOUR_API_KEY"')
+
+    fireEvent.click(screen.getByRole('button', { name: /OpenClaw/ }))
+    expectPreContains(`openclaw mcp set harbor-clerk '{"url":"https://clerk.example/t/YOUR_API_KEY"}'`)
+    expectPreContains('"url": "https://clerk.example/t/YOUR_API_KEY"')
   })
 })

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -131,9 +131,9 @@ export default function IntegrationsPage() {
     }
   }
 
-  const mcpUrl = settings.public_url
-    ? `${settings.public_url.replace(/\/$/, '')}/mcp`
-    : 'https://your-server.example.com/mcp'
+  const publicBaseUrl = settings.public_url ? settings.public_url.replace(/\/$/, '') : 'https://your-server.example.com'
+  const mcpUrl = `${publicBaseUrl}/mcp`
+  const mcpTokenUrl = `${publicBaseUrl}/t/YOUR_API_KEY`
   const appOrigin = typeof window !== 'undefined' ? window.location.origin : ''
   const cliBaseUrl = settings.public_url || appOrigin || 'https://your-server.example.com'
   const cliEnvBlock = `export HARBOR_CLERK_URL="${cliBaseUrl.replace(/\/$/, '')}"
@@ -380,7 +380,7 @@ export PATH="$HOME/.local/bin:$PATH"`
                 {
                   mcpServers: {
                     'harbor-clerk': {
-                      url: `${mcpUrl}?key=YOUR_API_KEY`,
+                      url: mcpTokenUrl,
                     },
                   },
                 },
@@ -391,7 +391,7 @@ export PATH="$HOME/.local/bin:$PATH"`
             <p className="mt-4 text-sm text-(--color-text-primary)">
               For <strong>Claude Code</strong> MCP setup, run:
             </p>
-            <CodeBlock>{`claude mcp add harbor-clerk "${mcpUrl}?key=YOUR_API_KEY"`}</CodeBlock>
+            <CodeBlock>{`claude mcp add harbor-clerk "${mcpTokenUrl}"`}</CodeBlock>
             <p className="mt-4 text-sm text-(--color-text-primary)">
               For shell-first Claude Code sessions, enable the CLI below, export the environment variables, and copy the
               Harbor Clerk skill markdown into your local skill directory.
@@ -452,7 +452,7 @@ export PATH="$HOME/.local/bin:$PATH"`
                 {
                   mcpServers: {
                     'harbor-clerk': {
-                      uri: `${mcpUrl}?key=YOUR_API_KEY`,
+                      uri: mcpTokenUrl,
                     },
                   },
                 },
@@ -505,9 +505,7 @@ export PATH="$HOME/.local/bin:$PATH"`
             <p className="mt-4 text-sm text-(--color-text-primary)">
               If your OpenClaw setup is using MCP instead, add Harbor Clerk as an MCP server in your OpenClaw config:
             </p>
-            <CodeBlock>
-              {`openclaw mcp set harbor-clerk '${JSON.stringify({ url: `${mcpUrl}?key=YOUR_API_KEY` })}'`}
-            </CodeBlock>
+            <CodeBlock>{`openclaw mcp set harbor-clerk '${JSON.stringify({ url: mcpTokenUrl })}'`}</CodeBlock>
             <p className="mt-3 text-sm text-(--color-text-primary)">
               Or add it directly to your{' '}
               <code className="rounded bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs">openclaw.json</code>:
@@ -517,7 +515,7 @@ export PATH="$HOME/.local/bin:$PATH"`
                 {
                   mcpServers: {
                     'harbor-clerk': {
-                      url: `${mcpUrl}?key=YOUR_API_KEY`,
+                      url: mcpTokenUrl,
                     },
                   },
                 },


### PR DESCRIPTION
## Summary
- switch authless MCP connector examples from the unsupported query-string form to the server token-path form: `/t/<api_key>`
- keep `/mcp` for OAuth/header-auth MCP setup
- add an Integrations page regression test for generated Claude, Gemini, and OpenClaw token-path URLs

## Verification
- `npm test -- --run src/pages/IntegrationsPage.test.tsx`
- `npm run type-check`
- `npm run lint` (passes with existing warnings)
- `npm run format:check`
- `rg -n "mcp\\?key|\\?key=YOUR_API_KEY" -g "!frontend/node_modules/**" -g "!node_modules/**" .`