### PR TITLE
Polish Documents and Explore discovery UI

### DIFF
--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -112,13 +112,15 @@ describe('DocumentsPage', () => {
 
   it('fetches entities for rows restored as expanded on load', async () => {
     sessionStorage.setItem('docs-page-state', JSON.stringify(SAVED_STATE))
-    getMock.mockImplementation((url) => {
+    const docsCalls: Array<Record<string, string | number> | undefined> = []
+    getMock.mockImplementation((url, params) => {
       if (url === '/api/docs/filters') {
         return Promise.resolve({ mime_types: [], doc_types: [], languages: [], entity_types: [] })
       }
       if (url === '/api/stats/topics') return Promise.resolve({ clusters: [] })
       if (url === '/api/watch/folders') return Promise.resolve([])
       if (url === '/api/docs') {
+        docsCalls.push(params)
         return Promise.resolve({
           items: [
             {
@@ -149,6 +151,14 @@ describe('DocumentsPage', () => {
 
     expect(await screen.findByText('Expanded doc')).toBeInTheDocument()
     expect(await screen.findByText('Acme Corp')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Acme Corp/ })).toHaveAttribute(
+      'href',
+      '/docs?entity=Acme%20Corp&entity_type=ORG',
+    )
+    fireEvent.click(screen.getByRole('link', { name: /Acme Corp/ }))
+    await waitFor(() => {
+      expect(docsCalls).toContainEqual(expect.objectContaining({ entity: 'Acme Corp', entity_type: 'ORG' }))
+    })
     expect(getMock).toHaveBeenCalledWith('/api/docs/doc-1/entities')
   })
 
@@ -197,6 +207,63 @@ describe('DocumentsPage', () => {
           summary_state: 'failed',
         }),
       )
+    })
+  })
+
+  it('shows active filter chips and removes individual filters', async () => {
+    const docsCalls: Array<Record<string, string | number> | undefined> = []
+    getMock.mockImplementation((url, params) => {
+      if (url === '/api/docs/filters') {
+        return Promise.resolve({
+          mime_types: [{ value: 'application/pdf', count: 1 }],
+          doc_types: [],
+          languages: [],
+          entity_types: [],
+        })
+      }
+      if (url === '/api/stats/topics') return Promise.resolve({ clusters: [] })
+      if (url === '/api/watch/folders') return Promise.resolve([])
+      if (url === '/api/docs') {
+        docsCalls.push(params)
+        return Promise.resolve({
+          items: [
+            {
+              doc_id: 'doc-1',
+              title: 'Filtered doc',
+              canonical_filename: 'filtered.pdf',
+              status: 'active',
+              pipeline_status: 'ready',
+              created_at: '2026-06-04T12:00:00Z',
+              updated_at: '2026-06-04T12:30:00Z',
+              summary: 'Short summary',
+              summary_model: 'extractive',
+              doc_type: 'contract',
+            },
+          ],
+          total: 1,
+          limit: 10,
+          offset: 0,
+        })
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`))
+    })
+
+    renderDocumentsPage()
+
+    expect(await screen.findByText('Filtered doc')).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('File type'), { target: { value: 'application/pdf' } })
+
+    const chip = await screen.findByRole('button', { name: /Type: PDF/ })
+    expect(chip).toBeInTheDocument()
+    await waitFor(() => {
+      expect(docsCalls).toContainEqual(expect.objectContaining({ mime_type: 'application/pdf' }))
+    })
+
+    fireEvent.click(chip)
+
+    await waitFor(() => {
+      const latestCall = docsCalls[docsCalls.length - 1]
+      expect(latestCall).not.toEqual(expect.objectContaining({ mime_type: 'application/pdf' }))
     })
   })
 })

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -13,6 +13,16 @@ import { documentTypeIcon } from '../utils/documentTypeIcon'
 import { entityTypeClass } from '../utils/entityTypeColors'
 
 const DOCS_STATE_KEY = 'docs-page-state'
+const DOC_FILTER_URL_KEYS = [
+  'entity',
+  'mime_type',
+  'language',
+  'doc_type',
+  'entity_type',
+  'folder',
+  'pipeline_status',
+  'summary_state',
+] as const
 
 interface SavedDocsState {
   currentPage: number
@@ -81,6 +91,70 @@ const PROCESSING_STATUSES = new Set([
   'summarizing',
   'summarized',
 ])
+
+const MIME_TYPE_LABELS: Record<string, string> = {
+  'application/pdf': 'PDF',
+  'message/rfc822': 'Email',
+  'text/plain': 'Plain text',
+  'text/markdown': 'Markdown',
+  'text/html': 'HTML',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'Word document',
+  'application/msword': 'Word document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'Excel spreadsheet',
+  'application/vnd.ms-excel': 'Excel spreadsheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'PowerPoint',
+  'application/vnd.ms-powerpoint': 'PowerPoint',
+  'application/rtf': 'RTF',
+  'application/epub+zip': 'EPUB',
+  'image/png': 'PNG image',
+  'image/jpeg': 'JPEG image',
+  'image/tiff': 'TIFF image',
+}
+
+const PIPELINE_STATUS_LABELS: Record<string, string> = {
+  ready: 'Ready',
+  error: 'Failed',
+  queued: 'Processing',
+  'queued,extracting,extracted,ocr_running,ocr_done,chunking,chunked,extracting_entities,entities_done,embedding,embedded,summarizing,summarized,finalizing':
+    'Processing',
+}
+
+const SUMMARY_STATE_LABELS: Record<string, string> = {
+  has: 'Has summary',
+  missing: 'Missing summary',
+  failed: 'Summary failed',
+  pending: 'Summary queued/running',
+}
+
+type DocsFilterKey =
+  | 'filter'
+  | 'mime'
+  | 'language'
+  | 'docType'
+  | 'entity'
+  | 'entityType'
+  | 'folder'
+  | 'pipeline'
+  | 'summary'
+
+function mimeTypeLabel(value: string): string {
+  if (MIME_TYPE_LABELS[value]) return MIME_TYPE_LABELS[value]
+  if (value.includes('/')) {
+    const [, subtype] = value.split('/', 2)
+    return subtype
+      .split(/[.+-]/)
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase() + part.slice(1))
+      .join(' ')
+  }
+  return value
+}
+
+function languageLabel(value: string): string {
+  if (!value) return value
+  if (value.length <= 3) return value.toUpperCase()
+  return value
+}
 
 function normalizeStatus(status?: string): string {
   if (!status) return 'unknown'
@@ -168,7 +242,7 @@ export default function DocumentsPage() {
   // (the API returns 403); on macOS the user-facing escape hatch is Reveal in
   // Finder via `window.harborclerk.revealInFinder`, not download.
   const canDownload = sysConfig.allowSourceDownload && sysConfig.loaded
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [pageSize, setPageSize] = useState(user?.preferences?.page_size || 10)
   const [docs, setDocs] = useState<DocSummary[]>([])
   const [total, setTotal] = useState(0)
@@ -211,14 +285,7 @@ export default function DocumentsPage() {
   const entityFetchesRef = useRef<Set<string>>(new Set())
 
   // Restore saved state from sessionStorage (URL params override)
-  const hasUrlParams =
-    searchParams.has('entity') ||
-    searchParams.has('mime_type') ||
-    searchParams.has('language') ||
-    searchParams.has('doc_type') ||
-    searchParams.has('entity_type') ||
-    searchParams.has('pipeline_status') ||
-    searchParams.has('summary_state')
+  const hasUrlParams = DOC_FILTER_URL_KEYS.some((key) => searchParams.has(key))
 
   // Helper: read a field from saved state or URL params
   function initField<K extends keyof SavedDocsState>(
@@ -409,11 +476,19 @@ export default function DocumentsPage() {
     setCurrentPage(1)
   }
 
-  function clearEntityFilter() {
+  function clearUrlFilterParams(keys?: readonly (typeof DOC_FILTER_URL_KEYS)[number][]) {
+    if (!hasUrlParams) return
+    const next = new URLSearchParams(searchParams)
+    for (const key of keys ?? DOC_FILTER_URL_KEYS) next.delete(key)
+    setSearchParams(next, { replace: true })
+  }
+
+  function clearEntityFilter({ clearUrl = true }: { clearUrl?: boolean } = {}) {
     setEntityFilter('')
     setEntityTypeFilter('')
     setEntityInput('')
     setEntitySuggestions([])
+    if (clearUrl) clearUrlFilterParams(['entity', 'entity_type'])
     setCurrentPage(1)
   }
 
@@ -651,6 +726,89 @@ export default function DocumentsPage() {
     pipelineStatusFilter ||
     summaryStateFilter
   )
+  const activeFilters: Array<{ key: DocsFilterKey; label: string }> = []
+  if (filter) activeFilters.push({ key: 'filter', label: `Filename: ${filter}` })
+  if (mimeFilter) activeFilters.push({ key: 'mime', label: `Type: ${mimeTypeLabel(mimeFilter)}` })
+  if (langFilter) activeFilters.push({ key: 'language', label: `Language: ${languageLabel(langFilter)}` })
+  if (docTypeFilter) activeFilters.push({ key: 'docType', label: `Category: ${docTypeFilter}` })
+  if (entityFilter) activeFilters.push({ key: 'entity', label: `Entity: ${entityFilter}` })
+  if (entityTypeFilter) activeFilters.push({ key: 'entityType', label: `Entity type: ${entityTypeFilter}` })
+  if (folderFilter) activeFilters.push({ key: 'folder', label: `Folder: ${folderFilter}` })
+  if (pipelineStatusFilter)
+    activeFilters.push({
+      key: 'pipeline',
+      label: `Status: ${PIPELINE_STATUS_LABELS[pipelineStatusFilter] ?? pipelineStatusFilter}`,
+    })
+  if (summaryStateFilter)
+    activeFilters.push({
+      key: 'summary',
+      label: `Summary: ${SUMMARY_STATE_LABELS[summaryStateFilter] ?? summaryStateFilter}`,
+    })
+
+  function clearDocsFilter(key: DocsFilterKey) {
+    if (key === 'filter') {
+      setFilter('')
+      setFilterInput('')
+    } else if (key === 'mime') {
+      setMimeFilter('')
+      clearUrlFilterParams(['mime_type'])
+    } else if (key === 'language') {
+      setLangFilter('')
+      clearUrlFilterParams(['language'])
+    } else if (key === 'docType') {
+      setDocTypeFilter('')
+      clearUrlFilterParams(['doc_type'])
+    } else if (key === 'entity') {
+      setEntityFilter('')
+      setEntityInput('')
+      setEntitySuggestions([])
+      clearUrlFilterParams(['entity'])
+    } else if (key === 'entityType') {
+      setEntityTypeFilter('')
+      clearUrlFilterParams(['entity_type'])
+    } else if (key === 'folder') {
+      setFolderFilter('')
+      clearUrlFilterParams(['folder'])
+    } else if (key === 'pipeline') {
+      setPipelineStatusFilter('')
+      clearUrlFilterParams(['pipeline_status'])
+    } else if (key === 'summary') {
+      setSummaryStateFilter('')
+      clearUrlFilterParams(['summary_state'])
+    }
+    setCurrentPage(1)
+  }
+
+  function clearAllFilters() {
+    setFilter('')
+    setFilterInput('')
+    setMimeFilter('')
+    setLangFilter('')
+    setDocTypeFilter('')
+    setFolderFilter('')
+    setPipelineStatusFilter('')
+    setSummaryStateFilter('')
+    clearEntityFilter({ clearUrl: false })
+    clearUrlFilterParams()
+    setCurrentPage(1)
+  }
+
+  function applyPivotFilters(next: { entity?: string; entityType?: string; folder?: string }) {
+    setFilter('')
+    setFilterInput('')
+    setMimeFilter('')
+    setLangFilter('')
+    setDocTypeFilter('')
+    setEntityFilter(next.entity ?? '')
+    setEntityInput(next.entity ?? '')
+    setEntityTypeFilter(next.entityType ?? '')
+    setFolderFilter(next.folder ?? '')
+    setPipelineStatusFilter('')
+    setSummaryStateFilter('')
+    setEntitySuggestions([])
+    setShowEntityDropdown(false)
+    setCurrentPage(1)
+  }
 
   let lastDoc: { doc_id: string; title: string } | null = null
   try {
@@ -736,7 +894,7 @@ export default function DocumentsPage() {
             />
             {entityFilter && (
               <button
-                onClick={clearEntityFilter}
+                onClick={() => clearEntityFilter()}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -766,6 +924,7 @@ export default function DocumentsPage() {
           {filterOptions.mime_types.length > 0 && (
             <select
               value={mimeFilter}
+              aria-label="File type"
               onChange={(e) => {
                 setMimeFilter(e.target.value)
                 setCurrentPage(1)
@@ -775,7 +934,7 @@ export default function DocumentsPage() {
               <option value="">All types</option>
               {filterOptions.mime_types.map((m) => (
                 <option key={m.value} value={m.value}>
-                  {m.value.split('/').pop()} ({m.count})
+                  {mimeTypeLabel(m.value)} ({m.count})
                 </option>
               ))}
             </select>
@@ -785,6 +944,7 @@ export default function DocumentsPage() {
           {filterOptions.languages.length > 0 && (
             <select
               value={langFilter}
+              aria-label="Language"
               onChange={(e) => {
                 setLangFilter(e.target.value)
                 setCurrentPage(1)
@@ -794,7 +954,7 @@ export default function DocumentsPage() {
               <option value="">All languages</option>
               {filterOptions.languages.map((l) => (
                 <option key={l.value} value={l.value}>
-                  {l.value.toUpperCase()} ({l.count})
+                  {languageLabel(l.value)} ({l.count})
                 </option>
               ))}
             </select>
@@ -804,6 +964,7 @@ export default function DocumentsPage() {
           {filterOptions.doc_types.length > 0 && (
             <select
               value={docTypeFilter}
+              aria-label="Document category"
               onChange={(e) => {
                 setDocTypeFilter(e.target.value)
                 setCurrentPage(1)
@@ -823,6 +984,7 @@ export default function DocumentsPage() {
           {folderOptions.length > 0 && (
             <select
               value={folderFilter}
+              aria-label="Folder"
               onChange={(e) => {
                 setFolderFilter(e.target.value)
                 setCurrentPage(1)
@@ -843,6 +1005,7 @@ export default function DocumentsPage() {
 
           <select
             value={pipelineStatusFilter}
+            aria-label="Document status"
             onChange={(e) => {
               setPipelineStatusFilter(e.target.value)
               setCurrentPage(1)
@@ -906,25 +1069,35 @@ export default function DocumentsPage() {
             docTypeFilter ||
             entityFilter ||
             entityTypeFilter ||
+            filter ||
             folderFilter ||
             pipelineStatusFilter ||
             summaryStateFilter) && (
-            <button
-              onClick={() => {
-                setMimeFilter('')
-                setLangFilter('')
-                setDocTypeFilter('')
-                setFolderFilter('')
-                setPipelineStatusFilter('')
-                setSummaryStateFilter('')
-                clearEntityFilter()
-                setCurrentPage(1)
-              }}
-              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-            >
+            <button onClick={clearAllFilters} className="text-xs text-blue-600 dark:text-blue-400 hover:underline">
               Clear filters
             </button>
           )}
+        </div>
+      )}
+
+      {activeFilters.length > 0 && (
+        <div className="mb-3 flex flex-wrap items-center gap-1.5" aria-label="Active document filters">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-(--color-text-secondary)">
+            Active filters
+          </span>
+          {activeFilters.map((entry) => (
+            <button
+              key={`${entry.key}-${entry.label}`}
+              onClick={() => clearDocsFilter(entry.key)}
+              className="inline-flex max-w-full items-center gap-1 rounded-full bg-(--area-accent-tint) px-2 py-1 text-[11px] font-medium text-(--area-accent-text) ring-1 ring-(--area-accent) hover:opacity-80"
+              title={`Remove ${entry.label}`}
+            >
+              <span className="truncate">{entry.label}</span>
+              <span aria-hidden="true" className="text-[13px] leading-none opacity-70">
+                ×
+              </span>
+            </button>
+          ))}
         </div>
       )}
 
@@ -1159,69 +1332,104 @@ export default function DocumentsPage() {
                       {isExpanded && (
                         <tr className="bg-gray-50/50 dark:bg-white/2">
                           <td colSpan={6} className="px-4 py-3 pl-14">
-                            <div className="p-3 space-y-3">
-                              {doc.doc_type && (
+                            <div className="grid gap-4 p-3 md:grid-cols-[minmax(0,1fr)_240px]">
+                              <div className="min-w-0 space-y-3">
                                 <div>
-                                  <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide mb-0.5">
-                                    Document Type
-                                  </p>
-                                  <p className="text-sm text-(--color-text-primary)">{doc.doc_type}</p>
-                                </div>
-                              )}
-                              <div>
-                                <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide mb-0.5">
-                                  Summary
-                                  {doc.summary_model && (
-                                    <span className="font-normal normal-case tracking-normal ml-1">
-                                      ({doc.summary_model})
-                                    </span>
-                                  )}
-                                </p>
-                                {doc.summary ? (
-                                  <p className="text-sm text-(--color-text-primary) leading-relaxed">{doc.summary}</p>
-                                ) : (
-                                  <p className="text-sm italic text-(--color-text-secondary)">No summary available</p>
-                                )}
-                              </div>
-                              {docEntities[doc.doc_id] && docEntities[doc.doc_id].length > 0 && (
-                                <div>
-                                  <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide mb-1">
-                                    Entities
-                                  </p>
-                                  <div className="flex flex-wrap gap-1">
-                                    {docEntities[doc.doc_id].slice(0, 15).map((e, i) => (
-                                      <span
-                                        key={i}
-                                        className={`inline-block rounded-md px-2 py-0.5 text-[11px] font-medium ${entityTypeClass(e.entity_type)}`}
-                                      >
-                                        {e.entity_text}
-                                        <span className="ml-1 opacity-60">{e.entity_type}</span>
-                                      </span>
-                                    ))}
-                                    {docEntities[doc.doc_id].length > 15 && (
-                                      <span className="text-[10px] text-gray-400 dark:text-gray-500">
-                                        +{docEntities[doc.doc_id].length - 15} more
+                                  <p className="mb-0.5 text-[11px] font-medium uppercase tracking-wide text-(--color-text-secondary)">
+                                    Summary
+                                    {doc.summary_model && (
+                                      <span className="ml-1 font-normal normal-case tracking-normal">
+                                        ({doc.summary_model})
                                       </span>
                                     )}
+                                  </p>
+                                  {doc.summary ? (
+                                    <p className="text-sm leading-relaxed text-(--color-text-primary)">{doc.summary}</p>
+                                  ) : (
+                                    <p className="text-sm italic text-(--color-text-secondary)">No summary available</p>
+                                  )}
+                                </div>
+                                {docEntities[doc.doc_id] && docEntities[doc.doc_id].length > 0 && (
+                                  <div>
+                                    <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-(--color-text-secondary)">
+                                      Entities
+                                    </p>
+                                    <div className="flex flex-wrap gap-1">
+                                      {docEntities[doc.doc_id].slice(0, 15).map((e, i) => (
+                                        <Link
+                                          key={`${e.entity_type}-${e.entity_text}-${i}`}
+                                          to={`/docs?entity=${encodeURIComponent(e.entity_text)}&entity_type=${encodeURIComponent(e.entity_type)}`}
+                                          onClick={() =>
+                                            applyPivotFilters({ entity: e.entity_text, entityType: e.entity_type })
+                                          }
+                                          className={`inline-block rounded-md px-2 py-0.5 text-[11px] font-medium hover:opacity-80 ${entityTypeClass(e.entity_type)}`}
+                                          title={`Show documents mentioning ${e.entity_text}`}
+                                        >
+                                          {e.entity_text}
+                                          <span className="ml-1 opacity-60">{e.entity_type}</span>
+                                        </Link>
+                                      ))}
+                                      {docEntities[doc.doc_id].length > 15 && (
+                                        <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                                          +{docEntities[doc.doc_id].length - 15} more
+                                        </span>
+                                      )}
+                                    </div>
                                   </div>
-                                </div>
-                              )}
-                              {doc.topic_id != null && topicNames[doc.topic_id] && (
-                                <div>
-                                  <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide mb-0.5">
-                                    Topic
+                                )}
+                              </div>
+                              <div className="space-y-3 rounded-lg border border-(--color-border) bg-(--color-bg-primary) p-3">
+                                <div className="flex items-center justify-between gap-3">
+                                  <p className="text-[11px] font-medium uppercase tracking-wide text-(--color-text-secondary)">
+                                    Document
                                   </p>
-                                  <p className="text-sm text-(--color-text-primary)">{topicNames[doc.topic_id]}</p>
+                                  <Link
+                                    to={`/docs/${doc.doc_id}`}
+                                    className="text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+                                  >
+                                    Open
+                                  </Link>
                                 </div>
-                              )}
-                              {doc.source_path && (
-                                <div>
-                                  <p className="text-[11px] font-medium text-(--color-text-secondary) uppercase tracking-wide mb-0.5">
-                                    Source
-                                  </p>
-                                  <p className="text-xs text-(--color-text-primary) font-mono">{doc.source_path}</p>
-                                </div>
-                              )}
+                                <dl className="space-y-2 text-xs">
+                                  {doc.doc_type && (
+                                    <div>
+                                      <dt className="text-(--color-text-secondary)">Category</dt>
+                                      <dd className="text-(--color-text-primary)">{doc.doc_type}</dd>
+                                    </div>
+                                  )}
+                                  {doc.folder_name && (
+                                    <div>
+                                      <dt className="text-(--color-text-secondary)">Folder</dt>
+                                      <dd>
+                                        <Link
+                                          to={`/docs?folder=${encodeURIComponent(doc.folder_name)}`}
+                                          onClick={() => applyPivotFilters({ folder: doc.folder_name })}
+                                          className="text-blue-600 hover:underline dark:text-blue-400"
+                                        >
+                                          {doc.folder_name}
+                                        </Link>
+                                      </dd>
+                                    </div>
+                                  )}
+                                  {doc.topic_id != null && topicNames[doc.topic_id] && (
+                                    <div>
+                                      <dt className="text-(--color-text-secondary)">Topic</dt>
+                                      <dd className="text-(--color-text-primary)">{topicNames[doc.topic_id]}</dd>
+                                    </div>
+                                  )}
+                                  {doc.source_path && (
+                                    <div>
+                                      <dt className="text-(--color-text-secondary)">Source path</dt>
+                                      <dd
+                                        className="truncate font-mono text-[11px] text-(--color-text-primary)"
+                                        title={doc.source_path}
+                                      >
+                                        {doc.source_path}
+                                      </dd>
+                                    </div>
+                                  )}
+                                </dl>
+                              </div>
                             </div>
                           </td>
                         </tr>

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -58,6 +58,25 @@ const ENTITY_SECTIONS = [
 const TICK_STYLE = { fontSize: 10, fill: 'var(--color-chart-tick)' }
 const SUB_PANE_KEY = 'explore-sub-pane'
 
+const MIME_TYPE_LABELS: Record<string, string> = {
+  'application/pdf': 'PDF',
+  'message/rfc822': 'Email',
+  'text/plain': 'Plain text',
+  'text/markdown': 'Markdown',
+  'text/html': 'HTML',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'Word document',
+  'application/msword': 'Word document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'Excel spreadsheet',
+  'application/vnd.ms-excel': 'Excel spreadsheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'PowerPoint',
+  'application/vnd.ms-powerpoint': 'PowerPoint',
+  'application/rtf': 'RTF',
+  'application/epub+zip': 'EPUB',
+  'image/png': 'PNG image',
+  'image/jpeg': 'JPEG image',
+  'image/tiff': 'TIFF image',
+}
+
 const PROCESSING_STATUSES = new Set([
   'queued',
   'extracting',
@@ -74,6 +93,19 @@ const PROCESSING_STATUSES = new Set([
   'summarizing',
   'summarized',
 ])
+
+function mimeTypeLabel(value: string): string {
+  if (MIME_TYPE_LABELS[value]) return MIME_TYPE_LABELS[value]
+  if (value.includes('/')) {
+    const [, subtype] = value.split('/', 2)
+    return subtype
+      .split(/[.+-]/)
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase() + part.slice(1))
+      .join(' ')
+  }
+  return value
+}
 
 function StatusBadge({ status }: { status: string }) {
   const display = !status ? 'unknown' : PROCESSING_STATUSES.has(status) ? 'processing' : status
@@ -744,7 +776,7 @@ function ExploreDocList({
             <option value="">All types</option>
             {filterOptions.mime_types.map((m) => (
               <option key={m.value} value={m.value}>
-                {m.value.split('/').pop()} ({m.count})
+                {mimeTypeLabel(m.value)} ({m.count})
               </option>
             ))}
           </select>
@@ -797,18 +829,66 @@ function ExploreDocList({
         </div>
 
         {hasActiveFilters && (
-          <button
-            onClick={() => {
-              setFilterInput('')
-              setFilter('')
-              setMimeFilter('')
-              setTopicFilter('')
-              setCurrentPage(1)
-            }}
-            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-          >
-            Clear filters
-          </button>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {filter && (
+              <button
+                onClick={() => {
+                  setFilterInput('')
+                  setFilter('')
+                  setCurrentPage(1)
+                }}
+                className="inline-flex items-center gap-1 rounded-full bg-(--area-accent-tint) px-2 py-1 text-[11px] font-medium text-(--area-accent-text) ring-1 ring-(--area-accent) hover:opacity-80"
+                title="Remove filename filter"
+              >
+                Filename: {filter}
+                <span aria-hidden="true" className="text-[13px] leading-none opacity-70">
+                  ×
+                </span>
+              </button>
+            )}
+            {mimeFilter && (
+              <button
+                onClick={() => {
+                  setMimeFilter('')
+                  setCurrentPage(1)
+                }}
+                className="inline-flex items-center gap-1 rounded-full bg-(--area-accent-tint) px-2 py-1 text-[11px] font-medium text-(--area-accent-text) ring-1 ring-(--area-accent) hover:opacity-80"
+                title="Remove file type filter"
+              >
+                Type: {mimeTypeLabel(mimeFilter)}
+                <span aria-hidden="true" className="text-[13px] leading-none opacity-70">
+                  ×
+                </span>
+              </button>
+            )}
+            {topicFilter && (
+              <button
+                onClick={() => {
+                  setTopicFilter('')
+                  setCurrentPage(1)
+                }}
+                className="inline-flex items-center gap-1 rounded-full bg-(--area-accent-tint) px-2 py-1 text-[11px] font-medium text-(--area-accent-text) ring-1 ring-(--area-accent) hover:opacity-80"
+                title="Remove topic filter"
+              >
+                Topic: {clusters.find((c) => String(c.cluster_id) === topicFilter)?.name ?? topicFilter}
+                <span aria-hidden="true" className="text-[13px] leading-none opacity-70">
+                  ×
+                </span>
+              </button>
+            )}
+            <button
+              onClick={() => {
+                setFilterInput('')
+                setFilter('')
+                setMimeFilter('')
+                setTopicFilter('')
+                setCurrentPage(1)
+              }}
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Clear filters
+            </button>
+          </div>
         )}
       </div>
 
@@ -881,40 +961,76 @@ function ExploreDocList({
                           </div>
                         </td>
                         <td className="px-4 py-3">
-                          <StatusBadge status={doc.status} />
+                          <div className="flex items-center gap-2">
+                            <StatusBadge status={doc.status} />
+                            {doc.summary_model && (
+                              <span className="hidden rounded-md bg-(--color-bg-secondary) px-1.5 py-0.5 text-[10px] text-(--color-text-secondary) xl:inline">
+                                {doc.summary_model}
+                              </span>
+                            )}
+                          </div>
                         </td>
-                        <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
-                          {new Date(doc.updated_at).toLocaleDateString()}
+                        <td className="px-4 py-3">
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm text-gray-500 dark:text-gray-400">
+                              {new Date(doc.updated_at).toLocaleDateString()}
+                            </span>
+                            <Link
+                              to={`/docs/${doc.doc_id}`}
+                              className="rounded-md bg-(--color-bg-secondary) px-2 py-1 text-[11px] font-medium text-(--color-text-primary) hover:bg-gray-200 dark:hover:bg-gray-700"
+                            >
+                              Open
+                            </Link>
+                          </div>
                         </td>
                       </tr>
                       {isExpanded && (
                         <tr className="bg-gray-50/50 dark:bg-white/2">
-                          <td colSpan={4} className="px-4 py-3 pl-14">
-                            <div className="space-y-1 text-sm">
-                              {doc.doc_type && (
-                                <div>
-                                  <span className="font-medium text-gray-500 dark:text-gray-400">Type: </span>
-                                  <span className="text-gray-700 dark:text-gray-300">{doc.doc_type}</span>
-                                </div>
-                              )}
-                              <div>
-                                <span className="font-medium text-gray-500 dark:text-gray-400">
+                          <td colSpan={3} className="px-4 py-3 pl-14">
+                            <div className="grid gap-3 text-sm md:grid-cols-[minmax(0,1fr)_180px]">
+                              <div className="min-w-0">
+                                <p className="mb-0.5 text-[11px] font-medium uppercase tracking-wide text-(--color-text-secondary)">
                                   Summary
                                   {doc.summary_model ? (
-                                    <span className="font-normal text-gray-400 dark:text-gray-500">
-                                      {' '}
+                                    <span className="ml-1 font-normal normal-case tracking-normal">
                                       ({doc.summary_model})
                                     </span>
-                                  ) : (
-                                    ''
-                                  )}
-                                  :{' '}
-                                </span>
+                                  ) : null}
+                                </p>
                                 {doc.summary ? (
-                                  <span className="text-gray-700 dark:text-gray-300">{doc.summary}</span>
+                                  <p className="leading-relaxed text-gray-700 dark:text-gray-300">{doc.summary}</p>
                                 ) : (
-                                  <span className="italic text-gray-400 dark:text-gray-500">No summary</span>
+                                  <p className="italic text-gray-400 dark:text-gray-500">No summary</p>
                                 )}
+                              </div>
+                              <div className="rounded-lg border border-(--color-border) bg-(--color-bg-primary) p-3 text-xs">
+                                <div className="mb-2 flex items-center justify-between gap-3">
+                                  <span className="font-medium uppercase tracking-wide text-(--color-text-secondary)">
+                                    Document
+                                  </span>
+                                  <Link
+                                    to={`/docs/${doc.doc_id}`}
+                                    className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                                  >
+                                    Open
+                                  </Link>
+                                </div>
+                                <dl className="space-y-2">
+                                  {doc.doc_type && (
+                                    <div>
+                                      <dt className="text-(--color-text-secondary)">Category</dt>
+                                      <dd className="text-(--color-text-primary)">{doc.doc_type}</dd>
+                                    </div>
+                                  )}
+                                  {doc.canonical_filename && (
+                                    <div>
+                                      <dt className="text-(--color-text-secondary)">Filename</dt>
+                                      <dd className="truncate font-mono text-[11px] text-(--color-text-primary)">
+                                        {doc.canonical_filename}
+                                      </dd>
+                                    </div>
+                                  )}
+                                </dl>
                               </div>
                             </div>
                           </td>


### PR DESCRIPTION
## Summary
- add friendlier Documents filter labels, active filter chips, and URL cleanup for filter/pivot links
- reshape expanded Documents rows around summary/entity preview plus document actions
- add active filter chips, clearer MIME labels, Open affordances, and richer expanded rows to Explore document sub-panes

## Fresh-eyes review
- Checked same-page Documents entity/folder pivots so they update mounted filter state instead of relying on a remount.
- Kept API payloads unchanged: filters still send the existing params; URL cleanup only removes known Documents filter params.
- No data model or backend behavior changes.

## Verification
- npm test -- --run src/pages/DocumentsPage.test.tsx
- npm test -- --run
- npm run type-check
- npm run lint (passes with existing warning baseline)
- npm run format:check
- npm run build
- git diff --check