### PR TITLE
fix(docker): add worker-llm so summarize actually runs on Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ docker compose logs -f app        # tail app logs
 docker compose logs -f watcher    # see what the watcher is picking up
 ```
 
-**Services:** `gateway` (Caddy), `app` (FastAPI + React SPA), `watcher` (folder watching + ingest queueing), `worker-io`, `worker-cpu`, `embedder` (multilingual-e5-small), `reranker` (cross-encoder re-ranking), `llama-server` (local LLM inference), `postgres` (pgvector + pg_trgm), `minio`, `tika`.
+**Services:** `gateway` (Caddy), `app` (FastAPI + React SPA), `watcher` (folder watching + ingest queueing), `worker-io`, `worker-cpu`, `worker-llm` (summarize), `embedder` (Granite-R2 multilingual, 768-dim), `reranker` (cross-encoder re-ranking), `llama-server` (local LLM inference), `postgres` (pgvector + pg_trgm), `minio`, `tika`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,12 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
+      # Required. settings.llama_server_url defaults to localhost:8102, which is
+      # the macOS-native subprocess port — inside this container that resolves to
+      # nothing, and summarize would silently degrade to extractive summaries
+      # after burning its retry budget. worker-io/worker-cpu don't need this
+      # because no stage on those queues calls the LLM.
+      LLAMA_SERVER_URL: http://llama-server:8080
       HARBOR_CLERK_MASTER_KEY: ${HARBOR_CLERK_MASTER_KEY:?master key required; see docs/secrets-and-keys.md}
       RERANKER_URL: http://reranker:8001
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,27 @@ services:
     networks:
       - harbor-clerk
 
+  # Summarize is routed to its own `llm` queue (see QUEUE_STAGES in
+  # worker/entry.py). Without this service nothing claims those jobs and
+  # documents silently never receive a summary. No hard dependency on
+  # llama-server: summarize degrades to an extractive summary when no LLM is
+  # reachable, matching how `app` treats llama-server as optional.
+  worker-llm:
+    build:
+      context: .
+      dockerfile: docker/app.Dockerfile
+    command: ["harbor-clerk-worker", "--queues", "llm"]
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      HARBOR_CLERK_MASTER_KEY: ${HARBOR_CLERK_MASTER_KEY:?master key required; see docs/secrets-and-keys.md}
+      RERANKER_URL: http://reranker:8001
+    depends_on:
+      app:
+        condition: service_healthy
+    networks:
+      - harbor-clerk
+
   watcher:
     build:
       context: .

--- a/tests/test_docker_compose_queues.py
+++ b/tests/test_docker_compose_queues.py
@@ -68,3 +68,24 @@ def test_compose_workers_only_reference_known_queues() -> None:
         f"docker-compose.yml subscribes to queue(s) {sorted(unknown)} that do not exist in "
         f"QUEUE_STAGES ({sorted(QUEUE_STAGES)}). Those workers would start and idle forever."
     )
+
+
+def test_llm_queue_worker_can_reach_llama_server() -> None:
+    """The llm-queue worker must be pointed at llama-server explicitly.
+
+    `settings.llama_server_url` defaults to localhost:8102 — the macOS-native
+    subprocess port. Inside a container that resolves to nothing, so summarize
+    would burn its retry budget and then silently fall back to an extractive
+    summary. Queue coverage alone does not prove the worker can reach what its
+    stages need.
+    """
+    offenders = [
+        name
+        for name, service in _load_services().items()
+        if "llm" in _queues_for_service(service) and "LLAMA_SERVER_URL" not in (service.get("environment") or {})
+    ]
+    assert not offenders, (
+        f"Service(s) {offenders} handle the 'llm' queue but do not set LLAMA_SERVER_URL. "
+        "They would fall back to the localhost:8102 default and silently produce "
+        "extractive summaries instead of LLM summaries."
+    )

--- a/tests/test_docker_compose_queues.py
+++ b/tests/test_docker_compose_queues.py
@@ -1,0 +1,70 @@
+"""Every worker queue defined in code must have a subscriber in docker-compose.
+
+Regression test for the bug where `summarize` was moved onto its own `llm`
+queue but `docker-compose.yml` only started workers for `io` and `cpu`. Nothing
+claimed the `llm` queue, so on Docker Compose deployments summarize jobs were
+enqueued and silently never ran — documents ingested fine but never received a
+summary. macOS was unaffected because ServiceManager spawns an llm worker pool.
+
+The failure mode is invisible at runtime (no error, no crash — jobs just sit),
+so it needs a static check.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from harbor_clerk.worker.entry import QUEUE_STAGES
+
+COMPOSE_PATH = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+WORKER_ENTRYPOINT = "harbor-clerk-worker"
+
+
+def _load_services() -> dict:
+    return yaml.safe_load(COMPOSE_PATH.read_text())["services"]
+
+
+def _queues_for_service(service: dict) -> set[str]:
+    """Resolve which queues a compose service subscribes to.
+
+    Mirrors the arg parsing in worker/entry.py: `--queues` uses nargs="+", so it
+    consumes every following token until the next flag. When absent, the worker
+    falls back to the RQ_QUEUES env var (comma-separated), defaulting to "io".
+    """
+    command = service.get("command") or []
+    if not isinstance(command, list) or WORKER_ENTRYPOINT not in " ".join(map(str, command)):
+        return set()
+
+    if "--queues" in command:
+        queues: set[str] = set()
+        for token in command[command.index("--queues") + 1 :]:
+            if str(token).startswith("-"):
+                break
+            queues.add(str(token).strip())
+        return queues
+
+    env = service.get("environment") or {}
+    raw = env.get("RQ_QUEUES", "io") if isinstance(env, dict) else "io"
+    return {q.strip() for q in str(raw).split(",") if q.strip()}
+
+
+def _subscribed_queues() -> set[str]:
+    return set().union(*(_queues_for_service(s) for s in _load_services().values()), set())
+
+
+def test_every_code_queue_has_a_compose_worker() -> None:
+    missing = set(QUEUE_STAGES) - _subscribed_queues()
+    orphaned_stages = [stage.value for q in sorted(missing) for stage in QUEUE_STAGES[q]]
+    assert not missing, (
+        f"docker-compose.yml has no worker subscribing to queue(s) {sorted(missing)}. "
+        f"Jobs for these stages would be enqueued and never claimed: {orphaned_stages}. "
+        "Add a worker service with --queues <name>."
+    )
+
+
+def test_compose_workers_only_reference_known_queues() -> None:
+    unknown = _subscribed_queues() - set(QUEUE_STAGES)
+    assert not unknown, (
+        f"docker-compose.yml subscribes to queue(s) {sorted(unknown)} that do not exist in "
+        f"QUEUE_STAGES ({sorted(QUEUE_STAGES)}). Those workers would start and idle forever."
+    )


### PR DESCRIPTION
Fixes #537.

## The bug

`summarize` is routed exclusively to the `llm` queue (`pipeline.py:69`, `QUEUE_STAGES` in `worker/entry.py`), but `docker-compose.yml` only started workers for `io` and `cpu`. Nothing claimed the `llm` queue, so **on every Docker Compose deployment, summarize jobs were enqueued and silently never ran** — documents ingested fine but never received a summary. No error surfaced; the jobs just sat.

macOS was unaffected, because `ServiceManager` spawns an llm worker pool. That asymmetry is why this went unnoticed.

`docs/watched-folders-docker.md:62` already referred to a `worker-llm` container as though it existed — the documented topology was correct and the compose file was the thing that lagged.

## The fix

Adds `worker-llm`, mirroring `worker-io`/`worker-cpu` with `--queues llm`.

It deliberately does **not** hard-depend on `llama-server`: summarize degrades to an extractive summary when no LLM is reachable, and `app` already treats `llama-server` as optional. A hard dependency would block worker startup for no benefit.

## Regression test

`tests/test_docker_compose_queues.py` asserts every queue in `QUEUE_STAGES` has a compose subscriber, plus the inverse (no compose worker references a queue that doesn't exist). The queue-resolution logic mirrors `entry.py`'s arg parsing — `--queues` uses `nargs="+"`, with an `RQ_QUEUES` env fallback.

Verified it actually catches the bug: with `worker-llm` removed it fails with

```
docker-compose.yml has no worker subscribing to queue(s) ['llm'].
Jobs for these stages would be enqueued and never claimed: ['summarize'].
Add a worker service with --queues <name>.
```

This failure mode is invisible at runtime, so a static check is the only thing that would have caught it.

## Also

README's service list gains `worker-llm`, and its embedder description is corrected from `multilingual-e5-small` to Granite-R2 768-dim — that changed in the embedding-v2 migration and the README was never updated.

## Existing deployments

Anyone who ran Docker Compose before this fix has documents with no summary. `POST /api/system/resummarize-all` (admin) is the backfill path. Worth mentioning in release notes.

## How this was found

Auditing `docs/architecture.md` for staleness. Its Docker diagram faithfully mirrors the compose file, so the diagram was "accurate" about a broken topology — a good argument for generating enumerations from code rather than hand-maintaining them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
