### PR TITLE
Add verifier validation report

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -153,6 +153,8 @@ leaving `research_verifier_revision_enabled` off. The sweep harness preserves
 per-citation verifier verdicts in response artifacts and aggregates them in
 `metrics.csv` so the release decision can be made from observed grounding
 signal quality rather than from the existence of the mechanism alone.
+Use `scripts.test_corpora.runner.verifier_report` to turn those columns into a
+Markdown/JSON validation artifact for the citation-support default-on decision.
 
 Public reports should summarize results instead of dumping raw partial sweeps
 into the README. Raw artifacts are useful for technical readers, but the

--- a/scripts/test_corpora/README.md
+++ b/scripts/test_corpora/README.md
@@ -116,6 +116,21 @@ Research response artifacts preserve per-citation SSE verdicts under
 only as validation data for a "citation support" or "grounding check" UI; do
 not present them as answer-correctness percentages.
 
+Generate a report from the verifier columns:
+
+```bash
+uv --project scripts/test_corpora run python -m scripts.test_corpora.runner.verifier_report \
+    --run-dir "$HOME/Library/Application Support/Harbor Clerk/test-corpora/results/verifier-smoke-YYYYMMDD-HHMM" \
+    --output verifier-report.md \
+    --json-output verifier-report.json
+```
+
+The report labels the run `candidate`, `review-required`, or
+`insufficient-data`. Treat `candidate` as permission to spot-check examples
+before a UI default-on decision, not as an automatic product verdict. Treat
+`review-required` as a prompt to inspect examples and decide whether the
+answers were weak, the citations were thin, or the verifier itself was noisy.
+
 ## Troubleshooting
 
 - **API unreachable:** check `curl "$HC_API_BASE/api/system/health"`. The default `HC_API_BASE` is `https://localhost` (Docker); on macOS native, set it to `http://localhost:8100` (or whatever port your Harbor Clerk Server is configured for).

--- a/scripts/test_corpora/runner/verifier_report.py
+++ b/scripts/test_corpora/runner/verifier_report.py
@@ -1,0 +1,364 @@
+"""Summarize citation-verifier validation metrics from a sweep run.
+
+The verifier is a candidate display-only "citation support" signal, not a
+calibrated correctness score. This reporter turns the raw ``metrics.csv``
+verdict columns into a small release-decision artifact: enough data, observed
+verdict mix, and whether the signal is quiet enough to consider for UI work or
+needs manual review first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+VERIFIER_COLUMNS = (
+    "verifier_total",
+    "verifier_supported",
+    "verifier_partial",
+    "verifier_unsupported",
+    "verifier_skipped",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifierRow:
+    phase: str
+    corpus: str
+    model: str
+    question_id: str
+    depth: str
+    status: str
+    total: int
+    supported: int
+    partial: int
+    unsupported: int
+    skipped: int
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifierSummary:
+    label: str
+    rows: int
+    rows_with_verdicts: int
+    total: int
+    supported: int
+    partial: int
+    unsupported: int
+    skipped: int
+    hint: str
+    reason: str
+
+    @property
+    def supported_rate(self) -> float:
+        return _rate(self.supported, self.total)
+
+    @property
+    def partial_rate(self) -> float:
+        return _rate(self.partial, self.total)
+
+    @property
+    def unsupported_rate(self) -> float:
+        return _rate(self.unsupported, self.total)
+
+    @property
+    def skipped_rate(self) -> float:
+        return _rate(self.skipped, self.total)
+
+
+@dataclasses.dataclass(frozen=True)
+class ReportThresholds:
+    min_verdicts: int = 20
+    max_partial_rate: float = 0.10
+    max_unsupported_rate: float = 0.00
+    max_skipped_rate: float = 0.25
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator
+
+
+def _int_value(row: dict[str, str], key: str) -> int:
+    raw = row.get(key, "")
+    if raw in ("", None):
+        return 0
+    return int(raw)
+
+
+def read_verifier_rows(metrics_path: Path) -> tuple[list[VerifierRow], bool]:
+    """Read sweep ``metrics.csv`` rows.
+
+    Returns ``(rows, has_verifier_columns)``. Legacy resumed sweeps may preserve
+    a pre-verifier CSV shape; callers should report that as insufficient data
+    instead of treating it as zero verifier signal.
+    """
+    if not metrics_path.exists():
+        raise FileNotFoundError(metrics_path)
+
+    with metrics_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = set(reader.fieldnames or [])
+        has_verifier_columns = all(col in fieldnames for col in VERIFIER_COLUMNS)
+        if not has_verifier_columns:
+            return [], False
+
+        rows = [
+            VerifierRow(
+                phase=row.get("phase", ""),
+                corpus=row.get("corpus", ""),
+                model=row.get("model", ""),
+                question_id=row.get("question_id", ""),
+                depth=row.get("depth", ""),
+                status=row.get("status", ""),
+                total=_int_value(row, "verifier_total"),
+                supported=_int_value(row, "verifier_supported"),
+                partial=_int_value(row, "verifier_partial"),
+                unsupported=_int_value(row, "verifier_unsupported"),
+                skipped=_int_value(row, "verifier_skipped"),
+            )
+            for row in reader
+        ]
+    return rows, True
+
+
+def classify_summary(summary: VerifierSummary, thresholds: ReportThresholds) -> tuple[str, str]:
+    """Return ``(hint, reason)`` for a summary.
+
+    The hint is intentionally a release-planning prompt, not a product-quality
+    verdict. Unsupported or partial citations may mean the verifier found real
+    answer issues, or it may mean the verifier itself is noisy. Either way,
+    those rows need human spot-checking before the UI becomes default-on.
+    """
+    if summary.total < thresholds.min_verdicts:
+        return (
+            "insufficient-data",
+            f"{summary.total} checked citations is below the {thresholds.min_verdicts} minimum",
+        )
+    if summary.unsupported_rate > thresholds.max_unsupported_rate:
+        return (
+            "review-required",
+            f"unsupported rate {summary.unsupported_rate:.1%} exceeds {thresholds.max_unsupported_rate:.1%}",
+        )
+    if summary.partial_rate > thresholds.max_partial_rate:
+        return (
+            "review-required",
+            f"partial rate {summary.partial_rate:.1%} exceeds {thresholds.max_partial_rate:.1%}",
+        )
+    if summary.skipped_rate > thresholds.max_skipped_rate:
+        return (
+            "review-required",
+            f"skipped rate {summary.skipped_rate:.1%} exceeds {thresholds.max_skipped_rate:.1%}",
+        )
+    return (
+        "candidate",
+        "enough checked citations and low noisy-verdict rates; spot-check before UI default-on",
+    )
+
+
+def summarize_rows(rows: list[VerifierRow], label: str, thresholds: ReportThresholds) -> VerifierSummary:
+    base = VerifierSummary(
+        label=label,
+        rows=len(rows),
+        rows_with_verdicts=sum(1 for row in rows if row.total > 0),
+        total=sum(row.total for row in rows),
+        supported=sum(row.supported for row in rows),
+        partial=sum(row.partial for row in rows),
+        unsupported=sum(row.unsupported for row in rows),
+        skipped=sum(row.skipped for row in rows),
+        hint="",
+        reason="",
+    )
+    hint, reason = classify_summary(base, thresholds)
+    return dataclasses.replace(base, hint=hint, reason=reason)
+
+
+def grouped_summaries(
+    rows: list[VerifierRow],
+    group_by: str,
+    thresholds: ReportThresholds,
+) -> list[VerifierSummary]:
+    buckets: dict[str, list[VerifierRow]] = defaultdict(list)
+    for row in rows:
+        key = getattr(row, group_by)
+        buckets[key or "(blank)"].append(row)
+    return [summarize_rows(bucket, label, thresholds) for label, bucket in sorted(buckets.items())]
+
+
+def summary_to_dict(summary: VerifierSummary) -> dict[str, Any]:
+    return {
+        "label": summary.label,
+        "rows": summary.rows,
+        "rows_with_verdicts": summary.rows_with_verdicts,
+        "verifier_total": summary.total,
+        "verifier_supported": summary.supported,
+        "verifier_partial": summary.partial,
+        "verifier_unsupported": summary.unsupported,
+        "verifier_skipped": summary.skipped,
+        "supported_rate": summary.supported_rate,
+        "partial_rate": summary.partial_rate,
+        "unsupported_rate": summary.unsupported_rate,
+        "skipped_rate": summary.skipped_rate,
+        "hint": summary.hint,
+        "reason": summary.reason,
+    }
+
+
+def render_markdown(
+    *,
+    run_label: str,
+    overall: VerifierSummary,
+    by_corpus: list[VerifierSummary],
+    by_model: list[VerifierSummary],
+    thresholds: ReportThresholds,
+) -> str:
+    lines = [
+        f"# Verifier Validation Report - {run_label}",
+        "",
+        "This report summarizes display-only citation verifier verdicts. It is",
+        "a release-planning aid for a possible citation-support or grounding-check",
+        "UI, not an answer-correctness score.",
+        "",
+        "## Overall",
+        "",
+        _markdown_table([overall]),
+        "",
+        "## By Corpus",
+        "",
+        _markdown_table(by_corpus),
+        "",
+        "## By Model",
+        "",
+        _markdown_table(by_model),
+        "",
+        "## Thresholds",
+        "",
+        f"- Minimum checked citations: {thresholds.min_verdicts}",
+        f"- Maximum partial rate: {thresholds.max_partial_rate:.1%}",
+        f"- Maximum unsupported rate: {thresholds.max_unsupported_rate:.1%}",
+        f"- Maximum skipped rate: {thresholds.max_skipped_rate:.1%}",
+        "",
+        "Treat `candidate` as permission to spot-check the run, not as an",
+        "automatic UI-default decision. Treat `review-required` as a request to",
+        "open examples and decide whether the answers are weak, the citations are",
+        "thin, or the verifier is noisy.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _markdown_table(summaries: list[VerifierSummary]) -> str:
+    if not summaries:
+        return "_No verifier rows._"
+    lines = [
+        "| Label | Hint | Rows | Checked | Supported | Partial | Unsupported | Skipped | Reason |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for summary in summaries:
+        lines.append(
+            f"| {_escape_md(summary.label)} | {summary.hint} | {summary.rows} | {summary.total} | {summary.supported} ({summary.supported_rate:.1%}) | "
+            f"{summary.partial} ({summary.partial_rate:.1%}) | {summary.unsupported} ({summary.unsupported_rate:.1%}) | "
+            f"{summary.skipped} ({summary.skipped_rate:.1%}) | {_escape_md(summary.reason)} |"
+        )
+    return "\n".join(lines)
+
+
+def _escape_md(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def build_report(
+    metrics_path: Path,
+    *,
+    run_label: str,
+    thresholds: ReportThresholds,
+) -> tuple[str, dict[str, Any]]:
+    rows, has_verifier_columns = read_verifier_rows(metrics_path)
+    if not has_verifier_columns:
+        payload = {
+            "run_label": run_label,
+            "hint": "insufficient-data",
+            "reason": "metrics.csv has no verifier columns; use a fresh verifier validation run",
+            "overall": None,
+            "by_corpus": [],
+            "by_model": [],
+        }
+        text = (
+            f"# Verifier Validation Report - {run_label}\n\n"
+            "metrics.csv has no verifier columns. Use a fresh verifier validation run.\n"
+        )
+        return text, payload
+
+    overall = summarize_rows(rows, "overall", thresholds)
+    by_corpus = grouped_summaries(rows, "corpus", thresholds)
+    by_model = grouped_summaries(rows, "model", thresholds)
+    text = render_markdown(
+        run_label=run_label,
+        overall=overall,
+        by_corpus=by_corpus,
+        by_model=by_model,
+        thresholds=thresholds,
+    )
+    payload = {
+        "run_label": run_label,
+        "hint": overall.hint,
+        "reason": overall.reason,
+        "overall": summary_to_dict(overall),
+        "by_corpus": [summary_to_dict(item) for item in by_corpus],
+        "by_model": [summary_to_dict(item) for item in by_model],
+        "thresholds": dataclasses.asdict(thresholds),
+    }
+    return text, payload
+
+
+def make_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="verifier-report")
+    p.add_argument(
+        "--run-dir",
+        required=True,
+        help="Sweep result directory containing metrics.csv, e.g. .../results/verifier-smoke-20260607",
+    )
+    p.add_argument("--label", default="", help="Human-readable report label. Defaults to the run directory name.")
+    p.add_argument("--output", default="", help="Write Markdown report to this path instead of stdout.")
+    p.add_argument("--json-output", default="", help="Optional JSON summary output path.")
+    p.add_argument("--min-verdicts", type=int, default=ReportThresholds.min_verdicts)
+    p.add_argument("--max-partial-rate", type=float, default=ReportThresholds.max_partial_rate)
+    p.add_argument("--max-unsupported-rate", type=float, default=ReportThresholds.max_unsupported_rate)
+    p.add_argument("--max-skipped-rate", type=float, default=ReportThresholds.max_skipped_rate)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    run_dir = Path(args.run_dir).expanduser()
+    thresholds = ReportThresholds(
+        min_verdicts=args.min_verdicts,
+        max_partial_rate=args.max_partial_rate,
+        max_unsupported_rate=args.max_unsupported_rate,
+        max_skipped_rate=args.max_skipped_rate,
+    )
+    text, payload = build_report(
+        run_dir / "metrics.csv",
+        run_label=args.label or run_dir.name,
+        thresholds=thresholds,
+    )
+
+    if args.output:
+        Path(args.output).expanduser().write_text(text)
+    else:
+        sys.stdout.write(text)
+
+    if args.json_output:
+        Path(args.json_output).expanduser().write_text(json.dumps(payload, indent=2) + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_corpora/tests/test_verifier_report.py
+++ b/scripts/test_corpora/tests/test_verifier_report.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import csv
+import json
+
+from scripts.test_corpora.runner.verifier_report import (
+    ReportThresholds,
+    build_report,
+    main,
+    read_verifier_rows,
+    summarize_rows,
+)
+
+
+def _write_metrics(path, rows, *, include_verifier=True):
+    fieldnames = [
+        "phase",
+        "corpus",
+        "model",
+        "question_id",
+        "depth",
+        "status",
+        "citation_overlap",
+        "citation_extra",
+        "entity_overlap",
+        "latency_seconds",
+        "judge_verdict",
+        "judge_completeness",
+    ]
+    if include_verifier:
+        fieldnames.extend(
+            [
+                "verifier_total",
+                "verifier_supported",
+                "verifier_partial",
+                "verifier_unsupported",
+                "verifier_skipped",
+            ]
+        )
+    else:
+        rows = [{key: value for key, value in row.items() if key in fieldnames} for row in rows]
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _row(
+    *,
+    corpus="cuad",
+    model="qwen36-35b-a3b",
+    question_id="q1",
+    total=0,
+    supported=0,
+    partial=0,
+    unsupported=0,
+    skipped=0,
+):
+    return {
+        "phase": "4",
+        "corpus": corpus,
+        "model": model,
+        "question_id": question_id,
+        "depth": "standard",
+        "status": "done",
+        "citation_overlap": "0.5",
+        "citation_extra": "0",
+        "entity_overlap": "0.5",
+        "latency_seconds": "12.0",
+        "judge_verdict": "",
+        "judge_completeness": "",
+        "verifier_total": str(total),
+        "verifier_supported": str(supported),
+        "verifier_partial": str(partial),
+        "verifier_unsupported": str(unsupported),
+        "verifier_skipped": str(skipped),
+    }
+
+
+def test_read_verifier_rows_detects_legacy_metrics(tmp_path):
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_row()], include_verifier=False)
+
+    rows, has_verifier_columns = read_verifier_rows(metrics)
+
+    assert rows == []
+    assert has_verifier_columns is False
+
+
+def test_summarize_rows_candidate_when_supported_verdicts_dominate(tmp_path):
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(
+        metrics,
+        [
+            _row(question_id="q1", total=10, supported=10),
+            _row(question_id="q2", total=10, supported=10),
+        ],
+    )
+    rows, has_verifier_columns = read_verifier_rows(metrics)
+
+    summary = summarize_rows(rows, "overall", ReportThresholds(min_verdicts=20))
+
+    assert has_verifier_columns is True
+    assert summary.total == 20
+    assert summary.supported == 20
+    assert summary.hint == "candidate"
+    assert "spot-check" in summary.reason
+
+
+def test_summarize_rows_insufficient_data_below_threshold(tmp_path):
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_row(total=5, supported=5)])
+    rows, _ = read_verifier_rows(metrics)
+
+    summary = summarize_rows(rows, "overall", ReportThresholds(min_verdicts=20))
+
+    assert summary.hint == "insufficient-data"
+    assert "below the 20 minimum" in summary.reason
+
+
+def test_summarize_rows_review_required_for_unsupported_verdicts(tmp_path):
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(
+        metrics,
+        [
+            _row(question_id="q1", total=10, supported=10),
+            _row(question_id="q2", total=10, supported=9, unsupported=1),
+        ],
+    )
+    rows, _ = read_verifier_rows(metrics)
+
+    summary = summarize_rows(rows, "overall", ReportThresholds(min_verdicts=20))
+
+    assert summary.hint == "review-required"
+    assert "unsupported rate" in summary.reason
+
+
+def test_build_report_groups_by_corpus_and_model(tmp_path):
+    run_dir = tmp_path / "results" / "verifier-smoke"
+    run_dir.mkdir(parents=True)
+    _write_metrics(
+        run_dir / "metrics.csv",
+        [
+            _row(corpus="cuad", model="qwen36-35b-a3b", question_id="q1", total=20, supported=20),
+            _row(corpus="enron", model="gemma4-26b-a4b", question_id="q2", total=20, supported=15, partial=5),
+        ],
+    )
+
+    markdown, payload = build_report(
+        run_dir / "metrics.csv",
+        run_label="verifier-smoke",
+        thresholds=ReportThresholds(min_verdicts=20),
+    )
+
+    assert "# Verifier Validation Report - verifier-smoke" in markdown
+    assert "| cuad | candidate |" in markdown
+    assert "| enron | review-required |" in markdown
+    assert payload["overall"]["verifier_total"] == 40
+    assert {row["label"] for row in payload["by_model"]} == {"gemma4-26b-a4b", "qwen36-35b-a3b"}
+
+
+def test_build_report_missing_verifier_columns_is_insufficient(tmp_path):
+    run_dir = tmp_path / "results" / "legacy-run"
+    run_dir.mkdir(parents=True)
+    _write_metrics(run_dir / "metrics.csv", [_row()], include_verifier=False)
+
+    markdown, payload = build_report(
+        run_dir / "metrics.csv",
+        run_label="legacy-run",
+        thresholds=ReportThresholds(),
+    )
+
+    assert "has no verifier columns" in markdown
+    assert payload["hint"] == "insufficient-data"
+    assert payload["overall"] is None
+
+
+def test_cli_writes_markdown_and_json_outputs(tmp_path):
+    run_dir = tmp_path / "results" / "verifier-smoke"
+    run_dir.mkdir(parents=True)
+    _write_metrics(run_dir / "metrics.csv", [_row(total=20, supported=20)])
+    report_path = tmp_path / "report.md"
+    json_path = tmp_path / "report.json"
+
+    rc = main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--output",
+            str(report_path),
+            "--json-output",
+            str(json_path),
+            "--min-verdicts",
+            "20",
+        ]
+    )
+
+    assert rc == 0
+    assert "Verifier Validation Report" in report_path.read_text()
+    payload = json.loads(json_path.read_text())
+    assert payload["hint"] == "candidate"


### PR DESCRIPTION
## Summary
- Add `scripts.test_corpora.runner.verifier_report` to summarize verifier metrics from sweep `metrics.csv`.
- Emit Markdown and optional JSON artifacts with overall, per-corpus, and per-model verifier verdict summaries.
- Label runs as `candidate`, `review-required`, or `insufficient-data` using conservative thresholds, with docs that these are planning hints rather than answer-correctness scores.
- Document the reporter in the test-corpora README and evaluation docs.

## Fresh-eyes review
- Checked that the reporter does not turn verifier counts into a calibrated correctness/confidence score.
- Confirmed legacy metrics without verifier columns are treated as insufficient data rather than zero signal.
- Confirmed `candidate` still requires human spot-checking before any default-on citation-support UI decision.

## Checks
- `uv --project scripts/test_corpora run pytest scripts/test_corpora/tests/test_verifier_report.py scripts/test_corpora/tests/test_plan_units.py -q`
- `uv --project scripts/test_corpora run ruff check scripts/test_corpora/runner/verifier_report.py scripts/test_corpora/tests/test_verifier_report.py`
- `uv --project scripts/test_corpora run ruff format --check scripts/test_corpora/runner/verifier_report.py scripts/test_corpora/tests/test_verifier_report.py`
- `frontend/node_modules/.bin/prettier --check scripts/test_corpora/README.md docs/evaluation.md`
- `git diff --check`