### PR TITLE
feat(docs): generate the MCP tool table from source, gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
         run: uv run ruff check .
       - name: Ruff format check
         run: uv run ruff format --check .
+      # Generated doc blocks must match a fresh render from source. Runs before
+      # the DB-backed tests so drift fails fast with a clear message; the test
+      # suite also covers this (tests/test_gen_docs.py) as defence in depth.
+      - name: Generated docs up to date
+        run: uv run python -m scripts.gen_docs --check
       - name: Create PG extensions
         run: |
           PGPASSWORD="" psql -h localhost -U lka -d lka_test -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS citext;"

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ surface, including `kb_find_all` via `harbor-clerk find-all`.
 | `kb_entity_overview` | Survey entities in the corpus (or scoped to a single doc). |
 | `kb_entity_search` | Find documents that mention a specific named entity (person, organization, place). |
 | `kb_expand_context` | Read N chunks immediately before/after a given chunk_id. |
-| `kb_find_all` | Enumerate documents matching a query — deduped by document, with |
+| `kb_find_all` | Enumerate documents matching a query — deduped by document, with optional literal-substring filtering. |
 | `kb_find_related` | Find documents related to a given doc_id by semantic overlap. |
 | `kb_get_document` | Get a document's metadata + summary by doc_id. |
 | `kb_ingest_status` | Inspect a document's ingestion pipeline status (operator-facing). |

--- a/README.md
+++ b/README.md
@@ -401,29 +401,37 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 
 ### MCP
 
-`POST /mcp` — Streamable HTTP transport. Authenticate with `Authorization: Bearer <api_key>`. 19 tools available; the CLI mirrors the same practical tool surface, including `kb_find_all` via `harbor-clerk find-all`.
+`POST /mcp` — Streamable HTTP transport. The CLI mirrors the same practical tool
+surface, including `kb_find_all` via `harbor-clerk find-all`.
+
+<!-- BEGIN GENERATED: mcp-tools -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**19 tools.** Authenticate with `Authorization: Bearer <api_key>`.
 
 | Tool | Description |
 |---|---|
-| `kb_search` | Hybrid search with pagination, detail modes, and optional filters |
-| `kb_batch_search` | Run up to 5 search queries in a single call |
-| `kb_find_all` | Unified enumeration: list, filter, and paginate matching documents |
-| `kb_read_passages` | Read specific passages by chunk ID |
-| `kb_expand_context` | Get surrounding chunks for a given chunk |
-| `kb_get_document` | Document metadata and summary |
-| `kb_read_document` | Read full document text or a page range |
-| `kb_list_recent` | Recently added documents with summaries |
-| `kb_documents_by_date` | List documents inside a date range, ordered chronologically |
-| `kb_verify_identifier` | Resolve a free-text identifier (title, filename, UUID) to a `doc_id` before issuing other tool calls |
-| `kb_corpus_overview` | Aggregate corpus stats (languages, types, dates) |
-| `kb_document_outline` | Document heading structure and page layout |
-| `kb_find_related` | Find similar documents via embedding similarity |
-| `kb_entity_search` | Search named entities across the corpus |
-| `kb_entity_overview` | Entity type breakdown (per-doc or corpus-wide) |
-| `kb_entity_cooccurrence` | Find entities that co-occur in the same chunk or document |
-| `kb_ingest_status` | Check ingestion progress |
-| `kb_reprocess` | Re-run ingestion on a document |
-| `kb_system_health` | System health check |
+| `kb_batch_search` | Run multiple search queries in one call (max 5), grouped per query. |
+| `kb_corpus_overview` | Survey the corpus: doc types, date ranges, sample titles. |
+| `kb_document_outline` | Get a document's section structure (table of contents). |
+| `kb_documents_by_date` | Return documents sorted by their effective date. |
+| `kb_entity_cooccurrence` | Find which entities appear together in the same documents or chunks. |
+| `kb_entity_overview` | Survey entities in the corpus (or scoped to a single doc). |
+| `kb_entity_search` | Find documents that mention a specific named entity (person, organization, place). |
+| `kb_expand_context` | Read N chunks immediately before/after a given chunk_id. |
+| `kb_find_all` | Enumerate documents matching a query — deduped by document, with |
+| `kb_find_related` | Find documents related to a given doc_id by semantic overlap. |
+| `kb_get_document` | Get a document's metadata + summary by doc_id. |
+| `kb_ingest_status` | Inspect a document's ingestion pipeline status (operator-facing). |
+| `kb_list_recent` | List the most recently-added documents in the corpus. |
+| `kb_read_document` | Read the full text of a document by doc_id. |
+| `kb_read_passages` | Read specific passages by chunk_id. |
+| `kb_reprocess` | Re-run the ingestion pipeline for a specific document. |
+| `kb_search` | Search the knowledge base by topic, keyword, or question. |
+| `kb_system_health` | Check HC's system health (PostgreSQL, storage, Tika, reranker). |
+| `kb_verify_identifier` | Verify a document identifier resolves to exactly one document. |
+<!-- END GENERATED: mcp-tools -->
+
 
 ---
 

--- a/docs/superpowers/plans/2026-07-21-generated-docs-plan.md
+++ b/docs/superpowers/plans/2026-07-21-generated-docs-plan.md
@@ -1,0 +1,133 @@
+# Generated Documentation — Implementation Plan
+
+**Date:** 2026-07-21
+**Tracks:** #539 (architecture rewrite), momentum task 7 (CLI/MCP parity)
+**Estimated:** 14–18 hours across 5 PRs
+
+## Why
+
+Docs about code drift silently and are then trusted with authority. An audit of
+`docs/architecture.md` (#539) found the embedding model, queue topology, OCR
+path, macOS service list, ports, auth semantics, and roughly half the data model
+all wrong — plus a real production bug (#537/#538) hiding behind a diagram that
+faithfully mirrored a broken compose file.
+
+The lesson from that audit: **enumerations rot continuously and silently;
+structure rots occasionally and traceably.** So generate every list, table,
+count, and name from source; hand-write prose and diagrams.
+
+The forcing function is a CI job that regenerates and fails on diff — the same
+pattern as `ruff format --check`. Docs then cannot drift.
+
+## Feasibility (verified 2026-07-21)
+
+| Source | Access | Result |
+|---|---|---|
+| MCP tools | `harbor_clerk.mcp_server.mcp` → tool manager | 19 tools |
+| REST endpoints | `harbor_clerk.api.app.app.openapi()` | 118 paths |
+| DB tables | `harbor_clerk.models.base.Base.metadata` | 29 tables |
+| Pipeline stages | `worker.pipeline.STAGE_CONFIG` | 7 stages |
+| Queues | `worker.entry.QUEUE_STAGES` | io/cpu/llm |
+| CLI subcommands | `cli.main.build_parser()` | argparse tree |
+| Compose services | `docker-compose.yml` | 12 services |
+
+All import cleanly without a database connection.
+
+## Design
+
+```
+scripts/gen_docs/
+  __main__.py          # python -m scripts.gen_docs [--check]
+  blocks.py            # marker-block find/replace
+  registry.py          # generator name -> callable
+  generators/
+    mcp_tools.py  rest_endpoints.py  db_tables.py
+    pipeline.py   compose.py         cli_commands.py
+```
+
+**Marker blocks** let narrative wrap generated content in place:
+
+```markdown
+<!-- BEGIN GENERATED: mcp-tools -->
+| Tool | Description |
+...
+<!-- END GENERATED: mcp-tools -->
+```
+
+**Runner contract**
+- `python -m scripts.gen_docs` rewrites every registered block in every target.
+- `--check` exits non-zero and prints a diff when any block is out of date.
+- Unknown block name, or a block present in a file but absent from the registry,
+  is an error — prevents silent no-ops.
+
+**CI:** a `docs-generated` job runs `--check`. Change a tool and forget to
+regenerate → red build. The tool-surface diff also becomes explicitly
+reviewable, which delivers the CLI/MCP parity check as a side effect.
+
+## Sequencing
+
+### PR 1 — Generator core + MCP tools (~4h)
+Block machinery, runner, `--check`, registry, first generator, README's 19-tool
+table converted to a generated block, CI job, unit tests including a
+"regenerating is idempotent" test and a "--check catches drift" test.
+
+**Exit:** `python -m scripts.gen_docs --check` passes; deliberately editing a
+generated block makes it fail.
+
+### PR 2 — REST, DB, pipeline, compose, CLI generators (~5h)
+Five more generators against the same machinery. REST table from OpenAPI (group
+by tag/prefix; exclude internals). DB tables from metadata (name + purpose +
+key columns). Pipeline from `STAGE_CONFIG` + `QUEUE_STAGES` — this one would
+have caught the #537 bug. Compose from the YAML. CLI from `build_parser()`.
+
+**Exit:** all six generators registered and passing `--check`.
+
+### PR 3 — CLI/MCP parity check (~1h)
+Assert every MCP tool has a CLI subcommand and vice versa, modulo an explicit
+allowlist of intentional asymmetries. Closes momentum task 7.
+
+### PR 4 — architecture.md rewrite (~4h)
+Rewrite using generated blocks; fix every HIGH finding in #539; add the
+subsystems currently missing entirely (Research, chat/LLM orchestration,
+secrets, topics, language packs, metadata extractors, markdown extraction
+branch); correct the auth section including OAuth 2.1; remove the staleness
+banner. Keep and hand-maintain the mermaid diagrams — with the OCR→Tika edge
+deleted and the summarize de-gating corrected.
+
+**Exit:** #539 closed; banner gone.
+
+### PR 5 — CLAUDE.md restructure, batches 1–2 (~2h)
+Apply the approved constitution: preamble with the authority rule, identity,
+non-negotiables (including the decomposed never-modify / copy-only-where-required
+pair), working agreement, review policy with the unprimed-reviewer rule and the
+new-subsystem trigger, and the knowledge-routing section. Delete the architecture
+cluster, ingestion pipeline, ingestion flow, and retrieval sections. Create
+`src/harbor_clerk/CLAUDE.md` with the audit-verified invariants.
+
+Batches 3–5 of the restructure are **deliberately excluded** — the owner asked to
+walk those through interactively.
+
+## Decisions taken without consultation
+
+Recorded because the owner is away; all are reversible.
+
+1. **`scripts/gen_docs/` over a `tools/` or root script** — matches the existing
+   `scripts/test_corpora/` precedent and keeps it out of the shipped package.
+2. **Marker blocks over whole generated files** — narrative and generated
+   content need to interleave in README and architecture.md.
+3. **`--check` in CI rather than auto-commit** — auto-committing from CI hides
+   contract changes that deserve review.
+4. **Generated tables kept terse** — name + one-line purpose. Full detail stays
+   in the source; the doc is an index, not a mirror.
+5. **Diagrams stay hand-written.** Generated mermaid would lose editorial
+   judgment (e.g. dashing the conditional OCR node) and churn noisily.
+
+## Risks
+
+- **Import side effects.** Generators import app modules; if one starts
+  requiring a live DB, the CI job breaks confusingly. Mitigation: generators
+  import lazily and the runner reports which generator failed.
+- **OpenAPI churn.** 118 paths is a lot of table. Mitigation: group and filter to
+  the documented public surface rather than dumping everything.
+- **Over-generation.** Not everything benefits; prose explaining *why* a
+  subsystem exists must stay hand-written.

--- a/scripts/gen_docs/__init__.py
+++ b/scripts/gen_docs/__init__.py
@@ -1,0 +1,1 @@
+"""Documentation generators. See docs/superpowers/plans/2026-07-21-generated-docs-plan.md."""

--- a/scripts/gen_docs/__main__.py
+++ b/scripts/gen_docs/__main__.py
@@ -1,0 +1,110 @@
+"""Regenerate (or verify) generated documentation blocks.
+
+    uv run python -m scripts.gen_docs            # rewrite blocks in place
+    uv run python -m scripts.gen_docs --check    # exit 1 if anything is stale
+
+`--check` is what CI runs. It is the forcing function: change a tool, forget to
+regenerate, red build. Documentation cannot drift from source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+from pathlib import Path
+
+from scripts.gen_docs.blocks import BlockError, find_blocks, replace_block
+from scripts.gen_docs.registry import GENERATORS, REPO_ROOT, TARGETS
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _render(path: Path) -> tuple[str, str, list[str]]:
+    """Return (original, regenerated, block names) for one target file."""
+    original = path.read_text()
+    updated = original
+    names = [b.name for b in find_blocks(original)]
+
+    for name in names:
+        generator = GENERATORS.get(name)
+        if generator is None:
+            raise BlockError(
+                f"{_rel(path)} contains block {name!r} but no generator is registered for it. "
+                f"Known generators: {sorted(GENERATORS)}"
+            )
+        try:
+            content = generator()
+        except Exception as exc:  # noqa: BLE001 - surface which generator failed
+            raise RuntimeError(f"generator {name!r} failed: {type(exc).__name__}: {exc}") from exc
+        updated = replace_block(updated, name, content)
+
+    return original, updated, names
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="gen_docs", description=__doc__)
+    parser.add_argument("--check", action="store_true", help="verify without writing; exit 1 if stale")
+    args = parser.parse_args(argv)
+
+    seen: set[str] = set()
+    stale: list[str] = []
+    written: list[str] = []
+
+    for target in TARGETS:
+        if not target.exists():
+            print(f"error: target {_rel(target)} does not exist", file=sys.stderr)
+            return 2
+        try:
+            original, updated, names = _render(target)
+        except (BlockError, RuntimeError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        seen.update(names)
+
+        if original == updated:
+            continue
+        if args.check:
+            stale.append(_rel(target))
+            diff = difflib.unified_diff(
+                original.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile=f"{_rel(target)} (committed)",
+                tofile=f"{_rel(target)} (regenerated)",
+            )
+            sys.stderr.writelines(diff)
+        else:
+            target.write_text(updated)
+            written.append(_rel(target))
+
+    unused = sorted(set(GENERATORS) - seen)
+    if unused:
+        print(
+            f"error: generator(s) {unused} are registered but no target file contains their block. "
+            "Add the marker block or remove the generator.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.check:
+        if stale:
+            print(f"\nerror: {len(stale)} file(s) out of date: {', '.join(stale)}", file=sys.stderr)
+            print("Run: uv run python -m scripts.gen_docs", file=sys.stderr)
+            return 1
+        print(f"docs up to date ({len(seen)} block(s) checked)")
+        return 0
+
+    if written:
+        print(f"regenerated: {', '.join(written)}")
+    else:
+        print(f"docs already up to date ({len(seen)} block(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_docs/blocks.py
+++ b/scripts/gen_docs/blocks.py
@@ -1,0 +1,99 @@
+"""Marker-block machinery for generated documentation.
+
+Generated content lives inside named marker blocks so that hand-written prose
+can wrap it in place:
+
+    <!-- BEGIN GENERATED: mcp-tools -->
+    ...generated...
+    <!-- END GENERATED: mcp-tools -->
+
+Everything outside the markers is owned by a human and never touched.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+BEGIN = "<!-- BEGIN GENERATED: {name} -->"
+END = "<!-- END GENERATED: {name} -->"
+
+_BEGIN_RE = re.compile(r"^[ \t]*<!--[ \t]*BEGIN GENERATED:[ \t]*(?P<name>[\w.-]+)[ \t]*-->[ \t]*$", re.M)
+_END_RE = re.compile(r"^[ \t]*<!--[ \t]*END GENERATED:[ \t]*(?P<name>[\w.-]+)[ \t]*-->[ \t]*$", re.M)
+
+DO_NOT_EDIT = "<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->"
+
+
+class BlockError(ValueError):
+    """A marker block is malformed, duplicated, or unterminated."""
+
+
+@dataclass(frozen=True)
+class Block:
+    """A located marker block. Offsets are into the source text."""
+
+    name: str
+    body_start: int  # first char after the BEGIN marker line
+    body_end: int  # first char of the END marker line
+    outer_start: int  # first char of the BEGIN marker line
+    outer_end: int  # first char after the END marker line
+
+    def body(self, text: str) -> str:
+        return text[self.body_start : self.body_end]
+
+
+def find_blocks(text: str) -> list[Block]:
+    """Locate every marker block, in document order.
+
+    Raises BlockError on unterminated, mismatched, overlapping, or duplicate
+    blocks — silent misbehaviour here would mean silently ungenerated docs.
+    """
+    begins = list(_BEGIN_RE.finditer(text))
+    ends = list(_END_RE.finditer(text))
+
+    if len(begins) != len(ends):
+        raise BlockError(f"{len(begins)} BEGIN marker(s) but {len(ends)} END marker(s)")
+
+    blocks: list[Block] = []
+    for begin, end in zip(begins, ends, strict=True):
+        if begin.group("name") != end.group("name"):
+            raise BlockError(f"marker mismatch: BEGIN {begin.group('name')!r} closed by END {end.group('name')!r}")
+        if end.start() < begin.end():
+            raise BlockError(f"END marker precedes BEGIN marker for block {begin.group('name')!r}")
+        blocks.append(
+            Block(
+                name=begin.group("name"),
+                body_start=begin.end() + 1 if text[begin.end() : begin.end() + 1] == "\n" else begin.end(),
+                body_end=end.start(),
+                outer_start=begin.start(),
+                outer_end=end.end(),
+            )
+        )
+
+    seen = [b.name for b in blocks]
+    dupes = {n for n in seen if seen.count(n) > 1}
+    if dupes:
+        raise BlockError(f"duplicate block name(s) in one file: {sorted(dupes)}")
+
+    for earlier, later in zip(blocks, blocks[1:], strict=False):
+        if later.outer_start < earlier.outer_end:
+            raise BlockError(f"blocks {earlier.name!r} and {later.name!r} overlap or nest")
+
+    return blocks
+
+
+def render_body(content: str) -> str:
+    """Wrap generated content in the standard body form.
+
+    Always exactly one blank line between the do-not-edit notice, the content,
+    and the closing marker, so regeneration is byte-stable.
+    """
+    return f"{DO_NOT_EDIT}\n\n{content.strip()}\n"
+
+
+def replace_block(text: str, name: str, content: str) -> str:
+    """Return `text` with block `name`'s body replaced by rendered `content`."""
+    for block in find_blocks(text):
+        if block.name == name:
+            return text[: block.body_start] + render_body(content) + text[block.body_end :]
+    raise BlockError(f"no block named {name!r} in this document")

--- a/scripts/gen_docs/generators/__init__.py
+++ b/scripts/gen_docs/generators/__init__.py
@@ -1,0 +1,1 @@
+"""Individual block generators."""

--- a/scripts/gen_docs/generators/mcp_tools.py
+++ b/scripts/gen_docs/generators/mcp_tools.py
@@ -1,0 +1,47 @@
+"""Generate the MCP tool table from the live server registration.
+
+Source of truth: the `@mcp.tool()`-decorated functions in
+`harbor_clerk.mcp_server`. Hand-maintained copies of this table have already
+drifted once (the count and the tool list appeared in both README and
+CLAUDE.md), which is what this generator exists to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def _load_tools() -> list:
+    from harbor_clerk.mcp_server import mcp
+
+    manager = getattr(mcp, "_tool_manager", None)
+    tools = manager.list_tools() if manager is not None else mcp.list_tools()
+    if asyncio.iscoroutine(tools):
+        tools = asyncio.run(tools)
+    return sorted(tools, key=lambda t: t.name)
+
+
+def _summary(description: str | None) -> str:
+    """First sentence of the docstring, collapsed to a single table cell."""
+    if not description:
+        return ""
+    first_line = next((line.strip() for line in description.strip().splitlines() if line.strip()), "")
+    # Keep it to the leading sentence; tool docstrings often continue with
+    # usage guidance that belongs in tools/list, not in a summary table.
+    for terminator in (". ", "! ", "? "):
+        if terminator in first_line:
+            first_line = first_line.split(terminator, 1)[0] + terminator.strip()
+            break
+    return first_line.replace("|", "\\|")
+
+
+def generate() -> str:
+    tools = _load_tools()
+    lines = [
+        f"**{len(tools)} tools.** Authenticate with `Authorization: Bearer <api_key>`.",
+        "",
+        "| Tool | Description |",
+        "|---|---|",
+    ]
+    lines.extend(f"| `{tool.name}` | {_summary(tool.description)} |" for tool in tools)
+    return "\n".join(lines)

--- a/scripts/gen_docs/generators/mcp_tools.py
+++ b/scripts/gen_docs/generators/mcp_tools.py
@@ -9,6 +9,7 @@ CLAUDE.md), which is what this generator exists to prevent.
 from __future__ import annotations
 
 import asyncio
+import re
 
 
 def _load_tools() -> list:
@@ -21,18 +22,31 @@ def _load_tools() -> list:
     return sorted(tools, key=lambda t: t.name)
 
 
+# Terminators that end an abbreviation rather than a sentence. Without this,
+# "Use e.g. a doc_id" would be cut at "Use e.g."
+_ABBREVIATIONS = ("e.g.", "i.e.", "etc.", "vs.", "cf.", "approx.", "Inc.", "Ltd.")
+
+_SENTENCE_END = re.compile(r"[.!?](?=\s|$)")
+
+
 def _summary(description: str | None) -> str:
-    """First sentence of the docstring, collapsed to a single table cell."""
+    """First sentence of the docstring, flattened into a single table cell.
+
+    Whitespace is normalised across the *whole* description before looking for
+    a sentence end. Docstrings wrap at 120 characters, so an opening sentence
+    frequently spans several source lines; reading only the first physical line
+    truncates mid-sentence and emits a fragment with no terminal punctuation.
+    """
     if not description:
         return ""
-    first_line = next((line.strip() for line in description.strip().splitlines() if line.strip()), "")
-    # Keep it to the leading sentence; tool docstrings often continue with
-    # usage guidance that belongs in tools/list, not in a summary table.
-    for terminator in (". ", "! ", "? "):
-        if terminator in first_line:
-            first_line = first_line.split(terminator, 1)[0] + terminator.strip()
-            break
-    return first_line.replace("|", "\\|")
+    text = " ".join(description.split())
+    for match in _SENTENCE_END.finditer(text):
+        candidate = text[: match.end()]
+        if any(candidate.endswith(abbr) for abbr in _ABBREVIATIONS):
+            continue
+        text = candidate
+        break
+    return text.replace("|", "\\|")
 
 
 def generate() -> str:

--- a/scripts/gen_docs/registry.py
+++ b/scripts/gen_docs/registry.py
@@ -1,0 +1,30 @@
+"""Registry mapping generated-block names to the callables that produce them.
+
+Generators are imported lazily inside their factory so that a heavy or broken
+import surfaces as "generator X failed" rather than taking down the whole run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Files scanned for generated blocks. A block in one of these files with no
+# registered generator is an error, and vice versa — see __main__.
+TARGETS: tuple[Path, ...] = (
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "architecture.md",
+)
+
+
+def _mcp_tools() -> str:
+    from scripts.gen_docs.generators.mcp_tools import generate
+
+    return generate()
+
+
+GENERATORS: dict[str, Callable[[], str]] = {
+    "mcp-tools": _mcp_tools,
+}

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -87,6 +87,46 @@ def test_every_generator_has_a_home() -> None:
     assert not (set(GENERATORS) - placed), "registered generator with no marker block in any target"
 
 
+def test_summary_handles_a_first_sentence_that_wraps_lines() -> None:
+    """Docstrings wrap at 120 chars, so the opening sentence spans source lines.
+
+    Reading only the first physical line truncates mid-sentence and emits a
+    fragment with no terminal punctuation. This shipped once: kb_find_all
+    rendered as "...deduped by document, with" in README.
+    """
+    from scripts.gen_docs.generators.mcp_tools import _summary
+
+    wrapped = "Enumerate documents matching a query — deduped by document, with\noptional filtering. Use this when asked to LIST."
+    assert _summary(wrapped) == "Enumerate documents matching a query — deduped by document, with optional filtering."
+
+
+def test_summary_does_not_cut_at_an_abbreviation() -> None:
+    from scripts.gen_docs.generators.mcp_tools import _summary
+
+    assert _summary("Pass a filter, e.g. a doc_id, to narrow results. Then read.") == (
+        "Pass a filter, e.g. a doc_id, to narrow results."
+    )
+
+
+def test_summary_escapes_table_delimiters() -> None:
+    from scripts.gen_docs.generators.mcp_tools import _summary
+
+    assert "\\|" in _summary("Accepts a|b as input. More text.")
+
+
+def test_every_generated_tool_summary_is_a_complete_sentence() -> None:
+    """Systemic guard: byte-stability alone cannot detect malformed content.
+
+    `--check` only compares committed bytes against a fresh render, so a
+    deterministic formatting bug reproduces identically forever and passes.
+    Content quality needs its own assertion.
+    """
+    from scripts.gen_docs.generators.mcp_tools import _load_tools, _summary
+
+    truncated = [t.name for t in _load_tools() if not _summary(t.description).endswith((".", "!", "?"))]
+    assert not truncated, f"tool summaries truncated mid-sentence: {truncated}"
+
+
 def test_mcp_tools_block_lists_every_registered_tool() -> None:
     from scripts.gen_docs.generators.mcp_tools import _load_tools, generate
 

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -1,0 +1,107 @@
+"""Tests for the generated-documentation machinery.
+
+The point of this system is that documentation cannot silently drift from
+source. That guarantee rests on two behaviours: regeneration is byte-stable
+(so `--check` doesn't produce false alarms), and `--check` actually fails when
+a generated block is edited or goes out of date.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.gen_docs.blocks import BlockError, find_blocks, render_body, replace_block
+from scripts.gen_docs.registry import GENERATORS, TARGETS
+
+SIMPLE = """# Title
+
+Prose before.
+
+<!-- BEGIN GENERATED: alpha -->
+old content
+<!-- END GENERATED: alpha -->
+
+Prose after.
+"""
+
+
+def test_finds_block_and_preserves_surrounding_prose() -> None:
+    blocks = find_blocks(SIMPLE)
+    assert [b.name for b in blocks] == ["alpha"]
+    assert blocks[0].body(SIMPLE).strip() == "old content"
+
+    updated = replace_block(SIMPLE, "alpha", "new content")
+    assert "new content" in updated
+    assert "old content" not in updated
+    assert updated.startswith("# Title")
+    assert updated.rstrip().endswith("Prose after.")
+
+
+def test_replacement_is_idempotent() -> None:
+    once = replace_block(SIMPLE, "alpha", "stable")
+    twice = replace_block(once, "alpha", "stable")
+    assert once == twice, "regeneration must be byte-stable or --check produces false alarms"
+
+
+def test_render_body_normalises_whitespace() -> None:
+    assert render_body("x") == render_body("\n\n  x  \n\n")
+
+
+@pytest.mark.parametrize(
+    ("text", "reason"),
+    [
+        ("<!-- BEGIN GENERATED: a -->\n", "unterminated"),
+        ("<!-- END GENERATED: a -->\n", "unopened"),
+        ("<!-- BEGIN GENERATED: a -->\n<!-- END GENERATED: b -->\n", "name mismatch"),
+        (
+            "<!-- BEGIN GENERATED: a -->\n<!-- END GENERATED: a -->\n"
+            "<!-- BEGIN GENERATED: a -->\n<!-- END GENERATED: a -->\n",
+            "duplicate name",
+        ),
+    ],
+)
+def test_malformed_markers_are_rejected(text: str, reason: str) -> None:
+    with pytest.raises(BlockError):
+        find_blocks(text)
+
+
+def test_replacing_unknown_block_is_an_error() -> None:
+    with pytest.raises(BlockError):
+        replace_block(SIMPLE, "nonexistent", "x")
+
+
+def test_every_registered_generator_is_deterministic() -> None:
+    """Two calls must agree, or CI would flap between pass and fail."""
+    for name, generator in GENERATORS.items():
+        assert generator() == generator(), f"generator {name!r} is not deterministic"
+
+
+def test_every_block_in_targets_has_a_generator() -> None:
+    for target in TARGETS:
+        for block in find_blocks(target.read_text()):
+            assert block.name in GENERATORS, f"{target.name} contains block {block.name!r} with no registered generator"
+
+
+def test_every_generator_has_a_home() -> None:
+    placed = {b.name for t in TARGETS for b in find_blocks(t.read_text())}
+    assert not (set(GENERATORS) - placed), "registered generator with no marker block in any target"
+
+
+def test_mcp_tools_block_lists_every_registered_tool() -> None:
+    from scripts.gen_docs.generators.mcp_tools import _load_tools, generate
+
+    output = generate()
+    for tool in _load_tools():
+        assert f"`{tool.name}`" in output, f"{tool.name} missing from the generated table"
+    assert f"**{len(_load_tools())} tools.**" in output
+
+
+def test_committed_docs_are_up_to_date() -> None:
+    """The CI gate, as a test: committed generated blocks match a fresh render."""
+    from scripts.gen_docs.__main__ import _render
+
+    for target in TARGETS:
+        original, regenerated, _ = _render(target)
+        assert original == regenerated, (
+            f"{target.name} has stale generated content. Run: uv run python -m scripts.gen_docs"
+        )


### PR DESCRIPTION
First slice of the generated-documentation system. Refs #539.

Plan: [`docs/superpowers/plans/2026-07-21-generated-docs-plan.md`](docs/superpowers/plans/2026-07-21-generated-docs-plan.md)

## Why

Documentation about code drifts silently and is then trusted with authority. The architecture audit (#539) found the embedding model, queue topology, OCR path, macOS service list, ports, auth semantics, and roughly half the data model all wrong — plus a production bug (#537) hiding behind a diagram that faithfully mirrored a broken compose file.

The governing observation from that audit:

> **Enumerations rot continuously and silently; structure rots occasionally and traceably.**

So: generate every list, table, count, and name from source. Keep prose and diagrams hand-written — a generated mermaid diagram would lose editorial judgement and churn noisily.

## What's here

**`scripts/gen_docs/blocks.py`** — named marker blocks, so generated content embeds inside hand-written prose:

```markdown
<!-- BEGIN GENERATED: mcp-tools -->
...generated...
<!-- END GENERATED: mcp-tools -->
```

Malformed, duplicated, mismatched, nested, or unterminated markers are hard errors. A silent no-op here would mean silently ungenerated docs — the exact failure this system exists to prevent.

**`scripts/gen_docs/registry.py`** — block name → generator, plus target files. A block with no generator *and* a generator with no block are both errors, so neither side can rot.

**`scripts/gen_docs/__main__.py`** — `uv run python -m scripts.gen_docs [--check]`. `--check` prints a unified diff and exits 1.

**First generator: the MCP tool table**, read from the live FastMCP registration rather than transcribed. That table previously existed in *both* README and CLAUDE.md and had already drifted.

## The forcing function

CI runs `--check` in the existing `python` job, before the DB-backed tests so drift fails fast. Change a tool, forget to regenerate → red build.

Deliberately a **step in an already-required job** rather than a new job, so no branch-protection change is needed. The test suite covers the same guarantee as defence in depth.

## Tests

Aimed at the properties the guarantee actually rests on, not just "it runs":

- Regeneration is **byte-stable** — otherwise `--check` flaps between pass and fail.
- `--check` **actually fails on a hand-edit** — verified by tampering with a table row and asserting exit 1 plus an actionable message.
- Every registered generator is **deterministic**.
- Committed blocks **match a fresh render**.
- Malformed markers are rejected (parametrised over unterminated / unopened / mismatched / duplicate).

Also verified the generator imports cleanly with **no `.env` and no `DATABASE_URL`**, matching how CI will run it.

## Next

PRs 2–5 per the plan: the remaining five generators (REST, DB tables, pipeline, compose, CLI), the CLI/MCP parity check, the `architecture.md` rewrite, and the CLAUDE.md restructure batches 1–2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
