### PR TITLE
polish(search): clarify result source metadata

### DIFF
--- a/frontend/src/components/SourceCitation.test.tsx
+++ b/frontend/src/components/SourceCitation.test.tsx
@@ -37,9 +37,10 @@ describe('SourceCitation', () => {
     )
 
     expect(screen.getByText('Contract, p. 4')).toBeInTheDocument()
-    expect(screen.getByText('Folder Contracts')).toBeInTheDocument()
+    expect(screen.getByText('Folder: Contracts')).toBeInTheDocument()
     expect(screen.getByText('Filename')).toBeInTheDocument()
     expect(screen.getByText('contract.pdf')).toBeInTheDocument()
+    expect(screen.getByLabelText('Filename contract.pdf')).toBeInTheDocument()
     expect(screen.getByTitle('vendors/contract.pdf')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/SourceCitation.tsx
+++ b/frontend/src/components/SourceCitation.tsx
@@ -25,20 +25,23 @@ export function SourceCitation({ source, citation, className = '' }: SourceCitat
     <span className={`inline-flex min-w-0 max-w-full flex-col gap-1 ${className}`}>
       {text && <span className="min-w-0 font-medium text-(--color-text-secondary)">{text}</span>}
       {(fileName || source?.folder_label) && (
-        <span className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-1.5">
+        <span className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-2">
           {fileName && (
             <span
-              className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md border border-(--color-border) bg-(--color-bg-secondary) px-1.5 py-0.5"
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-(--color-border) bg-(--color-bg-secondary) px-2 py-1 shadow-sm"
               title={source?.relative_path || fileName}
+              aria-label={`Filename ${fileName}`}
             >
-              <span className="shrink-0 text-[10px] font-medium text-gray-500 dark:text-gray-400">Filename</span>
-              <span className="min-w-0 max-w-[32rem] truncate font-mono text-[11px] text-(--color-text-secondary)">
+              <span className="shrink-0 rounded-sm bg-(--color-bg-tertiary) px-1 py-0.5 text-[10px] font-semibold uppercase text-(--color-text-secondary)">
+                Filename
+              </span>
+              <span className="min-w-0 max-w-[32rem] truncate font-mono text-[12px] font-medium text-(--color-text-primary)">
                 {fileName}
               </span>
             </span>
           )}
           {source?.folder_label && (
-            <span className="text-[11px] text-gray-500 dark:text-gray-400">Folder {source.folder_label}</span>
+            <span className="text-[11px] text-gray-500 dark:text-gray-400">Folder: {source.folder_label}</span>
           )}
         </span>
       )}

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -153,6 +153,8 @@ describe('SearchPage', () => {
     expect(screen.getByText('contract.pdf')).toBeInTheDocument()
     expect(screen.getByTitle('vendors/contract.pdf')).toBeInTheDocument()
     expect(screen.getByLabelText(/Relevance score 0.870/)).toBeInTheDocument()
+    expect(screen.getByText('Score')).toBeInTheDocument()
+    expect(screen.getByTitle('application/pdf')).toHaveTextContent('PDF')
   })
 
   it('serializes friendly filters into search request fields', async () => {

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -304,11 +304,11 @@ function RelevanceScore({ score, maxScore }: { score: number; maxScore: number }
   const safeMax = maxScore > 0 ? maxScore : 1
   const width = Math.max(0, Math.min(100, Math.round((score / safeMax) * 100)))
   const formatted = score.toFixed(3)
-  const tooltip = `Relevance score ${formatted}. Higher is a stronger match for this query; compare scores within this search, not across different searches.`
+  const tooltip = `Relevance score ${formatted}. Higher means a stronger match for this query. Compare scores within this search, not across different searches.`
 
   return (
     <div className="flex shrink-0 items-center gap-1.5" title={tooltip} aria-label={tooltip}>
-      <span className="text-[11px] font-medium text-gray-500 dark:text-gray-400">Relevance</span>
+      <span className="text-[11px] font-semibold text-gray-500 dark:text-gray-400">Score</span>
       <div className="h-1.5 w-24 rounded-full bg-gray-200 dark:bg-gray-600" aria-hidden="true">
         <div
           className="h-1.5 rounded-full bg-blue-500"
@@ -1026,7 +1026,7 @@ export default function SearchPage() {
                       <SourceCitation source={hit.source} citation={hit.citation} />
                       {hit.page_range && <span>Pages {hit.page_range}</span>}
                       {hit.language && <span>Lang: {hit.language}</span>}
-                      {hit.mime_type && <span>{hit.mime_type}</span>}
+                      {hit.mime_type && <span title={hit.mime_type}>{mimeTypeLabel(hit.mime_type)}</span>}
                     </div>
                   </Card>
                 )


### PR DESCRIPTION
## Summary
- Strengthen the shared source citation filename chip so filenames stand out more clearly in result metadata.
- Label search result match scores as Score while preserving the explanatory relevance tooltip/aria text.
- Render Find All result MIME types with friendly labels while preserving the raw MIME value as the tooltip/title.

## Verification
- npm test -- --run src/pages/SearchPage.test.tsx src/components/SourceCitation.test.tsx
- npm run type-check
- npm run format:check
- npm run lint (passes with existing warnings)
- git diff --check

## Fresh-eyes review
- No blockers found. Scope is presentational and confined to existing Search/source citation surfaces; tests cover the visible filename, score, and MIME label behavior.