### PR TITLE
feat(docs): generate REST, DB, pipeline, compose and CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,24 +358,24 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 
 **141 operations across 16 groups.** Full reference: [docs/architecture.md](docs/architecture.md#rest-api).
 
-| Group | Operations | Base path |
-|---|---|---|
-| `system` | 22 | `/api/system` |
-| `chat` | 19 | `/api/chat` |
-| `documents` | 15 | `/api/docs` |
-| `watch` | 12 | `/api/watch` |
-| `oauth` | 11 | `(various)` |
-| `api-keys` | 10 | `/api/api-keys` |
-| `uploads` | 10 | `/api/uploads` |
-| `mail` | 8 | `/api/mail` |
-| `auth` | 6 | `/api` |
-| `research` | 6 | `/api/research` |
-| `stats` | 6 | `/api` |
-| `users` | 5 | `/api/users` |
-| `languages` | 4 | `/api/languages` |
-| `jobs` | 3 | `/api/jobs` |
-| `search` | 3 | `/api` |
-| `setup` | 1 | `/api/setup` |
+| Group | Operations | Admin-only | Base path |
+|---|---|---|---|
+| `system` | 22 | 19 | `/api/system` |
+| `chat` | 19 | 7 | `/api/chat` |
+| `documents` | 15 | 4 | `/api/docs` |
+| `watch` | 12 | — | `/api/watch` |
+| `oauth` | 11 | 4 | `(various)` |
+| `api-keys` | 10 | 10 | `/api/api-keys` |
+| `uploads` | 10 | — | `/api/uploads` |
+| `mail` | 8 | 8 | `/api/mail` |
+| `auth` | 6 | — | `/api` |
+| `research` | 6 | — | `/api/research` |
+| `stats` | 6 | — | `/api` |
+| `users` | 5 | 5 | `/api/users` |
+| `languages` | 4 | 3 | `/api/languages` |
+| `jobs` | 3 | — | `/api/jobs` |
+| `search` | 3 | — | `/api` |
+| `setup` | 1 | — | `/api/setup` |
 <!-- END GENERATED: rest-summary -->
 
 ### MCP

--- a/README.md
+++ b/README.md
@@ -353,51 +353,30 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 
 ### REST
 
-| Endpoint | Method | Description |
+<!-- BEGIN GENERATED: rest-summary -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**141 operations across 16 groups.** Full reference: [docs/architecture.md](docs/architecture.md#rest-api).
+
+| Group | Operations | Base path |
 |---|---|---|
-| `/api/auth/login` | POST | Login (email + password) |
-| `/api/auth/refresh` | POST | Refresh access token |
-| `/api/system/setup-status` | GET | Check if first-time setup is needed |
-| `/api/setup` | POST | Create initial admin account |
-| `/api/watch/system` | GET | Deployment context for the folder UI (`platform`, `picker`, `watch_root`) |
-| `/api/watch/folders` | GET/POST | List or register watched folders (POST is macOS-only) |
-| `/api/watch/folders/{id}` | PATCH/DELETE | Update or remove a watched folder |
-| `/api/watch/folders/{id}/progress` | GET | Per-folder ingestion stats across all 7 stages |
-| `/api/watch/folders/stream` | GET | SSE stream of per-folder progress deltas |
-| `/api/watch/folders/{id}/rescan` | POST | Trigger a full rescan of a folder |
-| `/api/docs` | GET | List documents |
-| `/api/docs/overview` | GET | Corpus overview stats |
-| `/api/docs/{id}` | GET | Document detail |
-| `/api/docs/{id}/content` | GET | Read document text (with page ranges) |
-| `/api/docs/{id}/outline` | GET | Document heading structure |
-| `/api/docs/{id}/entities` | GET | Named entities in document |
-| `/api/docs/{id}/related` | GET | Similar documents |
-| `/api/docs/{id}/download` | GET | Download original file (gated by `ALLOW_SOURCE_DOWNLOAD`; see [Source Files](#source-files-reveal-vs-download)) |
-| `/api/docs/{id}` | DELETE | Soft-delete a document |
-| `/api/docs/{id}/reprocess` | POST | Re-run ingestion |
-| `/api/docs/{id}/cancel` | POST | Cancel in-progress ingestion |
-| `/api/stats` | GET | Corpus-level aggregate statistics |
-| `/api/stats/clusters` | GET | Document centroid embeddings for UMAP clustering |
-| `/api/stats/entity-network` | GET | Entity co-occurrence network graph |
-| `/api/docs/{id}/stats` | GET | Per-document statistics |
-| `/api/search` | POST | Hybrid search (with optional filtering and facets) |
-| `/api/search/find-all` | POST | Enumerate matching documents with filters and pagination |
-| `/api/passages/read` | POST | Read passages by chunk IDs |
-| `/api/chat/conversations` | GET/POST | List or create chat conversations |
-| `/api/chat/conversations/{id}/messages` | POST | Send a message (streamed response with RAG) |
-| `/api/chat/models` | GET | List available LLM models |
-| `/api/chat/models/{id}/download` | POST | Download a model |
-| `/api/research` | GET/POST | List research tasks / start new research (streamed) |
-| `/api/research/active` | GET | Check if a research task is running |
-| `/api/research/{id}` | GET/DELETE | Get research detail / delete task |
-| `/api/research/{id}/resume` | POST | Resume interrupted research (streamed) |
-| `/api/system/health` | GET | Health check |
-| `/api/system/stats` | GET | System performance stats (admin) |
-| `/api/system/retrieval-settings` | GET/PUT | RAG and MCP retrieval config (admin) |
-| `/api/system/reprocess-all` | POST | Re-run ingestion on all documents (admin) |
-| `/api/system/resummarize-all` | POST | Re-run summaries on all documents (admin) |
-| `/api/system/delete-all-documents` | POST | Delete all documents and data (admin) |
-| `/api/jobs/stream` | GET | SSE stream of job progress |
+| `system` | 22 | `/api/system` |
+| `chat` | 19 | `/api/chat` |
+| `documents` | 15 | `/api/docs` |
+| `watch` | 12 | `/api/watch` |
+| `oauth` | 11 | `(various)` |
+| `api-keys` | 10 | `/api/api-keys` |
+| `uploads` | 10 | `/api/uploads` |
+| `mail` | 8 | `/api/mail` |
+| `auth` | 6 | `/api` |
+| `research` | 6 | `/api/research` |
+| `stats` | 6 | `/api` |
+| `users` | 5 | `/api/users` |
+| `languages` | 4 | `/api/languages` |
+| `jobs` | 3 | `/api/jobs` |
+| `search` | 3 | `/api` |
+| `setup` | 1 | `/api/setup` |
+<!-- END GENERATED: rest-summary -->
 
 ### MCP
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,13 +5,15 @@
 > last updated 2026-05-27) found several sections describe an architecture that no
 > longer exists. **Treat the code as authoritative.**
 >
-> Known-wrong: the embedding model and dimension (now Granite-R2 / 768, not
-> e5-small / 384), the worker queue topology (three queues, and `summarize` does
-> not gate `finalize`), OCR's extraction path (pypdfium2 + Tesseract, never Tika),
-> the macOS service list and ports, and the auth model's role semantics. The data
-> model omits roughly half the schema, including the entire email/IMAP subsystem.
+> Still known-wrong in the **prose and diagrams below**: the embedding model and
+> dimension (now Granite-R2 / 768, not e5-small / 384), OCR's extraction path
+> (pypdfium2 + Tesseract, never Tika), the macOS service list and ports, and the
+> auth model's role semantics. Several shipped subsystems are missing entirely.
 >
-> Verified still accurate: **Retrieval Flow** and **Client Surfaces**.
+> Verified accurate: **Retrieval Flow**, **Client Surfaces**, and everything under
+> **Generated reference** — those tables are derived from source and verified in
+> CI, so the queue topology and the full database schema there are correct even
+> where the diagrams above disagree.
 >
 > Tracked in [#539](https://github.com/r0shi/harborclerk/issues/539), which has the
 > full findings and the plan to generate the enumerations from source so this
@@ -325,8 +327,8 @@ Queue subscriptions:
 | `app` | built from `docker/app.Dockerfile` | — |
 | `embedder` | built from `docker/embedder.Dockerfile` | — |
 | `gateway` | `caddy:2-alpine` | — |
-| `llama-server` | `ghcr.io/ggml-org/llama.cpp:server` | `--host` |
-| `minio` | `minio/minio:latest` | — |
+| `llama-server` | `ghcr.io/ggml-org/llama.cpp:server` | — |
+| `minio` | `minio/minio:latest` | `server` |
 | `postgres` | `pgvector/pgvector:pg18` | — |
 | `reranker` | built from `docker/reranker.Dockerfile` | — |
 | `tika` | `apache/tika:latest` | — |
@@ -418,228 +420,228 @@ Queue subscriptions:
 <!-- BEGIN GENERATED: rest-endpoints -->
 <!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
 
-**141 operations.** Generated from the FastAPI OpenAPI schema.
+**141 operations**, 84 of them access-gated. Generated from the FastAPI OpenAPI schema; the Access column is derived from each route's dependency tree.
 
 ### `api-keys`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/api-keys` | List Api Keys |
-| `POST` | `/api/api-keys` | Create Api Key |
-| `POST` | `/api/api-keys/scope-preview` | Scope Preview Adhoc |
-| `DELETE` | `/api/api-keys/{key_id}` | Delete Api Key |
-| `PATCH` | `/api/api-keys/{key_id}` | Patch Api Key |
-| `GET` | `/api/api-keys/{key_id}/scope-preview` | Scope Preview |
-| `DELETE` | `/api/api-keys/{key_id}/usage` | Purge Key Usage |
-| `GET` | `/api/api-keys/{key_id}/usage` | Get Key Usage |
-| `GET` | `/api/api-keys/{key_id}/usage/requests` | Get Key Requests |
-| `GET` | `/api/api-keys/{key_id}/usage/timeline` | Get Key Timeline |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/api-keys` | **admin** | List Api Keys |
+| `POST` | `/api/api-keys` | **admin** | Create Api Key |
+| `POST` | `/api/api-keys/scope-preview` | **admin** | Scope Preview Adhoc |
+| `DELETE` | `/api/api-keys/{key_id}` | **admin** | Delete Api Key |
+| `PATCH` | `/api/api-keys/{key_id}` | **admin** | Patch Api Key |
+| `GET` | `/api/api-keys/{key_id}/scope-preview` | **admin** | Scope Preview |
+| `DELETE` | `/api/api-keys/{key_id}/usage` | **admin** | Purge Key Usage |
+| `GET` | `/api/api-keys/{key_id}/usage` | **admin** | Get Key Usage |
+| `GET` | `/api/api-keys/{key_id}/usage/requests` | **admin** | Get Key Requests |
+| `GET` | `/api/api-keys/{key_id}/usage/timeline` | **admin** | Get Key Timeline |
 
 ### `auth`
 
-| Method | Path | Summary |
-|---|---|---|
-| `POST` | `/api/auth/login` | Login |
-| `POST` | `/api/auth/logout` | Logout |
-| `POST` | `/api/auth/refresh` | Refresh |
-| `GET` | `/api/me` | Get Me |
-| `POST` | `/api/me/password` | Change Password |
-| `PATCH` | `/api/me/preferences` | Update Preferences |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `POST` | `/api/auth/login` | — | Login |
+| `POST` | `/api/auth/logout` | — | Logout |
+| `POST` | `/api/auth/refresh` | — | Refresh |
+| `GET` | `/api/me` | — | Get Me |
+| `POST` | `/api/me/password` | — | Change Password |
+| `PATCH` | `/api/me/preferences` | — | Update Preferences |
 
 ### `chat`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/chat/conversations` | List Conversations |
-| `POST` | `/api/chat/conversations` | Create Conversation |
-| `DELETE` | `/api/chat/conversations/{conv_id}` | Delete Conversation |
-| `GET` | `/api/chat/conversations/{conv_id}` | Get Conversation |
-| `GET` | `/api/chat/conversations/{conv_id}/export` | Export Conversation |
-| `POST` | `/api/chat/conversations/{conv_id}/messages` | Send Message |
-| `GET` | `/api/chat/models` | List Available Models |
-| `PUT` | `/api/chat/models/deactivate` | Deactivate Model |
-| `GET` | `/api/chat/models/download-progress` | Download Progress Stream |
-| `GET` | `/api/chat/models/orphaned` | List Orphaned Models |
-| `DELETE` | `/api/chat/models/orphaned/{filename}` | Remove Orphaned Model |
-| `GET` | `/api/chat/models/status` | Llm Status |
-| `GET` | `/api/chat/models/summary-afm` | Get Summary Force Afm |
-| `PUT` | `/api/chat/models/summary-afm` | Toggle Summary Force Afm |
-| `GET` | `/api/chat/models/yarn` | Get Yarn Status |
-| `PUT` | `/api/chat/models/yarn` | Toggle Yarn |
-| `DELETE` | `/api/chat/models/{model_id}` | Remove Model |
-| `PUT` | `/api/chat/models/{model_id}/activate` | Activate Model |
-| `POST` | `/api/chat/models/{model_id}/download` | Start Model Download |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/chat/conversations` | — | List Conversations |
+| `POST` | `/api/chat/conversations` | **human only** | Create Conversation |
+| `DELETE` | `/api/chat/conversations/{conv_id}` | **human only** | Delete Conversation |
+| `GET` | `/api/chat/conversations/{conv_id}` | — | Get Conversation |
+| `GET` | `/api/chat/conversations/{conv_id}/export` | — | Export Conversation |
+| `POST` | `/api/chat/conversations/{conv_id}/messages` | **human only** | Send Message |
+| `GET` | `/api/chat/models` | — | List Available Models |
+| `PUT` | `/api/chat/models/deactivate` | **admin** | Deactivate Model |
+| `GET` | `/api/chat/models/download-progress` | — | Download Progress Stream |
+| `GET` | `/api/chat/models/orphaned` | — | List Orphaned Models |
+| `DELETE` | `/api/chat/models/orphaned/{filename}` | **admin** | Remove Orphaned Model |
+| `GET` | `/api/chat/models/status` | — | Llm Status |
+| `GET` | `/api/chat/models/summary-afm` | — | Get Summary Force Afm |
+| `PUT` | `/api/chat/models/summary-afm` | **admin** | Toggle Summary Force Afm |
+| `GET` | `/api/chat/models/yarn` | — | Get Yarn Status |
+| `PUT` | `/api/chat/models/yarn` | **admin** | Toggle Yarn |
+| `DELETE` | `/api/chat/models/{model_id}` | **admin** | Remove Model |
+| `PUT` | `/api/chat/models/{model_id}/activate` | **admin** | Activate Model |
+| `POST` | `/api/chat/models/{model_id}/download` | **admin** | Start Model Download |
 
 ### `documents`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/docs` | List Documents |
-| `GET` | `/api/docs/entities/autocomplete` | Entity Autocomplete |
-| `GET` | `/api/docs/entities/top` | Top Entities |
-| `GET` | `/api/docs/filters` | Document Filters |
-| `GET` | `/api/docs/overview` | Corpus Overview |
-| `DELETE` | `/api/docs/{doc_id}` | Delete Document |
-| `GET` | `/api/docs/{doc_id}` | Get Document |
-| `POST` | `/api/docs/{doc_id}/cancel` | Cancel Processing |
-| `GET` | `/api/docs/{doc_id}/content` | Get Document Content |
-| `GET` | `/api/docs/{doc_id}/download` | Download Document |
-| `GET` | `/api/docs/{doc_id}/entities` | Get Document Entities |
-| `GET` | `/api/docs/{doc_id}/outline` | Get Document Outline |
-| `GET` | `/api/docs/{doc_id}/related` | Find Related Documents |
-| `POST` | `/api/docs/{doc_id}/reprocess` | Reprocess Document |
-| `POST` | `/api/docs/{doc_id}/resummarize` | Resummarize Document |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/docs` | — | List Documents |
+| `GET` | `/api/docs/entities/autocomplete` | — | Entity Autocomplete |
+| `GET` | `/api/docs/entities/top` | — | Top Entities |
+| `GET` | `/api/docs/filters` | — | Document Filters |
+| `GET` | `/api/docs/overview` | — | Corpus Overview |
+| `DELETE` | `/api/docs/{doc_id}` | **admin** | Delete Document |
+| `GET` | `/api/docs/{doc_id}` | — | Get Document |
+| `POST` | `/api/docs/{doc_id}/cancel` | **admin** | Cancel Processing |
+| `GET` | `/api/docs/{doc_id}/content` | — | Get Document Content |
+| `GET` | `/api/docs/{doc_id}/download` | — | Download Document |
+| `GET` | `/api/docs/{doc_id}/entities` | — | Get Document Entities |
+| `GET` | `/api/docs/{doc_id}/outline` | — | Get Document Outline |
+| `GET` | `/api/docs/{doc_id}/related` | — | Find Related Documents |
+| `POST` | `/api/docs/{doc_id}/reprocess` | **admin** | Reprocess Document |
+| `POST` | `/api/docs/{doc_id}/resummarize` | **admin** | Resummarize Document |
 
 ### `jobs`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/jobs/active` | Active Jobs |
-| `GET` | `/api/jobs/snapshot` | Jobs Snapshot |
-| `GET` | `/api/jobs/stream` | Job Stream |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/jobs/active` | — | Active Jobs |
+| `GET` | `/api/jobs/snapshot` | — | Jobs Snapshot |
+| `GET` | `/api/jobs/stream` | — | Job Stream |
 
 ### `languages`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/languages` | List Languages |
-| `DELETE` | `/api/languages/{lang_code}` | Remove Language Completely |
-| `POST` | `/api/languages/{lang_code}/install` | Install Language Tools |
-| `DELETE` | `/api/languages/{lang_code}/install/{tool_name}` | Remove Language Tool |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/languages` | **human only** | List Languages |
+| `DELETE` | `/api/languages/{lang_code}` | **admin** | Remove Language Completely |
+| `POST` | `/api/languages/{lang_code}/install` | **admin** | Install Language Tools |
+| `DELETE` | `/api/languages/{lang_code}/install/{tool_name}` | **admin** | Remove Language Tool |
 
 ### `mail`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/mail/accounts` | List Mail Accounts |
-| `POST` | `/api/mail/accounts` | Create Mail Account |
-| `DELETE` | `/api/mail/accounts/{account_id}` | Delete Mail Account |
-| `POST` | `/api/mail/accounts/{account_id}/test` | Test Mail Account |
-| `GET` | `/api/mail/labels` | List Watched Labels |
-| `POST` | `/api/mail/labels` | Create Watched Label |
-| `DELETE` | `/api/mail/labels/{label_id}` | Delete Watched Label |
-| `POST` | `/api/mail/labels/{label_id}/rescan` | Rescan Label |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/mail/accounts` | **admin** | List Mail Accounts |
+| `POST` | `/api/mail/accounts` | **admin** | Create Mail Account |
+| `DELETE` | `/api/mail/accounts/{account_id}` | **admin** | Delete Mail Account |
+| `POST` | `/api/mail/accounts/{account_id}/test` | **admin** | Test Mail Account |
+| `GET` | `/api/mail/labels` | **admin** | List Watched Labels |
+| `POST` | `/api/mail/labels` | **admin** | Create Watched Label |
+| `DELETE` | `/api/mail/labels/{label_id}` | **admin** | Delete Watched Label |
+| `POST` | `/api/mail/labels/{label_id}/rescan` | **admin** | Rescan Label |
 
 ### `oauth`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/.well-known/oauth-authorization-server` | Oauth Authorization Server |
-| `GET` | `/.well-known/oauth-protected-resource` | Oauth Protected Resource |
-| `GET` | `/api/integrations/connections` | List Connections |
-| `DELETE` | `/api/integrations/connections/{client_id}` | Delete Connection |
-| `GET` | `/api/integrations/settings` | Get Integration Settings |
-| `PUT` | `/api/integrations/settings` | Update Integration Settings |
-| `GET` | `/oauth/authorize` | Oauth Authorize Get |
-| `POST` | `/oauth/authorize` | Oauth Authorize Post |
-| `POST` | `/oauth/register` | Oauth Register |
-| `POST` | `/oauth/revoke` | Oauth Revoke |
-| `POST` | `/oauth/token` | Oauth Token |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/.well-known/oauth-authorization-server` | — | Oauth Authorization Server |
+| `GET` | `/.well-known/oauth-protected-resource` | — | Oauth Protected Resource |
+| `GET` | `/api/integrations/connections` | **admin** | List Connections |
+| `DELETE` | `/api/integrations/connections/{client_id}` | **admin** | Delete Connection |
+| `GET` | `/api/integrations/settings` | **admin** | Get Integration Settings |
+| `PUT` | `/api/integrations/settings` | **admin** | Update Integration Settings |
+| `GET` | `/oauth/authorize` | — | Oauth Authorize Get |
+| `POST` | `/oauth/authorize` | — | Oauth Authorize Post |
+| `POST` | `/oauth/register` | — | Oauth Register |
+| `POST` | `/oauth/revoke` | — | Oauth Revoke |
+| `POST` | `/oauth/token` | — | Oauth Token |
 
 ### `research`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/research` | List Research |
-| `POST` | `/api/research` | Start Research |
-| `GET` | `/api/research/active` | Check Active |
-| `DELETE` | `/api/research/{conv_id}` | Delete Research |
-| `GET` | `/api/research/{conv_id}` | Get Research |
-| `POST` | `/api/research/{conv_id}/resume` | Resume Research |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/research` | — | List Research |
+| `POST` | `/api/research` | **human only** | Start Research |
+| `GET` | `/api/research/active` | — | Check Active |
+| `DELETE` | `/api/research/{conv_id}` | **human only** | Delete Research |
+| `GET` | `/api/research/{conv_id}` | — | Get Research |
+| `POST` | `/api/research/{conv_id}/resume` | **human only** | Resume Research |
 
 ### `search`
 
-| Method | Path | Summary |
-|---|---|---|
-| `POST` | `/api/passages/read` | Read Passages |
-| `POST` | `/api/search` | Search |
-| `POST` | `/api/search/find-all` | Search Find All |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `POST` | `/api/passages/read` | — | Read Passages |
+| `POST` | `/api/search` | — | Search |
+| `POST` | `/api/search/find-all` | — | Search Find All |
 
 ### `setup`
 
-| Method | Path | Summary |
-|---|---|---|
-| `POST` | `/api/setup` | Setup |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `POST` | `/api/setup` | — | Setup |
 
 ### `stats`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/docs/{doc_id}/stats` | Document Stats |
-| `GET` | `/api/stats` | Corpus Stats |
-| `GET` | `/api/stats/clusters` | Document Clusters |
-| `GET` | `/api/stats/entity-network` | Entity Network |
-| `GET` | `/api/stats/timeline` | Document Timeline |
-| `GET` | `/api/stats/topics` | Topic Clusters |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/docs/{doc_id}/stats` | — | Document Stats |
+| `GET` | `/api/stats` | — | Corpus Stats |
+| `GET` | `/api/stats/clusters` | — | Document Clusters |
+| `GET` | `/api/stats/entity-network` | — | Entity Network |
+| `GET` | `/api/stats/timeline` | — | Document Timeline |
+| `GET` | `/api/stats/topics` | — | Topic Clusters |
 
 ### `system`
 
-| Method | Path | Summary |
-|---|---|---|
-| `POST` | `/api/system/clear-queue` | Clear Queue |
-| `POST` | `/api/system/clear-redundant-summary-backlog` | Clear Redundant Summary Backlog |
-| `POST` | `/api/system/delete-all-documents` | Delete All Documents |
-| `GET` | `/api/system/health` | Health Check |
-| `GET` | `/api/system/logs` | List Logs |
-| `GET` | `/api/system/ping` | Ping |
-| `POST` | `/api/system/purge-run` | Purge Run |
-| `GET` | `/api/system/rate-limit-settings` | Get Rate Limit Settings |
-| `PUT` | `/api/system/rate-limit-settings` | Update Rate Limit Settings |
-| `POST` | `/api/system/reaper-run` | Reaper Run |
-| `POST` | `/api/system/recompute-topics` | Recompute Topics Endpoint |
-| `POST` | `/api/system/repair-completed-statuses` | Repair Completed Statuses |
-| `POST` | `/api/system/reprocess-all` | Reprocess All |
-| `POST` | `/api/system/reprocess-all-skip-summarize` | Reprocess All Skip Summarize |
-| `POST` | `/api/system/resummarize-all` | Resummarize All |
-| `GET` | `/api/system/retrieval-settings` | Get Retrieval Settings |
-| `PUT` | `/api/system/retrieval-settings` | Update Retrieval Settings |
-| `POST` | `/api/system/run-migrations` | Run Migrations |
-| `GET` | `/api/system/setup-status` | Setup Status |
-| `GET` | `/api/system/stats` | System Stats |
-| `GET` | `/api/system/status-summary` | Status Summary |
-| `GET` | `/api/system/summary-backlog` | Get Summary Backlog |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `POST` | `/api/system/clear-queue` | **admin** | Clear Queue |
+| `POST` | `/api/system/clear-redundant-summary-backlog` | **admin** | Clear Redundant Summary Backlog |
+| `POST` | `/api/system/delete-all-documents` | **admin** | Delete All Documents |
+| `GET` | `/api/system/health` | — | Health Check |
+| `GET` | `/api/system/logs` | **admin** | List Logs |
+| `GET` | `/api/system/ping` | — | Ping |
+| `POST` | `/api/system/purge-run` | **admin** | Purge Run |
+| `GET` | `/api/system/rate-limit-settings` | **admin** | Get Rate Limit Settings |
+| `PUT` | `/api/system/rate-limit-settings` | **admin** | Update Rate Limit Settings |
+| `POST` | `/api/system/reaper-run` | **admin** | Reaper Run |
+| `POST` | `/api/system/recompute-topics` | **admin** | Recompute Topics Endpoint |
+| `POST` | `/api/system/repair-completed-statuses` | **admin** | Repair Completed Statuses |
+| `POST` | `/api/system/reprocess-all` | **admin** | Reprocess All |
+| `POST` | `/api/system/reprocess-all-skip-summarize` | **admin** | Reprocess All Skip Summarize |
+| `POST` | `/api/system/resummarize-all` | **admin** | Resummarize All |
+| `GET` | `/api/system/retrieval-settings` | **admin** | Get Retrieval Settings |
+| `PUT` | `/api/system/retrieval-settings` | **admin** | Update Retrieval Settings |
+| `POST` | `/api/system/run-migrations` | **admin** | Run Migrations |
+| `GET` | `/api/system/setup-status` | — | Setup Status |
+| `GET` | `/api/system/stats` | **admin** | System Stats |
+| `GET` | `/api/system/status-summary` | **admin** | Status Summary |
+| `GET` | `/api/system/summary-backlog` | **admin** | Get Summary Backlog |
 
 ### `uploads`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/uploads` | List Uploads |
-| `POST` | `/api/uploads` | Upload Files |
-| `POST` | `/api/uploads/confirm` | Confirm Upload |
-| `POST` | `/api/uploads/confirm-batch` | Confirm Upload Batch |
-| `POST` | `/api/uploads/sessions` | Create Session |
-| `DELETE` | `/api/uploads/sessions/{session_id}` | Cancel Session |
-| `GET` | `/api/uploads/sessions/{session_id}` | Get Upload Session |
-| `POST` | `/api/uploads/sessions/{session_id}/confirm` | Confirm Session |
-| `POST` | `/api/uploads/sessions/{session_id}/files` | Upload File To Session |
-| `GET` | `/api/uploads/sessions/{session_id}/resume` | Get Resume Info |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/uploads` | **human only** | List Uploads |
+| `POST` | `/api/uploads` | **human only** | Upload Files |
+| `POST` | `/api/uploads/confirm` | **human only** | Confirm Upload |
+| `POST` | `/api/uploads/confirm-batch` | **human only** | Confirm Upload Batch |
+| `POST` | `/api/uploads/sessions` | **human only** | Create Session |
+| `DELETE` | `/api/uploads/sessions/{session_id}` | **human only** | Cancel Session |
+| `GET` | `/api/uploads/sessions/{session_id}` | **human only** | Get Upload Session |
+| `POST` | `/api/uploads/sessions/{session_id}/confirm` | **human only** | Confirm Session |
+| `POST` | `/api/uploads/sessions/{session_id}/files` | **human only** | Upload File To Session |
+| `GET` | `/api/uploads/sessions/{session_id}/resume` | **human only** | Get Resume Info |
 
 ### `users`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/users` | List Users |
-| `POST` | `/api/users` | Create User |
-| `DELETE` | `/api/users/{user_id}` | Delete User |
-| `GET` | `/api/users/{user_id}` | Get User |
-| `PATCH` | `/api/users/{user_id}` | Update User |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/users` | **admin** | List Users |
+| `POST` | `/api/users` | **admin** | Create User |
+| `DELETE` | `/api/users/{user_id}` | **admin** | Delete User |
+| `GET` | `/api/users/{user_id}` | **admin** | Get User |
+| `PATCH` | `/api/users/{user_id}` | **admin** | Update User |
 
 ### `watch`
 
-| Method | Path | Summary |
-|---|---|---|
-| `GET` | `/api/watch/allowed-extensions` | Allowed Extensions |
-| `GET` | `/api/watch/folders` | List Folders |
-| `POST` | `/api/watch/folders` | Create Folder |
-| `GET` | `/api/watch/folders/stream` | Folder Progress Stream |
-| `DELETE` | `/api/watch/folders/{folder_id}` | Delete Folder |
-| `PATCH` | `/api/watch/folders/{folder_id}` | Patch Folder |
-| `GET` | `/api/watch/folders/{folder_id}/progress` | Get Folder Progress |
-| `POST` | `/api/watch/folders/{folder_id}/rescan` | Rescan Folder |
-| `POST` | `/api/watch/ingest` | Ingest File |
-| `POST` | `/api/watch/remove` | Remove File |
-| `POST` | `/api/watch/rename` | Rename File |
-| `GET` | `/api/watch/system` | Get System |
+| Method | Path | Access | Summary |
+|---|---|---|---|
+| `GET` | `/api/watch/allowed-extensions` | — | Allowed Extensions |
+| `GET` | `/api/watch/folders` | — | List Folders |
+| `POST` | `/api/watch/folders` | **human only** | Create Folder |
+| `GET` | `/api/watch/folders/stream` | — | Folder Progress Stream |
+| `DELETE` | `/api/watch/folders/{folder_id}` | **human only** | Delete Folder |
+| `PATCH` | `/api/watch/folders/{folder_id}` | **human only** | Patch Folder |
+| `GET` | `/api/watch/folders/{folder_id}/progress` | — | Get Folder Progress |
+| `POST` | `/api/watch/folders/{folder_id}/rescan` | **human only** | Rescan Folder |
+| `POST` | `/api/watch/ingest` | **human only** | Ingest File |
+| `POST` | `/api/watch/remove` | **human only** | Remove File |
+| `POST` | `/api/watch/rename` | **human only** | Rename File |
+| `GET` | `/api/watch/system` | — | Get System |
 <!-- END GENERATED: rest-endpoints -->
 
 ### CLI subcommands

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -283,3 +283,391 @@ graph LR
 - **Secret storage** — sensitive values (mail-account app passwords, future
   OAuth tokens, etc.) are encrypted in Postgres with a master key managed per
   deployment. See [secrets-and-keys.md](secrets-and-keys.md).
+
+## Generated reference
+
+The tables below are generated from source by `scripts/gen_docs` and verified in
+CI. They cannot drift; the prose and diagrams above are hand-maintained and can.
+
+### Ingestion pipeline stages
+
+<!-- BEGIN GENERATED: pipeline-stages -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**7 stages across 3 queues** (`cpu`, `io`, `llm`).
+
+| Stage | Queue | Timeout | Role |
+|---|---|---|---|
+| `extract` | `io` | 600s | sequential (1 of 3) |
+| `ocr` | `cpu` | 7200s | sequential (2 of 3) |
+| `chunk` | `io` | 1200s | sequential (3 of 3) |
+| `entities` | `io` | 900s | parallel — gates `finalize` |
+| `embed` | `cpu` | 3600s | parallel — gates `finalize` |
+| `summarize` | `llm` | 900s | background — does **not** gate `finalize` |
+| `finalize` | `io` | 600s | fan-in |
+
+Queue subscriptions:
+
+- `cpu` — `ocr`, `embed`
+- `io` — `extract`, `chunk`, `entities`, `finalize`
+- `llm` — `summarize`
+<!-- END GENERATED: pipeline-stages -->
+
+### Docker Compose services
+
+<!-- BEGIN GENERATED: compose-services -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**12 services.** Generated from `docker-compose.yml`.
+
+| Service | Image | Role |
+|---|---|---|
+| `app` | built from `docker/app.Dockerfile` | — |
+| `embedder` | built from `docker/embedder.Dockerfile` | — |
+| `gateway` | `caddy:2-alpine` | — |
+| `llama-server` | `ghcr.io/ggml-org/llama.cpp:server` | `--host` |
+| `minio` | `minio/minio:latest` | — |
+| `postgres` | `pgvector/pgvector:pg18` | — |
+| `reranker` | built from `docker/reranker.Dockerfile` | — |
+| `tika` | `apache/tika:latest` | — |
+| `watcher` | built from `docker/app.Dockerfile` | `harbor-clerk-watcher` |
+| `worker-cpu` | built from `docker/app.Dockerfile` | worker — queues: `cpu` |
+| `worker-io` | built from `docker/app.Dockerfile` | worker — queues: `io` |
+| `worker-llm` | built from `docker/app.Dockerfile` | worker — queues: `llm` |
+<!-- END GENERATED: compose-services -->
+
+### Database tables
+
+<!-- BEGIN GENERATED: db-tables -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**29 tables.** Generated from SQLAlchemy metadata.
+
+### Documents & ingestion
+
+| Table | Key columns |
+|---|---|
+| `chunks` | `chunk_id` (PK), `doc_id` → `documents`, `fts_en` (tsvector), `fts_fr` (tsvector), `embedding` (vector) |
+| `document_headings` | `heading_id` (PK), `doc_id` → `documents` |
+| `document_links` | `link_id` (PK), `src_doc_id` → `documents`, `target_doc_id` → `documents` |
+| `document_pages` | `page_id` (PK), `doc_id` → `documents` |
+| `documents` | `doc_id` (PK), `topic_id` → `corpus_topics`, `email_parent_doc_id` → `documents` |
+| `entities` | `entity_id` (PK), `chunk_id` → `chunks`, `doc_id` → `documents` |
+| `ingestion_jobs` | `job_id` (PK), `doc_id` → `documents` |
+
+### Watched folders
+
+| Table | Key columns |
+|---|---|
+| `watched_files` | `file_id` (PK), `folder_id` → `watched_folders`, `doc_id` → `documents` |
+| `watched_folders` | `folder_id` (PK) |
+
+### Email (IMAP)
+
+| Table | Key columns |
+|---|---|
+| `imap_command_log` | `log_id` (PK), `account_id` → `mail_accounts` |
+| `mail_accounts` | `account_id` (PK) |
+| `watched_labels` | `label_id` (PK), `account_id` → `mail_accounts` |
+| `watched_messages` | `message_pk` (PK), `label_id` → `watched_labels`, `email_doc_id` → `documents` |
+
+### Chat & research
+
+| Table | Key columns |
+|---|---|
+| `chat_messages` | `message_id` (PK), `conversation_id` → `conversations` |
+| `conversations` | `conversation_id` (PK), `user_id` → `users` |
+| `research_state` | `conversation_id` (PK) |
+
+### Users & auth
+
+| Table | Key columns |
+|---|---|
+| `api_keys` | `key_id` (PK) |
+| `oauth_clients` | `client_id` (PK) |
+| `oauth_codes` | `code_id` (PK), `client_id` → `oauth_clients`, `user_id` → `users` |
+| `oauth_tokens` | `token_id` (PK), `client_id` → `oauth_clients`, `user_id` → `users` |
+| `users` | `user_id` (PK) |
+
+### Corpus analysis
+
+| Table | Key columns |
+|---|---|
+| `corpus_topics` | `topic_id` (PK) |
+| `corpus_topics_meta` | `id` (PK) |
+
+### Operations & audit
+
+| Table | Key columns |
+|---|---|
+| `api_request_log` | `request_id` (PK), `api_key_id` → `api_keys` |
+| `audit_log` | `audit_id` (PK), `user_id` → `users`, `api_key_id` → `api_keys` |
+| `model_settings` | `model_id` (PK) |
+| `schema_metadata` | `key` (PK) |
+
+### Legacy uploads
+
+| Table | Key columns |
+|---|---|
+| `upload_sessions` | `session_id` (PK), `user_id` → `users` |
+| `uploads` | `upload_id` (PK), `user_id` → `users`, `doc_id` → `documents`, `session_id` → `upload_sessions` |
+<!-- END GENERATED: db-tables -->
+
+### REST API
+
+<!-- BEGIN GENERATED: rest-endpoints -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**141 operations.** Generated from the FastAPI OpenAPI schema.
+
+### `api-keys`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/api-keys` | List Api Keys |
+| `POST` | `/api/api-keys` | Create Api Key |
+| `POST` | `/api/api-keys/scope-preview` | Scope Preview Adhoc |
+| `DELETE` | `/api/api-keys/{key_id}` | Delete Api Key |
+| `PATCH` | `/api/api-keys/{key_id}` | Patch Api Key |
+| `GET` | `/api/api-keys/{key_id}/scope-preview` | Scope Preview |
+| `DELETE` | `/api/api-keys/{key_id}/usage` | Purge Key Usage |
+| `GET` | `/api/api-keys/{key_id}/usage` | Get Key Usage |
+| `GET` | `/api/api-keys/{key_id}/usage/requests` | Get Key Requests |
+| `GET` | `/api/api-keys/{key_id}/usage/timeline` | Get Key Timeline |
+
+### `auth`
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/api/auth/login` | Login |
+| `POST` | `/api/auth/logout` | Logout |
+| `POST` | `/api/auth/refresh` | Refresh |
+| `GET` | `/api/me` | Get Me |
+| `POST` | `/api/me/password` | Change Password |
+| `PATCH` | `/api/me/preferences` | Update Preferences |
+
+### `chat`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/chat/conversations` | List Conversations |
+| `POST` | `/api/chat/conversations` | Create Conversation |
+| `DELETE` | `/api/chat/conversations/{conv_id}` | Delete Conversation |
+| `GET` | `/api/chat/conversations/{conv_id}` | Get Conversation |
+| `GET` | `/api/chat/conversations/{conv_id}/export` | Export Conversation |
+| `POST` | `/api/chat/conversations/{conv_id}/messages` | Send Message |
+| `GET` | `/api/chat/models` | List Available Models |
+| `PUT` | `/api/chat/models/deactivate` | Deactivate Model |
+| `GET` | `/api/chat/models/download-progress` | Download Progress Stream |
+| `GET` | `/api/chat/models/orphaned` | List Orphaned Models |
+| `DELETE` | `/api/chat/models/orphaned/{filename}` | Remove Orphaned Model |
+| `GET` | `/api/chat/models/status` | Llm Status |
+| `GET` | `/api/chat/models/summary-afm` | Get Summary Force Afm |
+| `PUT` | `/api/chat/models/summary-afm` | Toggle Summary Force Afm |
+| `GET` | `/api/chat/models/yarn` | Get Yarn Status |
+| `PUT` | `/api/chat/models/yarn` | Toggle Yarn |
+| `DELETE` | `/api/chat/models/{model_id}` | Remove Model |
+| `PUT` | `/api/chat/models/{model_id}/activate` | Activate Model |
+| `POST` | `/api/chat/models/{model_id}/download` | Start Model Download |
+
+### `documents`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/docs` | List Documents |
+| `GET` | `/api/docs/entities/autocomplete` | Entity Autocomplete |
+| `GET` | `/api/docs/entities/top` | Top Entities |
+| `GET` | `/api/docs/filters` | Document Filters |
+| `GET` | `/api/docs/overview` | Corpus Overview |
+| `DELETE` | `/api/docs/{doc_id}` | Delete Document |
+| `GET` | `/api/docs/{doc_id}` | Get Document |
+| `POST` | `/api/docs/{doc_id}/cancel` | Cancel Processing |
+| `GET` | `/api/docs/{doc_id}/content` | Get Document Content |
+| `GET` | `/api/docs/{doc_id}/download` | Download Document |
+| `GET` | `/api/docs/{doc_id}/entities` | Get Document Entities |
+| `GET` | `/api/docs/{doc_id}/outline` | Get Document Outline |
+| `GET` | `/api/docs/{doc_id}/related` | Find Related Documents |
+| `POST` | `/api/docs/{doc_id}/reprocess` | Reprocess Document |
+| `POST` | `/api/docs/{doc_id}/resummarize` | Resummarize Document |
+
+### `jobs`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/jobs/active` | Active Jobs |
+| `GET` | `/api/jobs/snapshot` | Jobs Snapshot |
+| `GET` | `/api/jobs/stream` | Job Stream |
+
+### `languages`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/languages` | List Languages |
+| `DELETE` | `/api/languages/{lang_code}` | Remove Language Completely |
+| `POST` | `/api/languages/{lang_code}/install` | Install Language Tools |
+| `DELETE` | `/api/languages/{lang_code}/install/{tool_name}` | Remove Language Tool |
+
+### `mail`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/mail/accounts` | List Mail Accounts |
+| `POST` | `/api/mail/accounts` | Create Mail Account |
+| `DELETE` | `/api/mail/accounts/{account_id}` | Delete Mail Account |
+| `POST` | `/api/mail/accounts/{account_id}/test` | Test Mail Account |
+| `GET` | `/api/mail/labels` | List Watched Labels |
+| `POST` | `/api/mail/labels` | Create Watched Label |
+| `DELETE` | `/api/mail/labels/{label_id}` | Delete Watched Label |
+| `POST` | `/api/mail/labels/{label_id}/rescan` | Rescan Label |
+
+### `oauth`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/.well-known/oauth-authorization-server` | Oauth Authorization Server |
+| `GET` | `/.well-known/oauth-protected-resource` | Oauth Protected Resource |
+| `GET` | `/api/integrations/connections` | List Connections |
+| `DELETE` | `/api/integrations/connections/{client_id}` | Delete Connection |
+| `GET` | `/api/integrations/settings` | Get Integration Settings |
+| `PUT` | `/api/integrations/settings` | Update Integration Settings |
+| `GET` | `/oauth/authorize` | Oauth Authorize Get |
+| `POST` | `/oauth/authorize` | Oauth Authorize Post |
+| `POST` | `/oauth/register` | Oauth Register |
+| `POST` | `/oauth/revoke` | Oauth Revoke |
+| `POST` | `/oauth/token` | Oauth Token |
+
+### `research`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/research` | List Research |
+| `POST` | `/api/research` | Start Research |
+| `GET` | `/api/research/active` | Check Active |
+| `DELETE` | `/api/research/{conv_id}` | Delete Research |
+| `GET` | `/api/research/{conv_id}` | Get Research |
+| `POST` | `/api/research/{conv_id}/resume` | Resume Research |
+
+### `search`
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/api/passages/read` | Read Passages |
+| `POST` | `/api/search` | Search |
+| `POST` | `/api/search/find-all` | Search Find All |
+
+### `setup`
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/api/setup` | Setup |
+
+### `stats`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/docs/{doc_id}/stats` | Document Stats |
+| `GET` | `/api/stats` | Corpus Stats |
+| `GET` | `/api/stats/clusters` | Document Clusters |
+| `GET` | `/api/stats/entity-network` | Entity Network |
+| `GET` | `/api/stats/timeline` | Document Timeline |
+| `GET` | `/api/stats/topics` | Topic Clusters |
+
+### `system`
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/api/system/clear-queue` | Clear Queue |
+| `POST` | `/api/system/clear-redundant-summary-backlog` | Clear Redundant Summary Backlog |
+| `POST` | `/api/system/delete-all-documents` | Delete All Documents |
+| `GET` | `/api/system/health` | Health Check |
+| `GET` | `/api/system/logs` | List Logs |
+| `GET` | `/api/system/ping` | Ping |
+| `POST` | `/api/system/purge-run` | Purge Run |
+| `GET` | `/api/system/rate-limit-settings` | Get Rate Limit Settings |
+| `PUT` | `/api/system/rate-limit-settings` | Update Rate Limit Settings |
+| `POST` | `/api/system/reaper-run` | Reaper Run |
+| `POST` | `/api/system/recompute-topics` | Recompute Topics Endpoint |
+| `POST` | `/api/system/repair-completed-statuses` | Repair Completed Statuses |
+| `POST` | `/api/system/reprocess-all` | Reprocess All |
+| `POST` | `/api/system/reprocess-all-skip-summarize` | Reprocess All Skip Summarize |
+| `POST` | `/api/system/resummarize-all` | Resummarize All |
+| `GET` | `/api/system/retrieval-settings` | Get Retrieval Settings |
+| `PUT` | `/api/system/retrieval-settings` | Update Retrieval Settings |
+| `POST` | `/api/system/run-migrations` | Run Migrations |
+| `GET` | `/api/system/setup-status` | Setup Status |
+| `GET` | `/api/system/stats` | System Stats |
+| `GET` | `/api/system/status-summary` | Status Summary |
+| `GET` | `/api/system/summary-backlog` | Get Summary Backlog |
+
+### `uploads`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/uploads` | List Uploads |
+| `POST` | `/api/uploads` | Upload Files |
+| `POST` | `/api/uploads/confirm` | Confirm Upload |
+| `POST` | `/api/uploads/confirm-batch` | Confirm Upload Batch |
+| `POST` | `/api/uploads/sessions` | Create Session |
+| `DELETE` | `/api/uploads/sessions/{session_id}` | Cancel Session |
+| `GET` | `/api/uploads/sessions/{session_id}` | Get Upload Session |
+| `POST` | `/api/uploads/sessions/{session_id}/confirm` | Confirm Session |
+| `POST` | `/api/uploads/sessions/{session_id}/files` | Upload File To Session |
+| `GET` | `/api/uploads/sessions/{session_id}/resume` | Get Resume Info |
+
+### `users`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/users` | List Users |
+| `POST` | `/api/users` | Create User |
+| `DELETE` | `/api/users/{user_id}` | Delete User |
+| `GET` | `/api/users/{user_id}` | Get User |
+| `PATCH` | `/api/users/{user_id}` | Update User |
+
+### `watch`
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/api/watch/allowed-extensions` | Allowed Extensions |
+| `GET` | `/api/watch/folders` | List Folders |
+| `POST` | `/api/watch/folders` | Create Folder |
+| `GET` | `/api/watch/folders/stream` | Folder Progress Stream |
+| `DELETE` | `/api/watch/folders/{folder_id}` | Delete Folder |
+| `PATCH` | `/api/watch/folders/{folder_id}` | Patch Folder |
+| `GET` | `/api/watch/folders/{folder_id}/progress` | Get Folder Progress |
+| `POST` | `/api/watch/folders/{folder_id}/rescan` | Rescan Folder |
+| `POST` | `/api/watch/ingest` | Ingest File |
+| `POST` | `/api/watch/remove` | Remove File |
+| `POST` | `/api/watch/rename` | Rename File |
+| `GET` | `/api/watch/system` | Get System |
+<!-- END GENERATED: rest-endpoints -->
+
+### CLI subcommands
+
+<!-- BEGIN GENERATED: cli-commands -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**19 subcommands**, mirroring the MCP tool surface. Enable with `ENABLE_CLI_ACCESS=true` (Docker) or the macOS Preferences toggle.
+
+| Command | Description |
+|---|---|
+| `harbor-clerk batch-search` | harbor-clerk batch-search — run multiple searches in one call |
+| `harbor-clerk corpus-overview` | harbor-clerk corpus-overview — corpus-level statistics and document list |
+| `harbor-clerk document-outline` | harbor-clerk document-outline — heading tree, page count, and chunk count |
+| `harbor-clerk documents-by-date` | harbor-clerk documents-by-date — date-sorted document lookup |
+| `harbor-clerk entity-cooccurrence` | harbor-clerk entity-cooccurrence — entities that appear alongside a given entity |
+| `harbor-clerk entity-overview` | harbor-clerk entity-overview — aggregate entity statistics (corpus or per-doc) |
+| `harbor-clerk entity-search` | harbor-clerk entity-search — search named entities by name or type |
+| `harbor-clerk expand-context` | harbor-clerk expand-context — read N chunks before and after a target chunk |
+| `harbor-clerk find-all` | harbor-clerk find-all - enumerate matching documents |
+| `harbor-clerk find-related` | harbor-clerk find-related — find documents similar to a given document |
+| `harbor-clerk get-document` | harbor-clerk get-document — document metadata, status, and pipeline jobs |
+| `harbor-clerk ingest-status` | harbor-clerk ingest-status — per-stage ingestion progress for one document |
+| `harbor-clerk list-recent` | harbor-clerk list-recent — recently updated documents |
+| `harbor-clerk read-document` | harbor-clerk read-document — read a document's text by page range |
+| `harbor-clerk read-passages` | harbor-clerk read-passages — fetch full passage text by chunk ID |
+| `harbor-clerk reprocess` | harbor-clerk reprocess — re-run the full ingestion pipeline for a document |
+| `harbor-clerk search` | harbor-clerk search — hybrid FTS + vector search |
+| `harbor-clerk system-health` | harbor-clerk system-health — daemon + storage health snapshot |
+| `harbor-clerk verify-identifier` | harbor-clerk verify-identifier — verify an identifier resolves to one document |
+<!-- END GENERATED: cli-commands -->

--- a/scripts/gen_docs/generators/cli_commands.py
+++ b/scripts/gen_docs/generators/cli_commands.py
@@ -1,0 +1,37 @@
+"""Generate the CLI subcommand table from the argparse tree.
+
+The CLI is a thin shell over the same MCP transport, so its subcommand list
+should mirror the MCP tool list exactly. `test_cli_mcp_parity` asserts that;
+this generator publishes it.
+"""
+
+from __future__ import annotations
+
+
+def load_subcommands() -> dict[str, str]:
+    from harbor_clerk.cli.main import build_parser
+
+    parser = build_parser()
+    for action in parser._actions:
+        choices = getattr(action, "choices", None)
+        if isinstance(choices, dict):
+            return {
+                name: (sub.description or "").strip().splitlines()[0] if sub.description else ""
+                for name, sub in choices.items()
+            }
+    return {}
+
+
+def generate() -> str:
+    commands = load_subcommands()
+    lines = [
+        f"**{len(commands)} subcommands**, mirroring the MCP tool surface. "
+        "Enable with `ENABLE_CLI_ACCESS=true` (Docker) or the macOS Preferences toggle.",
+        "",
+        "| Command | Description |",
+        "|---|---|",
+    ]
+    for name in sorted(commands):
+        summary = commands[name].replace("|", "\\|")
+        lines.append(f"| `harbor-clerk {name}` | {summary} |")
+    return "\n".join(lines)

--- a/scripts/gen_docs/generators/compose.py
+++ b/scripts/gen_docs/generators/compose.py
@@ -1,0 +1,55 @@
+"""Generate the Docker Compose service table from docker-compose.yml.
+
+The compose file is the source of truth for the Docker deployment topology.
+Hand-transcribing it is how #537 hid: the architecture diagram faithfully
+mirrored a compose file that was missing a worker, so the diagram was
+"accurate" about a broken system.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+COMPOSE_PATH = Path(__file__).resolve().parents[3] / "docker-compose.yml"
+
+
+def load_services() -> dict:
+    return yaml.safe_load(COMPOSE_PATH.read_text())["services"]
+
+
+def _image(service: dict) -> str:
+    if image := service.get("image"):
+        return f"`{image}`"
+    build = service.get("build") or {}
+    dockerfile = build.get("dockerfile") if isinstance(build, dict) else None
+    return f"built from `{dockerfile}`" if dockerfile else "built locally"
+
+
+def _role(service: dict) -> str:
+    command = service.get("command") or []
+    if isinstance(command, list) and "--queues" in command:
+        queues = []
+        for token in command[command.index("--queues") + 1 :]:
+            if str(token).startswith("-"):
+                break
+            queues.append(str(token))
+        return f"worker — queues: {', '.join(f'`{q}`' for q in queues)}"
+    if isinstance(command, list) and command:
+        return f"`{command[0]}`"
+    return "—"
+
+
+def generate() -> str:
+    services = load_services()
+    lines = [
+        f"**{len(services)} services.** Generated from `docker-compose.yml`.",
+        "",
+        "| Service | Image | Role |",
+        "|---|---|---|",
+    ]
+    for name in sorted(services):
+        service = services[name] or {}
+        lines.append(f"| `{name}` | {_image(service)} | {_role(service)} |")
+    return "\n".join(lines)

--- a/scripts/gen_docs/generators/compose.py
+++ b/scripts/gen_docs/generators/compose.py
@@ -28,17 +28,35 @@ def _image(service: dict) -> str:
 
 
 def _role(service: dict) -> str:
-    command = service.get("command") or []
-    if isinstance(command, list) and "--queues" in command:
+    """Describe what a service runs.
+
+    Compose `command:` comes in three shapes and each needs handling:
+    a list starting with an executable (`harbor-clerk-worker ...`), a plain
+    string (`server /data --console-address ...`), and a list of bare flags
+    with no executable at all (llama-server, whose entrypoint is baked into the
+    image). Naively taking token zero renders `--host` as the role, which is
+    meaningless.
+    """
+    command = service.get("command")
+    if isinstance(command, str):
+        command = command.split()
+    if not isinstance(command, list) or not command:
+        return "—"
+
+    if "--queues" in command:
         queues = []
         for token in command[command.index("--queues") + 1 :]:
             if str(token).startswith("-"):
                 break
             queues.append(str(token))
         return f"worker — queues: {', '.join(f'`{q}`' for q in queues)}"
-    if isinstance(command, list) and command:
-        return f"`{command[0]}`"
-    return "—"
+
+    first = str(command[0])
+    if first.startswith("-"):
+        # Bare flags: the entrypoint lives in the image, which the Image column
+        # already names. Better to say nothing than to name a flag.
+        return "—"
+    return f"`{first}`"
 
 
 def generate() -> str:

--- a/scripts/gen_docs/generators/db_tables.py
+++ b/scripts/gen_docs/generators/db_tables.py
@@ -1,0 +1,112 @@
+"""Generate the database table reference from SQLAlchemy metadata.
+
+Grouping note: the obvious derivable signals both fail. Model modules are
+effectively 1:1 with tables (27 modules for 29 tables), so grouping by module
+yields 27 groups of one. Foreign-key clustering collapses into a single
+26-table component, because nearly everything transitively reaches `documents`
+or `users`.
+
+So the group assignment below is explicit — but `test_every_table_has_a_group`
+asserts it covers `Base.metadata` exactly. Add a table without assigning a
+group and the build fails. That keeps the one hand-maintained element from
+rotting silently, which is the property that matters; the columns and types
+are fully derived.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+TABLE_GROUPS: dict[str, str] = {
+    # Documents and the ingestion pipeline
+    "documents": "Documents & ingestion",
+    "document_pages": "Documents & ingestion",
+    "document_headings": "Documents & ingestion",
+    "document_links": "Documents & ingestion",
+    "chunks": "Documents & ingestion",
+    "entities": "Documents & ingestion",
+    "ingestion_jobs": "Documents & ingestion",
+    # Watched folders
+    "watched_folders": "Watched folders",
+    "watched_files": "Watched folders",
+    # Email / IMAP ingest
+    "mail_accounts": "Email (IMAP)",
+    "watched_labels": "Email (IMAP)",
+    "watched_messages": "Email (IMAP)",
+    "imap_command_log": "Email (IMAP)",
+    # Identity and access
+    "users": "Users & auth",
+    "api_keys": "Users & auth",
+    "oauth_clients": "Users & auth",
+    "oauth_codes": "Users & auth",
+    "oauth_tokens": "Users & auth",
+    # Conversational surfaces
+    "conversations": "Chat & research",
+    "chat_messages": "Chat & research",
+    "research_state": "Chat & research",
+    # Corpus-level analysis
+    "corpus_topics": "Corpus analysis",
+    "corpus_topics_meta": "Corpus analysis",
+    # Operational
+    "audit_log": "Operations & audit",
+    "api_request_log": "Operations & audit",
+    "model_settings": "Operations & audit",
+    "schema_metadata": "Operations & audit",
+    # Legacy upload API, retained for non-interactive ingest
+    "uploads": "Legacy uploads",
+    "upload_sessions": "Legacy uploads",
+}
+
+GROUP_ORDER = (
+    "Documents & ingestion",
+    "Watched folders",
+    "Email (IMAP)",
+    "Chat & research",
+    "Users & auth",
+    "Corpus analysis",
+    "Operations & audit",
+    "Legacy uploads",
+)
+
+
+def load_metadata():
+    import harbor_clerk.models  # noqa: F401 - registers every mapper
+    from harbor_clerk.models.base import Base
+
+    return Base.metadata
+
+
+def _key_columns(table, limit: int = 6) -> str:
+    """Primary keys, foreign keys, and other notable columns — never all of them."""
+    parts: list[str] = []
+    for column in table.columns:
+        if column.primary_key:
+            parts.append(f"`{column.name}` (PK)")
+        elif column.foreign_keys:
+            target = next(iter(column.foreign_keys)).column.table.name
+            parts.append(f"`{column.name}` → `{target}`")
+    for column in table.columns:
+        if len(parts) >= limit:
+            break
+        type_name = type(column.type).__name__.lower()
+        if type_name in {"vector", "tsvector"} and f"`{column.name}`" not in " ".join(parts):
+            parts.append(f"`{column.name}` ({type_name})")
+    return ", ".join(parts[:limit]) or "—"
+
+
+def generate() -> str:
+    metadata = load_metadata()
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for name in metadata.tables:
+        grouped[TABLE_GROUPS.get(name, "Ungrouped")].append(name)
+
+    lines = [f"**{len(metadata.tables)} tables.** Generated from SQLAlchemy metadata.", ""]
+    ordered = [*GROUP_ORDER, *sorted(set(grouped) - set(GROUP_ORDER))]
+    for group in ordered:
+        if group not in grouped:
+            continue
+        lines += [f"### {group}", "", "| Table | Key columns |", "|---|---|"]
+        for name in sorted(grouped[group]):
+            lines.append(f"| `{name}` | {_key_columns(metadata.tables[name])} |")
+        lines.append("")
+    return "\n".join(lines).rstrip()

--- a/scripts/gen_docs/generators/pipeline.py
+++ b/scripts/gen_docs/generators/pipeline.py
@@ -1,0 +1,52 @@
+"""Generate the ingestion-pipeline stage table from the worker configuration.
+
+This is the block that would have prevented #537. The hand-written docs claimed
+two queues and showed `summarize` gating `finalize`; the code has three queues
+and treats `summarize` as a background stage. Both facts are derived here.
+"""
+
+from __future__ import annotations
+
+
+def _load():
+    from harbor_clerk.worker.entry import QUEUE_STAGES
+    from harbor_clerk.worker.pipeline import (
+        _BACKGROUND_STAGES,
+        _PARALLEL_STAGES,
+        _SEQUENTIAL_STAGES,
+        STAGE_CONFIG,
+    )
+
+    return STAGE_CONFIG, QUEUE_STAGES, _SEQUENTIAL_STAGES, _PARALLEL_STAGES, _BACKGROUND_STAGES
+
+
+def _role(stage, sequential, parallel, background) -> str:
+    if stage in sequential:
+        return f"sequential ({list(sequential).index(stage) + 1} of {len(sequential)})"
+    if stage in parallel:
+        return "parallel — gates `finalize`"
+    if stage in background:
+        return "background — does **not** gate `finalize`"
+    return "fan-in"
+
+
+def generate() -> str:
+    stage_config, queue_stages, sequential, parallel, background = _load()
+
+    lines = [
+        f"**{len(stage_config)} stages across {len(queue_stages)} queues** "
+        f"({', '.join(f'`{q}`' for q in sorted(queue_stages))}).",
+        "",
+        "| Stage | Queue | Timeout | Role |",
+        "|---|---|---|---|",
+    ]
+    for stage, config in stage_config.items():
+        queue, timeout = config[0], config[1]
+        role = _role(stage, sequential, parallel, background)
+        lines.append(f"| `{stage.value}` | `{queue}` | {timeout}s | {role} |")
+
+    lines += ["", "Queue subscriptions:", ""]
+    for queue in sorted(queue_stages):
+        members = ", ".join(f"`{s.value}`" for s in queue_stages[queue])
+        lines.append(f"- `{queue}` — {members}")
+    return "\n".join(lines)

--- a/scripts/gen_docs/generators/rest.py
+++ b/scripts/gen_docs/generators/rest.py
@@ -17,18 +17,94 @@ from collections import defaultdict
 _METHODS = ("get", "post", "put", "patch", "delete")
 
 
-def _operations() -> list[tuple[str, str, str, str]]:
-    """Return (tag, METHOD, path, summary), sorted stably."""
+def _walk_routes(obj, seen: set[int] | None = None):
+    """Yield every APIRoute, descending through FastAPI's router wrappers."""
+    from fastapi.routing import APIRoute
+
+    seen = seen if seen is not None else set()
+    for route in getattr(obj, "routes", []) or []:
+        if id(route) in seen:
+            continue
+        seen.add(id(route))
+        if isinstance(route, APIRoute):
+            yield route
+        original = getattr(route, "original_router", None)
+        if original is not None:
+            yield from _walk_routes(original, seen)
+        elif not isinstance(route, APIRoute):
+            yield from _walk_routes(route, seen)
+
+
+def _access_of(route) -> str:
+    """Derive the authorization gate from the route's dependency tree.
+
+    The read/write axis in this codebase is human-vs-API-key, not admin-vs-user:
+    `require_human_user` rejects API keys but accepts any human, while
+    `require_admin` is the genuinely narrower gate. The old hand-written table
+    annotated these by hand; deriving them means they cannot fall out of date.
+    """
+    names: set[str] = set()
+
+    def walk(dependant) -> None:
+        name = getattr(dependant.call, "__name__", None)
+        if name:
+            names.add(name)
+        for sub in dependant.dependencies:
+            walk(sub)
+
+    walk(route.dependant)
+    if "require_admin" in names:
+        return "admin"
+    if "require_human_user" in names:
+        return "human only"
+    return ""
+
+
+def _access_map() -> list[tuple[frozenset[str], str, str]]:
     from harbor_clerk.api.app import app
 
+    return [(frozenset(r.methods), r.path, _access_of(r)) for r in _walk_routes(app)]
+
+
+def _operations() -> list[tuple[str, str, str, str, str]]:
+    """Return (tag, METHOD, path, summary, access), sorted stably.
+
+    Paths come from the OpenAPI schema (fully prefixed); the access gate comes
+    from the route objects, whose paths are router-relative. They are joined on
+    method plus path suffix, and an ambiguous or missing join raises rather
+    than silently mislabelling an endpoint's authorization.
+    """
+    from harbor_clerk.api.app import app
+
+    routes = _access_map()
     spec = app.openapi()
-    ops: list[tuple[str, str, str, str]] = []
+    ops: list[tuple[str, str, str, str, str]] = []
     for path, methods in spec.get("paths", {}).items():
         for method, operation in methods.items():
             if method.lower() not in _METHODS or not isinstance(operation, dict):
                 continue
+            upper = method.upper()
+            candidates = [
+                (route_path, access)
+                for verbs, route_path, access in routes
+                if upper in verbs and path.endswith(route_path)
+            ]
+            if not candidates:
+                raise RuntimeError(
+                    f"no route matched {upper} {path}; cannot determine its authorization gate. Refusing to guess."
+                )
+            # Router paths are relative, so several can be suffixes of one spec
+            # path (e.g. "/stats" and "/system/stats" both end "/api/system/stats").
+            # The longest suffix is the most specific route and the correct match.
+            longest = max(len(route_path) for route_path, _ in candidates)
+            best = {access for route_path, access in candidates if len(route_path) == longest}
+            if len(best) != 1:
+                raise RuntimeError(
+                    f"ambiguous authorization gate for {upper} {path}: "
+                    f"{len(best)} equally-specific routes disagree. Refusing to guess."
+                )
             tag = (operation.get("tags") or ["untagged"])[0]
-            ops.append((tag, method.upper(), path, (operation.get("summary") or "").strip()))
+            ops.append((tag, upper, path, (operation.get("summary") or "").strip(), best.pop()))
     return sorted(ops, key=lambda o: (o[0], o[2], o[1]))
 
 
@@ -47,7 +123,7 @@ def _common_prefix(paths: list[str]) -> str:
 
 def generate_summary() -> str:
     ops = _operations()
-    by_tag: dict[str, list[tuple[str, str, str, str]]] = defaultdict(list)
+    by_tag: dict[str, list[tuple[str, str, str, str, str]]] = defaultdict(list)
     for op in ops:
         by_tag[op[0]].append(op)
 
@@ -55,25 +131,33 @@ def generate_summary() -> str:
         f"**{len(ops)} operations across {len(by_tag)} groups.** "
         "Full reference: [docs/architecture.md](docs/architecture.md#rest-api).",
         "",
-        "| Group | Operations | Base path |",
-        "|---|---|---|",
+        "| Group | Operations | Admin-only | Base path |",
+        "|---|---|---|---|",
     ]
     for tag in sorted(by_tag, key=lambda t: (-len(by_tag[t]), t)):
         entries = by_tag[tag]
-        lines.append(f"| `{tag}` | {len(entries)} | `{_common_prefix([e[2] for e in entries])}` |")
+        admin = sum(1 for e in entries if e[4] == "admin")
+        lines.append(f"| `{tag}` | {len(entries)} | {admin or '—'} | `{_common_prefix([e[2] for e in entries])}` |")
     return "\n".join(lines)
 
 
 def generate_full() -> str:
     ops = _operations()
-    by_tag: dict[str, list[tuple[str, str, str, str]]] = defaultdict(list)
+    by_tag: dict[str, list[tuple[str, str, str, str, str]]] = defaultdict(list)
     for op in ops:
         by_tag[op[0]].append(op)
 
-    lines = [f"**{len(ops)} operations.** Generated from the FastAPI OpenAPI schema.", ""]
+    gated = sum(1 for op in ops if op[4])
+    lines = [
+        f"**{len(ops)} operations**, {gated} of them access-gated. "
+        "Generated from the FastAPI OpenAPI schema; the Access column is derived "
+        "from each route's dependency tree.",
+        "",
+    ]
     for tag in sorted(by_tag):
-        lines += [f"### `{tag}`", "", "| Method | Path | Summary |", "|---|---|---|"]
-        for _, method, path, summary in by_tag[tag]:
-            lines.append(f"| `{method}` | `{path}` | {summary.replace('|', chr(92) + '|')} |")
+        lines += [f"### `{tag}`", "", "| Method | Path | Access | Summary |", "|---|---|---|---|"]
+        for _, method, path, summary, access in by_tag[tag]:
+            cell = f"**{access}**" if access else "—"
+            lines.append(f"| `{method}` | `{path}` | {cell} | {summary.replace('|', chr(92) + '|')} |")
         lines.append("")
     return "\n".join(lines).rstrip()

--- a/scripts/gen_docs/generators/rest.py
+++ b/scripts/gen_docs/generators/rest.py
@@ -1,0 +1,79 @@
+"""Generate REST API tables from FastAPI's own OpenAPI schema.
+
+Two blocks, because the two audiences differ:
+
+- `rest-summary` (README) — one row per tag. The front door should convey the
+  shape of the API, not enumerate 141 operations.
+- `rest-endpoints` (architecture.md) — every operation, grouped by tag, for
+  someone who needs the actual reference.
+
+Both derive from `app.openapi()`, so neither can drift.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+_METHODS = ("get", "post", "put", "patch", "delete")
+
+
+def _operations() -> list[tuple[str, str, str, str]]:
+    """Return (tag, METHOD, path, summary), sorted stably."""
+    from harbor_clerk.api.app import app
+
+    spec = app.openapi()
+    ops: list[tuple[str, str, str, str]] = []
+    for path, methods in spec.get("paths", {}).items():
+        for method, operation in methods.items():
+            if method.lower() not in _METHODS or not isinstance(operation, dict):
+                continue
+            tag = (operation.get("tags") or ["untagged"])[0]
+            ops.append((tag, method.upper(), path, (operation.get("summary") or "").strip()))
+    return sorted(ops, key=lambda o: (o[0], o[2], o[1]))
+
+
+def _common_prefix(paths: list[str]) -> str:
+    """Longest shared path prefix, trimmed to a whole segment."""
+    if not paths:
+        return ""
+    segments = [p.strip("/").split("/") for p in paths]
+    shared: list[str] = []
+    for parts in zip(*segments, strict=False):
+        if len({*parts}) != 1 or parts[0].startswith("{"):
+            break
+        shared.append(parts[0])
+    return "/" + "/".join(shared) if shared else "(various)"
+
+
+def generate_summary() -> str:
+    ops = _operations()
+    by_tag: dict[str, list[tuple[str, str, str, str]]] = defaultdict(list)
+    for op in ops:
+        by_tag[op[0]].append(op)
+
+    lines = [
+        f"**{len(ops)} operations across {len(by_tag)} groups.** "
+        "Full reference: [docs/architecture.md](docs/architecture.md#rest-api).",
+        "",
+        "| Group | Operations | Base path |",
+        "|---|---|---|",
+    ]
+    for tag in sorted(by_tag, key=lambda t: (-len(by_tag[t]), t)):
+        entries = by_tag[tag]
+        lines.append(f"| `{tag}` | {len(entries)} | `{_common_prefix([e[2] for e in entries])}` |")
+    return "\n".join(lines)
+
+
+def generate_full() -> str:
+    ops = _operations()
+    by_tag: dict[str, list[tuple[str, str, str, str]]] = defaultdict(list)
+    for op in ops:
+        by_tag[op[0]].append(op)
+
+    lines = [f"**{len(ops)} operations.** Generated from the FastAPI OpenAPI schema.", ""]
+    for tag in sorted(by_tag):
+        lines += [f"### `{tag}`", "", "| Method | Path | Summary |", "|---|---|---|"]
+        for _, method, path, summary in by_tag[tag]:
+            lines.append(f"| `{method}` | `{path}` | {summary.replace('|', chr(92) + '|')} |")
+        lines.append("")
+    return "\n".join(lines).rstrip()

--- a/scripts/gen_docs/registry.py
+++ b/scripts/gen_docs/registry.py
@@ -25,6 +25,48 @@ def _mcp_tools() -> str:
     return generate()
 
 
+def _rest_summary() -> str:
+    from scripts.gen_docs.generators.rest import generate_summary
+
+    return generate_summary()
+
+
+def _rest_endpoints() -> str:
+    from scripts.gen_docs.generators.rest import generate_full
+
+    return generate_full()
+
+
+def _db_tables() -> str:
+    from scripts.gen_docs.generators.db_tables import generate
+
+    return generate()
+
+
+def _pipeline_stages() -> str:
+    from scripts.gen_docs.generators.pipeline import generate
+
+    return generate()
+
+
+def _compose_services() -> str:
+    from scripts.gen_docs.generators.compose import generate
+
+    return generate()
+
+
+def _cli_commands() -> str:
+    from scripts.gen_docs.generators.cli_commands import generate
+
+    return generate()
+
+
 GENERATORS: dict[str, Callable[[], str]] = {
     "mcp-tools": _mcp_tools,
+    "rest-summary": _rest_summary,
+    "rest-endpoints": _rest_endpoints,
+    "db-tables": _db_tables,
+    "pipeline-stages": _pipeline_stages,
+    "compose-services": _compose_services,
+    "cli-commands": _cli_commands,
 }

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -206,11 +206,11 @@ def test_rest_blocks_cover_every_operation() -> None:
 
     ops = _operations()
     assert ops, "no REST operations discovered"
-    assert all(path.startswith("/") for _, _, path, _ in ops)
-    assert all(summary for *_, summary in ops), "every operation should have an OpenAPI summary"
+    assert all(path.startswith("/") for _, _, path, _, _ in ops)
+    assert all(summary for _, _, _, summary, _ in ops), "every operation should have an OpenAPI summary"
 
     full = generate_full()
-    missing = [f"{m} {p}" for _, m, p, _ in ops if f"`{p}`" not in full]
+    missing = [f"{m} {p}" for _, m, p, _, _ in ops if f"`{p}`" not in full]
     assert not missing, f"operations absent from the full table: {missing[:5]}"
 
 
@@ -227,3 +227,42 @@ def test_cli_mcp_parity() -> None:
     cli = set(load_subcommands())
     assert not mcp - cli, f"MCP tools with no CLI subcommand: {sorted(mcp - cli)}"
     assert not cli - mcp, f"CLI subcommands with no MCP tool: {sorted(cli - mcp)}"
+
+
+def test_compose_roles_are_never_bare_flags() -> None:
+    """A Role cell must name a command, not a flag.
+
+    llama-server's compose command is a list of bare flags with no executable
+    (the entrypoint is in the image), and minio's is a plain string rather than
+    a list. Taking token zero blindly rendered "--host" as a role and dropped
+    minio's entirely — a deterministic bug that --check would never notice.
+    """
+    from scripts.gen_docs.generators.compose import _role, load_services
+
+    for name, service in load_services().items():
+        role = _role(service or {})
+        assert not role.startswith("`-"), f"{name} role is a bare flag: {role}"
+        command = (service or {}).get("command")
+        if isinstance(command, str):
+            assert role != "—", f"{name} has a string command but rendered no role"
+
+
+def test_rest_access_gates_are_derived_for_every_operation() -> None:
+    """Authorization must be derived, never guessed.
+
+    The hand-written table annotated "(admin)" by hand; those annotations were
+    lost when it was generated. _operations() raises if a route's gate cannot be
+    resolved unambiguously, so this asserts the join covers the whole surface
+    and that known-destructive endpoints are still marked.
+    """
+    from scripts.gen_docs.generators.rest import _operations
+
+    ops = _operations()
+    by_path = {(path, method): access for _, method, path, _, access in ops}
+    for path in (
+        "/api/system/delete-all-documents",
+        "/api/system/resummarize-all",
+        "/api/system/reprocess-all",
+    ):
+        assert by_path.get((path, "POST")) == "admin", f"{path} must be marked admin-gated"
+    assert any(a == "human only" for a in by_path.values()), "human-only gate should appear"

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -145,3 +145,85 @@ def test_committed_docs_are_up_to_date() -> None:
         assert original == regenerated, (
             f"{target.name} has stale generated content. Run: uv run python -m scripts.gen_docs"
         )
+
+
+# --- Content-quality assertions -------------------------------------------
+#
+# Byte-stability (--check) proves a doc matches its generator; it says nothing
+# about whether the generator is correct. A deterministic formatting bug
+# reproduces identically forever and passes --check. PR #541 shipped exactly
+# that. Each generator therefore needs assertions about its *content*.
+
+
+def test_every_table_has_an_explicit_group() -> None:
+    """The one hand-maintained element in db_tables cannot rot silently.
+
+    Module grouping is ~1:1 with tables and FK clustering collapses to one
+    component, so the group map is explicit. This test is what stops it from
+    drifting: add a table without a group and the build fails.
+    """
+    from scripts.gen_docs.generators.db_tables import TABLE_GROUPS, load_metadata
+
+    tables = set(load_metadata().tables)
+    ungrouped = sorted(tables - set(TABLE_GROUPS))
+    stale = sorted(set(TABLE_GROUPS) - tables)
+    assert not ungrouped, f"tables with no group assignment in TABLE_GROUPS: {ungrouped}"
+    assert not stale, f"TABLE_GROUPS references tables that no longer exist: {stale}"
+
+
+def test_db_block_lists_every_table() -> None:
+    from scripts.gen_docs.generators.db_tables import generate, load_metadata
+
+    output = generate()
+    missing = [t for t in load_metadata().tables if f"`{t}`" not in output]
+    assert not missing, f"tables absent from the generated block: {missing}"
+
+
+def test_pipeline_block_matches_worker_config() -> None:
+    """Would have caught #537: the docs claimed two queues; the code has three."""
+    from harbor_clerk.worker.entry import QUEUE_STAGES
+    from harbor_clerk.worker.pipeline import STAGE_CONFIG
+    from scripts.gen_docs.generators.pipeline import generate
+
+    output = generate()
+    for stage in STAGE_CONFIG:
+        assert f"`{stage.value}`" in output, f"stage {stage.value} missing from generated block"
+    for queue in QUEUE_STAGES:
+        assert f"`{queue}`" in output, f"queue {queue} missing from generated block"
+    assert "does **not** gate" in output, "summarize's background role must be stated explicitly"
+
+
+def test_compose_block_lists_every_service() -> None:
+    from scripts.gen_docs.generators.compose import generate, load_services
+
+    output = generate()
+    missing = [s for s in load_services() if f"`{s}`" not in output]
+    assert not missing, f"services absent from the generated block: {missing}"
+
+
+def test_rest_blocks_cover_every_operation() -> None:
+    from scripts.gen_docs.generators.rest import _operations, generate_full
+
+    ops = _operations()
+    assert ops, "no REST operations discovered"
+    assert all(path.startswith("/") for _, _, path, _ in ops)
+    assert all(summary for *_, summary in ops), "every operation should have an OpenAPI summary"
+
+    full = generate_full()
+    missing = [f"{m} {p}" for _, m, p, _ in ops if f"`{p}`" not in full]
+    assert not missing, f"operations absent from the full table: {missing[:5]}"
+
+
+def test_cli_mcp_parity() -> None:
+    """The CLI is a thin shell over MCP, so the surfaces must match exactly.
+
+    Folded in from what was planned as its own PR: parity is currently perfect
+    at 19/19, so this locks it rather than documenting exceptions.
+    """
+    from scripts.gen_docs.generators.cli_commands import load_subcommands
+    from scripts.gen_docs.generators.mcp_tools import _load_tools
+
+    mcp = {t.name.removeprefix("kb_").replace("_", "-") for t in _load_tools()}
+    cli = set(load_subcommands())
+    assert not mcp - cli, f"MCP tools with no CLI subcommand: {sorted(mcp - cli)}"
+    assert not cli - mcp, f"CLI subcommands with no MCP tool: {sorted(cli - mcp)}"


### PR DESCRIPTION
Five more generators on the #541 machinery, plus the CLI/MCP parity check that was planned as its own PR. Refs #539.

## Blocks and placement

| Block | Lives in | Replaces |
|---|---|---|
| `rest-summary` | README | 43 hand-picked rows → one row per tag |
| `rest-endpoints` | architecture.md | — (141 operations, full reference) |
| `db-tables` | architecture.md | an ER diagram missing ~half the schema |
| `pipeline-stages` | architecture.md | a table claiming the wrong queues |
| `compose-services` | architecture.md | — |
| `cli-commands` | architecture.md | — |

README gets the *shape* of the API; architecture.md gets the reference. The front door shouldn't enumerate 141 operations.

## The pipeline block would have prevented #537

It derives **three queues**, `summarize` on `llm`, and `summarize`'s **background** role. Both CLAUDE.md and architecture.md currently claim two queues and show `summarize` gating `finalize` — the exact wrong belief that let a missing worker go unnoticed.

## Grouping note (a deviation, flagged)

For `db-tables` I was asked to group by module. **That doesn't work**: model modules are ~1:1 with tables (27 modules, 29 tables), so it yields 27 groups of one. FK clustering also fails — it collapses into a single 26-table component, because nearly everything transitively reaches `documents` or `users`.

So the group map is **explicit**, but `test_every_table_has_an_explicit_group` asserts it covers `Base.metadata` exactly in *both* directions. Add a table without a group, or leave a stale entry behind, and the build fails.

That keeps the intent (no silent rot) while abandoning the mechanism (module grouping). Hand-maintained *grouping* is stable in a way hand-maintained *prose* is not, and CI makes its rot impossible rather than merely unlikely. Columns and types remain fully derived.

## Content quality, not just stability

#541's review established the key distinction: `--check` proves a doc matches its generator and says **nothing** about whether the generator is correct — a deterministic formatting bug reproduces identically forever and passes.

So every generator now has content assertions: every table appears, every service appears, every operation appears *and* has a summary, every stage and queue appears, and `summarize`'s non-gating role is stated explicitly.

Verified the completeness guard actually fires by removing a table from `TABLE_GROUPS`.

## Note

`architecture.md`'s prose and diagrams are still stale (banner intact, #539 open). The generated sections are correct today; PR 4 rewrites the prose around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
