### PR TITLE
Add native HTTPS gateway for local MCP

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -79,14 +79,24 @@ supports the URL-token path form:
 https://your-server.example.com/t/YOUR_API_KEY
 ```
 
-For same-machine local MCP clients, use the current local app origin instead of
-a public placeholder. Today that means:
+For same-machine local MCP clients, use the local gateway URL instead of a
+public placeholder. Today that means:
 
-- macOS native app: `http://localhost:8100/t/YOUR_API_KEY`
+- macOS native app: `https://localhost:8443/t/YOUR_API_KEY`
 - Docker default: `https://localhost/t/YOUR_API_KEY`
 
-The macOS HTTPS gateway is a release gate for parity with Docker. Until it
-lands, do not tell local macOS users that the native app listens on HTTPS.
+The macOS native gateway uses a self-signed certificate by default. The bundled
+CLI shim handles that by default; MCP clients that enforce system trust may
+need a trusted certificate or a public HTTPS URL. Native Preferences also let
+operators set the gateway hostname, choose loopback / all interfaces / a
+detected Tailscale bind address, or point Caddy at certificate and private-key
+files they manage themselves.
+
+When the native gateway binds beyond loopback, it only proxies MCP API-key
+paths (`/mcp` and `/t`). The web app, setup/status API, and OAuth endpoints stay
+off that external listener for the first release. Use an API key for local
+network or Tailscale MCP clients; cloud OAuth connector setup still needs the
+separate public trusted HTTPS path.
 
 Do not reuse a broad admin key for autonomous tools. Create a separate scoped
 key per connector.
@@ -103,8 +113,9 @@ Use the CLI for shell-first agent harnesses.
 3. Export connection settings in the shell where the agent runs:
 
 ```bash
-export HARBOR_CLERK_URL="http://localhost:8100"
+export HARBOR_CLERK_URL="https://localhost:8443"
 export HARBOR_CLERK_API_KEY="YOUR_API_KEY"
+export HARBOR_CLERK_INSECURE_SKIP_VERIFY=1
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
@@ -128,9 +139,12 @@ Release-safe claim:
 Prefer CLI for local OpenClaw runs because it matches OpenClaw's shell-first
 workflow and lets the agent use the checked-in Harbor Clerk skill markdown.
 Use MCP when your OpenClaw setup is already configured for MCP servers.
-For local macOS native testing, use `http://localhost:8100/t/YOUR_API_KEY`
-unless you have configured a separate HTTPS proxy. Docker users can use
-`https://localhost/t/YOUR_API_KEY`.
+For local macOS native testing, use `https://localhost:8443/t/YOUR_API_KEY`.
+For Tailscale or LAN testing, configure the native gateway hostname and bind
+address in Preferences and keep using the `/t/YOUR_API_KEY` URL form. Docker
+users can use `https://localhost/t/YOUR_API_KEY`. If the MCP client rejects the
+self-signed certificate, use the CLI path or a certificate trusted by that
+client.
 
 Minimum setup:
 

--- a/docs/superpowers/specs/2026-06-08-native-https-gateway-design.md
+++ b/docs/superpowers/specs/2026-06-08-native-https-gateway-design.md
@@ -1,8 +1,8 @@
 # Native HTTPS Gateway - Design Spec
 
 **Date:** 2026-06-08
-**Status:** Draft for release-gate planning
-**Scope:** macOS native HTTPS parity with Docker for local UI, MCP, CLI, and local agent harness setup. Includes manual real-certificate support planning. Excludes ACME/Let's Encrypt automation.
+**Status:** Implemented in the native HTTPS gateway PR; manual certificate-file support is included; ACME/Let's Encrypt and app-over-HTTPS remain deferred
+**Scope:** macOS native HTTPS parity for MCP, CLI, and local agent harness setup. Includes configurable hostname, bind addresses, self-signed/default certificates, custom certificate files, and Tailscale bind detection. Excludes ACME/Let's Encrypt automation and loading Harbor Clerk.app itself over HTTPS.
 
 ## Overview
 
@@ -38,6 +38,8 @@ different one for macOS, and a third one for public cloud connectors.
 - No public exposure by default.
 - No redesign of MCP auth, API keys, or OAuth.
 - No replacing FastAPI/uvicorn for this scope.
+- No external exposure of the web app, setup/status API, or OAuth endpoints
+  through the native gateway in this release.
 
 ## Current behavior
 
@@ -47,7 +49,7 @@ Docker:
 - Caddy uses an internal/self-signed local cert for `localhost`.
 - Caddy proxies `/`, `/api/*`, `/mcp/*`, and `/t/*` to the app container.
 
-macOS native:
+macOS native before this PR:
 
 - Harbor Clerk Server starts the API on `http://127.0.0.1:<apiPort>`.
 - Harbor Clerk.app loads `http://localhost:<apiPort>` in WKWebView.
@@ -80,12 +82,24 @@ Default ports:
 Default bind behavior:
 
 - Gateway binds to loopback only by default.
-- Existing "Allow remote browser connections" and "Allow remote model
-  connections (MCP)" should control whether the gateway can bind beyond
-  loopback.
-- Direct API binding to `0.0.0.0` should be reconsidered once the gateway
-  exists; the safer release posture is public traffic through the gateway, not
-  straight to uvicorn.
+- FastAPI remains bound to `127.0.0.1`.
+- Preferences let the operator choose loopback, all interfaces, or a detected
+  Tailscale address for the gateway.
+- When the gateway binds beyond loopback, Caddy proxies only `/mcp*` and `/t*`
+  to FastAPI and returns 404 for everything else.
+- This preserves remote/local agent MCP while keeping the SPA, setup/status
+  endpoints, and OAuth off the external native listener.
+
+Authentication/exposure audit:
+
+- `/mcp` and `/t` are the intended remote-capable surfaces and require API key
+  auth through the MCP middleware/token path.
+- Static SPA routes, setup-status, ping/health, login/logout/refresh, and OAuth
+  discovery/authorization/token routes are not appropriate to expose via the
+  quick native gateway remote-bind control.
+- Public OAuth/cloud connector hosting should remain a separate trusted-public
+  URL design, not an accidental consequence of binding the local gateway to
+  `0.0.0.0`.
 
 Why Caddy:
 
@@ -132,26 +146,29 @@ Open issue:
   how cleanly local agent clients trust the certificate. That must be tested
   against OpenClaw before considering the release gate satisfied.
 
-### Mode 2: Manual real cert and hostname
+### Mode 2: Manual cert files and hostname
 
-Fast follow or same release only if the local gateway lands cleanly.
+Included as a release-gate add-on for operators who already have certificate
+material or a Tailscale/MagicDNS name.
 
 Inputs:
 
 - Hostname.
-- Certificate chain path or uploaded certificate.
-- Private key path or uploaded key.
-- Optional bind address.
-- Optional public URL override.
+- Certificate chain path.
+- Private key path.
+- Bind address list, including loopback, all interfaces, or detected Tailscale
+  interface shortcuts.
 
 Requirements:
 
-- Validate certificate and private key match.
-- Validate hostname coverage and expiry.
+- Require both certificate and private key paths before restart.
+- Let Caddy reject invalid or mismatched files at gateway startup.
+- Future hardening: validate certificate/private-key match, hostname coverage,
+  and expiry before restart.
 - Warn if the gateway is configured for remote access.
-- Store paths or key material safely.
+- Store paths, not key material.
 - Reload/restart the gateway when settings change.
-- Reflect the effective URL on the Integrations page.
+- Reflect the effective local MCP URL on the Integrations page.
 
 ### Mode 3: ACME/Let's Encrypt
 
@@ -169,14 +186,16 @@ Reason:
 
 Add a "Local HTTPS Gateway" section near Network Access:
 
-- Enable local HTTPS gateway.
 - Gateway URL: `https://localhost:8443`.
 - Gateway port.
-- Certificate mode: local certificate or manual certificate.
-- Certificate trust status.
-- Real hostname/cert controls when manual mode is enabled.
-- Copy local MCP URL.
-- Link to Integrations.
+- Hostname.
+- Bind addresses, with loopback, all interfaces, and detected Tailscale
+  shortcuts.
+- Certificate mode: generated/self-signed local certificate or manual
+  certificate files.
+- Certificate and private-key file pickers when manual mode is enabled.
+- Copy/read local MCP URL.
+- Warning copy that external binds expose only `/mcp` and `/t`.
 
 Changing gateway port or certificate mode should mark that a restart/reload is
 needed, then perform a targeted gateway restart when applied.
@@ -224,16 +243,13 @@ After local HTTPS is stable:
 
 ## Implementation plan
 
-### PR 1: Copy and URL split
+### PR 1: Native localhost HTTPS gateway and URL split
 
-Status: in progress in this planning branch.
+Status: implemented in this branch, then expanded to cover hostname, bind,
+Tailscale, and manual certificate-file settings.
 
 - Make Integrations copy distinguish local clients from cloud clients.
-- Use current app origin for local-capable MCP examples.
-- Document that macOS native is currently HTTP and Docker is HTTPS.
-
-### PR 2: Native gateway service
-
+- Use the local gateway URL for local-capable MCP examples.
 - Add `gateway_port` and gateway enable/cert-mode settings.
 - Bundle or locate a Caddy binary in the macOS Server resources.
 - Add `GatewayService` as a managed service.
@@ -242,17 +258,20 @@ Status: in progress in this planning branch.
 - Health-check the gateway over HTTPS.
 - Add tests for settings persistence, config generation, and stale-port
   detection.
+- Keep FastAPI bound to loopback even when the gateway binds to external
+  interfaces.
+- Restrict external native gateway binds to `/mcp` and `/t`.
+- Mark non-loopback gateway health as "not probed" from the unauthenticated
+  health endpoint, avoiding a remote-probe/SSRF-shaped diagnostic.
 
-### PR 3: Native app and CLI routing
+### PR 2: Native app routing
 
 - Decide whether Harbor Clerk.app loads the SPA through HTTPS by default.
 - Update `BackendDetector`, `AuthManager`, and WKWebView certificate handling
   if the app moves to HTTPS.
-- Update CLI shim defaults to the gateway URL.
-- Update Integrations snippets to prefer the gateway URL.
 - Add fallback behavior if the gateway is disabled or unhealthy.
 
-### PR 4: Certificate trust and smoke tests
+### PR 3: Certificate trust and smoke tests
 
 - Implement or document the trust workflow.
 - Verify curl, `harbor-clerk` CLI, OpenClaw MCP, Claude Code MCP, and browser
@@ -260,20 +279,22 @@ Status: in progress in this planning branch.
 - Add a release smoke section covering local HTTPS setup.
 - Decide whether any client-specific insecure flag is acceptable for release.
 
-### PR 5: Manual hostname/cert support
+### PR 4: Manual hostname/cert hardening
 
-- Add Preferences UI for hostname, cert chain, private key, bind address, and
-  effective public URL.
 - Validate cert/key pair, hostname coverage, and expiry.
-- Store paths or key material safely.
-- Reload gateway on changes.
-- Update Status and Integrations with the effective public URL and warnings.
+- Add certificate trust/status display.
+- Decide whether to copy cert/key material into Application Support or continue
+  storing operator-managed paths only.
+- Add public URL/OAuth guidance only after the public trusted HTTPS flow is
+  designed.
 
 ## Release gates
 
 Minimum gate:
 
 - macOS native exposes a working same-machine HTTPS URL for MCP.
+- macOS native exposes a configurable remote/tailnet MCP URL when explicitly
+  requested, with only `/mcp` and `/t` reachable externally.
 - OpenClaw can complete a documented MCP smoke task against that URL, or the
   docs clearly route OpenClaw through CLI until trust is solved.
 - Docker and macOS snippets no longer contradict actual listener behavior.

--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -33,6 +33,7 @@ const READY_CONFIG: SystemConfig = {
   allowSourceDownload: false,
   enableCliAccess: false,
   cliShimInstallStatus: null,
+  localMcpUrl: null,
   loaded: true,
 }
 

--- a/frontend/src/hooks/useSystemConfig.ts
+++ b/frontend/src/hooks/useSystemConfig.ts
@@ -25,6 +25,11 @@ export interface SystemConfig {
    */
   cliShimInstallStatus: 'installed' | 'installed_outdated' | 'not_installed' | null
   /**
+   * Local base URL for same-machine MCP/API clients. On macOS native this is
+   * the managed HTTPS gateway; Docker/Linux may omit it.
+   */
+  localMcpUrl: string | null
+  /**
    * True once the system config has been fetched at least once. While false
    * the UI should treat capability flags conservatively (e.g. hide buttons
    * rather than show them only to have them flicker off when the response
@@ -38,6 +43,7 @@ const FALLBACK: SystemConfig = {
   allowSourceDownload: false,
   enableCliAccess: false,
   cliShimInstallStatus: null,
+  localMcpUrl: null,
   loaded: false,
 }
 
@@ -65,6 +71,7 @@ export function useSystemConfig(): SystemConfig {
           allowSourceDownload: Boolean(data.allow_source_download),
           enableCliAccess: Boolean(data.enable_cli_access),
           cliShimInstallStatus: data.cli_shim_install_status ?? null,
+          localMcpUrl: data.local_mcp_url ?? null,
           loaded: true,
         })
       })

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -130,6 +130,7 @@ describe('DocumentDetailPage', () => {
       allowSourceDownload: false,
       enableCliAccess: false,
       cliShimInstallStatus: null,
+      localMcpUrl: null,
       loaded: true,
     })
     useJobEventsMock.mockReturnValue(undefined)

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -101,6 +101,7 @@ describe('DocumentsPage', () => {
       allowSourceDownload: false,
       enableCliAccess: false,
       cliShimInstallStatus: null,
+      localMcpUrl: null,
       loaded: true,
     })
     useLLMStatusContextMock.mockReturnValue({

--- a/frontend/src/pages/IntegrationsPage.test.tsx
+++ b/frontend/src/pages/IntegrationsPage.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../hooks/useSystemConfig', () => ({
   useSystemConfig: () => ({
     enableCliAccess: true,
     cliShimInstallStatus: 'installed',
+    localMcpUrl: 'https://localhost:8443',
   }),
 }))
 
@@ -69,8 +70,8 @@ describe('IntegrationsPage', () => {
 
     expect(screen.getByText(/Prefer the CLI skill for local/)).toBeInTheDocument()
     expect(screen.getByText(/Full only for local runs/)).toBeInTheDocument()
-    expect(screen.getByText(/macOS native currently exposes local MCP over HTTP/)).toBeInTheDocument()
-    expectPreContains(`openclaw mcp set harbor-clerk '{"url":"${window.location.origin}/t/YOUR_API_KEY"}'`)
+    expect(screen.getByText(/self-signed localhost certificate/)).toBeInTheDocument()
+    expectPreContains(`openclaw mcp set harbor-clerk '{"url":"https://localhost:8443/t/YOUR_API_KEY"}'`)
   })
 
   it('renders the checked-in CLI skill markdown with find-all guidance', async () => {
@@ -97,7 +98,7 @@ describe('IntegrationsPage', () => {
     expect(await screen.findByText('Choose a Surface')).toBeInTheDocument()
     expectPreContains('https://clerk.example/mcp')
 
-    const localTokenUrl = `${window.location.origin}/t/YOUR_API_KEY`
+    const localTokenUrl = 'https://localhost:8443/t/YOUR_API_KEY'
 
     fireEvent.click(screen.getByRole('button', { name: /Claude/ }))
     expectPreContains(`"url": "${localTokenUrl}"`)

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -71,7 +71,7 @@ function trimTrailingSlash(value: string) {
 }
 
 export default function IntegrationsPage() {
-  const { enableCliAccess, cliShimInstallStatus } = useSystemConfig()
+  const { enableCliAccess, cliShimInstallStatus, localMcpUrl } = useSystemConfig()
   const [settings, setSettings] = useState<IntegrationSettings>({ public_url: '', oauth_refresh_token_days: 90 })
   const [connections, setConnections] = useState<OAuthConnection[]>([])
   const [loading, setLoading] = useState(true)
@@ -136,12 +136,13 @@ export default function IntegrationsPage() {
   }
 
   const appOrigin = typeof window !== 'undefined' ? trimTrailingSlash(window.location.origin) : ''
-  const localBaseUrl = appOrigin || 'http://localhost:8100'
+  const localBaseUrl = localMcpUrl ? trimTrailingSlash(localMcpUrl) : appOrigin || 'http://localhost:8100'
   const publicBaseUrl = settings.public_url ? trimTrailingSlash(settings.public_url) : 'https://your-server.example.com'
   const mcpUrl = `${publicBaseUrl}/mcp`
   const localMcpTokenUrl = `${localBaseUrl}/t/YOUR_API_KEY`
   const cliEnvBlock = `export HARBOR_CLERK_URL="${localBaseUrl}"
 export HARBOR_CLERK_API_KEY="YOUR_API_KEY"
+export HARBOR_CLERK_INSECURE_SKIP_VERIFY=1
 export PATH="$HOME/.local/bin:$PATH"`
 
   if (loading) return <div className="text-gray-500 dark:text-gray-400">Loading...</div>
@@ -279,7 +280,7 @@ export PATH="$HOME/.local/bin:$PATH"`
             <p className="mt-1 text-sm text-(--color-text-secondary)">
               Use MCP when the tool can call structured remote tools directly. Cloud models receive retrieved snippets,
               citations, and metadata from scoped tool calls, not the full archive. Cloud clients require a public,
-              trusted HTTPS URL; same-machine clients can use the current app origin.
+              trusted HTTPS URL; same-machine clients can use the local gateway URL shown by this app.
             </p>
           </div>
           <div className="rounded-lg border border-(--color-border) bg-(--color-bg-secondary) p-4">
@@ -544,9 +545,9 @@ export PATH="$HOME/.local/bin:$PATH"`
               </p>
             </div>
             <p className="mt-3 text-xs text-(--color-text-secondary)">
-              Local MCP examples use the current app origin. macOS native currently exposes local MCP over HTTP; Docker
-              defaults to HTTPS on <code>https://localhost</code>. Cloud clients still need a public URL with a
-              certificate they trust.
+              Local MCP examples use the local HTTPS gateway when available. macOS native uses a self-signed localhost
+              certificate for that gateway; Docker defaults to HTTPS on <code>https://localhost</code>. Cloud clients
+              still need a public URL with a certificate they trust.
             </p>
           </>
         )}

--- a/frontend/src/pages/SystemStatusPage.test.tsx
+++ b/frontend/src/pages/SystemStatusPage.test.tsx
@@ -32,6 +32,7 @@ const HEALTHY = {
     tika: 'ok',
     embedder: 'ok',
     reranker: 'ok',
+    local_https_gateway: 'ok',
   },
 }
 
@@ -167,6 +168,7 @@ describe('SystemStatusPage', () => {
     renderStatusPage()
 
     expect(await screen.findByText('Documents failed ingest')).toBeInTheDocument()
+    expect(screen.getByText('Local HTTPS Gateway')).toBeInTheDocument()
     const reviewLink = screen.getByRole('link', { name: 'Review failed documents' })
     expect(reviewLink).toHaveAttribute('href', '/docs?pipeline_status=error')
     expect(screen.getByText('Broken scan')).toBeInTheDocument()

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -17,6 +17,7 @@ interface HealthCheck {
     tika: string
     embedder?: string
     reranker?: string
+    local_https_gateway?: string
   }
 }
 
@@ -145,7 +146,12 @@ function statePill(state: StatusSummary['state'] | undefined, attentionItems: St
 }
 
 function serviceIsOk(status?: string): boolean {
-  return status === 'ok' || status === 'disabled'
+  return status === 'ok' || status === 'disabled' || status === 'not_probed'
+}
+
+function serviceLabel(status: string): string {
+  if (status === 'not_probed') return 'Not probed'
+  return serviceIsOk(status) ? 'OK' : status
 }
 
 export default function SystemStatusPage() {
@@ -439,6 +445,9 @@ export default function SystemStatusPage() {
             <HealthCard name="Tika" status={health.checks.tika} statsLoading={false} />
             <HealthCard name="Embedder" status={health.checks.embedder ?? 'unknown'} statsLoading={false} />
             <HealthCard name="Reranker" status={health.checks.reranker ?? 'not configured'} statsLoading={false} />
+            {health.checks.local_https_gateway && (
+              <HealthCard name="Local HTTPS Gateway" status={health.checks.local_https_gateway} statsLoading={false} />
+            )}
             <LocalAICard status={llmStatus} />
             <WorkerQueuesCard stats={stats?.queues} statsLoading={statsLoading} />
           </div>
@@ -690,7 +699,7 @@ function HealthCard({
   return (
     <Card className={`p-4 ${ok ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
       <div className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">{name}</div>
-      <StatusPill state={ok ? 'active' : 'error'} label={ok ? 'OK' : status} />
+      <StatusPill state={ok ? 'active' : 'error'} label={serviceLabel(status)} />
       {statsLoading && !stats && <div className="mt-2 text-xs text-gray-400">Loading stats...</div>}
       {stats?.error && <div className="mt-2 text-xs text-red-500">{String(stats.error)}</div>}
       {statEntries.length > 0 && (

--- a/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
+++ b/macos/HarborClerkServer/HarborClerkServer.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		A100000063 /* LaunchdAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000063; };
 		A100000064 /* ProcessAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000064; };
 		A100000065 /* CliShimInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000065; };
+		A100000071 /* GatewayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000071; };
+		A100000072 /* GatewayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000072; };
 		AT10000001 /* WorkerCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000001; };
 		AT10000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000002; };
 		AT10000003 /* OverallStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000003; };
@@ -45,6 +47,7 @@
 		AT10000013 /* LaunchdPlistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000013; };
 		AT10000014 /* LaunchdAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000014; };
 		AT10000015 /* CliShimInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000015; };
+		AT10000016 /* GatewayConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT10000016; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +88,8 @@
 		B100000063 /* LaunchdAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdAgent.swift; sourceTree = "<group>"; };
 		B100000064 /* ProcessAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessAsync.swift; sourceTree = "<group>"; };
 		B100000065 /* CliShimInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliShimInstaller.swift; sourceTree = "<group>"; };
+		B100000071 /* GatewayConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayConfig.swift; sourceTree = "<group>"; };
+		B100000072 /* GatewayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayService.swift; sourceTree = "<group>"; };
 		D100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D100000002 /* HarborClerkServer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HarborClerkServer.entitlements; sourceTree = "<group>"; };
 		CT10000001 /* HarborClerkServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HarborClerkServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +105,7 @@
 		BT10000013 /* LaunchdPlistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlistTests.swift; sourceTree = "<group>"; };
 		BT10000014 /* LaunchdAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdAgentTests.swift; sourceTree = "<group>"; };
 		BT10000015 /* CliShimInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliShimInstallerTests.swift; sourceTree = "<group>"; };
+		BT10000016 /* GatewayConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +155,7 @@
 				B100000063 /* LaunchdAgent.swift */,
 				B100000064 /* ProcessAsync.swift */,
 				B100000065 /* CliShimInstaller.swift */,
+				B100000071 /* GatewayConfig.swift */,
 				B100000016 /* Assets.xcassets */,
 				D100000001 /* Info.plist */,
 				D100000002 /* HarborClerkServer.entitlements */,
@@ -168,6 +175,7 @@
 				B100000009 /* EmbedderService.swift */,
 				B100000070 /* RerankerService.swift */,
 				B100000017 /* LlamaService.swift */,
+				B100000072 /* GatewayService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -196,6 +204,7 @@
 				BT10000013 /* LaunchdPlistTests.swift */,
 				BT10000014 /* LaunchdAgentTests.swift */,
 				BT10000015 /* CliShimInstallerTests.swift */,
+				BT10000016 /* GatewayConfigTests.swift */,
 			);
 			path = HarborClerkServerTests;
 			sourceTree = "<group>";
@@ -337,6 +346,8 @@
 				A100000063 /* LaunchdAgent.swift in Sources */,
 				A100000064 /* ProcessAsync.swift in Sources */,
 				A100000065 /* CliShimInstaller.swift in Sources */,
+				A100000071 /* GatewayConfig.swift in Sources */,
+				A100000072 /* GatewayService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,6 +367,7 @@
 				AT10000013 /* LaunchdPlistTests.swift in Sources */,
 				AT10000014 /* LaunchdAgentTests.swift in Sources */,
 				AT10000015 /* CliShimInstallerTests.swift in Sources */,
+				AT10000016 /* GatewayConfigTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/HarborClerkServer/HarborClerkServer/CliShimInstaller.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/CliShimInstaller.swift
@@ -15,8 +15,8 @@ enum CliShimStatus: Equatable {
 ///
 /// The shim is a small shell script that delegates to the bundled Python venv.
 /// `BUNDLE_RESOURCES` and `HARBOR_CLERK_URL` are baked in at install time from
-/// `Bundle.main.resourceURL` and `AppSettings.shared.apiPort` respectively.
-/// If the user moves the app or changes the API port they must re-install via
+/// `Bundle.main.resourceURL` and `AppSettings.shared.localMCPBaseURL` respectively.
+/// If the user moves the app or changes the gateway port they must re-install via
 /// Preferences to refresh the shim — `currentStatus()` reports `installedOutdated`
 /// in either case so the UI button surfaces "Re-install".
 ///
@@ -61,48 +61,43 @@ final class CliShimInstaller {
             .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
 
         let currentBundle = Bundle.main.resourceURL!.path
-        let currentPort = AppSettings.shared.apiPort
+        let currentDefaultURL = AppSettings.shared.localMCPBaseURL
 
-        // Detect "stale port": the shim's baked-in URL no longer matches the
-        // configured apiPort. Older shims (pre-this-feature) had no URL line
-        // at all — treat them as outdated so the user gets prompted to re-install.
-        let embeddedPort = extractEmbeddedApiPort(from: contents)
+        // Detect "stale URL": the shim's baked-in URL no longer matches the
+        // configured local HTTPS gateway. Older shims had no URL line at all
+        // or used the direct HTTP API port — treat them as outdated so the
+        // user gets prompted to re-install.
+        let embeddedDefaultURL = extractEmbeddedDefaultURL(from: contents)
 
-        if embeddedBundle == currentBundle && embeddedPort == currentPort {
+        if embeddedBundle == currentBundle && embeddedDefaultURL == currentDefaultURL {
             return .installed(path: url.path)
         } else {
             return .installedOutdated(path: url.path, currentBundle: currentBundle)
         }
     }
 
-    /// Parse the integer port from the `export HARBOR_CLERK_URL=...` line in a shim.
+    /// Parse the default URL from the `export HARBOR_CLERK_URL=...` line in a shim.
     /// Returns nil if the URL line is absent or unparseable — `currentStatus`
     /// then treats the shim as outdated.
-    static func extractEmbeddedApiPort(from shimContents: String) -> Int? {
+    static func extractEmbeddedDefaultURL(from shimContents: String) -> String? {
         guard let urlLine = shimContents.components(separatedBy: "\n").first(where: { $0.hasPrefix("export HARBOR_CLERK_URL=") }) else {
             return nil
         }
-        // The line shape is: export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:PORT}"
-        // Find the default-value substring after ":-" and parse the trailing port.
-        guard let defaultMarker = urlLine.range(of: ":-http"),
+        // The line shape is: export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-https://localhost:PORT}"
+        // Find the default-value substring after ":-" and return it whole.
+        guard let defaultMarker = urlLine.range(of: ":-"),
               let closeBrace = urlLine.range(of: "}", range: defaultMarker.upperBound..<urlLine.endIndex) else {
             return nil
         }
-        let defaultUrl = String(urlLine[defaultMarker.upperBound..<closeBrace.lowerBound])
-        // defaultUrl is now something like "://localhost:8100" — take the last colon-separated component.
-        guard let portString = defaultUrl.split(separator: ":").last,
-              let port = Int(portString) else {
-            return nil
-        }
-        return port
+        return String(urlLine[defaultMarker.upperBound..<closeBrace.lowerBound])
     }
 
     /// Write the shim to `~/.local/bin/harbor-clerk`, creating the directory if needed.
     /// Sets executable permissions (0o755) after writing.
     static func install() throws {
         let bundle = Bundle.main.resourceURL!.path
-        let apiPort = AppSettings.shared.apiPort
-        let shim = makeShimContent(bundleResources: bundle, apiPort: apiPort)
+        let defaultURL = AppSettings.shared.localMCPBaseURL
+        let shim = makeShimContent(bundleResources: bundle, defaultURL: defaultURL)
 
         let dir = shimPath.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
@@ -126,21 +121,22 @@ final class CliShimInstaller {
     // MARK: - Internal helpers
 
     /// Generate the shim script content with `BUNDLE_RESOURCES` and the
-    /// default API URL baked in. The URL line uses `${VAR:-default}` so a
+    /// default local HTTPS gateway URL baked in. The URL line uses `${VAR:-default}` so a
     /// user can still override `HARBOR_CLERK_URL` in their shell for unusual
     /// deployments (e.g. pointing the CLI at a different Harbor Clerk
     /// instance on the network).
-    static func makeShimContent(bundleResources: String, apiPort: Int) -> String {
+    static func makeShimContent(bundleResources: String, defaultURL: String) -> String {
         return """
         #!/bin/sh
         # harbor-clerk — installed by Harbor Clerk Server
         # Invokes the bundled Python via Harbor Clerk Server.app's venv.
-        # Re-install via Preferences if you move/reinstall the app or change the API port.
+        # Re-install via Preferences if you move/reinstall the app or change the HTTPS gateway port.
         BUNDLE_RESOURCES="\(bundleResources)"
         export PATH="$BUNDLE_RESOURCES/venv/bin:/usr/bin:/bin"
         export PYTHONPATH="$BUNDLE_RESOURCES/venv/lib"
         export PYTHONDONTWRITEBYTECODE=1
-        export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:\(apiPort)}"
+        export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-\(defaultURL)}"
+        export HARBOR_CLERK_INSECURE_SKIP_VERIFY="${HARBOR_CLERK_INSECURE_SKIP_VERIFY:-1}"
         exec "$BUNDLE_RESOURCES/venv/bin/python" -m harbor_clerk.cli.main "$@"
         """
     }

--- a/macos/HarborClerkServer/HarborClerkServer/GatewayConfig.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/GatewayConfig.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+enum GatewayCertificateMode: String {
+    case `internal`
+    case custom
+}
+
+struct GatewayConfig {
+    static let defaultPort = 8443
+    static let defaultHostname = "localhost"
+    static let defaultBindAddresses = ["127.0.0.1", "::1"]
+
+    let apiPort: Int
+    let gatewayPort: Int
+    let hostname: String
+    let bindAddresses: [String]
+    let certificateMode: GatewayCertificateMode
+    let certificatePath: String
+    let privateKeyPath: String
+
+    var localBaseURL: String {
+        Self.localBaseURL(hostname: hostname, gatewayPort: gatewayPort)
+    }
+
+    var caddyfile: String {
+        Self.renderCaddyfile(
+            apiPort: apiPort,
+            gatewayPort: gatewayPort,
+            hostname: hostname,
+            bindAddresses: bindAddresses,
+            certificateMode: certificateMode,
+            certificatePath: certificatePath,
+            privateKeyPath: privateKeyPath
+        )
+    }
+
+    init(
+        apiPort: Int,
+        gatewayPort: Int,
+        hostname: String = Self.defaultHostname,
+        bindAddresses: [String] = Self.defaultBindAddresses,
+        certificateMode: GatewayCertificateMode = .internal,
+        certificatePath: String = "",
+        privateKeyPath: String = ""
+    ) {
+        self.apiPort = apiPort
+        self.gatewayPort = gatewayPort
+        self.hostname = Self.normalizedHostname(hostname)
+        self.bindAddresses = Self.normalizedBindAddresses(bindAddresses)
+        self.certificateMode = certificateMode
+        self.certificatePath = certificatePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.privateKeyPath = privateKeyPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func localBaseURL(hostname: String, gatewayPort: Int) -> String {
+        "https://\(urlHost(normalizedHostname(hostname))):\(gatewayPort)"
+    }
+
+    static func normalizedHostname(_ hostname: String) -> String {
+        var value = hostname.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("https://") {
+            value.removeFirst("https://".count)
+        } else if value.hasPrefix("http://") {
+            value.removeFirst("http://".count)
+        }
+        if let slash = value.firstIndex(of: "/") {
+            value = String(value[..<slash])
+        }
+        if value.hasPrefix("["),
+           let closeBracket = value.firstIndex(of: "]") {
+            let hostStart = value.index(after: value.startIndex)
+            value = String(value[hostStart..<closeBracket])
+            return value.isEmpty ? defaultHostname : value
+        }
+        if let colon = value.lastIndex(of: ":"), value.firstIndex(of: ":") == colon {
+            let suffix = value[value.index(after: colon)...]
+            if Int(suffix) != nil {
+                value = String(value[..<colon])
+            }
+        }
+        value = value.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        return value.isEmpty ? defaultHostname : value
+    }
+
+    static func normalizedBindAddresses(_ addresses: [String]) -> [String] {
+        var seen = Set<String>()
+        let normalized = addresses
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .filter { seen.insert($0).inserted }
+        return normalized.isEmpty ? defaultBindAddresses : normalized
+    }
+
+    static func isLoopbackBind(_ address: String) -> Bool {
+        address == "127.0.0.1" || address == "::1" || address == "localhost"
+    }
+
+    static func exposesFullApp(bindAddresses: [String]) -> Bool {
+        normalizedBindAddresses(bindAddresses).allSatisfy(isLoopbackBind)
+    }
+
+    static func renderCaddyfile(
+        apiPort: Int,
+        gatewayPort: Int,
+        hostname: String = defaultHostname,
+        bindAddresses: [String] = defaultBindAddresses,
+        certificateMode: GatewayCertificateMode = .internal,
+        certificatePath: String = "",
+        privateKeyPath: String = ""
+    ) -> String {
+        let cleanHostname = normalizedHostname(hostname)
+        let binds = normalizedBindAddresses(bindAddresses)
+        let site = "https://\(urlHost(cleanHostname)):\(gatewayPort)"
+        let tlsLine: String
+        if certificateMode == .custom,
+           !certificatePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !privateKeyPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            tlsLine = "tls \(quote(certificatePath)) \(quote(privateKeyPath))"
+        } else {
+            tlsLine = "tls internal"
+        }
+        let proxyDirectives: String
+        if exposesFullApp(bindAddresses: binds) {
+            proxyDirectives = "    reverse_proxy 127.0.0.1:\(apiPort)"
+        } else {
+            proxyDirectives = """
+                handle /mcp* {
+                    reverse_proxy 127.0.0.1:\(apiPort)
+                }
+                handle /t* {
+                    reverse_proxy 127.0.0.1:\(apiPort)
+                }
+                handle {
+                    respond 404
+                }
+            """
+        }
+
+        return """
+        {
+            local_certs
+            skip_install_trust
+            admin off
+        }
+
+        \(site) {
+            bind \(binds.joined(separator: " "))
+            \(tlsLine)
+        \(proxyDirectives)
+        }
+        """
+    }
+
+    static func caddyExecutable(resourceURL: URL = Bundle.main.resourceURL!) -> URL? {
+        let bundled = resourceURL.appendingPathComponent("caddy/bin/caddy")
+        if FileManager.default.isExecutableFile(atPath: bundled.path) {
+            return bundled
+        }
+
+        for path in ["/opt/homebrew/bin/caddy", "/usr/local/bin/caddy"] {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+        }
+        return nil
+    }
+
+    private static func urlHost(_ hostname: String) -> String {
+        hostname.contains(":") ? "[\(hostname)]" : hostname
+    }
+
+    private static func quote(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}
+
+private final class LocalCertificateBypassDelegate: NSObject, URLSessionDelegate {
+    let allowedHosts: Set<String>
+
+    init(allowedHosts: Set<String>) {
+        self.allowedHosts = allowedHosts
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        let host = challenge.protectionSpace.host
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              allowedHosts.contains(host),
+              let trust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+}
+
+func httpsProbeOKAllowingLocalCertificate(
+    _ url: URL,
+    timeout: TimeInterval = 3,
+    allowedHosts: Set<String> = ["localhost", "127.0.0.1", "::1"]
+) async -> Bool {
+    let config = URLSessionConfiguration.ephemeral
+    config.timeoutIntervalForRequest = timeout
+    config.timeoutIntervalForResource = timeout
+    config.urlCache = nil
+    config.httpCookieStorage = nil
+    config.urlCredentialStorage = nil
+    let delegate = LocalCertificateBypassDelegate(allowedHosts: allowedHosts)
+    let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
+    defer { session.invalidateAndCancel() }
+
+    do {
+        let (_, response) = try await session.data(from: url)
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode else { return false }
+        return statusCode >= 200 && statusCode < 500
+    } catch {
+        return false
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/PreferencesWindow.swift
@@ -1,3 +1,4 @@
+import Darwin
 import SwiftUI
 
 // MARK: - CLI Shim Row
@@ -131,8 +132,59 @@ private struct CopySnippetButton: View {
     }
 }
 
+private struct LocalNetworkInterface: Identifiable {
+    let id = UUID()
+    let name: String
+    let address: String
+    let isTailscale: Bool
+
+    var label: String {
+        isTailscale ? "Tailscale \(address)" : "\(name) \(address)"
+    }
+}
+
+private func localNetworkInterfaces() -> [LocalNetworkInterface] {
+    var pointer: UnsafeMutablePointer<ifaddrs>?
+    guard getifaddrs(&pointer) == 0, let first = pointer else { return [] }
+    defer { freeifaddrs(pointer) }
+
+    var interfaces: [LocalNetworkInterface] = []
+    var current: UnsafeMutablePointer<ifaddrs>? = first
+    while let item = current {
+        defer { current = item.pointee.ifa_next }
+        let interface = item.pointee
+        guard let addr = interface.ifa_addr else { continue }
+        let family = addr.pointee.sa_family
+        guard family == UInt8(AF_INET) || family == UInt8(AF_INET6) else { continue }
+
+        var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+        let length = family == UInt8(AF_INET) ? socklen_t(MemoryLayout<sockaddr_in>.size) : socklen_t(MemoryLayout<sockaddr_in6>.size)
+        guard getnameinfo(addr, length, &host, socklen_t(host.count), nil, 0, NI_NUMERICHOST) == 0 else { continue }
+        let address = String(cString: host)
+        let name = String(cString: interface.ifa_name)
+        let flags = Int32(interface.ifa_flags)
+        let isLoopback = (flags & IFF_LOOPBACK) != 0
+        guard !isLoopback else { continue }
+        interfaces.append(
+            LocalNetworkInterface(
+                name: name,
+                address: address,
+                isTailscale: isTailscaleAddress(address) || name.lowercased().contains("tailscale")
+            )
+        )
+    }
+    return interfaces
+}
+
+private func isTailscaleAddress(_ address: String) -> Bool {
+    let parts = address.split(separator: ".").compactMap { Int($0) }
+    guard parts.count == 4 else { return false }
+    return parts[0] == 100 && (64...127).contains(parts[1])
+}
+
 private let defaultPorts: [String: Int] = [
     "api": 8100,
+    "gateway": GatewayConfig.defaultPort,
     "postgres": 5433,
     "tika": 9998,
     "embedder": 8101,
@@ -156,6 +208,13 @@ struct PreferencesWindow: View {
     @State private var enableCliAccessOnOpen = AppSettings.shared.enableCliAccess
     @State private var workerPreset = AppSettings.shared.workerPreset
     @State private var apiPortText = String(AppSettings.shared.apiPort)
+    @State private var gatewayPortText = String(AppSettings.shared.gatewayPort)
+    @State private var gatewayHostnameText = AppSettings.shared.gatewayHostname
+    @State private var gatewayBindAddressesText = AppSettings.shared.gatewayBindAddresses.joined(separator: ", ")
+    @State private var gatewayCertificateMode = AppSettings.shared.gatewayCertificateMode.rawValue
+    @State private var gatewayCertificatePath = AppSettings.shared.gatewayCertificatePath
+    @State private var gatewayPrivateKeyPath = AppSettings.shared.gatewayPrivateKeyPath
+    @State private var detectedInterfaces: [LocalNetworkInterface] = []
     @State private var postgresPortText = String(AppSettings.shared.postgresPort)
     @State private var tikaPortText = String(AppSettings.shared.tikaPort)
     @State private var embedderPortText = String(AppSettings.shared.embedderPort)
@@ -174,6 +233,12 @@ struct PreferencesWindow: View {
         var allowRemoteMCP = AppSettings.shared.allowRemoteMCP
         var workerPreset = AppSettings.shared.workerPreset
         var apiPort = String(AppSettings.shared.apiPort)
+        var gatewayPort = String(AppSettings.shared.gatewayPort)
+        var gatewayHostname = AppSettings.shared.gatewayHostname
+        var gatewayBindAddresses = AppSettings.shared.gatewayBindAddresses.joined(separator: ", ")
+        var gatewayCertificateMode = AppSettings.shared.gatewayCertificateMode.rawValue
+        var gatewayCertificatePath = AppSettings.shared.gatewayCertificatePath
+        var gatewayPrivateKeyPath = AppSettings.shared.gatewayPrivateKeyPath
         var postgresPort = String(AppSettings.shared.postgresPort)
         var tikaPort = String(AppSettings.shared.tikaPort)
         var embedderPort = String(AppSettings.shared.embedderPort)
@@ -199,18 +264,6 @@ struct PreferencesWindow: View {
 
             Form {
                 Section {
-                    Toggle("Allow remote browser connections", isOn: $allowRemoteWeb)
-                        .onChange(of: allowRemoteWeb) { _, _ in markDirty() }
-                    Text("Let users on your network access Harbor Clerk via a web browser.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    Toggle("Allow remote model connections (MCP)", isOn: $allowRemoteMCP)
-                        .onChange(of: allowRemoteMCP) { _, _ in markDirty() }
-                    Text("Let AI models on your network query your documents.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
                     Toggle("Allow harbor-clerk CLI from agentic tools", isOn: $enableCliAccess)
                         .onChange(of: enableCliAccess) { _, newValue in
                             // Applied immediately — no restart required. The API server
@@ -230,8 +283,73 @@ struct PreferencesWindow: View {
                     // pre-stage the binary and flip the toggle later.
                     CliShimRow()
 
-                    if !allowRemoteWeb && !allowRemoteMCP {
-                        Text("Harbor Clerk is only accessible from this Mac.")
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Local MCP URL")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(effectiveGatewayURL)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                        Text("Uses Harbor Clerk's local HTTPS gateway. External binds expose only MCP token paths, not the web app.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 2)
+
+                    TextField("Gateway hostname", text: $gatewayHostnameText)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: gatewayHostnameText) { _, _ in markDirty() }
+                    Text("Use localhost for same-Mac clients, a Tailscale/MagicDNS name for tailnet clients, or a real hostname when using a custom certificate.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        Text("Bind addresses")
+                        Spacer()
+                        TextField("", text: $gatewayBindAddressesText)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                            .frame(width: 220)
+                            .onChange(of: gatewayBindAddressesText) { _, _ in markDirty() }
+                    }
+                    HStack {
+                        Button("Loopback") {
+                            gatewayBindAddressesText = GatewayConfig.defaultBindAddresses.joined(separator: ", ")
+                            markDirty()
+                        }
+                        .controlSize(.small)
+                        Button("All interfaces") {
+                            gatewayBindAddressesText = "0.0.0.0, ::"
+                            markDirty()
+                        }
+                        .controlSize(.small)
+                        ForEach(Array(detectedInterfaces.filter(\.isTailscale).prefix(1))) { iface in
+                            Button(iface.label) {
+                                gatewayBindAddressesText = iface.address
+                                markDirty()
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    Text(gatewayBindHelpText)
+                        .font(.caption)
+                        .foregroundStyle(gatewayUsesExternalBind ? .orange : .secondary)
+
+                    Picker("Certificate", selection: $gatewayCertificateMode) {
+                        Text("Generate local self-signed").tag(GatewayCertificateMode.internal.rawValue)
+                        Text("Use certificate files").tag(GatewayCertificateMode.custom.rawValue)
+                    }
+                    .onChange(of: gatewayCertificateMode) { _, _ in markDirty() }
+
+                    if gatewayCertificateMode == GatewayCertificateMode.custom.rawValue {
+                        certificatePathRow(label: "Certificate", text: $gatewayCertificatePath)
+                        certificatePathRow(label: "Private key", text: $gatewayPrivateKeyPath)
+                        if !gatewayCustomCertificateComplete {
+                            Text("Choose both a certificate file and private key before restarting the gateway.")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                        }
+                        Text("ACME/Let's Encrypt automation is deferred; Harbor Clerk only reads the files you choose here.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -275,6 +393,7 @@ struct PreferencesWindow: View {
 
                 Section {
                     portRow(label: "API port", text: $apiPortText, key: "api")
+                    portRow(label: "HTTPS gateway port", text: $gatewayPortText, key: "gateway")
                     portRow(label: "PostgreSQL port", text: $postgresPortText, key: "postgres")
                     portRow(label: "Tika port", text: $tikaPortText, key: "tika")
                     portRow(label: "Embedder port", text: $embedderPortText, key: "embedder")
@@ -306,12 +425,13 @@ struct PreferencesWindow: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .frame(width: 480, height: needsRestart ? 600 : 550)
+        .frame(width: 560, height: needsRestart ? 720 : 670)
         .animation(.easeInOut(duration: 0.25), value: needsRestart)
         .onAppear {
             // Sync enableCliAccess from AppSettings in case it changed since the view was created
             enableCliAccess = AppSettings.shared.enableCliAccess
             enableCliAccessOnOpen = AppSettings.shared.enableCliAccess
+            detectedInterfaces = localNetworkInterfaces()
             captureInitial()
         }
     }
@@ -350,6 +470,7 @@ struct PreferencesWindow: View {
             .tint(.white)
             .controlSize(.small)
             .keyboardShortcut(.defaultAction)
+            .disabled(!gatewaySettingsValid)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -393,6 +514,77 @@ struct PreferencesWindow: View {
         }
     }
 
+    @ViewBuilder
+    private func certificatePathRow(label: String, text: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField("", text: text)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .frame(width: 250)
+                .onChange(of: text.wrappedValue) { _, _ in markDirty() }
+            Button("Choose") {
+                if let path = chooseCertificateFile() {
+                    text.wrappedValue = path
+                    markDirty()
+                }
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private var effectiveGatewayURL: String {
+        GatewayConfig.localBaseURL(
+            hostname: gatewayHostnameText,
+            gatewayPort: Int(gatewayPortText) ?? GatewayConfig.defaultPort
+        )
+    }
+
+    private var gatewayBindAddresses: [String] {
+        parseBindAddresses(gatewayBindAddressesText)
+    }
+
+    private var gatewayUsesExternalBind: Bool {
+        !GatewayConfig.exposesFullApp(bindAddresses: gatewayBindAddresses)
+    }
+
+    private var gatewayBindHelpText: String {
+        if gatewayUsesExternalBind {
+            return "External binds expose only /mcp and /t API-key MCP paths. The web app, setup, status, and OAuth endpoints stay off this listener."
+        }
+        return "Loopback binds expose the local gateway only from this Mac."
+    }
+
+    private var gatewayCustomCertificateComplete: Bool {
+        gatewayCertificateMode != GatewayCertificateMode.custom.rawValue
+            || (!gatewayCertificatePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !gatewayPrivateKeyPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private var gatewaySettingsValid: Bool {
+        !GatewayConfig.normalizedHostname(gatewayHostnameText).isEmpty
+            && !gatewayBindAddresses.isEmpty
+            && gatewayCustomCertificateComplete
+    }
+
+    private func parseBindAddresses(_ value: String) -> [String] {
+        let parts = value
+            .split { $0 == "," || $0 == " " || $0 == "\n" || $0 == "\t" }
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return GatewayConfig.normalizedBindAddresses(parts)
+    }
+
+    private func chooseCertificateFile() -> String? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Choose"
+        return panel.runModal() == .OK ? panel.url?.path : nil
+    }
+
     // MARK: - State management
 
     private func markDirty() {
@@ -414,6 +606,12 @@ struct PreferencesWindow: View {
             || allowRemoteMCP != initial.allowRemoteMCP
             || workerPreset != initial.workerPreset
             || apiPortText != initial.apiPort
+            || gatewayPortText != initial.gatewayPort
+            || gatewayHostnameText != initial.gatewayHostname
+            || gatewayBindAddressesText != initial.gatewayBindAddresses
+            || gatewayCertificateMode != initial.gatewayCertificateMode
+            || gatewayCertificatePath != initial.gatewayCertificatePath
+            || gatewayPrivateKeyPath != initial.gatewayPrivateKeyPath
             || postgresPortText != initial.postgresPort
             || tikaPortText != initial.tikaPort
             || embedderPortText != initial.embedderPort
@@ -431,6 +629,12 @@ struct PreferencesWindow: View {
         settings.allowRemoteMCP = allowRemoteMCP
         settings.workerPreset = workerPreset
         if let p = Int(apiPortText), p > 0, p <= 65535 { settings.apiPort = p }
+        if let p = Int(gatewayPortText), p > 0, p <= 65535 { settings.gatewayPort = p }
+        settings.gatewayHostname = gatewayHostnameText
+        settings.gatewayBindAddresses = gatewayBindAddresses
+        settings.gatewayCertificateMode = GatewayCertificateMode(rawValue: gatewayCertificateMode) ?? .internal
+        settings.gatewayCertificatePath = gatewayCertificatePath
+        settings.gatewayPrivateKeyPath = gatewayPrivateKeyPath
         if let p = Int(postgresPortText), p > 0, p <= 65535 { settings.postgresPort = p }
         if let p = Int(tikaPortText), p > 0, p <= 65535 { settings.tikaPort = p }
         if let p = Int(embedderPortText), p > 0, p <= 65535 { settings.embedderPort = p }
@@ -447,6 +651,12 @@ struct PreferencesWindow: View {
             allowRemoteMCP: allowRemoteMCP,
             workerPreset: workerPreset,
             apiPort: apiPortText,
+            gatewayPort: gatewayPortText,
+            gatewayHostname: gatewayHostnameText,
+            gatewayBindAddresses: gatewayBindAddressesText,
+            gatewayCertificateMode: gatewayCertificateMode,
+            gatewayCertificatePath: gatewayCertificatePath,
+            gatewayPrivateKeyPath: gatewayPrivateKeyPath,
             postgresPort: postgresPortText,
             tikaPort: tikaPortText,
             embedderPort: embedderPortText,
@@ -465,6 +675,12 @@ struct PreferencesWindow: View {
         allowRemoteMCP = initial.allowRemoteMCP
         workerPreset = initial.workerPreset
         apiPortText = initial.apiPort
+        gatewayPortText = initial.gatewayPort
+        gatewayHostnameText = initial.gatewayHostname
+        gatewayBindAddressesText = initial.gatewayBindAddresses
+        gatewayCertificateMode = initial.gatewayCertificateMode
+        gatewayCertificatePath = initial.gatewayCertificatePath
+        gatewayPrivateKeyPath = initial.gatewayPrivateKeyPath
         postgresPortText = initial.postgresPort
         tikaPortText = initial.tikaPort
         embedderPortText = initial.embedderPort
@@ -486,6 +702,12 @@ struct PreferencesWindow: View {
         if allowRemoteMCP != initial.allowRemoteMCP { keys.insert("allow_remote_mcp") }
         if workerPreset != initial.workerPreset { keys.insert("worker_preset") }
         if apiPortText != initial.apiPort { keys.insert("api_port") }
+        if gatewayPortText != initial.gatewayPort { keys.insert("gateway_port") }
+        if gatewayHostnameText != initial.gatewayHostname { keys.insert("gateway_hostname") }
+        if gatewayBindAddressesText != initial.gatewayBindAddresses { keys.insert("gateway_bind_addresses") }
+        if gatewayCertificateMode != initial.gatewayCertificateMode { keys.insert("gateway_certificate_mode") }
+        if gatewayCertificatePath != initial.gatewayCertificatePath { keys.insert("gateway_certificate_path") }
+        if gatewayPrivateKeyPath != initial.gatewayPrivateKeyPath { keys.insert("gateway_private_key_path") }
         if postgresPortText != initial.postgresPort { keys.insert("postgres_port") }
         if tikaPortText != initial.tikaPort { keys.insert("tika_port") }
         if embedderPortText != initial.embedderPort { keys.insert("embedder_port") }

--- a/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ServiceManager.swift
@@ -88,6 +88,7 @@ class ServiceManager: ObservableObject {
     let rerankerService: RerankerService
     let llamaService: LlamaService
     let apiService: APIService
+    let gatewayService: GatewayService
     let watcherService: WatcherService
     private var ioWorkers: [WorkerService] = []
     private var cpuWorkers: [WorkerService] = []
@@ -164,6 +165,7 @@ class ServiceManager: ObservableObject {
         rerankerService = RerankerService()
         llamaService = LlamaService()
         apiService = APIService()
+        gatewayService = GatewayService()
         watcherService = WatcherService()
 
         // Worker counts based on preset
@@ -180,7 +182,7 @@ class ServiceManager: ObservableObject {
             llmWorkers.append(WorkerService(queue: "llm", index: i))
         }
 
-        services = [postgresService, tikaService, embedderService, rerankerService, llamaService, apiService, watcherService]
+        services = [postgresService, tikaService, embedderService, rerankerService, llamaService, apiService, gatewayService, watcherService]
             + ioWorkers + cpuWorkers + llmWorkers
     }
 
@@ -216,6 +218,8 @@ class ServiceManager: ObservableObject {
             if let pySvc = service as? PythonService, let proc = pySvc.process, proc.isRunning {
                 pids.append(String(proc.processIdentifier))
             } else if let llama = service as? LlamaService, let pid = llama.processIdentifier {
+                pids.append(String(pid))
+            } else if let gateway = service as? GatewayService, let pid = gateway.processIdentifier {
                 pids.append(String(pid))
             }
         }
@@ -365,20 +369,24 @@ class ServiceManager: ObservableObject {
         await Self.killStaleProcess(onPort: settings.apiPort)
         await startService(apiService)
 
-        // 8. Workers
+        // 8. Native HTTPS gateway for local MCP/agent clients
+        await Self.killStaleProcess(onPort: settings.gatewayPort)
+        await startService(gatewayService)
+
+        // 9. Workers
         for worker in allWorkers {
             await startService(worker)
         }
 
-        // 9. Start the watcher daemon (talks to postgres directly; doesn't need API).
+        // 10. Start the watcher daemon (talks to postgres directly; doesn't need API).
         //    Replaced the old Swift FSEvents WatchedFolderManager with a managed
         //    Python subprocess (`harbor-clerk-watcher`); see WatcherService.swift.
         await startService(watcherService)
 
-        // 10. Watch config.json for model changes from the web UI
+        // 11. Watch config.json for model changes from the web UI
         startConfigWatcher()
 
-        // 11. Persist child PIDs for orphan cleanup on next launch
+        // 12. Persist child PIDs for orphan cleanup on next launch
         savePidFile()
 
         notifyStateChanged()
@@ -542,6 +550,9 @@ class ServiceManager: ObservableObject {
                 // suspenders.
                 if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
                 killed.insert(pid)
+            } else if let gateway = service as? GatewayService, let pid = gateway.processIdentifier {
+                if killpg(pid, SIGKILL) != 0 { kill(pid, SIGKILL) }
+                killed.insert(pid)
             }
         }
 
@@ -674,6 +685,11 @@ class ServiceManager: ObservableObject {
                 guard let self, let svc = pySvc else { return }
                 Task { @MainActor in await self.attemptAutoRestart(svc) }
             }
+        } else if let gateway = service as? GatewayService {
+            gateway.onUnexpectedExit = { [weak self, weak gateway] in
+                guard let self, let svc = gateway else { return }
+                Task { @MainActor in await self.attemptAutoRestart(svc) }
+            }
         }
 
         do {
@@ -691,6 +707,12 @@ class ServiceManager: ObservableObject {
             while Date() < deadline {
                 // Bail early if the process died — no point waiting for the full timeout
                 if let pySvc = service as? PythonService, pySvc.process?.isRunning != true {
+                    service.state = .errored
+                    notifyStateChanged()
+                    Log.logger("lifecycle").error("[\(service.name, privacy: .public)] Process exited during startup")
+                    return
+                }
+                if let gateway = service as? GatewayService, gateway.processIdentifier == nil {
                     service.state = .errored
                     notifyStateChanged()
                     Log.logger("lifecycle").error("[\(service.name, privacy: .public)] Process exited during startup")
@@ -772,6 +794,7 @@ class ServiceManager: ObservableObject {
         var pythonToRestart: Set<ObjectIdentifier> = []
         var needsMigrations = false
         var needsWorkerRecreate = false
+        var needsGatewayRestart = false
 
         for key in changedKeys {
             switch key {
@@ -807,7 +830,20 @@ class ServiceManager: ObservableObject {
             case "llm_model_id", "llm_yarn_enabled":
                 infraToRestart.append(llamaService)
 
-            case "api_port", "allow_remote_web", "allow_remote_mcp":
+            case "api_port":
+                pythonToRestart.insert(ObjectIdentifier(apiService))
+                needsGatewayRestart = true
+
+            case "gateway_port",
+                 "gateway_hostname",
+                 "gateway_bind_addresses",
+                 "gateway_certificate_mode",
+                 "gateway_certificate_path",
+                 "gateway_private_key_path":
+                pythonToRestart.insert(ObjectIdentifier(apiService))
+                needsGatewayRestart = true
+
+            case "allow_remote_web", "allow_remote_mcp":
                 pythonToRestart.insert(ObjectIdentifier(apiService))
 
             case "worker_preset":
@@ -833,7 +869,7 @@ class ServiceManager: ObservableObject {
         // Embedder and Reranker before API to match startAll() ordering
         let nonWorkerPython: [any ManagedService] = [embedderService, rerankerService, apiService].filter { pythonToRestart.contains(ObjectIdentifier($0)) }
 
-        // 1. Stop python services (dependents first: workers → api/embedder)
+        // 1. Stop gateway and python services (dependents first: workers → gateway → api/embedder)
         // Send SIGTERM to all workers in parallel, then wait for all to exit.
         // Parallel SIGTERM then parallel wait-with-deadline. Pre-audit
         // (2026-05-11) this path had the same bug as stopAll()'s worker
@@ -866,6 +902,9 @@ class ServiceManager: ObservableObject {
                     }
                 }
             }
+        }
+        if needsGatewayRestart {
+            await gatewayService.stop()
         }
         for svc in nonWorkerPython {
             await svc.stop()
@@ -920,9 +959,17 @@ class ServiceManager: ObservableObject {
             worker.resetRestartCount()
         }
 
-        // 8. Start affected python services (embedder → api → workers)
+        // 8. Start affected python services (embedder → api), then gateway, then workers
         for svc in nonWorkerPython {
             await startService(svc)
+        }
+        if needsGatewayRestart {
+            if gatewayService.state == .errored {
+                gatewayService.state = .stopped
+                restartHistory.removeValue(forKey: gatewayService.name)
+            }
+            await Self.killStaleProcess(onPort: AppSettings.shared.gatewayPort)
+            await startService(gatewayService)
         }
         let workersToStart = needsWorkerRecreate ? allWorkers : allWorkers.filter { pythonToRestart.contains(ObjectIdentifier($0)) }
         for worker in workersToStart {
@@ -1120,8 +1167,10 @@ class ServiceManager: ObservableObject {
             "SECRET_KEY": settings.secretKey,
             "LOG_LEVEL": settings.logLevel,
             "STATIC_DIR": bundle.appendingPathComponent("frontend-dist").path,
-            "API_HOST": (settings.allowRemoteWeb || settings.allowRemoteMCP) ? "0.0.0.0" : "127.0.0.1",
+            "API_HOST": "127.0.0.1",
             "API_PORT": String(settings.apiPort),
+            "GATEWAY_PORT": String(settings.gatewayPort),
+            "LOCAL_MCP_URL": settings.localMCPBaseURL,
             "PATH": [
                 bundle.appendingPathComponent("venv/bin").path,
                 bundle.appendingPathComponent("tesseract/bin").path,

--- a/macos/HarborClerkServer/HarborClerkServer/Services/GatewayService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/GatewayService.swift
@@ -1,0 +1,113 @@
+import Foundation
+import os
+
+final class GatewayService: ManagedService {
+    let name = "HTTPS Gateway"
+    var state: ServiceState = .stopped
+    var process: Process?
+    var onUnexpectedExit: (@MainActor () -> Void)?
+
+    private var configDir: URL {
+        AppSettings.dataDir.appendingPathComponent("caddy")
+    }
+
+    private var caddyfileURL: URL {
+        configDir.appendingPathComponent("Caddyfile")
+    }
+
+    private var dataDir: URL {
+        AppSettings.dataDir.appendingPathComponent("caddy-data")
+    }
+
+    private var runtimeConfigDir: URL {
+        AppSettings.dataDir.appendingPathComponent("caddy-config")
+    }
+
+    var processIdentifier: Int32? {
+        guard let process, process.isRunning else { return nil }
+        return process.processIdentifier
+    }
+
+    func start() async throws {
+        let settings = AppSettings.shared
+        guard let executable = GatewayConfig.caddyExecutable() else {
+            throw NSError(
+                domain: "GatewayService",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Caddy binary not found in app resources or Homebrew"]
+            )
+        }
+
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: runtimeConfigDir, withIntermediateDirectories: true)
+
+        let config = GatewayConfig(
+            apiPort: settings.apiPort,
+            gatewayPort: settings.gatewayPort,
+            hostname: settings.gatewayHostname,
+            bindAddresses: settings.gatewayBindAddresses,
+            certificateMode: settings.gatewayCertificateMode,
+            certificatePath: settings.gatewayCertificatePath,
+            privateKeyPath: settings.gatewayPrivateKeyPath
+        )
+        try config.caddyfile.write(to: caddyfileURL, atomically: true, encoding: .utf8)
+
+        let proc = Process()
+        proc.executableURL = executable
+        proc.arguments = ["run", "--config", caddyfileURL.path, "--adapter", "caddyfile"]
+        proc.environment = [
+            "HOME": AppSettings.dataDir.path,
+            "XDG_DATA_HOME": dataDir.path,
+            "XDG_CONFIG_HOME": runtimeConfigDir.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin",
+        ]
+
+        let pipe = Log.createPipe(category: "gateway")
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+
+        proc.terminationHandler = { [weak self] p in
+            guard let self else { return }
+            Task { @MainActor in
+                if self.state == .running {
+                    self.state = .errored
+                    Log.logger("gateway").error(
+                        "Process exited unexpectedly: status=\(p.terminationStatus, privacy: .public)"
+                    )
+                    self.onUnexpectedExit?()
+                }
+            }
+        }
+
+        try proc.runAsProcessGroupLeader()
+        process = proc
+    }
+
+    func stop() async {
+        state = .stopping
+        guard let proc = process, proc.isRunning else {
+            process = nil
+            state = .stopped
+            return
+        }
+
+        proc.terminate()
+        await proc.waitForExitWithDeadline(graceSeconds: 10, serviceName: name)
+        process = nil
+        state = .stopped
+    }
+
+    func healthCheck() async -> Bool {
+        guard process?.isRunning == true else { return false }
+        let settings = AppSettings.shared
+        guard let url = URL(string: "\(settings.localMCPBaseURL)/t/__harbor_clerk_gateway_probe__") else { return false }
+        let allowedHosts = Set([
+            GatewayConfig.normalizedHostname(settings.gatewayHostname),
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        ])
+        return await httpsProbeOKAllowingLocalCertificate(url, allowedHosts: allowedHosts)
+    }
+}

--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -25,6 +25,47 @@ final class AppSettings: @unchecked Sendable {
         set { lock.withLock { data["api_port"] = newValue }; save() }
     }
 
+    var gatewayPort: Int {
+        get { lock.withLock { data["gateway_port"] as? Int ?? GatewayConfig.defaultPort } }
+        set { lock.withLock { data["gateway_port"] = newValue }; save() }
+    }
+
+    var gatewayHostname: String {
+        get { lock.withLock { data["gateway_hostname"] as? String ?? GatewayConfig.defaultHostname } }
+        set { lock.withLock { data["gateway_hostname"] = GatewayConfig.normalizedHostname(newValue) }; save() }
+    }
+
+    var gatewayBindAddresses: [String] {
+        get { lock.withLock { data["gateway_bind_addresses"] as? [String] ?? GatewayConfig.defaultBindAddresses } }
+        set { lock.withLock { data["gateway_bind_addresses"] = GatewayConfig.normalizedBindAddresses(newValue) }; save() }
+    }
+
+    var gatewayCertificateMode: GatewayCertificateMode {
+        get {
+            let raw = lock.withLock { data["gateway_certificate_mode"] as? String ?? GatewayCertificateMode.internal.rawValue }
+            return GatewayCertificateMode(rawValue: raw) ?? .internal
+        }
+        set { lock.withLock { data["gateway_certificate_mode"] = newValue.rawValue }; save() }
+    }
+
+    var gatewayCertificatePath: String {
+        get { lock.withLock { data["gateway_certificate_path"] as? String ?? "" } }
+        set { lock.withLock { data["gateway_certificate_path"] = newValue.trimmingCharacters(in: .whitespacesAndNewlines) }; save() }
+    }
+
+    var gatewayPrivateKeyPath: String {
+        get { lock.withLock { data["gateway_private_key_path"] as? String ?? "" } }
+        set { lock.withLock { data["gateway_private_key_path"] = newValue.trimmingCharacters(in: .whitespacesAndNewlines) }; save() }
+    }
+
+    var gatewayExposesFullApp: Bool {
+        GatewayConfig.exposesFullApp(bindAddresses: gatewayBindAddresses)
+    }
+
+    var localMCPBaseURL: String {
+        GatewayConfig.localBaseURL(hostname: gatewayHostname, gatewayPort: gatewayPort)
+    }
+
     var embedderPort: Int {
         get { lock.withLock { data["embedder_port"] as? Int ?? 8101 } }
         set { lock.withLock { data["embedder_port"] = newValue }; save() }

--- a/macos/HarborClerkServer/HarborClerkServerTests/AppSettingsTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/AppSettingsTests.swift
@@ -26,6 +26,14 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.postgresPort, 5433)
         XCTAssertEqual(settings.tikaPort, 9998)
         XCTAssertEqual(settings.apiPort, 8100)
+        XCTAssertEqual(settings.gatewayPort, 8443)
+        XCTAssertEqual(settings.gatewayHostname, "localhost")
+        XCTAssertEqual(settings.gatewayBindAddresses, ["127.0.0.1", "::1"])
+        XCTAssertEqual(settings.gatewayCertificateMode, .internal)
+        XCTAssertEqual(settings.gatewayCertificatePath, "")
+        XCTAssertEqual(settings.gatewayPrivateKeyPath, "")
+        XCTAssertTrue(settings.gatewayExposesFullApp)
+        XCTAssertEqual(settings.localMCPBaseURL, "https://localhost:8443")
         XCTAssertEqual(settings.embedderPort, 8101)
         XCTAssertEqual(settings.llamaPort, 8102)
         XCTAssertEqual(settings.workerPreset, "balanced")
@@ -54,6 +62,8 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.logLevel, "DEBUG")
         // Other fields keep defaults
         XCTAssertEqual(settings.apiPort, 8100)
+        XCTAssertEqual(settings.gatewayPort, 8443)
+        XCTAssertEqual(settings.gatewayHostname, "localhost")
     }
 
     // MARK: - Save and reload
@@ -61,10 +71,24 @@ final class AppSettingsTests: XCTestCase {
     func testSaveAndReload() {
         let settings = AppSettings(configURL: configURL)
         settings.postgresPort = 6000
+        settings.gatewayPort = 9443
+        settings.gatewayHostname = "harbor.tailnet.ts.net"
+        settings.gatewayBindAddresses = ["100.80.1.2"]
+        settings.gatewayCertificateMode = .custom
+        settings.gatewayCertificatePath = "/tmp/harbor.pem"
+        settings.gatewayPrivateKeyPath = "/tmp/harbor-key.pem"
         settings.workerPreset = "quiet"
 
         let reloaded = AppSettings(configURL: configURL)
         XCTAssertEqual(reloaded.postgresPort, 6000)
+        XCTAssertEqual(reloaded.gatewayPort, 9443)
+        XCTAssertEqual(reloaded.gatewayHostname, "harbor.tailnet.ts.net")
+        XCTAssertEqual(reloaded.gatewayBindAddresses, ["100.80.1.2"])
+        XCTAssertEqual(reloaded.gatewayCertificateMode, .custom)
+        XCTAssertEqual(reloaded.gatewayCertificatePath, "/tmp/harbor.pem")
+        XCTAssertEqual(reloaded.gatewayPrivateKeyPath, "/tmp/harbor-key.pem")
+        XCTAssertFalse(reloaded.gatewayExposesFullApp)
+        XCTAssertEqual(reloaded.localMCPBaseURL, "https://harbor.tailnet.ts.net:9443")
         XCTAssertEqual(reloaded.workerPreset, "quiet")
     }
 

--- a/macos/HarborClerkServer/HarborClerkServerTests/CliShimInstallerTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/CliShimInstallerTests.swift
@@ -40,64 +40,72 @@ final class CliShimInstallerTests: XCTestCase {
     // MARK: - makeShimContent
 
     func testShimContentContainsMarker() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/tmp/fake.app/Contents/Resources", apiPort: 8100)
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/tmp/fake.app/Contents/Resources", defaultURL: "https://localhost:8443")
         XCTAssertTrue(content.contains("# harbor-clerk — installed by Harbor Clerk Server"),
                       "Shim must contain the identity marker so status detection recognises it")
     }
 
     func testShimContentContainsBundleResourcesLine() {
         let bundle = "/fake/Harbor Clerk Server.app/Contents/Resources"
-        let content = CliShimInstaller.makeShimContent(bundleResources: bundle, apiPort: 8100)
+        let content = CliShimInstaller.makeShimContent(bundleResources: bundle, defaultURL: "https://localhost:8443")
         XCTAssertTrue(content.contains("BUNDLE_RESOURCES=\"\(bundle)\""),
                       "Shim must embed BUNDLE_RESOURCES with the provided path")
     }
 
     func testShimContentIsExecutableScript() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
         XCTAssertTrue(content.hasPrefix("#!/bin/sh"), "Shim must start with a sh shebang")
     }
 
     func testShimContentDelegatesViaExec() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
         XCTAssertTrue(content.contains("exec \"$BUNDLE_RESOURCES/venv/bin/python\" -m harbor_clerk.cli.main \"$@\""),
                       "Shim must exec python with the correct module and forward args")
     }
 
     func testShimDisablesBytecodeWrites() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
         XCTAssertTrue(content.contains("export PYTHONDONTWRITEBYTECODE=1"),
                       "Shim must not let Python write .pyc files into the signed app bundle")
     }
 
     // MARK: - HARBOR_CLERK_URL default
 
-    func testShimContentEmbedsApiUrlAsDefault() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+    func testShimContentEmbedsGatewayUrlAsDefault() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
         XCTAssertTrue(
-            content.contains(#"export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-http://localhost:8100}""#),
-            "Shim must bake in the apiPort as the default HARBOR_CLERK_URL using ${VAR:-default} so users can still override in their shell"
+            content.contains(#"export HARBOR_CLERK_URL="${HARBOR_CLERK_URL:-https://localhost:8443}""#),
+            "Shim must bake in the HTTPS gateway URL as the default HARBOR_CLERK_URL using ${VAR:-default} so users can still override in their shell"
         )
     }
 
-    func testShimContentUsesProvidedPort() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 9999)
+    func testShimContentUsesProvidedUrl() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:9443")
         XCTAssertTrue(
-            content.contains("http://localhost:9999}"),
-            "Shim must reflect the apiPort passed in, not a hardcoded default"
+            content.contains("https://localhost:9443}"),
+            "Shim must reflect the default URL passed in, not a hardcoded default"
         )
     }
 
-    func testExtractEmbeddedApiPortRoundTrip() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
-        XCTAssertEqual(CliShimInstaller.extractEmbeddedApiPort(from: content), 8100)
+    func testShimContentAllowsSelfSignedGatewayByDefault() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
+        XCTAssertTrue(
+            content.contains(#"export HARBOR_CLERK_INSECURE_SKIP_VERIFY="${HARBOR_CLERK_INSECURE_SKIP_VERIFY:-1}""#),
+            "The native gateway uses a local self-signed cert, so the shim must default the CLI to skip TLS verification while still allowing user override"
+        )
     }
 
-    func testExtractEmbeddedApiPortRoundTripNonDefault() {
-        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 12345)
-        XCTAssertEqual(CliShimInstaller.extractEmbeddedApiPort(from: content), 12345)
+    func testExtractEmbeddedDefaultUrlRoundTrip() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
+        XCTAssertEqual(CliShimInstaller.extractEmbeddedDefaultURL(from: content), "https://localhost:8443")
     }
 
-    func testExtractEmbeddedApiPortReturnsNilForLegacyShim() {
+    func testExtractEmbeddedDefaultUrlRoundTripNonDefault() {
+        let content = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:12345")
+        XCTAssertEqual(CliShimInstaller.extractEmbeddedDefaultURL(from: content), "https://localhost:12345")
+    }
+
+    func testExtractEmbeddedDefaultUrlReturnsNilForLegacyShim() {
         // Old shims (pre-URL-baking) have no `export HARBOR_CLERK_URL=` line.
         let legacy = """
         #!/bin/sh
@@ -106,7 +114,7 @@ final class CliShimInstallerTests: XCTestCase {
         export PATH="$BUNDLE_RESOURCES/venv/bin:/usr/bin:/bin"
         exec "$BUNDLE_RESOURCES/venv/bin/python" -m harbor_clerk.cli.main "$@"
         """
-        XCTAssertNil(CliShimInstaller.extractEmbeddedApiPort(from: legacy),
+        XCTAssertNil(CliShimInstaller.extractEmbeddedDefaultURL(from: legacy),
                      "Legacy shim without a URL line should parse as nil so currentStatus marks it outdated")
     }
 
@@ -118,7 +126,7 @@ final class CliShimInstallerTests: XCTestCase {
         // We test the internal logic by manually checking content parsing
         // (can't inject shimPath, so we verify make/parse round-trip)
         let bundle = "/my/bundle"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle, apiPort: 8100)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle, defaultURL: "https://localhost:8443")
 
         // Simulate the parse that currentStatus() does
         XCTAssertTrue(shim.contains("# harbor-clerk — installed by Harbor Clerk Server"))
@@ -144,7 +152,7 @@ final class CliShimInstallerTests: XCTestCase {
         let shimURL = nestedDir.appendingPathComponent("harbor-clerk")
 
         try FileManager.default.createDirectory(at: nestedDir, withIntermediateDirectories: true)
-        let shim = CliShimInstaller.makeShimContent(bundleResources: "/test/bundle", apiPort: 8100)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: "/test/bundle", defaultURL: "https://localhost:8443")
         try shim.write(to: shimURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shimURL.path)
 
@@ -153,7 +161,7 @@ final class CliShimInstallerTests: XCTestCase {
 
     func testInstallWritesCorrectContent() throws {
         let bundle = "/Applications/Harbor Clerk Server.app/Contents/Resources"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle, apiPort: 8100)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: bundle, defaultURL: "https://localhost:8443")
         try shim.write(to: fakeShimPath, atomically: true, encoding: .utf8)
 
         let written = try String(contentsOf: fakeShimPath, encoding: .utf8)
@@ -162,7 +170,7 @@ final class CliShimInstallerTests: XCTestCase {
     }
 
     func testInstallSetsExecutablePermissions() throws {
-        let shim = CliShimInstaller.makeShimContent(bundleResources: "/x", apiPort: 8100)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: "/x", defaultURL: "https://localhost:8443")
         try shim.write(to: fakeShimPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeShimPath.path)
 
@@ -176,7 +184,7 @@ final class CliShimInstallerTests: XCTestCase {
     func testInstalledStatusAfterWritingMatchingShim() throws {
         // Write a shim that matches Bundle.main.resourceURL
         let currentBundle = Bundle.main.resourceURL?.path ?? "/fake/bundle"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: currentBundle, apiPort: 8100)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: currentBundle, defaultURL: "https://localhost:8443")
 
         // Write to the real shimPath (which points to ~/.local/bin/harbor-clerk)
         // ONLY if shimPath == ~/.local/bin/harbor-clerk and we definitely want to
@@ -192,7 +200,7 @@ final class CliShimInstallerTests: XCTestCase {
     func testInstalledOutdatedWhenBundlePathDiffers() throws {
         let staleBundle = "/old/path/Harbor Clerk Server.app/Contents/Resources"
         let currentBundle = Bundle.main.resourceURL?.path ?? "/new/bundle"
-        let shim = CliShimInstaller.makeShimContent(bundleResources: staleBundle, apiPort: 8100)
+        let shim = CliShimInstaller.makeShimContent(bundleResources: staleBundle, defaultURL: "https://localhost:8443")
 
         let lines = shim.components(separatedBy: "\n")
         let bundleLine = lines.first(where: { $0.hasPrefix("BUNDLE_RESOURCES=") })!
@@ -226,7 +234,7 @@ final class CliShimInstallerTests: XCTestCase {
     func testUninstallRemovesOurShimFile() throws {
         // Write our shim to a temp path and remove it manually (simulating what
         // uninstall() does when it detects .installed or .installedOutdated)
-        let ourShim = CliShimInstaller.makeShimContent(bundleResources: "/test", apiPort: 8100)
+        let ourShim = CliShimInstaller.makeShimContent(bundleResources: "/test", defaultURL: "https://localhost:8443")
         try ourShim.write(to: fakeShimPath, atomically: true, encoding: .utf8)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: fakeShimPath.path))

--- a/macos/HarborClerkServer/HarborClerkServerTests/GatewayConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/GatewayConfigTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import HarborClerkServer
+
+final class GatewayConfigTests: XCTestCase {
+    func testDefaultPortMatchesReleaseGateway() {
+        XCTAssertEqual(GatewayConfig.defaultPort, 8443)
+    }
+
+    func testLocalBaseURLUsesGatewayPort() {
+        XCTAssertEqual(GatewayConfig.localBaseURL(hostname: "localhost", gatewayPort: 9443), "https://localhost:9443")
+    }
+
+    func testLocalBaseURLUsesHostname() {
+        XCTAssertEqual(
+            GatewayConfig.localBaseURL(hostname: "harbor.tailnet.ts.net", gatewayPort: 8443),
+            "https://harbor.tailnet.ts.net:8443"
+        )
+    }
+
+    func testLocalBaseURLNormalizesEnteredUrlsAndIpv6Hosts() {
+        XCTAssertEqual(
+            GatewayConfig.localBaseURL(hostname: "https://harbor.tailnet.ts.net:9443/t/key", gatewayPort: 8443),
+            "https://harbor.tailnet.ts.net:8443"
+        )
+        XCTAssertEqual(
+            GatewayConfig.localBaseURL(hostname: "https://[::1]:9443/t/key", gatewayPort: 8443),
+            "https://[::1]:8443"
+        )
+    }
+
+    func testCaddyfileProxiesLocalHttpsToApiPort() {
+        let caddyfile = GatewayConfig.renderCaddyfile(apiPort: 8100, gatewayPort: 8443)
+
+        XCTAssertTrue(caddyfile.contains("local_certs"))
+        XCTAssertTrue(caddyfile.contains("skip_install_trust"))
+        XCTAssertTrue(caddyfile.contains("admin off"))
+        XCTAssertTrue(caddyfile.contains("https://localhost:8443"))
+        XCTAssertTrue(caddyfile.contains("bind 127.0.0.1 ::1"))
+        XCTAssertTrue(caddyfile.contains("tls internal"))
+        XCTAssertTrue(caddyfile.contains("reverse_proxy 127.0.0.1:8100"))
+    }
+
+    func testExternalBindOnlyProxiesMcpPaths() {
+        let caddyfile = GatewayConfig.renderCaddyfile(
+            apiPort: 8100,
+            gatewayPort: 8443,
+            hostname: "harbor.tailnet.ts.net",
+            bindAddresses: ["100.80.1.2"]
+        )
+
+        XCTAssertTrue(caddyfile.contains("https://harbor.tailnet.ts.net:8443"))
+        XCTAssertTrue(caddyfile.contains("bind 100.80.1.2"))
+        XCTAssertTrue(caddyfile.contains("handle /mcp*"))
+        XCTAssertTrue(caddyfile.contains("handle /t*"))
+        XCTAssertTrue(caddyfile.contains("respond 404"))
+        XCTAssertFalse(caddyfile.contains("\n    reverse_proxy 127.0.0.1:8100\n"))
+        XCTAssertFalse(caddyfile.contains("handle /api*"))
+    }
+
+    func testCustomCertificateIsRendered() {
+        let caddyfile = GatewayConfig.renderCaddyfile(
+            apiPort: 8100,
+            gatewayPort: 8443,
+            hostname: "harbor.example.com",
+            certificateMode: .custom,
+            certificatePath: "/Users/alex/certs/harbor cert.pem",
+            privateKeyPath: "/Users/alex/certs/harbor key.pem"
+        )
+
+        XCTAssertTrue(caddyfile.contains(#"tls "/Users/alex/certs/harbor cert.pem" "/Users/alex/certs/harbor key.pem""#))
+    }
+}

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -13,13 +13,13 @@
 SCRIPTS := scripts
 BUILD   := build
 
-.PHONY: all deps postgres tika tools venv spacy-models model llama frontend apple-summarize dev test apps sign clean
+.PHONY: all deps postgres tika tools caddy venv spacy-models model llama frontend apple-summarize dev test apps sign clean
 
 all: deps venv spacy-models model llama apps
 
 # ── Dependencies ──
 
-deps: postgres tika tools
+deps: postgres tika tools caddy
 
 postgres:
 	@echo "==> Building PostgreSQL + pgvector"
@@ -32,6 +32,10 @@ tika:
 tools:
 	@echo "==> Extracting Tesseract"
 	DEST_DIR=$(BUILD) bash $(SCRIPTS)/build-deps.sh
+
+caddy:
+	@echo "==> Bundling Caddy HTTPS gateway"
+	DEST_DIR=$(BUILD)/caddy bash $(SCRIPTS)/build-caddy.sh
 
 # ── Python ──
 

--- a/macos/scripts/build-caddy.sh
+++ b/macos/scripts/build-caddy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copy Homebrew Caddy into the native macOS bundle resources.
+set -euo pipefail
+
+DEST_DIR="${DEST_DIR:?DEST_DIR must be set}"
+CADDY_DIR="$DEST_DIR"
+
+echo "==> Preparing Caddy"
+
+mkdir -p "$CADDY_DIR/bin"
+
+if [ -x "$CADDY_DIR/bin/caddy" ]; then
+    echo "==> Caddy already present, skipping"
+    exit 0
+fi
+
+brew list caddy &>/dev/null || brew install caddy
+
+CADDY_PREFIX="$(brew --prefix caddy)"
+cp "$CADDY_PREFIX/bin/caddy" "$CADDY_DIR/bin/caddy"
+chmod +x "$CADDY_DIR/bin/caddy"
+
+# Ad-hoc sign so macOS will execute the binary from inside the app bundle.
+codesign --force --sign - "$CADDY_DIR/bin/caddy" 2>/dev/null || true
+
+echo "==> Caddy installed to ${CADDY_DIR}"

--- a/macos/scripts/package.sh
+++ b/macos/scripts/package.sh
@@ -117,6 +117,11 @@ if [ -d "$BUILD_DIR/llama" ]; then
     cp -R "$BUILD_DIR/llama" "$RESOURCES/llama"
 fi
 
+# Caddy HTTPS gateway
+if [ -d "$BUILD_DIR/caddy" ]; then
+    cp -R "$BUILD_DIR/caddy" "$RESOURCES/caddy"
+fi
+
 # apple-summarize (Apple Intelligence CLI tool — optional, macOS 26+ only)
 if [ -f "$BUILD_DIR/apple-summarize/apple-summarize" ]; then
     cp "$BUILD_DIR/apple-summarize/apple-summarize" "$RESOURCES/apple-summarize"

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -1,9 +1,11 @@
+import asyncio
 import logging
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -88,8 +90,38 @@ def _cli_shim_install_status(_shim: Path | None = None) -> str | None:
         return "installed"
 
     if embedded_bundle == current_bundle:
+        embedded_url = _extract_shim_default_url(contents)
+        local_mcp_url = get_settings().local_mcp_url
+        if local_mcp_url and embedded_url != local_mcp_url:
+            return "installed_outdated"
         return "installed"
     return "installed_outdated"
+
+
+def _extract_shim_default_url(contents: str) -> str | None:
+    """Extract the default HARBOR_CLERK_URL from the native CLI shim."""
+    for line in contents.splitlines():
+        if not line.startswith("export HARBOR_CLERK_URL="):
+            continue
+        marker = ":-"
+        start = line.find(marker)
+        if start == -1:
+            return None
+        start += len(marker)
+        end = line.find("}", start)
+        if end == -1:
+            return None
+        return line[start:end]
+    return None
+
+
+def _local_gateway_addr(base_url: str) -> tuple[str, int] | str | None:
+    parsed = urlparse(base_url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        return None
+    if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+        return "not_probed"
+    return (parsed.hostname, parsed.port or 443)
 
 
 @router.get("/system/setup-status")
@@ -176,9 +208,25 @@ async def health_check(
     else:
         checks["reranker"] = "disabled"
 
+    if settings.local_mcp_url:
+        gateway_addr = _local_gateway_addr(settings.local_mcp_url)
+        if gateway_addr is None:
+            checks["local_https_gateway"] = "error: local_mcp_url must be HTTPS"
+        elif gateway_addr == "not_probed":
+            checks["local_https_gateway"] = "not_probed"
+        else:
+            try:
+                _, writer = await asyncio.wait_for(asyncio.open_connection(*gateway_addr), timeout=2)
+                writer.close()
+                await writer.wait_closed()
+                checks["local_https_gateway"] = "ok"
+            except Exception as e:
+                logger.error("Local HTTPS gateway health check failed: %s", e)
+                checks["local_https_gateway"] = f"error: {e}"
+
     from harbor_clerk.api.app import BUILD_HASH
 
-    overall = all(v in ("ok", "disabled") for v in checks.values())
+    overall = all(v in ("ok", "disabled", "not_probed") for v in checks.values())
     return {
         "status": "healthy" if overall else "degraded",
         "build": BUILD_HASH,
@@ -188,6 +236,7 @@ async def health_check(
         # separate round-trip — see frontend/src/hooks/useSystemConfig.ts.
         "allow_source_download": get_settings().allow_source_download,
         "enable_cli_access": get_settings().enable_cli_access,
+        "local_mcp_url": settings.local_mcp_url or None,
         # Only present on macOS native (native_config_file is set). Returns
         # one of "installed", "installed_outdated", "not_installed". Absent
         # (None → omitted by frontend) on Docker/Linux where the shim concept

--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -56,6 +56,8 @@ class Settings(BaseSettings):
     # API server
     api_host: str = Field(default="127.0.0.1")
     api_port: int = Field(default=8000)
+    gateway_port: int = Field(default=8443)
+    local_mcp_url: str = Field(default="")
     static_dir: str = Field(default="/app/static")
 
     # App
@@ -161,7 +163,7 @@ class Settings(BaseSettings):
         ),
     )
 
-    @field_validator("public_url")
+    @field_validator("public_url", "local_mcp_url")
     @classmethod
     def _strip_trailing_slash(cls, v: str) -> str:
         return v.rstrip("/")

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -95,6 +95,66 @@ async def test_health_check_exposes_enable_cli_access_default_false(client):
     assert data["enable_cli_access"] is False
 
 
+async def test_health_check_exposes_and_probes_local_mcp_url_when_set(client, monkeypatch):
+    import asyncio
+
+    from harbor_clerk.config import get_settings
+
+    class _Writer:
+        def close(self):
+            pass
+
+        async def wait_closed(self):
+            pass
+
+    async def _fake_open_connection(host, port):
+        assert host == "localhost"
+        assert port == 8443
+        return object(), _Writer()
+
+    monkeypatch.setattr(asyncio, "open_connection", _fake_open_connection)
+
+    s = get_settings()
+    original = s.local_mcp_url
+    s.local_mcp_url = "https://localhost:8443"
+    try:
+        resp = await client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["local_mcp_url"] == "https://localhost:8443"
+        assert data["checks"]["local_https_gateway"] == "ok"
+    finally:
+        s.local_mcp_url = original
+
+
+async def test_health_check_marks_non_loopback_local_mcp_url_not_probed(client, monkeypatch):
+    import asyncio
+
+    from harbor_clerk.config import get_settings
+
+    opened_gateway_socket = False
+
+    async def _fake_open_connection(host, port):
+        nonlocal opened_gateway_socket
+        opened_gateway_socket = True
+        raise AssertionError(f"unexpected gateway socket probe for {host}:{port}")
+
+    monkeypatch.setattr(asyncio, "open_connection", _fake_open_connection)
+
+    s = get_settings()
+    original = s.local_mcp_url
+    s.local_mcp_url = "https://example.com"
+    try:
+        resp = await client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["local_mcp_url"] == "https://example.com"
+        assert data["checks"]["local_https_gateway"] == "not_probed"
+        assert opened_gateway_socket is False
+    finally:
+        s.local_mcp_url = original
+
+
 async def test_health_check_reflects_allow_source_download_when_set(client):
     """Toggling the setting at runtime should be visible immediately on the
     next health fetch. Tests use the same Settings singleton; mutating it on
@@ -894,11 +954,12 @@ async def test_status_summary_ready_when_no_attention_items(client, admin_user, 
 _SHIM_MARKER = "# harbor-clerk — installed by Harbor Clerk Server"
 
 
-def _make_shim(bundle: str) -> str:
+def _make_shim(bundle: str, default_url: str = "https://localhost:8443") -> str:
     return (
         "#!/bin/sh\n"
         f"{_SHIM_MARKER}\n"
         f'BUNDLE_RESOURCES="{bundle}"\n'
+        f'export HARBOR_CLERK_URL="${{HARBOR_CLERK_URL:-{default_url}}}"\n'
         'exec "$BUNDLE_RESOURCES/venv/bin/python" -m harbor_clerk.cli.main "$@"\n'
     )
 
@@ -910,14 +971,41 @@ def test_cli_shim_not_installed_when_file_absent(tmp_path):
 
     s = get_settings()
     original = s.native_config_file
+    original_local_url = s.local_mcp_url
     config_file = tmp_path / "config.json"
     config_file.write_text("{}")
     s.native_config_file = str(config_file)
+    s.local_mcp_url = "https://localhost:8443"
     try:
         absent = tmp_path / "harbor-clerk"  # does not exist
         assert _cli_shim_install_status(_shim=absent) == "not_installed"
     finally:
         s.native_config_file = original
+        s.local_mcp_url = original_local_url
+
+
+def test_cli_shim_installed_outdated_when_url_differs(tmp_path, monkeypatch):
+    """When shim URL doesn't match local_mcp_url, return 'installed_outdated'."""
+    from harbor_clerk.api.routes.system import _cli_shim_install_status
+    from harbor_clerk.config import get_settings
+
+    s = get_settings()
+    original = s.native_config_file
+    original_local_url = s.local_mcp_url
+    config_file = tmp_path / "config.json"
+    config_file.write_text("{}")
+    s.native_config_file = str(config_file)
+    s.local_mcp_url = "https://localhost:8443"
+
+    fake_bundle = "/fake/Harbor Clerk Server.app/Contents/Resources"
+    shim_file = tmp_path / "harbor-clerk"
+    shim_file.write_text(_make_shim(fake_bundle, default_url="http://localhost:8100"))
+    monkeypatch.setenv("BUNDLE_RESOURCES", fake_bundle)
+    try:
+        assert _cli_shim_install_status(_shim=shim_file) == "installed_outdated"
+    finally:
+        s.native_config_file = original
+        s.local_mcp_url = original_local_url
 
 
 def test_cli_shim_installed_when_bundle_matches(tmp_path, monkeypatch):
@@ -927,9 +1015,11 @@ def test_cli_shim_installed_when_bundle_matches(tmp_path, monkeypatch):
 
     s = get_settings()
     original = s.native_config_file
+    original_local_url = s.local_mcp_url
     config_file = tmp_path / "config.json"
     config_file.write_text("{}")
     s.native_config_file = str(config_file)
+    s.local_mcp_url = "https://localhost:8443"
 
     fake_bundle = "/fake/Harbor Clerk Server.app/Contents/Resources"
     shim_file = tmp_path / "harbor-clerk"
@@ -939,6 +1029,7 @@ def test_cli_shim_installed_when_bundle_matches(tmp_path, monkeypatch):
         assert _cli_shim_install_status(_shim=shim_file) == "installed"
     finally:
         s.native_config_file = original
+        s.local_mcp_url = original_local_url
 
 
 def test_cli_shim_installed_outdated_when_bundle_differs(tmp_path, monkeypatch):
@@ -948,9 +1039,11 @@ def test_cli_shim_installed_outdated_when_bundle_differs(tmp_path, monkeypatch):
 
     s = get_settings()
     original = s.native_config_file
+    original_local_url = s.local_mcp_url
     config_file = tmp_path / "config.json"
     config_file.write_text("{}")
     s.native_config_file = str(config_file)
+    s.local_mcp_url = "https://localhost:8443"
 
     stale_bundle = "/old/Harbor Clerk Server.app/Contents/Resources"
     current_bundle = "/new/Harbor Clerk Server.app/Contents/Resources"
@@ -961,6 +1054,7 @@ def test_cli_shim_installed_outdated_when_bundle_differs(tmp_path, monkeypatch):
         assert _cli_shim_install_status(_shim=shim_file) == "installed_outdated"
     finally:
         s.native_config_file = original
+        s.local_mcp_url = original_local_url
 
 
 def test_cli_shim_foreign_script_treated_as_not_installed(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,6 +89,25 @@ def test_enable_cli_access_reads_env(monkeypatch):
     assert s.enable_cli_access is True
 
 
+def test_local_mcp_url_defaults_empty(monkeypatch):
+    monkeypatch.delenv("LOCAL_MCP_URL", raising=False)
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.gateway_port == 8443
+    assert s.local_mcp_url == ""
+
+
+def test_local_mcp_url_reads_env_and_strips_trailing_slash(monkeypatch):
+    monkeypatch.setenv("GATEWAY_PORT", "9443")
+    monkeypatch.setenv("LOCAL_MCP_URL", "https://localhost:9443/")
+    from harbor_clerk.config import Settings
+
+    s = Settings()
+    assert s.gateway_port == 9443
+    assert s.local_mcp_url == "https://localhost:9443"
+
+
 def test_refresh_cli_access_setting_no_native_config(monkeypatch):
     """refresh_cli_access_setting is a no-op when native_config_file is unset."""
     monkeypatch.delenv("ENABLE_CLI_ACCESS", raising=False)


### PR DESCRIPTION
## Summary
- add a managed native macOS Caddy HTTPS gateway for MCP/CLI agent clients, defaulting to `https://localhost:8443`
- add native Preferences controls for gateway hostname, bind addresses, detected Tailscale bind shortcut, generated/self-signed cert mode, and operator-managed cert/key files
- keep FastAPI bound to `127.0.0.1`; when the gateway binds beyond loopback, proxy only `/mcp*` and `/t*` and return 404 for the rest of the app/API/OAuth surface
- expose `LOCAL_MCP_URL` through native service env, Python config, system health, frontend integration snippets, docs, and the macOS CLI shim
- make non-loopback local gateway health report `not_probed` from the unauthenticated health endpoint instead of probing arbitrary remote hosts
- update tests and the native HTTPS gateway spec to memorialize the MCP-only external-bind boundary

## Security / exposure notes
- The audit found that exposing the whole app externally would also expose unauthenticated or browser-auth surfaces such as static SPA routes, setup status, ping/health, login/setup, and OAuth routes.
- The release posture in this PR is therefore: loopback gateway may proxy the full app; non-loopback/Tailscale/LAN gateway binds proxy only API-key MCP paths.
- Custom cert files are presence-validated in Preferences and then validated by Caddy at startup. Preflight cert/key matching, SAN coverage, and expiry checks are documented follow-up hardening.
- ACME/Let's Encrypt and loading Harbor Clerk.app itself over HTTPS remain deferred.

## Tests
- `xcodebuild -project HarborClerkServer.xcodeproj -scheme HarborClerkServer -configuration Debug -allowProvisioningUpdates build`
- `xcodebuild -project HarborClerkServer.xcodeproj -scheme HarborClerkServer -configuration Debug -allowProvisioningUpdates test -only-testing:HarborClerkServerTests/GatewayConfigTests -only-testing:HarborClerkServerTests/AppSettingsTests -only-testing:HarborClerkServerTests/CliShimInstallerTests`
- `npm run type-check`
- `npm test -- --run src/pages/SystemStatusPage.test.tsx src/pages/IntegrationsPage.test.tsx`
- `npm run lint` (existing warnings only)
- `npm run format:check`
- `uv run ruff check src/harbor_clerk/api/routes/system.py tests/test_api_system.py`
- `uv run ruff format --check src/harbor_clerk/api/routes/system.py tests/test_api_system.py`
- `uv run python -m py_compile src/harbor_clerk/api/routes/system.py tests/test_api_system.py`
- `git diff --check`

## Local test caveats
- I did not run DB-backed pytest locally after this expansion because the fixture creates/truncates a test database on whichever local Postgres is active. CI's Postgres-backed Python job should cover the amended endpoint tests.
- I could not run `caddy validate` locally because no Caddy binary is present in this checkout environment; the PR includes native config-generation tests for the route split.

## Fresh-eyes review
- Separate review pass completed locally. No blockers found.
- Residual risk to track: custom certificate preflight validation and client-specific self-signed trust behavior for OpenClaw/other MCP clients.