### PR TITLE
Capture verifier verdicts in eval sweeps

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -133,6 +133,12 @@ Useful entry points:
 - [`docs/agent-memory-eval.md`](agent-memory-eval.md): OpenClaw and agent-memory
   claim ladder.
 
+Verifier validation runs should enable `research_verifier_enabled` while
+leaving `research_verifier_revision_enabled` off. The sweep harness preserves
+per-citation verifier verdicts in response artifacts and aggregates them in
+`metrics.csv` so the release decision can be made from observed grounding
+signal quality rather than from the existence of the mechanism alone.
+
 Public reports should summarize results instead of dumping raw partial sweeps
 into the README. Raw artifacts are useful for technical readers, but the
 release page should explain what was tested, what passed, what failed, and

--- a/scripts/test_corpora/README.md
+++ b/scripts/test_corpora/README.md
@@ -5,7 +5,7 @@ three structurally-different corpora (CUAD legal contracts, Enron email
 subset, synthetic bilingual small-business). Six sequential phases, fully
 restartable.
 
-> **⚠️  Destructive.** This sweep wipes the Harbor Clerk instance's documents,
+> **⚠️ Destructive.** This sweep wipes the Harbor Clerk instance's documents,
 > watch folders, and storage objects between every corpus ingest. Use a
 > dedicated HC instance — never run it against one that holds documents you
 > care about. See [RUNBOOK.md](RUNBOOK.md#%EF%B8%8F--this-sweep-is-destructive) for the full impact list.
@@ -16,10 +16,10 @@ See [`docs/superpowers/specs/2026-05-04-test-corpora-execution-design.md`](../..
 
 Prerequisite: Harbor Clerk is running locally — either the macOS Server menubar app or `docker compose up`.
 
-| Setup | URL | TLS? |
-| --- | --- | --- |
-| **macOS native** | `http://localhost:8100` (default; check Preferences if changed) | no |
-| **Docker Compose** | `https://localhost:443` (Caddy + self-signed) | yes — pass `--insecure` |
+| Setup              | URL                                                             | TLS?                    |
+| ------------------ | --------------------------------------------------------------- | ----------------------- |
+| **macOS native**   | `http://localhost:8100` (default; check Preferences if changed) | no                      |
+| **Docker Compose** | `https://localhost:443` (Caddy + self-signed)                   | yes — pass `--insecure` |
 
 The harness has its own `pyproject.toml` and venv (separate from Harbor
 Clerk's main venv, since it needs different deps — `anthropic`, `mcp`,
@@ -83,14 +83,38 @@ uv run python -m scripts.test_corpora.runner.sweep \
 
 `<workdir>/results/<run-id>/`:
 
-| Path | What |
-| --- | --- |
-| `state.json` | resumable state — every (phase, corpus, model, q, depth) cell |
-| `baselines/<corpus>/<question_id>.json` | Claude Sonnet 4.6 baseline output |
-| `responses/<corpus>/<model>/<question_id>__<depth>.json` | local-model response |
-| `judge/<corpus>/<model>/<question_id>__<depth>.json` | Phase-5 judge verdict |
-| `metrics.csv` | one row per completion |
-| `log.txt` | full run log |
+| Path                                                     | What                                                          |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| `state.json`                                             | resumable state — every (phase, corpus, model, q, depth) cell |
+| `baselines/<corpus>/<question_id>.json`                  | Claude Sonnet 4.6 baseline output                             |
+| `responses/<corpus>/<model>/<question_id>__<depth>.json` | local-model response                                          |
+| `judge/<corpus>/<model>/<question_id>__<depth>.json`     | Phase-5 judge verdict                                         |
+| `metrics.csv`                                            | one row per completion                                        |
+| `log.txt`                                                | full run log                                                  |
+
+## Verifier validation runs
+
+Harbor Clerk's citation verifier is off by default. To validate it as a
+display-only grounding signal, enable verifier emission without enabling the
+revision pass, then run a focused Research sweep:
+
+```bash
+jq '.research_verifier_enabled = true | .research_verifier_revision_enabled = false' \
+    "$HOME/Library/Application Support/Harbor Clerk/config.json" > /tmp/hc-config.json
+mv /tmp/hc-config.json "$HOME/Library/Application Support/Harbor Clerk/config.json"
+
+uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.sweep \
+    --run-id verifier-smoke-$(date +%Y%m%d-%H%M) \
+    --workdir ~/Library/Application\ Support/Harbor\ Clerk/test-corpora \
+    --phases 4 --models qwen36-35b-a3b --corpora cuad
+```
+
+Research response artifacts preserve per-citation SSE verdicts under
+`result.verifier_verdicts`. `metrics.csv` also includes aggregate
+`verifier_total`, `verifier_supported`, `verifier_partial`,
+`verifier_unsupported`, and `verifier_skipped` columns. Use those aggregates
+only as validation data for a "citation support" or "grounding check" UI; do
+not present them as answer-correctness percentages.
 
 ## Troubleshooting
 

--- a/scripts/test_corpora/runner/client.py
+++ b/scripts/test_corpora/runner/client.py
@@ -437,6 +437,7 @@ class HarborClerkClient:
         abort_reason: dict[str, str] = {}
         conv_id_holder: list[str | None] = [None]
         response_holder: list[Any] = [None]
+        verifier_verdicts: list[dict[str, Any]] = []
         # Last-event timestamp; updated by the main loop on every parsed SSE
         # event. The watchdog reads it to detect the "zombie llama" case where
         # the model_status keeps reporting `ready` but no events flow.
@@ -502,6 +503,8 @@ class HarborClerkClient:
                     # quiet (not just when we're slow to drain a buffer).
                     last_event_at[0] = time.time()
                     etype = event.get("type")
+                    if etype == "verifier_pass":
+                        verifier_verdicts.append(event)
                     if etype in ("done", "error"):
                         break
             except Exception:
@@ -516,6 +519,8 @@ class HarborClerkClient:
 
         # Fetch the final state (status, report, citations, messages).
         final = self.poll_research(conv_id)
+        if verifier_verdicts:
+            final["verifier_verdicts"] = verifier_verdicts
         if abort_reason:
             final = {
                 **final,

--- a/scripts/test_corpora/runner/sweep.py
+++ b/scripts/test_corpora/runner/sweep.py
@@ -377,6 +377,32 @@ def _is_retryable_research_failure(out: dict) -> bool:
     return result.get("status") in ("failed", "interrupted")
 
 
+def _verifier_counts(result: dict) -> dict[str, int]:
+    """Count display-only citation verifier verdicts in a Research result.
+
+    The verifier is intentionally off by default. When an operator enables it
+    for validation, `HarborClerkClient.run_research()` preserves each
+    `verifier_pass` SSE payload under `verifier_verdicts`. These counts make
+    metrics.csv useful for deciding whether the signal is release-worthy
+    without opening every response artifact.
+    """
+    counts = {
+        "total": 0,
+        "supported": 0,
+        "partial": 0,
+        "unsupported": 0,
+        "skipped": 0,
+    }
+    for item in result.get("verifier_verdicts") or []:
+        if not isinstance(item, dict):
+            continue
+        counts["total"] += 1
+        verdict = item.get("verdict")
+        if verdict in counts:
+            counts[verdict] += 1
+    return counts
+
+
 # ── argparse ──
 
 
@@ -987,26 +1013,39 @@ def main(argv: list[str] | None = None) -> int:
 
         # CSV metrics
         metrics_path = run_dir / "metrics.csv"
-        new_csv = not metrics_path.exists()
+        metrics_header = [
+            "phase",
+            "corpus",
+            "model",
+            "question_id",
+            "depth",
+            "status",
+            "citation_overlap",
+            "citation_extra",
+            "entity_overlap",
+            "latency_seconds",
+            "judge_verdict",
+            "judge_completeness",
+            "verifier_total",
+            "verifier_supported",
+            "verifier_partial",
+            "verifier_unsupported",
+            "verifier_skipped",
+        ]
+        new_csv = not metrics_path.exists() or metrics_path.stat().st_size == 0
+        include_verifier_metrics = True
+        if not new_csv:
+            existing_header = metrics_path.read_text().splitlines()[0].split(",")
+            include_verifier_metrics = "verifier_total" in existing_header
+            if not include_verifier_metrics:
+                log.warning(
+                    "metrics.csv lacks verifier columns; preserving legacy row shape for this resumed run. "
+                    "Use a fresh --run-id for verifier validation metrics."
+                )
         metrics_f = metrics_path.open("a", newline="")
         metrics_writer = csv.writer(metrics_f)
         if new_csv:
-            metrics_writer.writerow(
-                [
-                    "phase",
-                    "corpus",
-                    "model",
-                    "question_id",
-                    "depth",
-                    "status",
-                    "citation_overlap",
-                    "citation_extra",
-                    "entity_overlap",
-                    "latency_seconds",
-                    "judge_verdict",
-                    "judge_completeness",
-                ]
-            )
+            metrics_writer.writerow(metrics_header)
 
         sampler = Sampler(every_n=cfg.SAMPLE_EVERY_N)
         sweep_started = time.time()
@@ -1543,6 +1582,7 @@ def main(argv: list[str] | None = None) -> int:
                 co = ce = eo = 0.0
                 judge_verdict = ""
                 judge_completeness = 0
+                verifier_counts = _verifier_counts(out.get("result", {}) or {})
                 if phase in (4, 5):
                     baseline_path = run_dir / "baselines" / u.corpus / f"{u.question_id}.json"
                     # Cross-language ids resolve their baseline to the canonical EN id
@@ -1636,22 +1676,31 @@ def main(argv: list[str] | None = None) -> int:
                         )
 
                 row_unit = sf.get(u.phase, u.corpus, u.model, u.question_id, u.depth)
-                metrics_writer.writerow(
-                    [
-                        phase,
-                        u.corpus,
-                        u.model,
-                        u.question_id,
-                        u.depth,
-                        row_unit.status.value if row_unit else "unknown",
-                        f"{co:.3f}",
-                        ce,
-                        f"{eo:.3f}",
-                        f"{latency:.1f}",
-                        judge_verdict,
-                        judge_completeness,
-                    ]
-                )
+                metrics_row = [
+                    phase,
+                    u.corpus,
+                    u.model,
+                    u.question_id,
+                    u.depth,
+                    row_unit.status.value if row_unit else "unknown",
+                    f"{co:.3f}",
+                    ce,
+                    f"{eo:.3f}",
+                    f"{latency:.1f}",
+                    judge_verdict,
+                    judge_completeness,
+                ]
+                if include_verifier_metrics:
+                    metrics_row.extend(
+                        [
+                            verifier_counts["total"],
+                            verifier_counts["supported"],
+                            verifier_counts["partial"],
+                            verifier_counts["unsupported"],
+                            verifier_counts["skipped"],
+                        ]
+                    )
+                metrics_writer.writerow(metrics_row)
                 metrics_f.flush()
 
                 # Closing marker for this unit — pairs with the "Starting"

--- a/scripts/test_corpora/tests/test_client.py
+++ b/scripts/test_corpora/tests/test_client.py
@@ -549,6 +549,40 @@ def test_run_research_drains_sse_stream_until_done():
     assert result["report"] == "hello world"
 
 
+def test_run_research_preserves_verifier_pass_events():
+    """Verifier validation runs need the per-citation verdicts. The server
+    emits them as SSE events before ``done``; the harness should persist them
+    in the final ResearchDetail artifact rather than discarding the stream."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/api/research":
+            body = (
+                'data: {"type":"started"}\n\n'
+                'data: {"type":"verifier_pass","doc_id":"D1","doc_title":"Contract A",'
+                '"verdict":"supported","reason":"matches","index":0,"total":2}\n\n'
+                'data: {"type":"verifier_pass","doc_id":"D2","doc_title":"Contract B",'
+                '"verdict":"partial","reason":"thin support","index":1,"total":2}\n\n'
+                'data: {"type":"done","conversation_id":"conv-verifier"}\n\n'
+            )
+            return httpx.Response(
+                200,
+                headers={"X-Research-Id": "conv-verifier", "Content-Type": "text/event-stream"},
+                content=body,
+            )
+        if request.method == "GET" and request.url.path == "/api/research/conv-verifier":
+            return httpx.Response(
+                200,
+                json={"status": "completed", "report": "done", "conversation_id": "conv-verifier"},
+            )
+        return httpx.Response(404)
+
+    c = make_client(handler)
+    _, result = c.run_research("Q?", depth="standard", time_limit_minutes=1)
+
+    assert [v["verdict"] for v in result["verifier_verdicts"]] == ["supported", "partial"]
+    assert result["verifier_verdicts"][0]["doc_title"] == "Contract A"
+
+
 def test_evaluate_health_no_abort_when_model_ready_and_research_running():
     state = _WatchdogState()
     kind, detail = _evaluate_health("ready", "running", state)

--- a/scripts/test_corpora/tests/test_plan_units.py
+++ b/scripts/test_corpora/tests/test_plan_units.py
@@ -3,7 +3,7 @@ and --corpora filter interaction with phase ranges."""
 
 from __future__ import annotations
 
-from scripts.test_corpora.runner.sweep import _plan_units
+from scripts.test_corpora.runner.sweep import _plan_units, _verifier_counts
 
 
 def _qbc(corpora: list[str]) -> dict[str, dict]:
@@ -127,3 +127,25 @@ def test_phase_planning_is_additive_after_prior_phase(tmp_path):
     sf2.load()
     phases_seen = {u.phase for u in sf2.units()}
     assert phases_seen == {0, 1, 4}, f"expected phases {{0,1,4}}, got {phases_seen}"
+
+
+def test_verifier_counts_summarizes_research_verdicts():
+    result = {
+        "verifier_verdicts": [
+            {"verdict": "supported"},
+            {"verdict": "partial"},
+            {"verdict": "unsupported"},
+            {"verdict": "skipped"},
+            {"verdict": "supported"},
+            {"verdict": "unknown"},
+            "bad-event",
+        ]
+    }
+
+    assert _verifier_counts(result) == {
+        "total": 6,
+        "supported": 2,
+        "partial": 1,
+        "unsupported": 1,
+        "skipped": 1,
+    }


### PR DESCRIPTION
## Summary
- preserve Research `verifier_pass` SSE events in sweep response artifacts as `result.verifier_verdicts`
- add verifier aggregate columns to fresh `metrics.csv` files, while preserving legacy row shape for resumed older runs
- document verifier-only validation runs and link the evaluation guidance to the new artifacts

## Fresh-eyes review
- Checked that this does not enable the verifier or revision pass by default.
- Checked legacy `metrics.csv` compatibility so resumed older sweeps do not get wider rows under old headers.
- Checked docs language frames verdicts as citation support / grounding-check validation data, not answer correctness.

## Tests
- `uv --project scripts/test_corpora run pytest scripts/test_corpora/tests/test_client.py scripts/test_corpora/tests/test_plan_units.py -q`
- `uv --project scripts/test_corpora run ruff check scripts/test_corpora/runner/client.py scripts/test_corpora/runner/sweep.py scripts/test_corpora/tests/test_client.py scripts/test_corpora/tests/test_plan_units.py`
- `uv --project scripts/test_corpora run ruff format --check scripts/test_corpora/runner/client.py scripts/test_corpora/runner/sweep.py scripts/test_corpora/tests/test_client.py scripts/test_corpora/tests/test_plan_units.py`
- `frontend/node_modules/.bin/prettier --check docs/evaluation.md scripts/test_corpora/README.md`
- `git diff --check`