### PR TITLE
feat(search): add readiness state filters

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -19,16 +19,18 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Install dependencies first (cached layer)
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+# Install dependencies first (cached layer). Keep uv's cache on the image
+# filesystem so large packages can hardlink into .venv instead of being copied
+# twice from a BuildKit cache mount.
+RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=uv.lock,target=uv.lock \
-    uv sync --locked --no-install-project --no-editable
+    uv sync --locked --no-install-project --no-editable \
+    && uv cache clean
 
 # Copy source and install project
 COPY . /app
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable
+RUN uv sync --locked --no-editable \
+    && uv cache clean
 
 # Download spaCy NER models (spacy download requires pip)
 RUN uv pip install pip --python /app/.venv/bin/python \

--- a/docker/embedder.Dockerfile
+++ b/docker/embedder.Dockerfile
@@ -6,16 +6,18 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Install dependencies first (cached layer)
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=embedder/pyproject.toml,target=pyproject.toml \
+# Install dependencies first (cached layer). Keep uv's cache on the image
+# filesystem so large packages can hardlink into .venv instead of being copied
+# twice from a BuildKit cache mount.
+RUN --mount=type=bind,source=embedder/pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=embedder/uv.lock,target=uv.lock \
-    uv sync --locked --no-install-project --no-editable
+    uv sync --locked --no-install-project --no-editable \
+    && uv cache clean
 
 # Copy source and install project
 COPY embedder/ /app/
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable
+RUN uv sync --locked --no-editable \
+    && uv cache clean
 
 # Pre-download the Granite-R2 weights at build time so the container
 # starts immediately. ~700 MB to image size; acceptable per project policy.

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -171,6 +171,9 @@ describe('SearchPage', () => {
     fireEvent.change(screen.getByLabelText('Exact text'), { target: { value: 'force majeure' } })
     fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'en' } })
     fireEvent.change(screen.getByLabelText('MIME type'), { target: { value: 'application/pdf' } })
+    fireEvent.change(screen.getByLabelText('Summary'), { target: { value: 'missing' } })
+    fireEvent.change(screen.getByLabelText('Pipeline'), { target: { value: 'processing' } })
+    fireEvent.change(screen.getByLabelText('Ingest issue'), { target: { value: 'entity_skipped' } })
     fireEvent.change(screen.getByLabelText('Email from'), { target: { value: 'alice@example.com' } })
     fireEvent.change(screen.getByLabelText('Email subject'), { target: { value: 'invoice' } })
     fireEvent.click(screen.getByText('Advanced identifier filter'))
@@ -183,6 +186,9 @@ describe('SearchPage', () => {
     )
     expect(screen.getByText('Text: force majeure')).toBeInTheDocument()
     expect(screen.getByText('Type: PDF')).toBeInTheDocument()
+    expect(screen.getByText('Summary: Missing summary')).toBeInTheDocument()
+    expect(screen.getByText('Pipeline: Processing')).toBeInTheDocument()
+    expect(screen.getByText('Issue: Entity extraction skipped')).toBeInTheDocument()
     expect(screen.getByText('From: alice@example.com')).toBeInTheDocument()
     expect(screen.getByText('Document UUID: 11111111-1111-1111-1111-111111111111')).toBeInTheDocument()
 
@@ -199,6 +205,9 @@ describe('SearchPage', () => {
         text_contains: 'force majeure',
         language: 'en',
         mime_type: 'application/pdf',
+        summary_state: 'missing',
+        pipeline_status: 'processing',
+        job_issue: 'entity_skipped',
         metadata_filter: {
           'email.from_address': 'alice@example.com',
           'email.subject_contains': 'invoice',

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -31,6 +31,9 @@ interface SearchFilters {
   emailCc: string
   emailSubject: string
   docId: string
+  summaryState: string
+  pipelineStatus: string
+  jobIssue: string
 }
 
 interface SearchHit {
@@ -109,6 +112,9 @@ const EMPTY_FILTERS: SearchFilters = {
   emailCc: '',
   emailSubject: '',
   docId: '',
+  summaryState: '',
+  pipelineStatus: '',
+  jobIssue: '',
 }
 
 const MIME_TYPE_LABELS: Record<string, string> = {
@@ -124,6 +130,30 @@ const MIME_TYPE_LABELS: Record<string, string> = {
   'text/html': 'HTML',
   'text/markdown': 'Markdown',
   'text/plain': 'Plain text',
+}
+
+const SUMMARY_STATE_LABELS: Record<string, string> = {
+  has: 'Has summary',
+  missing: 'Missing summary',
+  pending: 'Summary pending',
+  failed: 'Summary failed',
+}
+
+const PIPELINE_STATUS_LABELS: Record<string, string> = {
+  ready: 'Ready',
+  processing: 'Processing',
+  error: 'Failed',
+}
+
+const JOB_ISSUE_LABELS: Record<string, string> = {
+  any_issue: 'Any ingest issue',
+  failed_job: 'Any failed stage',
+  ocr_failed: 'OCR failed',
+  entity_skipped: 'Entity extraction skipped',
+  summary_failed: 'Summary failed',
+  summary_blocked: 'Summary paused',
+  summary_pending: 'Summary pending',
+  status_cleanup: 'Status cleanup needed',
 }
 
 interface SearchState {
@@ -207,6 +237,10 @@ function normalizedFilters(filters?: Partial<SearchFilters>): SearchFilters {
   return { ...EMPTY_FILTERS, ...filters }
 }
 
+function optionLabel(labels: Record<string, string>, value: string): string {
+  return labels[value] || value
+}
+
 function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
 }
@@ -233,6 +267,9 @@ function buildFilterPayload(filters: SearchFilters) {
     ...(filters.before && { before: filters.before }),
     ...(filters.language && { language: filters.language }),
     ...(filters.mimeType.trim() && { mime_type: filters.mimeType.trim() }),
+    ...(filters.summaryState && { summary_state: filters.summaryState }),
+    ...(filters.pipelineStatus && { pipeline_status: filters.pipelineStatus }),
+    ...(filters.jobIssue && { job_issue: filters.jobIssue }),
     ...(Object.keys(metadataFilter).length > 0 && { metadata_filter: metadataFilter }),
   }
 }
@@ -245,6 +282,15 @@ function activeFilterEntries(filters: SearchFilters): Array<{ key: keyof SearchF
   if (filters.language) entries.push({ key: 'language', label: `Language: ${filters.language}` })
   if (filters.mimeType.trim())
     entries.push({ key: 'mimeType', label: `Type: ${mimeTypeLabel(filters.mimeType.trim())}` })
+  if (filters.summaryState)
+    entries.push({ key: 'summaryState', label: `Summary: ${optionLabel(SUMMARY_STATE_LABELS, filters.summaryState)}` })
+  if (filters.pipelineStatus)
+    entries.push({
+      key: 'pipelineStatus',
+      label: `Pipeline: ${optionLabel(PIPELINE_STATUS_LABELS, filters.pipelineStatus)}`,
+    })
+  if (filters.jobIssue)
+    entries.push({ key: 'jobIssue', label: `Issue: ${optionLabel(JOB_ISSUE_LABELS, filters.jobIssue)}` })
   if (filters.emailFrom.trim()) entries.push({ key: 'emailFrom', label: `From: ${filters.emailFrom.trim()}` })
   if (filters.emailTo.trim()) entries.push({ key: 'emailTo', label: `To: ${filters.emailTo.trim()}` })
   if (filters.emailCc.trim()) entries.push({ key: 'emailCc', label: `Cc: ${filters.emailCc.trim()}` })
@@ -721,6 +767,51 @@ export default function SearchPage() {
                     {mimeTypeOptionLabel(option)}
                   </option>
                 ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Summary</span>
+              <select
+                value={filters.summaryState}
+                onChange={(e) => updateFilter('summaryState', e.target.value)}
+                className="input-base"
+              >
+                <option value="">Any summary state</option>
+                <option value="has">Has summary</option>
+                <option value="missing">Missing summary</option>
+                <option value="pending">Summary pending</option>
+                <option value="failed">Summary failed</option>
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Pipeline</span>
+              <select
+                value={filters.pipelineStatus}
+                onChange={(e) => updateFilter('pipelineStatus', e.target.value)}
+                className="input-base"
+              >
+                <option value="">Any pipeline state</option>
+                <option value="ready">Ready</option>
+                <option value="processing">Processing</option>
+                <option value="error">Failed</option>
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-(--color-text-secondary)">Ingest issue</span>
+              <select
+                value={filters.jobIssue}
+                onChange={(e) => updateFilter('jobIssue', e.target.value)}
+                className="input-base"
+              >
+                <option value="">Any issue state</option>
+                <option value="any_issue">Any ingest issue</option>
+                <option value="failed_job">Any failed stage</option>
+                <option value="ocr_failed">OCR failed</option>
+                <option value="entity_skipped">Entity extraction skipped</option>
+                <option value="summary_failed">Summary failed</option>
+                <option value="summary_blocked">Summary paused</option>
+                <option value="summary_pending">Summary pending</option>
+                <option value="status_cleanup">Status cleanup needed</option>
               </select>
             </label>
             <label className="block">

--- a/src/harbor_clerk/api/routes/search.py
+++ b/src/harbor_clerk/api/routes/search.py
@@ -224,6 +224,11 @@ async def search(
             mime_type=body.mime_type,
             metadata_filter=body.metadata_filter,
             text_contains=body.text_contains,
+            summary_state=body.summary_state,
+            pipeline_status=body.pipeline_status,
+            job_stage=body.job_stage,
+            job_status=body.job_status,
+            job_issue=body.job_issue,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
@@ -364,6 +369,11 @@ async def search_find_all(
             language=body.language,
             mime_type=body.mime_type,
             metadata_filter=body.metadata_filter,
+            summary_state=body.summary_state,
+            pipeline_status=body.pipeline_status,
+            job_stage=body.job_stage,
+            job_status=body.job_status,
+            job_issue=body.job_issue,
             presentation=body.presentation,
         )
     except ValueError as exc:

--- a/src/harbor_clerk/api/schemas/search.py
+++ b/src/harbor_clerk/api/schemas/search.py
@@ -22,6 +22,23 @@ class SearchRequest(BaseModel):
     mime_type: str | None = None
     metadata_filter: dict[str, Any] | None = None
     text_contains: str | None = None
+    summary_state: Literal["has", "missing", "failed", "pending"] | None = None
+    pipeline_status: str | None = None
+    job_stage: Literal["extract", "ocr", "chunk", "entities", "embed", "summarize", "finalize"] | None = None
+    job_status: Literal["queued", "running", "done", "error"] | None = None
+    job_issue: (
+        Literal[
+            "any_issue",
+            "failed_job",
+            "ocr_failed",
+            "entity_skipped",
+            "summary_failed",
+            "summary_blocked",
+            "summary_pending",
+            "status_cleanup",
+        ]
+        | None
+    ) = None
     faceted: bool = False
     scope: ScopeSpec | None = None
 
@@ -84,6 +101,23 @@ class FindAllRequest(BaseModel):
     language: str | None = None
     mime_type: str | None = None
     metadata_filter: dict[str, Any] | None = None
+    summary_state: Literal["has", "missing", "failed", "pending"] | None = None
+    pipeline_status: str | None = None
+    job_stage: Literal["extract", "ocr", "chunk", "entities", "embed", "summarize", "finalize"] | None = None
+    job_status: Literal["queued", "running", "done", "error"] | None = None
+    job_issue: (
+        Literal[
+            "any_issue",
+            "failed_job",
+            "ocr_failed",
+            "entity_skipped",
+            "summary_failed",
+            "summary_blocked",
+            "summary_pending",
+            "status_cleanup",
+        ]
+        | None
+    ) = None
     scope: ScopeSpec | None = None
 
     @model_validator(mode="after")

--- a/src/harbor_clerk/search.py
+++ b/src/harbor_clerk/search.py
@@ -12,7 +12,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from harbor_clerk.config import get_settings
-from harbor_clerk.models import Chunk, Document
+from harbor_clerk.models import Chunk, Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
 from harbor_clerk.search_rerank import rerank_hits
 from harbor_clerk.search_types import ConflictSource, FindAllHit, FindAllResult, SearchHit, SearchResult
 
@@ -35,6 +36,23 @@ logger = logging.getLogger(__name__)
 # Max docs returned when presentation="full" — keeps payload under ~20 KB
 # (top chunk text per doc, ~500 chars).
 _FIND_ALL_FULL_MAX_RESULTS = 30
+
+_PROCESSING_PIPELINE_STATUSES: tuple[PipelineStatus, ...] = (
+    PipelineStatus.queued,
+    PipelineStatus.extracting,
+    PipelineStatus.extracted,
+    PipelineStatus.ocr_running,
+    PipelineStatus.ocr_done,
+    PipelineStatus.chunking,
+    PipelineStatus.chunked,
+    PipelineStatus.extracting_entities,
+    PipelineStatus.entities_done,
+    PipelineStatus.embedding,
+    PipelineStatus.embedded,
+    PipelineStatus.summarizing,
+    PipelineStatus.summarized,
+    PipelineStatus.finalizing,
+)
 
 
 async def _embed_query(query: str) -> list[float]:
@@ -183,6 +201,149 @@ def _normalize_scores(scores: dict[uuid.UUID, float]) -> dict[uuid.UUID, float]:
     return {k: (v - min_score) / spread for k, v in scores.items()}
 
 
+def _parse_pipeline_status_filter(value: str | None) -> list[PipelineStatus]:
+    """Parse UI/REST pipeline status filters.
+
+    Accepts concrete PipelineStatus enum values plus the friendly "processing"
+    group used by the Search Workbench.
+    """
+    if not value:
+        return []
+
+    statuses: list[PipelineStatus] = []
+    seen: set[PipelineStatus] = set()
+    for raw_status in value.split(","):
+        raw_status = raw_status.strip()
+        if not raw_status:
+            continue
+        if raw_status == "processing":
+            candidates = list(_PROCESSING_PIPELINE_STATUSES)
+        else:
+            try:
+                candidates = [PipelineStatus(raw_status)]
+            except ValueError as exc:
+                allowed = ", ".join([s.value for s in PipelineStatus] + ["processing"])
+                raise ValueError(f"Invalid pipeline_status {raw_status!r}. Expected one of: {allowed}") from exc
+        for status in candidates:
+            if status not in seen:
+                seen.add(status)
+                statuses.append(status)
+    return statuses
+
+
+def _current_job_exists(
+    *,
+    stage: JobStage | None = None,
+    statuses: tuple[JobStatus, ...] = (),
+    reason: str | None = None,
+) -> Any:
+    conditions = [
+        IngestionJob.doc_id == Document.doc_id,
+        IngestionJob.pipeline_seq == Document.pipeline_seq,
+    ]
+    if stage is not None:
+        conditions.append(IngestionJob.stage == stage)
+    if statuses:
+        conditions.append(IngestionJob.status.in_(statuses))
+    if reason is not None:
+        conditions.append(IngestionJob.metrics["reason"].astext == reason)
+    return select(IngestionJob.job_id).where(*conditions).exists()
+
+
+def _summary_state_condition(summary_state: str) -> Any:
+    if summary_state == "has":
+        return func.length(func.trim(func.coalesce(Document.summary, ""))) > 0
+    if summary_state == "missing":
+        return func.length(func.trim(func.coalesce(Document.summary, ""))) == 0
+    if summary_state == "failed":
+        return _current_job_exists(stage=JobStage.summarize, statuses=(JobStatus.error,))
+    if summary_state == "pending":
+        return _current_job_exists(stage=JobStage.summarize, statuses=(JobStatus.queued, JobStatus.running))
+    raise ValueError("Invalid summary_state. Expected one of: has, missing, failed, pending")
+
+
+def _status_cleanup_condition() -> Any:
+    return (
+        select(IngestionJob.job_id)
+        .where(
+            IngestionJob.doc_id == Document.doc_id,
+            IngestionJob.pipeline_seq == Document.pipeline_seq,
+            IngestionJob.stage == JobStage.finalize,
+            IngestionJob.status == JobStatus.done,
+            Document.pipeline_status.in_(_PROCESSING_PIPELINE_STATUSES),
+        )
+        .exists()
+    )
+
+
+def _job_issue_condition(job_issue: str) -> Any:
+    failed_job = _current_job_exists(statuses=(JobStatus.error,))
+    ocr_failed = _current_job_exists(stage=JobStage.ocr, statuses=(JobStatus.error,))
+    entity_skipped = _current_job_exists(stage=JobStage.entities, reason="spacy_unavailable")
+    summary_failed = _current_job_exists(stage=JobStage.summarize, statuses=(JobStatus.error,))
+    summary_blocked = _current_job_exists(
+        stage=JobStage.summarize,
+        statuses=(JobStatus.queued, JobStatus.running),
+        reason="apple_intelligence_unavailable",
+    )
+    summary_pending = _current_job_exists(stage=JobStage.summarize, statuses=(JobStatus.queued, JobStatus.running))
+    status_cleanup = _status_cleanup_condition()
+
+    if job_issue == "any_issue":
+        return or_(
+            Document.pipeline_status == PipelineStatus.error,
+            failed_job,
+            entity_skipped,
+            summary_failed,
+            summary_blocked,
+            status_cleanup,
+        )
+    if job_issue == "failed_job":
+        return failed_job
+    if job_issue == "ocr_failed":
+        return ocr_failed
+    if job_issue == "entity_skipped":
+        return entity_skipped
+    if job_issue == "summary_failed":
+        return summary_failed
+    if job_issue == "summary_blocked":
+        return summary_blocked
+    if job_issue == "summary_pending":
+        return summary_pending
+    if job_issue == "status_cleanup":
+        return status_cleanup
+
+    raise ValueError(
+        "Invalid job_issue. Expected one of: any_issue, failed_job, ocr_failed, entity_skipped, "
+        "summary_failed, summary_blocked, summary_pending, status_cleanup"
+    )
+
+
+def _apply_document_state_filters(
+    doc_conditions: list,
+    *,
+    pipeline_status: str | None = None,
+    summary_state: str | None = None,
+    job_stage: str | None = None,
+    job_status: str | None = None,
+    job_issue: str | None = None,
+) -> None:
+    statuses = _parse_pipeline_status_filter(pipeline_status)
+    if statuses:
+        doc_conditions.append(Document.pipeline_status.in_(statuses))
+
+    if summary_state:
+        doc_conditions.append(_summary_state_condition(summary_state))
+
+    if job_stage or job_status:
+        stage = JobStage(job_stage) if job_stage else None
+        statuses_tuple = (JobStatus(job_status),) if job_status else ()
+        doc_conditions.append(_current_job_exists(stage=stage, statuses=statuses_tuple))
+
+    if job_issue:
+        doc_conditions.append(_job_issue_condition(job_issue))
+
+
 async def hybrid_search(
     session: AsyncSession,
     query: str,
@@ -197,6 +358,11 @@ async def hybrid_search(
     mime_type: str | None = None,
     metadata_filter: dict[str, Any] | None = None,
     text_contains: str | None = None,
+    summary_state: str | None = None,
+    pipeline_status: str | None = None,
+    job_stage: str | None = None,
+    job_status: str | None = None,
+    job_issue: str | None = None,
     bypass_reranker: bool = False,
 ) -> SearchResult:
     """Run hybrid FTS + vector search, merge scores, return top K."""
@@ -226,6 +392,14 @@ async def hybrid_search(
         doc_conditions.append(Document.created_at < before)
     if mime_type is not None:
         doc_conditions.append(Document.mime_type == mime_type)
+    _apply_document_state_filters(
+        doc_conditions,
+        pipeline_status=pipeline_status,
+        summary_state=summary_state,
+        job_stage=job_stage,
+        job_status=job_status,
+        job_issue=job_issue,
+    )
     # Metadata filter translation. Each "<namespace>.<key>": value pair
     # becomes either:
     #   - JSONB @> containment: doc_metadata @> '{"ns": {"key": value}}'
@@ -414,6 +588,11 @@ async def find_all(
     language: str | None = None,
     mime_type: str | None = None,
     metadata_filter: dict[str, Any] | None = None,
+    summary_state: str | None = None,
+    pipeline_status: str | None = None,
+    job_stage: str | None = None,
+    job_status: str | None = None,
+    job_issue: str | None = None,
     presentation: str = "brief",
 ) -> FindAllResult:
     """Doc-level enumeration. Aggregates chunks → docs, sorts, paginates.
@@ -461,6 +640,11 @@ async def find_all(
         mime_type=mime_type,
         metadata_filter=metadata_filter,
         text_contains=text_contains,
+        summary_state=summary_state,
+        pipeline_status=pipeline_status,
+        job_stage=job_stage,
+        job_status=job_status,
+        job_issue=job_issue,
         bypass_reranker=True,  # enumeration must see the full candidate pool
     )
 

--- a/tests/api/test_find_all_route.py
+++ b/tests/api/test_find_all_route.py
@@ -89,6 +89,11 @@ async def test_search_find_all_forwards_filters_and_returns_sources(monkeypatch)
             language="en",
             mime_type="application/pdf",
             metadata_filter={"sidecar.vendor": "Pinnacle"},
+            summary_state="has",
+            pipeline_status="ready",
+            job_stage="summarize",
+            job_status="done",
+            job_issue="summary_pending",
         ),
         principal=Principal(type="user", id=uuid4(), role="admin"),
         session=session,
@@ -106,6 +111,11 @@ async def test_search_find_all_forwards_filters_and_returns_sources(monkeypatch)
     assert captured["language"] == "en"
     assert captured["mime_type"] == "application/pdf"
     assert captured["metadata_filter"] == {"sidecar.vendor": "Pinnacle"}
+    assert captured["summary_state"] == "has"
+    assert captured["pipeline_status"] == "ready"
+    assert captured["job_stage"] == "summarize"
+    assert captured["job_status"] == "done"
+    assert captured["job_issue"] == "summary_pending"
     assert captured["source_doc_ids"] == [str(doc_id)]
 
     assert response.total_matches == 1

--- a/tests/api/test_search_filter_parity.py
+++ b/tests/api/test_search_filter_parity.py
@@ -33,6 +33,11 @@ async def test_rest_search_forwards_metadata_filter_and_text_contains(monkeypatc
             "sidecar.vendor": "Pinnacle Tech Solutions",
         },
         text_contains="force majeure",
+        summary_state="missing",
+        pipeline_status="processing",
+        job_stage="entities",
+        job_status="done",
+        job_issue="entity_skipped",
     )
 
     response = await search_route.search(request, principal=principal, session=session)
@@ -45,6 +50,11 @@ async def test_rest_search_forwards_metadata_filter_and_text_contains(monkeypatc
         "sidecar.vendor": "Pinnacle Tech Solutions",
     }
     assert captured["text_contains"] == "force majeure"
+    assert captured["summary_state"] == "missing"
+    assert captured["pipeline_status"] == "processing"
+    assert captured["job_stage"] == "entities"
+    assert captured["job_status"] == "done"
+    assert captured["job_issue"] == "entity_skipped"
 
 
 @pytest.mark.anyio

--- a/tests/test_search_filtered.py
+++ b/tests/test_search_filtered.py
@@ -5,8 +5,8 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from harbor_clerk.models import Chunk, Document
-from harbor_clerk.models.enums import PipelineStatus
+from harbor_clerk.models import Chunk, Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
 from harbor_clerk.search import hybrid_search
 
 # ---------------------------------------------------------------------------
@@ -226,6 +226,101 @@ async def test_hybrid_search_text_contains_filters_chunks(db_session):
         text_contains="off-balance-sheet",
     )
     assert {h.doc_id for h in result.hits} == {str(doc_a.doc_id)}
+
+
+async def test_hybrid_search_pipeline_status_filter_accepts_processing_group(db_session):
+    ready_doc = Document(
+        title="Ready",
+        status="active",
+        sha256=b"sha_ready_0000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+    )
+    processing_doc = Document(
+        title="Processing",
+        status="active",
+        sha256=b"sha_proc_00000000000000000000000",
+        pipeline_status=PipelineStatus.chunking,
+    )
+    db_session.add_all([ready_doc, processing_doc])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            Chunk(doc_id=ready_doc.doc_id, chunk_num=0, chunk_text="The contract was disclosed.", language="en"),
+            Chunk(doc_id=processing_doc.doc_id, chunk_num=0, chunk_text="The contract was disclosed.", language="en"),
+        ]
+    )
+    await db_session.flush()
+
+    result = await hybrid_search(db_session, "disclosed", k=10, pipeline_status="processing")
+
+    assert {h.doc_id for h in result.hits} == {str(processing_doc.doc_id)}
+
+
+async def test_hybrid_search_summary_state_filters_documents(db_session):
+    summarized_doc = Document(
+        title="Summarized",
+        status="active",
+        sha256=b"sha_sum_0000000000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        summary="A useful summary.",
+    )
+    missing_doc = Document(
+        title="Missing",
+        status="active",
+        sha256=b"sha_missing_00000000000000000000",
+        pipeline_status=PipelineStatus.ready,
+        summary="",
+    )
+    db_session.add_all([summarized_doc, missing_doc])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            Chunk(doc_id=summarized_doc.doc_id, chunk_num=0, chunk_text="The contract was disclosed.", language="en"),
+            Chunk(doc_id=missing_doc.doc_id, chunk_num=0, chunk_text="The contract was disclosed.", language="en"),
+        ]
+    )
+    await db_session.flush()
+
+    has_result = await hybrid_search(db_session, "disclosed", k=10, summary_state="has")
+    missing_result = await hybrid_search(db_session, "disclosed", k=10, summary_state="missing")
+
+    assert {h.doc_id for h in has_result.hits} == {str(summarized_doc.doc_id)}
+    assert {h.doc_id for h in missing_result.hits} == {str(missing_doc.doc_id)}
+
+
+async def test_hybrid_search_job_issue_filters_entity_skipped(db_session):
+    skipped_doc = Document(
+        title="Skipped entities",
+        status="active",
+        sha256=b"sha_entity_skip_0000000000000000",
+        pipeline_status=PipelineStatus.ready,
+    )
+    normal_doc = Document(
+        title="Normal",
+        status="active",
+        sha256=b"sha_entity_ok_00000000000000000",
+        pipeline_status=PipelineStatus.ready,
+    )
+    db_session.add_all([skipped_doc, normal_doc])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            Chunk(doc_id=skipped_doc.doc_id, chunk_num=0, chunk_text="The contract was disclosed.", language="en"),
+            Chunk(doc_id=normal_doc.doc_id, chunk_num=0, chunk_text="The contract was disclosed.", language="en"),
+            IngestionJob(
+                doc_id=skipped_doc.doc_id,
+                stage=JobStage.entities,
+                status=JobStatus.done,
+                pipeline_seq=skipped_doc.pipeline_seq,
+                metrics={"skipped": True, "reason": "spacy_unavailable"},
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    result = await hybrid_search(db_session, "disclosed", k=10, job_issue="entity_skipped")
+
+    assert {h.doc_id for h in result.hits} == {str(skipped_doc.doc_id)}
 
 
 async def test_hybrid_search_text_contains_case_insensitive(db_session):


### PR DESCRIPTION
Summary:
- Add Search/Find All request filters for summary state, pipeline state, job stage/status, and common ingest issue states.
- Wire the Search page filter panel to friendly Summary, Pipeline, and Ingest issue dropdowns with active chips.
- Add backend and frontend tests covering route parity, SQL filtering behavior, and Search payload serialization.

Verification:
- uv run pytest tests/api/test_search_filter_parity.py tests/api/test_find_all_route.py tests/test_search_filtered.py tests/test_find_all.py -q
- npm test -- --run src/pages/SearchPage.test.tsx
- uv run ruff check src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py src/harbor_clerk/search.py tests/api/test_search_filter_parity.py tests/api/test_find_all_route.py tests/test_search_filtered.py
- uv run ruff format --check src/harbor_clerk/api/schemas/search.py src/harbor_clerk/api/routes/search.py src/harbor_clerk/search.py tests/api/test_search_filter_parity.py tests/api/test_find_all_route.py tests/test_search_filtered.py
- npm run type-check
- npm run format:check
- npm run lint (passes with existing warnings)

Fresh-eyes review note:
- No code blockers found. Product caveat: these are Search/Find All filters, so they narrow matching retrieval results. Documents remains the better inventory surface for empty-query 'show me all broken things' workflows.