### PR TITLE
Document cloud model boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ Everything runs on your machine. No SaaS account. No background sync. No shared 
 
 Harbor Clerk is designed for document-heavy small teams, independent operators, researchers, and privacy-focused individuals. It runs comfortably on a Mac mini or similar hardware and includes cited answers powered by local AI models.
 
-If you want to connect external AI tools, Harbor Clerk exposes an MCP endpoint that allows them to search your knowledge base safely. They receive only the retrieved passages needed to answer a question — never your full documents.
+If you want to connect external AI tools, Harbor Clerk exposes an MCP endpoint
+that allows them to search your knowledge base safely. With the recommended
+cloud-connector scope, they receive retrieved passages and citations rather
+than the whole corpus.
+
+Cloud models are supported through scoped MCP/connectors in the current release.
+Direct cloud-backed Ask or Research inside the app is a separate fast-follow,
+not a requirement for the initial release; see
+[Cloud model boundaries](docs/cloud-model-boundaries.md) for the release gate.
 
 This isn't a platform. It's a tool.
 It keeps your documents where they belong — and makes them useful.
@@ -97,6 +105,8 @@ from current, reproducible eval runs.
 
 See [Evaluation and release claims](docs/evaluation.md) for the current claim
 posture, eval methodology pointers, and the OpenClaw claim ladder.
+[Cloud model boundaries](docs/cloud-model-boundaries.md) explains the current
+MCP/cloud connector path and the go/no-go bar for future in-app cloud mode.
 
 Known limitations for the initial release:
 
@@ -110,6 +120,9 @@ Known limitations for the initial release:
   enterprise platform.
 - Advanced integrations such as MCP, CLI, cloud LLMs, OpenClaw, and Docker
   require operator setup.
+- Direct cloud-backed Ask/Research inside the app is a fast-follow unless the
+  citation, key-storage, disclosure, path-policy, and failure-mode checklist is
+  satisfied.
 - Backup and restore are documented but not yet a polished in-app workflow.
 
 ## Why Harbor Clerk?

--- a/docs/cloud-model-boundaries.md
+++ b/docs/cloud-model-boundaries.md
@@ -1,0 +1,90 @@
+# Cloud Model Boundaries
+
+Harbor Clerk supports cloud LLMs today through controlled integrations. It does
+not need to call a cloud provider from inside Ask or Research for the initial
+release.
+
+This distinction matters because Harbor Clerk's trust story is about local
+documents, scoped tool access, and citations. Cloud models can be useful
+operators over the corpus, but users should always know what leaves the
+machine, which interface sent it, and how citations are preserved.
+
+## Current Release
+
+Supported cloud path:
+
+- A cloud LLM or connector calls Harbor Clerk through MCP.
+- The connector authenticates with a scoped API key or OAuth flow.
+- Harbor Clerk returns tool responses: retrieved snippets, citations, titles,
+  folder labels, relative paths, and structured metadata needed for the
+  request.
+- The provider can see those tool responses and the tool arguments it is asked
+  to run.
+- The full corpus is not uploaded by Harbor Clerk.
+
+This is the right release path for ChatGPT, Claude, Claude Desktop, Gemini CLI,
+and other MCP-capable clients. It keeps cloud usage operator-controlled and
+lets the MCP/CLI citation contract remain the source of truth.
+
+## In-App Cloud Mode
+
+In-app cloud mode means Harbor Clerk itself would call a provider from Ask or
+Research using a user-supplied provider API key. This could be valuable: it
+would combine Harbor Clerk retrieval and first-class citations with stronger
+cloud synthesis.
+
+It is also a different product surface from MCP. In-app cloud mode should not
+ship until the core path is stable enough that cloud answers are no more
+confusing than local answers.
+
+Release go criteria:
+
+- Ask and Research preserve clickable, inspectable citations through the same
+  source contract used by search, MCP, and CLI results.
+- The model selector clearly distinguishes local AI from cloud AI before the
+  user sends a prompt.
+- Provider API keys have an acceptable storage path for public release. On
+  macOS, prefer Keychain or the existing encrypted-secret machinery; avoid
+  surprising plaintext files.
+- Each cloud run shows a boundary disclosure: provider, model, prompt/context
+  flow, and whether retrieved source snippets are being sent.
+- Absolute local filesystem paths are not sent to cloud-visible prompts,
+  results, logs, or traces by default.
+- Errors, logs, telemetry, and diagnostics do not persist provider keys or full
+  prompt/context bodies.
+- Invalid keys, rate limits, network loss, cancellation, long-context overflow,
+  provider errors, and offline behavior fail gracefully without breaking local
+  search or local AI.
+- At least one provider path has mocked tests plus a live smoke checklist for
+  no-key, invalid-key, successful answer, citation rendering, long context,
+  email and attachment citations, cancellation, and offline behavior.
+
+Defer in-app cloud mode if:
+
+- Citation chips depend on parsing the cloud model's prose after the fact.
+- "Private AI" copy could be read as applying to cloud runs.
+- Provider-key storage is still unsettled.
+- Path disclosure is not enforced by tests.
+- Cloud failures create confusing Ask or Research states.
+- The release story depends on cloud mode to compensate for local model
+  quality.
+
+For the initial release, the default decision is to keep cloud model usage in
+MCP/connectors and document in-app cloud mode as a fast-follow.
+
+## Copy Rules
+
+Use language like:
+
+- "Cloud LLMs can use Harbor Clerk through MCP and receive scoped, cited tool
+  responses."
+- "Local AI keeps prompts and retrieved snippets on the machine."
+- "Future in-app cloud mode would send the selected prompt and retrieved
+  context to the chosen provider."
+
+Avoid language like:
+
+- "All AI is private."
+- "Cloud models never see document content."
+- "In-app cloud Ask/Research is release-ready" unless the go criteria above
+  have been met.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -80,6 +80,18 @@ Use qualitative tiers in user-facing UI and docs:
 If numeric scores are published, keep them in dated eval reports with corpus,
 commit, model, and methodology details.
 
+## Cloud model boundary
+
+Cloud LLMs are part of the release story through MCP and connector-style access:
+they can call scoped Harbor Clerk tools and receive cited snippets. Direct
+provider-backed Ask/Research inside the Harbor Clerk app is a different surface
+and should remain a fast-follow unless the checklist in
+[Cloud model boundaries](cloud-model-boundaries.md) is satisfied.
+
+This keeps the public claim honest: local AI runs locally, MCP/cloud connectors
+receive scoped tool responses, and future in-app cloud mode would send selected
+prompt/context to the chosen provider.
+
 ## Agent memory and OpenClaw
 
 The current release-safe agent claim is:
@@ -107,6 +119,9 @@ comparison for outcome improvement.
   enterprise platform.
 - Advanced integrations such as MCP, CLI, cloud LLMs, OpenClaw, and Docker
   require operator setup.
+- Direct cloud-backed Ask/Research inside the app is not part of the initial
+  release unless citation preservation, provider-key storage, disclosure, path
+  policy, and failure-mode tests are stable.
 - Backup and restore are documented but not yet a polished in-app workflow.
 - The verifier/revision loop should not be marketed as a default quality
   improvement. Display-only citation support may become useful, but it should

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -29,6 +29,12 @@ By default, agent-visible paths should avoid absolute local filesystem paths.
 Use relative paths and folder aliases unless a local-only workflow explicitly
 needs more detail.
 
+Cloud access through MCP is the supported release path for external models.
+Direct provider-backed Ask/Research inside the Harbor Clerk app is a separate
+fast-follow surface and should ship only after citation preservation, provider
+key storage, disclosure, path policy, and failure-mode tests are stable. See
+[Cloud model boundaries](cloud-model-boundaries.md) for the release gate.
+
 ## API Key Guidance
 
 Create a dedicated API key for each external tool or harness.
@@ -187,6 +193,11 @@ Make the data boundary explicit when helping users set this up:
 - Retrieved snippets and citation metadata can be sent to the provider.
 - API keys should be scoped.
 - Audit logs should be reviewed if an autonomous agent may call tools in loops.
+
+This is different from future in-app cloud Ask/Research. In the current release,
+cloud models use Harbor Clerk as a cited retrieval tool through MCP; the app's
+own Ask and Research surfaces remain local-AI-first unless an explicit cloud
+mode is later added.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add a dedicated cloud model boundary doc for the current MCP connector path vs future in-app cloud Ask/Research.
- Link the boundary from README, Integrations, and Evaluation docs.
- Tighten README wording so cloud connectors are described as receiving scoped tool responses rather than over-broad “never full documents” language.

## Fresh-eyes review
- Checked that the docs distinguish local AI, MCP/cloud connectors, and future in-app cloud provider calls.
- Verified the copy does not imply all AI is private or that cloud providers never see retrieved snippets.
- Confirmed in-app cloud mode is documented as a fast-follow unless citation, key-storage, disclosure, path-policy, and failure-mode gates are met.

## Checks
- `frontend/node_modules/.bin/prettier --check docs/cloud-model-boundaries.md docs/integrations.md docs/evaluation.md`
- `npm run format:check` (frontend)
- `git diff --check`
- targeted overclaim scan for stale cloud/privacy phrasing

Note: `README.md` already fails standalone Prettier at HEAD; this PR avoids repo-wide README formatting churn and the normal frontend format check remains clean.