### PR TITLE
docs: flag architecture.md as stale, correct embedder docstring

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,22 @@
 # Harbor Clerk Architecture
 
+> [!WARNING]
+> **This document is known to be stale.** An audit on 2026-07-21 (against content
+> last updated 2026-05-27) found several sections describe an architecture that no
+> longer exists. **Treat the code as authoritative.**
+>
+> Known-wrong: the embedding model and dimension (now Granite-R2 / 768, not
+> e5-small / 384), the worker queue topology (three queues, and `summarize` does
+> not gate `finalize`), OCR's extraction path (pypdfium2 + Tesseract, never Tika),
+> the macOS service list and ports, and the auth model's role semantics. The data
+> model omits roughly half the schema, including the entire email/IMAP subsystem.
+>
+> Verified still accurate: **Retrieval Flow** and **Client Surfaces**.
+>
+> Tracked in [#539](https://github.com/r0shi/harborclerk/issues/539), which has the
+> full findings and the plan to generate the enumerations from source so this
+> cannot drift again.
+
 ## System Overview
 
 ```mermaid

--- a/embedder/src/embedder/app.py
+++ b/embedder/src/embedder/app.py
@@ -1,6 +1,9 @@
 """Embedding model server.
 
-Loads multilingual-e5-small (384-dim) and exposes POST /embed.
+Loads the model named by EMBED_MODEL — Granite-R2 multilingual (768-dim) by
+default — and exposes POST /embed. See MODEL_NAME/NEEDS_PREFIX below; the e5
+family is a supported fallback and needs "query: "/"passage: " prefixes that
+Granite-R2 does not.
 """
 
 import logging


### PR DESCRIPTION
Interim measure while the real fix (#539) is built.

## Staleness banner

The audit found `docs/architecture.md` is not trustworthy as a current reference. Rather than leave it silently wrong or delete it wholesale, this adds a banner that names **specifically** what is wrong and what is still correct, so a reader can calibrate:

- Known-wrong: embedding model/dimension, queue topology, OCR path, macOS services and ports, auth role semantics, and ~half the data model (including the entire email/IMAP subsystem).
- Verified accurate: Retrieval Flow and Client Surfaces.

Full findings and the generation plan are in #539.

## Embedder docstring

`embedder/src/embedder/app.py` disagreed with itself three lines apart — the module docstring said multilingual-e5-small (384-dim) while line 17 has defaulted to Granite-R2 (768-dim) since the embedding-v2 migration. Corrected to describe the actual default and note the e5 fallback prefix behaviour.

Docs and one docstring only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)