### PR TITLE
Fix native HTTPS gateway startup and service log visibility

### DIFF
--- a/frontend/src/pages/ServiceLogsPage.tsx
+++ b/frontend/src/pages/ServiceLogsPage.tsx
@@ -41,6 +41,9 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
+const DOCKER_LOGS_COMMAND =
+  'docker compose logs -f gateway app watcher worker-io worker-cpu worker-llm embedder reranker llama-server tika postgres'
+
 export default function ServiceLogsPage() {
   const [logs, setLogs] = useState<LogsResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -74,9 +77,9 @@ export default function ServiceLogsPage() {
             </p>
             <div className="flex items-center">
               <code className="block flex-1 rounded-sm bg-(--color-bg-tertiary) px-3 py-2 text-xs font-mono text-(--color-text-primary) select-all">
-                docker compose logs -f app worker-io worker-cpu
+                {DOCKER_LOGS_COMMAND}
               </code>
-              <CopyButton text="docker compose logs -f app worker-io worker-cpu" />
+              <CopyButton text={DOCKER_LOGS_COMMAND} />
             </div>
           </div>
         ) : logs.files.length === 0 ? (

--- a/macos/HarborClerkServer/HarborClerkServer/GatewayConfig.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/GatewayConfig.swift
@@ -17,6 +17,7 @@ struct GatewayConfig {
     let certificateMode: GatewayCertificateMode
     let certificatePath: String
     let privateKeyPath: String
+    let logLevel: String
 
     var localBaseURL: String {
         Self.localBaseURL(hostname: hostname, gatewayPort: gatewayPort)
@@ -30,7 +31,8 @@ struct GatewayConfig {
             bindAddresses: bindAddresses,
             certificateMode: certificateMode,
             certificatePath: certificatePath,
-            privateKeyPath: privateKeyPath
+            privateKeyPath: privateKeyPath,
+            logLevel: logLevel
         )
     }
 
@@ -41,7 +43,8 @@ struct GatewayConfig {
         bindAddresses: [String] = Self.defaultBindAddresses,
         certificateMode: GatewayCertificateMode = .internal,
         certificatePath: String = "",
-        privateKeyPath: String = ""
+        privateKeyPath: String = "",
+        logLevel: String = "INFO"
     ) {
         self.apiPort = apiPort
         self.gatewayPort = gatewayPort
@@ -50,6 +53,7 @@ struct GatewayConfig {
         self.certificateMode = certificateMode
         self.certificatePath = certificatePath.trimmingCharacters(in: .whitespacesAndNewlines)
         self.privateKeyPath = privateKeyPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.logLevel = Self.caddyLogLevel(logLevel)
     }
 
     static func localBaseURL(hostname: String, gatewayPort: Int) -> String {
@@ -106,10 +110,12 @@ struct GatewayConfig {
         bindAddresses: [String] = defaultBindAddresses,
         certificateMode: GatewayCertificateMode = .internal,
         certificatePath: String = "",
-        privateKeyPath: String = ""
+        privateKeyPath: String = "",
+        logLevel: String = "INFO"
     ) -> String {
         let cleanHostname = normalizedHostname(hostname)
         let binds = normalizedBindAddresses(bindAddresses)
+        let cleanLogLevel = caddyLogLevel(logLevel)
         let site = "https://\(urlHost(cleanHostname)):\(gatewayPort)"
         let tlsLine: String
         if certificateMode == .custom,
@@ -140,7 +146,11 @@ struct GatewayConfig {
         {
             local_certs
             skip_install_trust
+            auto_https disable_redirects
             admin off
+            log {
+                level \(cleanLogLevel)
+            }
         }
 
         \(site) {
@@ -174,6 +184,19 @@ struct GatewayConfig {
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
         return "\"\(escaped)\""
+    }
+
+    static func caddyLogLevel(_ level: String) -> String {
+        switch level.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+        case "DEBUG":
+            return "DEBUG"
+        case "WARN", "WARNING":
+            return "WARN"
+        case "ERROR":
+            return "ERROR"
+        default:
+            return "INFO"
+        }
     }
 }
 

--- a/macos/HarborClerkServer/HarborClerkServer/LogManager.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/LogManager.swift
@@ -9,22 +9,78 @@ enum Log {
     }
 
     /// Creates a Pipe that forwards subprocess output line-by-line to os.Logger.
-    static func createPipe(category: String) -> Pipe {
+    ///
+    /// Some native subprocesses (notably Caddy and llama-server) do not use
+    /// Harbor Clerk's Python logging setup, so they need Swift-side file
+    /// capture for the Service Logs page. When `fileURL` is provided, raw
+    /// subprocess bytes are appended to that file as well.
+    static func createPipe(category: String, fileURL: URL? = nil) -> Pipe {
         let logger = Logger(subsystem: subsystem, category: category)
         let pipe = Pipe()
+        let fileHandle = openLogFile(fileURL)
         pipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else {
+            guard !data.isEmpty else {
                 // EOF: nil out handler so the pipe fully closes.
                 // Without this, waitUntilExit() deadlocks because it waits
                 // for the pipe's read end to close.
                 handle.readabilityHandler = nil
+                try? fileHandle?.close()
                 return
             }
+            if let fileHandle {
+                try? fileHandle.write(contentsOf: data)
+            }
+            guard let text = String(data: data, encoding: .utf8) else { return }
             for line in text.components(separatedBy: .newlines) where !line.isEmpty {
                 logger.info("\(line, privacy: .public)")
             }
         }
         return pipe
+    }
+
+    private static func openLogFile(_ fileURL: URL?) -> FileHandle? {
+        guard let fileURL else { return nil }
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            rotateLogIfNeeded(fileURL, maxBytes: 5 * 1024 * 1024, keep: 3)
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: fileURL)
+            try handle.seekToEnd()
+            return handle
+        } catch {
+            logger(categoryForFile(fileURL)).warning(
+                "Could not open subprocess log file \(fileURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+
+    private static func rotateLogIfNeeded(_ fileURL: URL, maxBytes: UInt64, keep: Int) {
+        guard let size = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size]) as? UInt64,
+              size >= maxBytes else {
+            return
+        }
+
+        for index in stride(from: keep, through: 1, by: -1) {
+            let source = index == 1 ? fileURL : URL(fileURLWithPath: "\(fileURL.path).\(index - 1)")
+            let destination = URL(fileURLWithPath: "\(fileURL.path).\(index)")
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try? FileManager.default.removeItem(at: destination)
+            }
+            if FileManager.default.fileExists(atPath: source.path) {
+                try? FileManager.default.moveItem(at: source, to: destination)
+            }
+        }
+    }
+
+    private static func categoryForFile(_ fileURL: URL?) -> String {
+        guard let fileURL else { return "logs" }
+        return fileURL.deletingPathExtension().lastPathComponent
     }
 }

--- a/macos/HarborClerkServer/HarborClerkServer/Services/GatewayService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/GatewayService.swift
@@ -49,7 +49,8 @@ final class GatewayService: ManagedService {
             bindAddresses: settings.gatewayBindAddresses,
             certificateMode: settings.gatewayCertificateMode,
             certificatePath: settings.gatewayCertificatePath,
-            privateKeyPath: settings.gatewayPrivateKeyPath
+            privateKeyPath: settings.gatewayPrivateKeyPath,
+            logLevel: settings.logLevel
         )
         try config.caddyfile.write(to: caddyfileURL, atomically: true, encoding: .utf8)
 
@@ -63,7 +64,10 @@ final class GatewayService: ManagedService {
             "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin",
         ]
 
-        let pipe = Log.createPipe(category: "gateway")
+        let pipe = Log.createPipe(
+            category: "gateway",
+            fileURL: settings.logsDir.appendingPathComponent("gateway.log")
+        )
         proc.standardOutput = pipe
         proc.standardError = pipe
 

--- a/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/LlamaService.swift
@@ -81,7 +81,10 @@ final class LlamaService: ManagedService {
         }
         proc.arguments = args
 
-        let pipe = Log.createPipe(category: "llm")
+        let pipe = Log.createPipe(
+            category: "llm",
+            fileURL: settings.logsDir.appendingPathComponent("llm.log")
+        )
         proc.standardOutput = pipe
         proc.standardError = pipe
 

--- a/macos/HarborClerkServer/HarborClerkServerTests/GatewayConfigTests.swift
+++ b/macos/HarborClerkServer/HarborClerkServerTests/GatewayConfigTests.swift
@@ -33,7 +33,9 @@ final class GatewayConfigTests: XCTestCase {
 
         XCTAssertTrue(caddyfile.contains("local_certs"))
         XCTAssertTrue(caddyfile.contains("skip_install_trust"))
+        XCTAssertTrue(caddyfile.contains("auto_https disable_redirects"))
         XCTAssertTrue(caddyfile.contains("admin off"))
+        XCTAssertTrue(caddyfile.contains("level INFO"))
         XCTAssertTrue(caddyfile.contains("https://localhost:8443"))
         XCTAssertTrue(caddyfile.contains("bind 127.0.0.1 ::1"))
         XCTAssertTrue(caddyfile.contains("tls internal"))
@@ -68,5 +70,14 @@ final class GatewayConfigTests: XCTestCase {
         )
 
         XCTAssertTrue(caddyfile.contains(#"tls "/Users/alex/certs/harbor cert.pem" "/Users/alex/certs/harbor key.pem""#))
+    }
+
+    func testCaddyLogLevelMapsAppLogLevels() {
+        XCTAssertEqual(GatewayConfig.caddyLogLevel("DEBUG"), "DEBUG")
+        XCTAssertEqual(GatewayConfig.caddyLogLevel("WARNING"), "WARN")
+        XCTAssertEqual(GatewayConfig.caddyLogLevel("WARN"), "WARN")
+        XCTAssertEqual(GatewayConfig.caddyLogLevel("ERROR"), "ERROR")
+        XCTAssertEqual(GatewayConfig.caddyLogLevel("TRACE"), "INFO")
+        XCTAssertEqual(GatewayConfig.caddyLogLevel(""), "INFO")
     }
 }

--- a/src/harbor_clerk/api/routes/system.py
+++ b/src/harbor_clerk/api/routes/system.py
@@ -1642,10 +1642,14 @@ async def list_logs(
 
     service_labels = {
         "api": "API Server",
+        "gateway": "HTTPS Gateway",
+        "llm": "LLM",
         "worker": "Worker",
+        "watcher": "Watcher",
         "embedder": "Embedder",
         "reranker": "Reranker",
         "postgres": "PostgreSQL",
+        "tika": "Tika",
     }
 
     files = []
@@ -1657,9 +1661,11 @@ async def list_logs(
         stem = p.stem.split("-")[0] if "-" in p.stem else p.stem
         label = service_labels.get(stem, stem.title())
         if stem == "worker" and "-io" in p.name:
-            label = "Worker (IO)"
+            label = "Worker IO"
         elif stem == "worker" and "-cpu" in p.name:
-            label = "Worker (CPU)"
+            label = "Worker CPU"
+        elif stem == "worker" and "-llm" in p.name:
+            label = "Worker LLM"
         files.append(
             {
                 "name": p.name,

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -155,6 +155,46 @@ async def test_health_check_marks_non_loopback_local_mcp_url_not_probed(client, 
         s.local_mcp_url = original
 
 
+async def test_native_service_logs_label_gateway_llm_and_worker_queues(
+    client, admin_user, admin_token, monkeypatch, tmp_path
+):
+    config_file = tmp_path / "config.json"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    config_file.write_text("{}", encoding="utf-8")
+    for name in (
+        "api.log",
+        "gateway.log",
+        "llm.log",
+        "worker-io.log",
+        "worker-cpu.log",
+        "worker-llm.log",
+        "watcher.log",
+        "tika-launchd.log",
+        "postgres-Mon.log",
+    ):
+        (logs_dir / name).write_text("hello\n", encoding="utf-8")
+
+    monkeypatch.setenv("NATIVE_CONFIG_FILE", str(config_file))
+
+    resp = await client.get("/api/system/logs", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mode"] == "native"
+    assert data["logs_dir"] == str(logs_dir)
+
+    labels = {item["name"]: item["service"] for item in data["files"]}
+    assert labels["api.log"] == "API Server"
+    assert labels["gateway.log"] == "HTTPS Gateway"
+    assert labels["llm.log"] == "LLM"
+    assert labels["worker-io.log"] == "Worker IO"
+    assert labels["worker-cpu.log"] == "Worker CPU"
+    assert labels["worker-llm.log"] == "Worker LLM"
+    assert labels["watcher.log"] == "Watcher"
+    assert labels["tika-launchd.log"] == "Tika"
+    assert labels["postgres-Mon.log"] == "PostgreSQL"
+
+
 async def test_health_check_reflects_allow_source_download_when_set(client):
     """Toggling the setting at runtime should be visible immediately on the
     next health fetch. Tests use the same Settings singleton; mutating it on


### PR DESCRIPTION
## Summary\n- disable Caddy's automatic HTTP-to-HTTPS redirect listener so the native HTTPS gateway does not try to bind privileged port 80\n- pass Harbor Clerk log verbosity into the generated Caddyfile\n- capture Caddy and llama-server stdout/stderr into native log files for the Service Logs page\n- label gateway, LLM, Tika, Watcher, and Worker LLM logs correctly, and broaden the Docker logs command\n\n## Verification\n- Caddy validate against the new local gateway Caddyfile shape\n- local Caddy runtime smoke: gateway stayed alive on 8443 and proxied probe to API with HTTP 401\n- uv run pytest tests/test_api_system.py::test_native_service_logs_label_gateway_llm_and_worker_queues -q\n- uv run ruff check src/harbor_clerk/api/routes/system.py tests/test_api_system.py\n- uv run ruff format --check src/harbor_clerk/api/routes/system.py tests/test_api_system.py\n- npm run type-check\n- npm run format:check\n- npm run lint (warnings only; existing fast-refresh/hooks warnings)\n- xcodebuild test -project macos/HarborClerkServer/HarborClerkServer.xcodeproj -scheme HarborClerkServer -destination 'platform=macOS' -only-testing:HarborClerkServerTests/GatewayConfigTests\n\n## Review\nNeeds fresh-eyes review: this changes native service startup/logging and the admin log surface.\n