### PR TITLE
Clarify local MCP URLs and plan native HTTPS

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -66,8 +66,8 @@ reads, then tell the operator which broader capability was denied.
 Use MCP for ChatGPT, Claude Desktop, Gemini CLI, and any other client that can
 call remote MCP servers.
 
-1. Set a public HTTPS URL in **Settings -> Integrations** if the client is not
-   running on the same machine.
+1. Set a public HTTPS URL in **Settings -> Integrations** if the client is a
+   cloud connector or is not running on the same machine.
 2. Create a scoped API key in **Settings -> API Keys**.
 3. Use the MCP URL shown in the Integrations page.
 
@@ -78,6 +78,15 @@ supports the URL-token path form:
 ```text
 https://your-server.example.com/t/YOUR_API_KEY
 ```
+
+For same-machine local MCP clients, use the current local app origin instead of
+a public placeholder. Today that means:
+
+- macOS native app: `http://localhost:8100/t/YOUR_API_KEY`
+- Docker default: `https://localhost/t/YOUR_API_KEY`
+
+The macOS HTTPS gateway is a release gate for parity with Docker. Until it
+lands, do not tell local macOS users that the native app listens on HTTPS.
 
 Do not reuse a broad admin key for autonomous tools. Create a separate scoped
 key per connector.
@@ -119,6 +128,9 @@ Release-safe claim:
 Prefer CLI for local OpenClaw runs because it matches OpenClaw's shell-first
 workflow and lets the agent use the checked-in Harbor Clerk skill markdown.
 Use MCP when your OpenClaw setup is already configured for MCP servers.
+For local macOS native testing, use `http://localhost:8100/t/YOUR_API_KEY`
+unless you have configured a separate HTTPS proxy. Docker users can use
+`https://localhost/t/YOUR_API_KEY`.
 
 Minimum setup:
 

--- a/docs/superpowers/specs/2026-06-08-native-https-gateway-design.md
+++ b/docs/superpowers/specs/2026-06-08-native-https-gateway-design.md
@@ -1,0 +1,325 @@
+# Native HTTPS Gateway - Design Spec
+
+**Date:** 2026-06-08
+**Status:** Draft for release-gate planning
+**Scope:** macOS native HTTPS parity with Docker for local UI, MCP, CLI, and local agent harness setup. Includes manual real-certificate support planning. Excludes ACME/Let's Encrypt automation.
+
+## Overview
+
+Docker already presents Harbor Clerk through a Caddy HTTPS gateway at
+`https://localhost`, while the macOS native app currently serves the API and
+SPA directly over `http://localhost:<apiPort>`. That mismatch leaks into the
+Integrations page, CLI defaults, OpenClaw setup, and cloud/local connector
+messaging.
+
+Native HTTPS should be a release gate because Harbor Clerk is explicitly
+positioned as a tool surface for agentic frameworks and cloud LLM connectors.
+Operators should not have to reason about one local URL shape for Docker, a
+different one for macOS, and a third one for public cloud connectors.
+
+## Goals
+
+- Add a managed macOS HTTPS gateway that mirrors the Docker Caddy gateway.
+- Keep the FastAPI app bound to an internal loopback HTTP port.
+- Give local MCP clients a stable HTTPS URL on macOS.
+- Make CLI/OpenClaw/Codex/Claude Code setup copy consistent across Docker and
+  macOS.
+- Keep cloud connector guidance explicit: cloud clients still require a public
+  URL with a certificate trusted by the provider.
+- Prepare the architecture for manual real hostname/certificate configuration.
+- Surface gateway health, cert mode, and externally reachable URL clearly in
+  Preferences, Status, and Integrations.
+
+## Non-goals
+
+- No ACME or Let's Encrypt automation in the initial release gate.
+- No privileged port 443 default on macOS.
+- No silent system-trust modification without user-visible consent.
+- No public exposure by default.
+- No redesign of MCP auth, API keys, or OAuth.
+- No replacing FastAPI/uvicorn for this scope.
+
+## Current behavior
+
+Docker:
+
+- Caddy listens on port 443.
+- Caddy uses an internal/self-signed local cert for `localhost`.
+- Caddy proxies `/`, `/api/*`, `/mcp/*`, and `/t/*` to the app container.
+
+macOS native:
+
+- Harbor Clerk Server starts the API on `http://127.0.0.1:<apiPort>`.
+- Harbor Clerk.app loads `http://localhost:<apiPort>` in WKWebView.
+- The CLI shim bakes in `http://localhost:<apiPort>`.
+- The generic CLI default is `https://localhost`, which currently matches
+  Docker better than macOS.
+- Public URL remains an operator-configured integration setting used by OAuth
+  and cloud-facing MCP snippets.
+
+## Recommended architecture
+
+Add a new managed native gateway service, likely backed by a bundled Caddy
+binary:
+
+```text
+Local clients
+  -> https://localhost:<gatewayPort>
+  -> Caddy native gateway
+  -> http://127.0.0.1:<apiPort>
+  -> FastAPI / React SPA / MCP
+```
+
+Default ports:
+
+- Keep `apiPort` at `8100` for the internal app listener.
+- Add `gatewayPort`, defaulting to a non-privileged port such as `8443`.
+- Do not use `443` by default because it needs privilege, may conflict with
+  other local services, and complicates install/uninstall.
+
+Default bind behavior:
+
+- Gateway binds to loopback only by default.
+- Existing "Allow remote browser connections" and "Allow remote model
+  connections (MCP)" should control whether the gateway can bind beyond
+  loopback.
+- Direct API binding to `0.0.0.0` should be reconsidered once the gateway
+  exists; the safer release posture is public traffic through the gateway, not
+  straight to uvicorn.
+
+Why Caddy:
+
+- Already used in Docker, so config and behavior converge.
+- Handles TLS and reverse proxying cleanly.
+- Makes later manual cert/hostname support mostly a config problem.
+- Avoids baking TLS ownership into FastAPI or the Swift app.
+
+Rejected alternatives:
+
+- Uvicorn TLS directly: lower initial code, but worse long-term parity and
+  real-certificate support.
+- A custom Swift reverse proxy: unnecessary complexity and more security
+  surface.
+- Requiring users to install their own reverse proxy: not acceptable for the
+  Mac-native product promise.
+
+## Certificate modes
+
+### Mode 1: Local self-signed or local CA certificate
+
+Release-gate default for macOS parity.
+
+Expected URL:
+
+```text
+https://localhost:8443/t/YOUR_API_KEY
+```
+
+Requirements:
+
+- Generate or let Caddy generate a localhost certificate.
+- Store gateway config and cert material under Application Support, with
+  private material protected by normal user-only file permissions.
+- Provide an explicit trust workflow if the cert needs to be trusted by system
+  clients.
+- Verify WKWebView, CLI, OpenClaw, Claude Code, Codex, and curl behavior.
+- Document any client that still requires an insecure flag or manual trust
+  import.
+
+Open issue:
+
+- The main unknown is not whether Caddy can serve HTTPS. It can. The unknown is
+  how cleanly local agent clients trust the certificate. That must be tested
+  against OpenClaw before considering the release gate satisfied.
+
+### Mode 2: Manual real cert and hostname
+
+Fast follow or same release only if the local gateway lands cleanly.
+
+Inputs:
+
+- Hostname.
+- Certificate chain path or uploaded certificate.
+- Private key path or uploaded key.
+- Optional bind address.
+- Optional public URL override.
+
+Requirements:
+
+- Validate certificate and private key match.
+- Validate hostname coverage and expiry.
+- Warn if the gateway is configured for remote access.
+- Store paths or key material safely.
+- Reload/restart the gateway when settings change.
+- Reflect the effective URL on the Integrations page.
+
+### Mode 3: ACME/Let's Encrypt
+
+Deferred.
+
+Reason:
+
+- Requires DNS or HTTP challenge UX, renewal, firewall/router/tunnel guidance,
+  and more failure modes.
+- It is valuable, but it should not block the first public release.
+
+## User-facing surfaces
+
+### Harbor Clerk Server Preferences
+
+Add a "Local HTTPS Gateway" section near Network Access:
+
+- Enable local HTTPS gateway.
+- Gateway URL: `https://localhost:8443`.
+- Gateway port.
+- Certificate mode: local certificate or manual certificate.
+- Certificate trust status.
+- Real hostname/cert controls when manual mode is enabled.
+- Copy local MCP URL.
+- Link to Integrations.
+
+Changing gateway port or certificate mode should mark that a restart/reload is
+needed, then perform a targeted gateway restart when applied.
+
+### Status page
+
+Add gateway state alongside API/search/local AI:
+
+- Gateway running.
+- Certificate valid.
+- Certificate trusted by this Mac, if detectable.
+- Public URL configured or not configured.
+- Remote access enabled or disabled.
+
+The Status page should distinguish:
+
+- "Local HTTPS unavailable" for local gateway failures.
+- "Public HTTPS not configured" for cloud connectors. This is informational
+  unless the user is trying to set up cloud MCP/OAuth.
+
+### Integrations page
+
+Split URLs by use case:
+
+- Local URL: effective same-machine URL, preferably `https://localhost:8443`
+  after this work lands.
+- Public URL: operator-configured trusted HTTPS URL for cloud connectors.
+
+Copy should be explicit:
+
+- ChatGPT/cloud connector examples use Public URL only.
+- OpenClaw/Codex/Claude Code local examples use Local URL by default.
+- If Public URL is unset, cloud connector examples should show a placeholder
+  and say setup is incomplete.
+
+### CLI shim
+
+After local HTTPS is stable:
+
+- Bake `HARBOR_CLERK_URL=https://localhost:<gatewayPort>` into the macOS shim.
+- Mark old HTTP shims stale so users reinstall.
+- Keep an environment-variable override for unusual deployments.
+- Consider whether the CLI should default to HTTPS localhost everywhere after
+  macOS parity lands.
+
+## Implementation plan
+
+### PR 1: Copy and URL split
+
+Status: in progress in this planning branch.
+
+- Make Integrations copy distinguish local clients from cloud clients.
+- Use current app origin for local-capable MCP examples.
+- Document that macOS native is currently HTTP and Docker is HTTPS.
+
+### PR 2: Native gateway service
+
+- Add `gateway_port` and gateway enable/cert-mode settings.
+- Bundle or locate a Caddy binary in the macOS Server resources.
+- Add `GatewayService` as a managed service.
+- Render a Caddyfile from settings into Application Support.
+- Start gateway after API is healthy.
+- Health-check the gateway over HTTPS.
+- Add tests for settings persistence, config generation, and stale-port
+  detection.
+
+### PR 3: Native app and CLI routing
+
+- Decide whether Harbor Clerk.app loads the SPA through HTTPS by default.
+- Update `BackendDetector`, `AuthManager`, and WKWebView certificate handling
+  if the app moves to HTTPS.
+- Update CLI shim defaults to the gateway URL.
+- Update Integrations snippets to prefer the gateway URL.
+- Add fallback behavior if the gateway is disabled or unhealthy.
+
+### PR 4: Certificate trust and smoke tests
+
+- Implement or document the trust workflow.
+- Verify curl, `harbor-clerk` CLI, OpenClaw MCP, Claude Code MCP, and browser
+  behavior.
+- Add a release smoke section covering local HTTPS setup.
+- Decide whether any client-specific insecure flag is acceptable for release.
+
+### PR 5: Manual hostname/cert support
+
+- Add Preferences UI for hostname, cert chain, private key, bind address, and
+  effective public URL.
+- Validate cert/key pair, hostname coverage, and expiry.
+- Store paths or key material safely.
+- Reload gateway on changes.
+- Update Status and Integrations with the effective public URL and warnings.
+
+## Release gates
+
+Minimum gate:
+
+- macOS native exposes a working same-machine HTTPS URL for MCP.
+- OpenClaw can complete a documented MCP smoke task against that URL, or the
+  docs clearly route OpenClaw through CLI until trust is solved.
+- Docker and macOS snippets no longer contradict actual listener behavior.
+- Cloud connector docs continue to require public trusted HTTPS.
+- Status exposes whether the gateway is healthy.
+- CLI still works when the gateway is disabled or unavailable.
+
+Preferred gate:
+
+- Harbor Clerk.app, CLI shim, and local MCP snippets all use the same local
+  HTTPS gateway URL by default.
+- Certificate trust is first-class enough that local agent users do not need to
+  hand-edit insecure flags.
+- Public/manual cert configuration is at least designed and not blocked by the
+  local gateway architecture.
+
+## Risks
+
+- Local certificate trust may be client-specific and messy.
+- WKWebView may need explicit certificate challenge handling if the app loads
+  through the gateway before system trust is installed.
+- Bundling Caddy may affect notarization/signing expectations.
+- Port conflicts on `8443` need a clear recovery path.
+- Remote-access toggles may need to move from "bind uvicorn broadly" to "bind
+  gateway broadly and keep uvicorn loopback."
+- Self-signed local HTTPS could give users a false sense that cloud connectors
+  are configured; copy must keep the boundary explicit.
+
+## Open questions
+
+- Should Harbor Clerk.app switch to HTTPS in the same PR as the gateway, or
+  should the gateway initially exist only for CLI/MCP?
+- What default gateway port is least surprising: `8443`, `9443`, or another?
+- Can OpenClaw trust the local cert through normal system trust, or does it
+  require an explicit client setting?
+- Should manual cert mode store private key paths or copy key material into
+  Harbor Clerk's Application Support directory?
+- Should public URL settings be web-only, native Preferences-only, or shared
+  across both surfaces?
+
+## Estimated effort
+
+- Copy and docs correction: less than 1 day.
+- Native self-signed HTTPS gateway: 3 to 5 engineering days.
+- Release-quality local HTTPS with status, trust handling, CLI/app snippet
+  updates, and OpenClaw smoke: about 1 week.
+- Manual real cert and hostname support: 1 to 2 additional weeks.
+- ACME/Let's Encrypt automation: defer; likely 2 to 4 weeks depending on UX
+  scope.

--- a/frontend/src/pages/IntegrationsPage.test.tsx
+++ b/frontend/src/pages/IntegrationsPage.test.tsx
@@ -69,6 +69,8 @@ describe('IntegrationsPage', () => {
 
     expect(screen.getByText(/Prefer the CLI skill for local/)).toBeInTheDocument()
     expect(screen.getByText(/Full only for local runs/)).toBeInTheDocument()
+    expect(screen.getByText(/macOS native currently exposes local MCP over HTTP/)).toBeInTheDocument()
+    expectPreContains(`openclaw mcp set harbor-clerk '{"url":"${window.location.origin}/t/YOUR_API_KEY"}'`)
   })
 
   it('renders the checked-in CLI skill markdown with find-all guidance', async () => {
@@ -79,7 +81,7 @@ describe('IntegrationsPage', () => {
     expect(screen.getByText(/harbor-clerk find-all/)).toBeInTheDocument()
   })
 
-  it('renders authless MCP examples with token-path URLs', async () => {
+  it('keeps cloud MCP examples public and same-machine MCP examples local', async () => {
     getMock.mockImplementation((path: string) => {
       if (path === '/api/integrations/settings') {
         return Promise.resolve({ public_url: 'https://clerk.example/', oauth_refresh_token_days: 90 })
@@ -93,16 +95,19 @@ describe('IntegrationsPage', () => {
     renderPage()
 
     expect(await screen.findByText('Choose a Surface')).toBeInTheDocument()
+    expectPreContains('https://clerk.example/mcp')
+
+    const localTokenUrl = `${window.location.origin}/t/YOUR_API_KEY`
 
     fireEvent.click(screen.getByRole('button', { name: /Claude/ }))
-    expectPreContains('"url": "https://clerk.example/t/YOUR_API_KEY"')
-    expectPreContains('claude mcp add harbor-clerk "https://clerk.example/t/YOUR_API_KEY"')
+    expectPreContains(`"url": "${localTokenUrl}"`)
+    expectPreContains(`claude mcp add harbor-clerk "${localTokenUrl}"`)
 
     fireEvent.click(screen.getByRole('button', { name: /Gemini/ }))
-    expectPreContains('"uri": "https://clerk.example/t/YOUR_API_KEY"')
+    expectPreContains(`"uri": "${localTokenUrl}"`)
 
     fireEvent.click(screen.getByRole('button', { name: /OpenClaw/ }))
-    expectPreContains(`openclaw mcp set harbor-clerk '{"url":"https://clerk.example/t/YOUR_API_KEY"}'`)
-    expectPreContains('"url": "https://clerk.example/t/YOUR_API_KEY"')
+    expectPreContains(`openclaw mcp set harbor-clerk '{"url":"${localTokenUrl}"}'`)
+    expectPreContains(`"url": "${localTokenUrl}"`)
   })
 })

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -66,6 +66,10 @@ function CodeBlock({ children }: { children: string }) {
   )
 }
 
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
 export default function IntegrationsPage() {
   const { enableCliAccess, cliShimInstallStatus } = useSystemConfig()
   const [settings, setSettings] = useState<IntegrationSettings>({ public_url: '', oauth_refresh_token_days: 90 })
@@ -131,12 +135,12 @@ export default function IntegrationsPage() {
     }
   }
 
-  const publicBaseUrl = settings.public_url ? settings.public_url.replace(/\/$/, '') : 'https://your-server.example.com'
+  const appOrigin = typeof window !== 'undefined' ? trimTrailingSlash(window.location.origin) : ''
+  const localBaseUrl = appOrigin || 'http://localhost:8100'
+  const publicBaseUrl = settings.public_url ? trimTrailingSlash(settings.public_url) : 'https://your-server.example.com'
   const mcpUrl = `${publicBaseUrl}/mcp`
-  const mcpTokenUrl = `${publicBaseUrl}/t/YOUR_API_KEY`
-  const appOrigin = typeof window !== 'undefined' ? window.location.origin : ''
-  const cliBaseUrl = settings.public_url || appOrigin || 'https://your-server.example.com'
-  const cliEnvBlock = `export HARBOR_CLERK_URL="${cliBaseUrl.replace(/\/$/, '')}"
+  const localMcpTokenUrl = `${localBaseUrl}/t/YOUR_API_KEY`
+  const cliEnvBlock = `export HARBOR_CLERK_URL="${localBaseUrl}"
 export HARBOR_CLERK_API_KEY="YOUR_API_KEY"
 export PATH="$HOME/.local/bin:$PATH"`
 
@@ -274,7 +278,8 @@ export PATH="$HOME/.local/bin:$PATH"`
             <p className="text-sm font-semibold text-(--color-text-primary)">MCP for cloud and connector clients</p>
             <p className="mt-1 text-sm text-(--color-text-secondary)">
               Use MCP when the tool can call structured remote tools directly. Cloud models receive retrieved snippets,
-              citations, and metadata from scoped tool calls, not the full archive.
+              citations, and metadata from scoped tool calls, not the full archive. Cloud clients require a public,
+              trusted HTTPS URL; same-machine clients can use the current app origin.
             </p>
           </div>
           <div className="rounded-lg border border-(--color-border) bg-(--color-bg-secondary) p-4">
@@ -380,7 +385,7 @@ export PATH="$HOME/.local/bin:$PATH"`
                 {
                   mcpServers: {
                     'harbor-clerk': {
-                      url: mcpTokenUrl,
+                      url: localMcpTokenUrl,
                     },
                   },
                 },
@@ -391,7 +396,7 @@ export PATH="$HOME/.local/bin:$PATH"`
             <p className="mt-4 text-sm text-(--color-text-primary)">
               For <strong>Claude Code</strong> MCP setup, run:
             </p>
-            <CodeBlock>{`claude mcp add harbor-clerk "${mcpTokenUrl}"`}</CodeBlock>
+            <CodeBlock>{`claude mcp add harbor-clerk "${localMcpTokenUrl}"`}</CodeBlock>
             <p className="mt-4 text-sm text-(--color-text-primary)">
               For shell-first Claude Code sessions, enable the CLI below, export the environment variables, and copy the
               Harbor Clerk skill markdown into your local skill directory.
@@ -452,7 +457,7 @@ export PATH="$HOME/.local/bin:$PATH"`
                 {
                   mcpServers: {
                     'harbor-clerk': {
-                      uri: mcpTokenUrl,
+                      uri: localMcpTokenUrl,
                     },
                   },
                 },
@@ -505,7 +510,7 @@ export PATH="$HOME/.local/bin:$PATH"`
             <p className="mt-4 text-sm text-(--color-text-primary)">
               If your OpenClaw setup is using MCP instead, add Harbor Clerk as an MCP server in your OpenClaw config:
             </p>
-            <CodeBlock>{`openclaw mcp set harbor-clerk '${JSON.stringify({ url: mcpTokenUrl })}'`}</CodeBlock>
+            <CodeBlock>{`openclaw mcp set harbor-clerk '${JSON.stringify({ url: localMcpTokenUrl })}'`}</CodeBlock>
             <p className="mt-3 text-sm text-(--color-text-primary)">
               Or add it directly to your{' '}
               <code className="rounded bg-(--color-bg-secondary) px-1.5 py-0.5 text-xs">openclaw.json</code>:
@@ -515,7 +520,7 @@ export PATH="$HOME/.local/bin:$PATH"`
                 {
                   mcpServers: {
                     'harbor-clerk': {
-                      url: mcpTokenUrl,
+                      url: localMcpTokenUrl,
                     },
                   },
                 },
@@ -538,6 +543,11 @@ export PATH="$HOME/.local/bin:$PATH"`
                 to monitor usage.
               </p>
             </div>
+            <p className="mt-3 text-xs text-(--color-text-secondary)">
+              Local MCP examples use the current app origin. macOS native currently exposes local MCP over HTTP; Docker
+              defaults to HTTPS on <code>https://localhost</code>. Cloud clients still need a public URL with a
+              certificate they trust.
+            </p>
           </>
         )}
       </Card>


### PR DESCRIPTION
## Summary
- split Integrations URL examples so cloud connector setup keeps using the Public URL while same-machine MCP/CLI examples use the current app origin
- document the temporary macOS native HTTP vs Docker HTTPS behavior for OpenClaw/local MCP testing
- add a native HTTPS gateway release-gate spec covering Caddy-based local HTTPS, manual cert/hostname support, and ACME deferral

## Tests
- npm test -- --run src/pages/IntegrationsPage.test.tsx
- npx eslint src/pages/IntegrationsPage.tsx src/pages/IntegrationsPage.test.tsx
- npm run type-check