### PR TITLE
docs: add technical design specs, split strategy docs to a private repo (+ brace-expansion security fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ redis_data/
 # per-model reports, raw SSE captures, and analysis writeups. Stays on
 # the developer's machine — nothing here ships in the repo.
 research-debugging/
+
+# Private strategy docs. Positioning, competitive analysis, claim posture,
+# and candid project assessment live in a separate PRIVATE repo checked out
+# here (github.com/r0shi/harborclerk-strategy). Technical design specs and
+# implementation plans stay public under docs/superpowers/.
+/docs/strategy/

--- a/docs/superpowers/specs/2026-05-27-cli-vs-tool-call-small-model-experiment-design.md
+++ b/docs/superpowers/specs/2026-05-27-cli-vs-tool-call-small-model-experiment-design.md
@@ -1,0 +1,76 @@
+# CLI vs JSON tool-call surface for small local models — experiment spec
+
+**Status:** Deferred. Run after the next full research-harness baseline (the one that captures all the recent MCP fixes — PR-E/G/H/J/find_all). Picking up earlier would muddle the comparison.
+
+## Motivation
+
+The research harness currently exposes tools to LLMs as OpenAI-style function-calling JSON (`src/harbor_clerk/llm/tools.py:_BASE_CHAT_TOOLS`, ~2,000 tokens, 15 tools). Now that the CLI (`harbor-clerk <command>`, one command per MCP tool, full `--help` pages under `src/harbor_clerk/cli/help/`) exists, the question is whether small local models (Qwen3 4B, Phi-4 Mini, SmolLM3 3B) would perform better invoking tools as shell commands than as JSON.
+
+## Hypothesis
+
+Distribution shift, not context savings, is the real lever. Small models have seen vastly more `command --flag value | jq ...` patterns in pretraining than function-calling JSON dialogues. Prior work (CodeAct, Wang et al.) showed measurable gains from shell/code-shaped tool invocation on small models. The HC CLI is a near-ideal substrate because every command already returns JSON, so the response channel is unchanged — only invocation moves.
+
+**Null hypothesis to beat:** modern instruct models (Qwen3, Phi-4, SmolLM3) already received explicit function-calling post-training, so the distribution gap may have closed. The experiment is to find out.
+
+## Token accounting (already done)
+
+| Surface | Tokens (approx) |
+|---|---|
+| Full MCP docstrings (Claude/Opus path) | ~5,400 |
+| `_BASE_CHAT_TOOLS` (small-model path today) | ~2,000 |
+| All 19 CLI help files combined | ~15,000 |
+| Single CLI help file (e.g. `search.txt`) | ~740 |
+| `harbor-clerk --help` top-level only | <200 (estimate) |
+
+Dumping all help upfront is a loss. Progressive disclosure (`--help` top-level + drill-in on demand) lands around 1.5–2k for a typical run — same magnitude as today. **The context-savings argument is weak; do not rely on it.** The experiment is purely about capability.
+
+## Experiment design
+
+**Pick one weak model.** Qwen3 4B is the lead candidate — already in `llm/models.py`, reasonable inference cost, has shown room to grow in prior eval runs.
+
+**Build a minimal CLI-faker tool layer.** Same backend functions as current tool dispatch; different surface:
+
+- Model emits a string like `search "termination clause" -k 5` instead of a JSON tool call.
+- Executor pattern-matches `<command> [args]`, validates against an allowlist (`search`, `read-passages`, `expand-context`, `get-document`, `list-recent`), calls the same Python function, returns the same JSON the tool call would have returned.
+- One bootstrap message in the system prompt: the `harbor-clerk --help` top-level listing.
+- Model can issue `harbor-clerk <command> --help` to fetch a single help page; that page enters context, no LRU eviction.
+
+**Match the existing eval rig.** Reuse `scripts/test_corpora/runner/` with the same corpora, questions, judges, and groundtruth used in the post-fix baseline run. Two configurations:
+
+- **Control:** Qwen3 4B + current `_BASE_CHAT_TOOLS` JSON tool calls.
+- **Treatment:** Qwen3 4B + CLI-faker shell-command surface.
+
+Same model weights, same temperature, same retrieval backend. Only invocation surface changes.
+
+**Metrics:**
+
+1. Eval pass rate (judged answer correctness — primary).
+2. Tool-call success rate (well-formed invocations / total attempts).
+3. Tokens consumed per question (input + output).
+4. Number of tool calls per question.
+5. Distribution of tool usage (which commands the model reaches for).
+
+## Success criteria
+
+- **≥10% absolute improvement** in eval pass rate over control → distribution-shift hypothesis confirmed, productize.
+- **5–10% improvement** → ambiguous; re-run on a second model (Phi-4 Mini) before deciding.
+- **<5% / wash / worse** → null hypothesis stands. Park the CLI surface as a CLI-only thing for human-driven agent harnesses (OpenClaw, Claude Code), not a research-harness route.
+
+## Out of scope
+
+- Productionizing the CLI surface inside the chat path. Experiment first; ship later only if results justify it.
+- Cloud models (Claude, GPT). Their JSON tool-call training is mature; the distribution-shift argument doesn't apply.
+- Free-form text output parsing. HC CLI already returns JSON; this experiment does not need to test scraping.
+- Sandbox/security hardening of a real shell executor. The faker is regex-based command dispatch, not actual shell exec.
+
+## Prerequisite
+
+Wait for the next full research-harness baseline run (capturing PR-E/G/H/J/find_all/etc.). Comparing CLI vs JSON before that baseline lands would conflate two independent improvements. The post-baseline state is the new control.
+
+## Reference: where this idea was vetted
+
+Brainstorm conversation 2026-05-27. Three pieces of background that shaped the spec:
+
+1. The full MCP spec is NOT the small-model baseline today — `_BASE_CHAT_TOOLS` already trimmed it. Any future framing of "save tokens" needs to compare against `_BASE_CHAT_TOOLS`, not against full MCP.
+2. CodeAct-style results from 2024 are the closest prior art. Cite when writing this up.
+3. The CLI's JSON-returning help pages are what makes this substrate cheap to test. If the CLI returned free-form text, this experiment would not be worth running.

--- a/docs/superpowers/specs/2026-06-03-local-model-ux-design.md
+++ b/docs/superpowers/specs/2026-06-03-local-model-ux-design.md
@@ -1,0 +1,219 @@
+# Local Model UX and Private AI Framing - Design Spec
+
+**Date:** 2026-06-03
+**Status:** Accepted for planning
+**Scope:** Model selection, onboarding, model labels, warnings, eval disclosure, and the in-app wording for local AI. This spec does not change model-serving internals.
+
+## Overview
+
+The recent eval and implementation work changes the product read: curated local models are not just a demo. They can produce useful cited answers on some document tasks, especially after weaker models were removed and prompts/tools were tightened. The UI should therefore present local AI as a real product capability, while staying honest about task and model limits.
+
+The phrase "assistant" should be avoided. It is too broad and too generic. For now, use "private AI," "local AI," "cited answers," or "research" depending on the surface. "Private AI" is not perfect, but it is acceptable placeholder copy.
+
+## Goals
+
+- Ask the user to choose/download a model during startup/onboarding, not silently auto-select one.
+- Warn on weaker/smaller models instead of hard-blocking them.
+- Present curated models with qualitative labels that map to real user expectations.
+- Surface model identity in Ask and Research without turning normal use into a benchmark dashboard.
+- Keep eval scores out of primary UI unless they are qualitative and stable.
+- Explain local/cloud boundaries clearly.
+- Leave room for a future cloud-model in-app mode that keeps Harbor Clerk citations first-class.
+- Define a clear go/no-go bar for whether cloud-model in-app mode belongs in the initial release.
+- Make display-only verifier/validator output a candidate default-on citation-support signal, without presenting it as a calibrated correctness score.
+
+## Non-goals
+
+- No new model benchmark publication system in this scope.
+- No automatic model download before user consent.
+- No hard quality gate that prevents users from choosing a smaller curated model.
+- No "frontier quality on your Mac" claim.
+- No cloud-provider integration implementation in this spec.
+
+## Startup and onboarding
+
+At initial launch, Harbor Clerk generally does not have models downloaded. Model setup should be explicit:
+
+- During setup, after folder selection or during the first AI action, ask the user to choose a local AI model.
+- Explain storage size, expected speed tier, and recommended use in plain language.
+- Allow "skip for now" if the user only wants search/browse.
+- If no model is configured and the user opens Ask/Research, show a focused setup prompt.
+
+Do not auto-download a model on first launch. The download is large enough and operationally meaningful enough that user consent matters.
+
+## Model labels
+
+Recommended initial labels:
+
+- Qwen3.6 35B-A3B: Best local research.
+- Gemma 26B-A4B: Balanced local research.
+- GPT-OSS 20B: Strong tables and comparisons.
+- Qwen3 8B: Lightweight lookup.
+- Qwen3 4B: Smallest usable model.
+
+The exact model IDs can be visible in technical detail, but the main label should describe the job the model is good at. This is especially important for less technical users who do not know what a model family or parameter count implies.
+
+## Warnings
+
+Warn, do not block:
+
+- Smaller models may miss details in long or messy corpora.
+- Some models are better for quick lookup than multi-step research.
+- Important answers should be verified from citations.
+- Research mode may be slower or less complete on smaller models.
+
+Warnings should appear:
+
+- In model selection cards.
+- In Ask/Research model tooltips or model selector detail.
+- In docs, with a calmer and more complete explanation.
+
+Avoid modal warnings that make normal use feel broken.
+
+## Ask and Research surfaces
+
+Ask and Research should show the active model in a compact way:
+
+- Model name in the header or composer area.
+- Tooltip or popover with label, local/cloud status, and warning tier.
+- Clear action to change model, probably linking to Settings -> Models.
+
+The answer UI should keep citations visually primary. Model identity is helpful context, but citations are the trust mechanism.
+
+## Qualitative tiers
+
+Use qualitative tiers until benchmark publishing is automated enough to avoid stale public numbers:
+
+- Best local research.
+- Balanced.
+- Lightweight.
+- Experimental or not recommended for Research, if any future model warrants it.
+
+If numeric evals appear in docs, they should live in eval docs, not the main product UI.
+
+## Boundary disclosure
+
+Every model surface should distinguish:
+
+- Local AI: prompts and retrieved snippets stay on the machine.
+- MCP/cloud model access: cloud model receives only the tool responses/snippets allowed by the API key and tool contract.
+- Future in-app cloud mode: provider receives the selected prompt and retrieved context needed to answer.
+
+Err on too much disclosure. This is a trust feature, not copy clutter.
+
+## Future cloud-model in-app mode
+
+A sophisticated-operator feature is worth designing separately: let users connect cloud LLMs directly to local Ask and Research while preserving Harbor Clerk's first-class citations.
+
+Potential value:
+
+- Frontier/cloud reasoning and synthesis quality.
+- Harbor Clerk retrieval, source policy, and citations remain the grounding layer.
+- Users can compare local and cloud answers over the same corpus.
+- Useful for teams that already have API keys and understand cloud data boundaries.
+
+Constraints:
+
+- Requires provider API keys.
+- May require valid HTTPS/TLS setup depending on transport.
+- Needs extremely clear disclosure of what leaves the machine.
+- Must use the same `SourceRef` contract so citations survive synthesis.
+- Should have a per-run/model visible boundary indicator.
+
+Recommendation: design this as a fast-follow after SourceRef and Search/Find All parity. It should not block the initial release unless the release is deliberately targeted at sophisticated operators only.
+
+### Cloud in-app go/no-go
+
+Cloud in-app models can be included in the initial public release only if the core path is boringly stable. Otherwise, keep cloud use to MCP/connector/operator docs and ship in-app cloud mode as a fast-follow.
+
+Go criteria:
+
+- `SourceRef` is implemented for the Ask/Research path, and cloud answers preserve clickable/inspectable citations without relying on brittle string parsing.
+- The model selector clearly distinguishes local AI from cloud AI before the user sends a prompt.
+- Provider API keys have an acceptable storage story for public release. On macOS, prefer Keychain or an equivalently explicit secure-storage path; do not bury keys in surprising plaintext locations.
+- The UI has a per-run boundary disclosure: what prompt/context leaves the machine, which provider receives it, and whether source snippets or tool results are sent.
+- Absolute paths are not sent to cloud-visible prompts/results unless a future explicit path-disclosure scope opts into it.
+- Logs, errors, traces, and analytics do not accidentally persist provider keys or full prompt/context bodies.
+- Network failures, invalid keys, rate limits, cancellation, and provider errors fail gracefully without losing the local answer/search workflow.
+- At least one provider path has mocked tests plus a live smoke-test checklist that covers no-key, invalid-key, successful answer, citation rendering, long context, email/attachment citation, cancellation, and offline behavior.
+- Cloud mode remains optional. Search, Documents, local AI, MCP, and CLI should not depend on it.
+
+No-go / defer criteria:
+
+- Citation chips require post-hoc parsing of the cloud model's prose.
+- Data-boundary copy is ambiguous enough that "private AI" could be read as applying to cloud runs.
+- Provider-key storage is not settled.
+- Path disclosure policy is not enforced by tests.
+- Cloud failures create confusing or broken states in Ask/Research.
+- The release story starts depending on cloud mode to make local model quality look better.
+
+"Stable" means the boring failure cases have been exercised, not merely that a happy-path API call works once.
+
+## Citation-support indicator
+
+The verifier/validator should not be marketed as a correctness score. It is not calibrated, and the 2026-06-01 A/B showed that using verifier feedback to revise reports was net-negative overall. However, display-only verifier verdicts may be valuable as a transparency feature if framed correctly.
+
+Recommended label: **Citation support** or **Grounding check**, not "confidence."
+
+Target default:
+
+- Enable the display-only verifier by default for Research once the validation bar below is met.
+- Keep the revision/rewrite pass disabled by default.
+- Run the check as a trust signal for the user, not as an automatic answer modifier.
+- If latency is noticeable, prefer showing the answer/report first with a "checking citations..." state and updating the badge when the check completes.
+- Start with Research reports, where the verifier already has a report + citation structure. Extend to Ask after `SourceRef` gives the chat path equally reliable citation spans.
+
+Possible stoplight:
+
+- Green: cited claims checked; no partial or unsupported citations found.
+- Yellow: some citations are partial, thin, skipped, or could not be checked.
+- Red: at least one cited claim appears unsupported by the cited source.
+- Gray: not checked, verifier unavailable, no citations, or check failed.
+
+Rules:
+
+- The indicator says whether citations appear to support cited claims. It does not say the whole answer is true.
+- Show a compact global badge plus expandable per-citation verdicts and reasons.
+- Keep revision disabled by default. The display signal and the rewrite loop are separate features.
+- Fail open: if the verifier fails, keep the answer and show "not checked" rather than damaging a valid answer.
+- Do not show percentages. A stoplight or short qualitative status is enough.
+- Prefer deterministic checks first where possible: citation resolves, chunk exists, page/source exists, and source text is inspectable. Use the LLM verifier for support judgment, not basic provenance.
+
+Go criteria for shipping the indicator:
+
+- Human spot-checks or eval traces show the verdicts are directionally useful and not mostly noise.
+- False red/yellow rates are low enough that the UI does not train users to ignore the badge.
+- The UI copy makes the boundary clear: "citation support," not "answer correctness."
+- The added latency is visible and acceptable, or the check runs after the answer/report is produced.
+- Local and cloud model modes both produce compatible verifier inputs through `SourceRef`.
+- Settings allow an advanced user to disable the citation-support check if the added latency or compute cost is undesirable.
+
+If this bar is not met, do not make the check default-on. Keep verifier verdicts as an experimental diagnostics/eval feature until the signal is stable enough to help users rather than distract them.
+
+## Release-blocking requirements
+
+- Initial setup has a clear model selection/download path.
+- Users can skip AI setup and still use Search/Documents/Folders.
+- Ask/Research clearly show which model is active.
+- Weaker curated models show warnings, not blocks.
+- Public copy says local AI is useful but variable.
+- "Assistant" language is reduced or removed from primary surfaces.
+- Cloud in-app models are excluded unless the go/no-go criteria above are satisfied.
+- Display-only verifier/validator output is targeted to be enabled by default as a citation-support signal once the validation bar is met.
+- Verifier revision is not enabled by default; any verifier-derived UI is framed as citation support, not correctness confidence.
+
+## Tests
+
+- Frontend tests or manual coverage for no-model, model-selected, and model-download-in-progress states.
+- Manual startup flow verification on a fresh install.
+- Manual Ask/Research verification that model identity appears and does not crowd citations.
+- Docs/copy review for local/cloud boundary clarity.
+- Cloud in-app go/no-go checklist if cloud mode is considered for release.
+- Verifier indicator validation if citation-support UI is considered for release.
+
+## Open questions
+
+- Whether "private AI" should become the stable label. Recommendation: acceptable for now, revisit after the larger copy pass.
+- Whether to show model family names in the main label. Recommendation: yes, but pair them with plain-language use labels.
+- Whether cloud in-app mode should be part of the first public release. Decision: no unless the explicit go/no-go criteria above are satisfied.
+- Whether verifier output can become a default-on public-facing trust signal. Recommendation: yes for display-only citation support after validation; no for revision or numerical correctness/confidence scoring.

--- a/docs/superpowers/specs/2026-06-03-status-ingest-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-03-status-ingest-recovery-design.md
@@ -1,0 +1,246 @@
+# Status, Ingest, and Recovery UX - Design Spec
+
+**Date:** 2026-06-03
+**Status:** Accepted for planning
+**Scope:** User-facing operational health, failed ingest visibility, plain recovery actions, diagnostics, and minimal backup guidance. This spec is not the full backup/restore design.
+
+## Overview
+
+Harbor Clerk is a local system with several moving parts: watched folders, database, Tika, workers, embeddings, reranker, local model server, and the Mac menu app. Users should not need to think in those terms during normal operation. The release UI should expose a Status area that answers:
+
+- Is the system ready?
+- Is anything stuck or failed?
+- What can I do about it?
+- Where do I go for deeper diagnostics?
+
+"Health" and raw service controls are useful to developers and advanced operators, but they should not be the main recovery interface.
+
+## Goals
+
+- Rename or reframe the normal operational surface as Status.
+- Add an advanced Diagnostics section for logs, raw service health, and low-level details.
+- Show failed/needs-attention documents in both Documents and Status.
+- Provide plain recovery actions instead of raw process controls.
+- Remove stale or misleading "show logs in console" controls.
+- Include simple backup guidance in docs for initial release.
+- Add an always-visible global status signal that links into the fuller Status surface.
+- Note future self-help/docs RAG as a possible recovery aid.
+
+## Non-goals
+
+- No full backup/restore product flow in this scope.
+- No time-machine style versioning.
+- No remote monitoring or alerting.
+- No exposing every subprocess control in the main UI.
+- No large ingest pipeline redesign.
+
+## Status page model
+
+Status should be organized around user questions:
+
+### Ready
+
+Examples:
+
+- Search index ready.
+- Folders watching.
+- Local AI ready or not configured.
+- No failed documents.
+
+### Needs attention
+
+Examples:
+
+- Documents failed ingest.
+- Folder access lost.
+- Local AI server stopped.
+- Search services unavailable.
+- Summaries pending or failed, if user-visible.
+
+### Recent activity
+
+Examples:
+
+- Recently indexed documents.
+- Currently processing documents.
+- Retry history.
+
+### Advanced diagnostics
+
+Examples:
+
+- Raw service status.
+- Logs.
+- Worker queues.
+- Configuration detail.
+
+Advanced diagnostics can be in the Status page behind an advanced section or in a separate Settings -> Diagnostics route. The user-facing label should still be Status.
+
+## Global status signal
+
+Recommendation: add a global status pill in the app chrome, with a fuller Status page/tray as drill-down.
+
+The pill should be compact and boring:
+
+- Ready
+- Processing
+- Needs attention
+- Local AI unavailable
+- Folder access issue
+
+Clicking the pill should open Status, or a small tray that links to Status. The pill is better than a full always-open tray for release because it keeps the primary app surfaces calm while still making system state visible.
+
+Use the existing queue tray where it helps, but keep the concepts distinct:
+
+- Queue tray: current/recent processing activity.
+- Status pill/page: readiness, failures, recovery actions, and operational needs.
+
+If the pill becomes too dense, the next step is a small tray or popover. The default should not be a large persistent panel.
+
+## Recovery actions
+
+Use task-level actions:
+
+- Restart search services.
+- Retry failed documents.
+- Restart local AI.
+- Repair folder access.
+- Rescan folder.
+- Recompute summaries, if summary failure is user-visible.
+
+Avoid primary buttons like:
+
+- Restart container.
+- Restart postgres.
+- Kill worker.
+- Show logs in console.
+
+Raw actions may remain under Diagnostics if truly needed.
+
+## Failed ingest visibility
+
+Failed documents should appear in two places:
+
+### Documents
+
+- Filter or chip for failed documents.
+- Row state that makes failure visible without opening detail.
+- Retry action when available.
+
+### Status
+
+- Needs-attention queue summarizing failed documents.
+- Bulk retry action.
+- Link to filtered Documents view.
+
+This dual placement matters because Documents is where users inspect the corpus, while Status is where they resolve operational problems.
+
+## Known escalation note: entity extraction outages
+
+2026-06-04 dev-system observation: a macOS bundle could have spaCy installed but be missing the packaged spaCy NER model packages. The expected safe behavior when NER is unavailable is that the `entities` stage is skipped with `spacy_unavailable` and existing entity rows are left alone. Existing entity rows should disappear only when a document is intentionally reprocessed or chunks are rebuilt, or if `run_entities()` executes and replaces prior rows with an empty extraction result.
+
+Do not chase this further on a noisy dev system unless it recurs. Escalate if any of these happen in a cleaner environment:
+
+- Corpus or document entity counts drop after a bundle/model outage without an explicit reprocess.
+- Documents that previously had entity rows show zero entities and their latest `entities` job is only a skipped `spacy_unavailable`.
+- Documents reach ready state after model availability is restored but still have no entity rows and no visible recovery path.
+
+First read-only checks:
+
+- Inspect `ingestion_jobs` for `stage='entities'`, `metrics.reason='spacy_unavailable'`, timestamps, and retry/reprocess history.
+- Compare whether `chunks` were deleted or recreated for affected docs.
+- Compare entity row counts by document before and after the suspected outage if a backup or previous snapshot exists.
+
+Potential product follow-ups:
+
+- Show "entity extraction skipped" as a recoverable status distinct from a hard ingest failure.
+- Add an entity-stage-only retry that does not rebuild chunks or embeddings.
+- Include NER model availability in the global Status/Diagnostics surface.
+
+## Folder access recovery
+
+For macOS watched folders, Status should be able to tell the user when a folder is missing, moved, or permission-denied. Recovery should use normal user language:
+
+- "Repair folder access"
+- "Choose folder again"
+- "Reveal folder"
+- "Remove folder"
+
+The UI should not make the user infer folder state from low-level watcher errors.
+
+## Local AI recovery
+
+If Ask/Research cannot reach the local model server:
+
+- Status shows local AI as needing attention.
+- Ask/Research show a local inline banner with a link to Status or Models.
+- Recovery action says "Restart local AI."
+- If no model is configured, action says "Choose a model" instead of restart.
+
+## Logs and diagnostics
+
+Logs should be available, but not as primary UX.
+
+Decision:
+
+- Remove "show logs in console" if no logs actually go there or if that path is deprecated.
+- Keep log access under Diagnostics.
+- Prefer in-app log viewing/export if implemented later.
+- Make clear that Diagnostics is for advanced troubleshooting.
+
+## Backup guidance for initial release
+
+Full backup/restore is a separate spec. For initial release docs, include simple guidance:
+
+- Quit Harbor Clerk.
+- Copy `~/Library/Application Support/Harbor Clerk/` to backup storage.
+- Keep watched-folder source files backed up separately, because Harbor Clerk reads them in place.
+- Restore should be documented cautiously and tested before being presented as a polished workflow.
+
+This is basic, but better than no guidance.
+
+## Future: self-help documentation RAG
+
+The Status/recovery UX will likely require comprehensive docs. A future feature could let Harbor Clerk answer questions about itself by indexing its own documentation and using a local model to provide guided troubleshooting.
+
+Potential value:
+
+- Users can ask "why is local AI unavailable?" or "how do I back this up?" in natural language.
+- Answers can cite Harbor Clerk docs, keeping the same product pattern of inspectable sources.
+- This could reduce support burden without pretending every user should understand the internals.
+
+Constraints:
+
+- Keep this out of the initial repair loop unless it is very stable.
+- It must not replace clear buttons for common recovery actions.
+- It should cite docs and distinguish product guidance from live system diagnosis.
+- It should avoid sending local config, logs, or sensitive paths into model prompts unless explicitly scoped.
+
+Recommendation: document this as a future self-help layer after the core Status page, diagnostics, and backup docs exist.
+
+## Release-blocking requirements
+
+- Status exists as the normal user-facing health/recovery label.
+- A global status pill or equivalent signal makes needs-attention state visible outside Settings.
+- Failed documents are discoverable from Documents and Status.
+- Plain recovery actions exist for the most common failure modes.
+- "Show logs in console" is removed if stale.
+- Backup docs include the simple Application Support folder guidance.
+
+## Tests
+
+- Backend/API tests for failed-ingest summaries if a new endpoint is added.
+- Frontend tests for Status needs-attention rendering where practical.
+- Manual failure scenarios:
+  - Stop local AI.
+  - Add a file that fails ingest.
+  - Remove or deny access to a watched folder.
+  - Restart search services.
+- Manual verification that logs/diagnostics are still reachable for advanced operators.
+
+## Open questions
+
+- Whether Status should be top-level or under Settings. Decision: Status lives inside Settings and also appears as a global status pill or equivalent chrome signal.
+- Whether the queue tray and Status page should share components. Recommendation: yes where possible, but do not let component reuse dictate the user story.
+- Whether backup guidance should appear in-app or docs only. Recommendation: docs only for the initial release.
+- Whether Harbor Clerk should answer questions about its own documentation. Recommendation: promising fast-follow/future self-help layer, not a release blocker.

--- a/docs/superpowers/specs/2026-06-03-ui-chrome-information-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-03-ui-chrome-information-architecture-design.md
@@ -1,0 +1,176 @@
+# UI Chrome and Information Architecture Refresh - Design Spec
+
+**Date:** 2026-06-03
+**Status:** Accepted for planning
+**Scope:** Navigation, first-run routing, admin/settings consolidation, and the UX audit needed before promoting Search and Find All. This spec does not redesign every page.
+
+## Overview
+
+Harbor Clerk's current UI has accumulated several top-level surfaces: Ask, Research, Search, Documents, Folders, Observatory, Models, Integrations, API Keys, Health/System pages, and operational controls. For release, the top-level chrome should communicate the product's core workflow:
+
+1. Add folders.
+2. Search and browse the corpus.
+3. Ask or research with citations.
+4. Connect models, agents, and admin controls when needed.
+
+The default landing page should become Search once the corpus exists. During onboarding or empty state, the app should drop the user into Folders because no other mode can be useful until a corpus exists.
+
+## Goals
+
+- Make Search the default working surface for a populated corpus.
+- Send empty/onboarding users to Folders.
+- Keep Documents, Ask, Research, Folders, and Observatory visible at top level for the initial release.
+- Move Models, Integrations, API Keys, Health, Preferences, and low-level system controls into a unified Settings/Admin area.
+- Pair Search promotion with a UI audit of the document list, document detail, result rows, citations, and chunk-context behavior.
+- Keep Observatory visible because the visualizations are appealing and help the product feel tangible, even if they are not core productivity tooling.
+
+## Non-goals
+
+- Do not remove Ask or Research from top-level navigation for the initial release.
+- Do not hide Observatory outright.
+- Do not ship a full Collections/Projects system as part of the IA pass.
+- Do not redesign every settings page in detail before the release-critical routing and grouping work lands.
+- Do not turn the app into a landing page. The first screen should be a working surface.
+
+## Proposed top-level navigation
+
+Top-level:
+
+- Search
+- Documents
+- Ask
+- Research
+- Folders
+- Explore, pending the audit below
+- Observatory
+- Settings
+
+Settings children:
+
+- Models
+- Integrations
+- API Keys
+- Status
+- Diagnostics
+- Preferences
+- Security / Users, if present for the deployment
+
+The exact labels can shift, but the important move is that model/admin/health pages stop competing with corpus work in the primary nav.
+
+## Routing behavior
+
+### First launch or empty corpus
+
+If no active watched folder exists, or no indexed documents exist after setup, route the user to Folders. The empty state should make the next action obvious: add or choose a folder, then watch ingest progress.
+
+### Populated corpus
+
+Default route should be Search. Search is the strongest neutral starting point because it works for technical and less technical users, does not require model selection, and teaches the citation/result model before the user asks an LLM to synthesize.
+
+### Existing deep links
+
+Existing routes should keep working. Redirect only the app's default route and nav grouping. Do not break links to `/models`, `/integrations`, or `/admin/api-keys` during the transition; either keep aliases or redirect into Settings.
+
+## Search promotion and related UX audit
+
+Promoting Search means its current rough edges become first-impression issues. The audit should cover:
+
+- Search result row density, scannability, and citation clarity.
+- Chunk-first behavior: the user sees the matching chunk first, with a clear way to open the full document at that context.
+- Document-deduped behavior in Find All mode, where appropriate.
+- The document list expansion/turndown content compared with the document detail page.
+- Existing Explorer UI patterns and whether any should be reused in Search Workbench.
+- Whether metadata, summary state, email headers, folder labels, and ingestion status appear in the right place.
+- How failed or partial ingestion appears in Documents, Search, and Status.
+- Mobile/narrow-window behavior for filter rows and result rows.
+
+The deliverable for this audit should be a short annotated plan before broad UI editing starts.
+
+## Explorer placement
+
+The existing Explorer tab is not just legacy navigation. It currently provides corpus discovery through people, places, organizations, topic clusters, timeline, related topics, entity-topic cross references, and filtered document sub-panes. That overlaps with Search and Documents, but it is a different mode:
+
+- Search is targeted retrieval: "find the best matching passages" or "find all matches for this condition."
+- Documents is corpus inventory and document inspection.
+- Explorer is browse/discovery: "show me what is in this archive and let me pivot through facets."
+
+Recommendation for the release IA:
+
+- Do not fold Explorer wholesale into Search before the Search Workbench exists.
+- Audit Explorer's UI elements and reuse the good ones where they fit: facet chips, topic/entity pivots, related-topic chips, filtered document sub-panes, compact result tables, and timeline-as-filter ideas.
+- Keep Explorer as a candidate top-level page for release if nav space allows after admin pages move under Settings.
+- If nav becomes too crowded, move Explorer under Observatory or Documents before deleting it. It is closer to corpus discovery than to system administration.
+- Revisit consolidation after Search Workbench ships. At that point, decide whether Explorer remains a separate discovery surface, becomes a Search side-panel/discovery mode, or merges with Observatory.
+
+This keeps the useful and fun parts of Explorer alive without overloading the default Search screen.
+
+## Documents page decision points
+
+The Documents page remains top-level, but it needs a tighter job:
+
+- Browse the corpus by document.
+- Inspect ingest state, summaries, metadata, and source details.
+- Open the document detail view.
+- Filter for failed, missing, or stale documents.
+
+The current list turndown and detail page should be compared. Information should not be duplicated just because both surfaces happen to exist. The rough rule:
+
+- List row and turndown: status, identity, summary preview, folder, date, top metadata, and quick actions.
+- Detail page: full metadata, chunks/passages, citations, source path policy, related entities, email header detail, and operational actions.
+
+## Ask and Research placement
+
+Ask and Research stay top-level for now:
+
+- Ask is useful for quick cited lookup and follow-up questions.
+- Research is useful for structured, longer-running corpus exploration.
+- They should not be the default landing surface because they depend on corpus health, model health, and user understanding of citations.
+
+Future possibility: Ask and Research could become sub-modes under a broader "AI" or "Work" area, but that should wait until the release has real usage feedback.
+
+## Observatory placement
+
+Observatory remains visible. The name is acceptable for now. "Playground" is a possible alternative if future visualization work becomes more exploratory, but the current name has charm and does not block release.
+
+Possible future additions should be evaluated separately:
+
+- More interactive corpus map views.
+- Topic clustering drill-down.
+- Entity network exploration.
+- Ingest performance visualizations.
+- Search/retrieval quality visualizations.
+
+This spec does not start that work.
+
+## Settings and Status distinction
+
+Settings should be the umbrella. Status should be the user-facing operational health area inside it.
+
+- Status: "what needs attention and what can I do?"
+- Diagnostics: logs, raw service health, advanced traces, and developer/operator detail.
+- Preferences: app behavior and local options.
+- Models: model download/selection/health.
+- Integrations: MCP, CLI, OpenClaw, Codex, Claude Code, ChatGPT/Claude connector guidance.
+- API Keys: key creation, scoping, audit links, and tool access disclosure.
+
+## Release-blocking requirements
+
+- Default route chooses Folders for empty/onboarding and Search for populated corpus.
+- Top-level nav no longer exposes every admin/system page as a peer of Search/Documents.
+- Existing routes remain reachable.
+- Search page is visibly ready to be the default working surface.
+- Status replaces low-level Health as the normal user-facing operational label.
+- "Show logs in console" is removed if it is stale or misleading.
+
+## Testing
+
+- Frontend route tests for empty vs populated default route, if current test infrastructure supports it.
+- Manual browser verification on initial setup, empty corpus, and populated corpus.
+- Manual narrow-window verification for the nav and Search filters.
+- Regression check that deep links to old admin pages still reach the right destination.
+
+## Open questions
+
+- Whether Settings should be a page with left-side subnav or a top-level route with cards. Recommendation: left-side subnav once inside Settings, because this is an operational app and predictable navigation matters.
+- Whether API Keys belongs under Settings or Integrations. Recommendation: Settings primary, with Integrations linking into it when setup docs require key creation.
+- Whether Observatory should be renamed before release. Recommendation: no.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2367,9 +2367,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Commits four technical design specs that had been sitting untracked, and establishes a public/private boundary for planning material.

## The boundary

Drawn by **content**, not folder:

- **Public** (`docs/superpowers/`) — implementation plans, technical design specs, architecture, eval methodology and results, todos, known limitations, future work. This material documents the system and is worth reading.
- **Private** (`docs/strategy/`, now gitignored) — positioning and marketing strategy, competitive analysis, claim posture/claim ladders, and candid project assessment. These live in a separate private repo checked out at that path, so the files stay available in the working tree during development without ever reaching a public remote.

## Specs added

- `2026-05-27-cli-vs-tool-call-small-model-experiment-design.md`
- `2026-06-03-local-model-ux-design.md`
- `2026-06-03-status-ingest-recovery-design.md`
- `2026-06-03-ui-chrome-information-architecture-design.md`

## Scope

Docs-only plus one `.gitignore` entry. **No existing docs were removed, and nothing previously committed changes visibility.** `docs/evaluation.md` and `docs/agent-memory-eval.md` remain intentionally public — they're linked from the README as honest-limitations documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
