### PR TITLE
docs: finish CLAUDE.md restructure, add three scoped files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,15 @@ wrong place.
 | Eval harness and methodology | `scripts/test_corpora/`, `docs/evaluation.md` |
 | Integration setup (MCP, CLI, connectors) | `docs/integrations.md` |
 | Backend gotchas and pipeline invariants | `src/harbor_clerk/CLAUDE.md` |
+| Frontend conventions and ESLint/Tailwind traps | `frontend/CLAUDE.md` |
+| Swift process management, networking, presets | `macos/CLAUDE.md` |
+| Migration and schema conventions | `alembic/CLAUDE.md` |
 
-Entry points are declared in `pyproject.toml`. The MCP tool surface is defined
-in `src/harbor_clerk/mcp_server.py` and published as a generated table — read
-those rather than a transcription.
+Console scripts, MCP tools, REST routes, database tables, pipeline stages and
+Compose services are all **generated** into
+[`docs/architecture.md`](docs/architecture.md#generated-reference) from source.
+Read those rather than any transcription, and regenerate with
+`uv run python -m scripts.gen_docs` after changing them.
 
 ## Linting & formatting
 
@@ -109,52 +114,3 @@ those rather than a transcription.
 Five required checks on PRs to `main`: `python`, `frontend`, `codeql`,
 `dependency-audit`, `container-scan`. The `python` job also verifies generated
 docs are current.
-
----
-
-## Pending restructure (batches 3–5)
-
-The sections below were **not** part of the batches 1–2 restructure and are kept
-here awaiting a placement decision. Factual errors in them have been corrected —
-leaving a known-wrong statement in place to preserve a batch boundary would be
-the wrong trade — but where they should ultimately live is still open.
-
-### Python Package
-
-Package name: `harbor_clerk` (under `src/harbor_clerk/`). Entry points are
-declared in `pyproject.toml`:
-
-- `harbor-clerk-api` — FastAPI server
-- `harbor-clerk-worker` — PostgreSQL-polling background worker
-- `harbor-clerk-watcher` — folder + IMAP watcher (one process per deployment)
-- `harbor-clerk-seed` — database seeder
-- `harbor-clerk` — CLI for agent harnesses; off by default, gated by
-  `ENABLE_CLI_ACCESS`. Talks to `/mcp` over JSON-RPC using `HARBOR_CLERK_API_KEY`
-
-### Key API surface
-
-REST, MCP and CLI surfaces are **generated** from source — see
-[`docs/architecture.md#generated-reference`](docs/architecture.md#generated-reference).
-Do not transcribe them here; the previous hand-written copy drifted.
-
-### Database
-
-PostgreSQL 18 with `vector`, `pg_trgm`, and `citext`. No tenant table, no
-`tenant_id` columns.
-
-`chunks` has dual FTS columns (`fts_en`, `fts_fr`) as generated stored columns
-with GIN indexes, plus `embedding vector(768)` (Granite-R2) with an HNSW index.
-`schema_metadata` records the embedding model and dimension; startup refuses a
-mismatch. The full table list is generated; current schema lives in
-`alembic/versions/`.
-
-Storage (legacy uploads only): bucket `originals`, key pattern
-`originals/<doc_id>/<original_filename>`. Watched-folder documents are read in
-place from `source_path` and never stored in MinIO.
-
-### Worker presets (C = logical cores)
-
-- **Quiet**: io=1, cpu=1 · **Balanced**: io=max(2, C//4), cpu=2 · **Fast**:
-  io=max(2, C//2), cpu=3
-- Hard caps: io ≤ 8, cpu ≤ 4. The `llm` queue runs a single worker in every
-  preset.

--- a/alembic/CLAUDE.md
+++ b/alembic/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — `alembic`
+
+Async Alembic migrations against PostgreSQL 18 with `vector`, `pg_trgm`, and
+`citext`. The current schema is whatever `versions/` produces; the table list in
+`docs/architecture.md` is generated from SQLAlchemy metadata, not hand-written.
+
+## Enum member names must be lowercase
+
+Both `postgresql.ENUM` and `sa.Enum` send the Python member **`.name`**, not its
+`.value`. So this works:
+
+```python
+class Role(enum.Enum):
+    admin = "admin"      # correct — name matches the PG label
+```
+
+and this silently produces `ADMIN` in SQL against a type whose label is `admin`:
+
+```python
+class Role(enum.Enum):
+    ADMIN = "admin"      # wrong
+```
+
+## Embedding dimension is pinned by a sentinel
+
+`chunks.embedding` is `vector(768)` (Granite-R2). `schema_metadata` records the
+embedding model and dimension, and startup **refuses to run against a
+mismatch**. Changing the model is a migration plus a re-embed, not a config
+edit — a dimension change invalidates every stored vector.
+
+## No `tenant_id`
+
+Single-tenant by design. No tenant table, no tenant column, not in a migration,
+not "for later".
+
+## Log-table conventions
+
+Audit and request logs follow a shape established by `imap_command_log`, and new
+ones should match so a single admin view can serve them:
+
+- table named `<domain>_log`
+- typed FK columns (`account_id`, `api_key_id`) rather than opaque strings
+- `created_at` indexed, because the retention reaper scans it
+- `details` as JSONB for variable payloads; scalar columns for fixed shapes
+- an explicit per-table retention policy
+
+## Generated columns
+
+`chunks.fts_en` and `chunks.fts_fr` are **generated stored** tsvector columns
+with GIN indexes — they are computed by PostgreSQL, so never write to them from
+application code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -694,6 +694,22 @@ Queue subscriptions:
 | `GET` | `/api/watch/system` | — | Get System |
 <!-- END GENERATED: rest-endpoints -->
 
+### Console scripts
+
+<!-- BEGIN GENERATED: entry-points -->
+<!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
+
+**5 console scripts**, declared in `[project.scripts]`.
+
+| Command | Target | Purpose |
+|---|---|---|
+| `harbor-clerk` | `harbor_clerk.cli.main:main` | CLI for agent harnesses. Off by default, gated by `ENABLE_CLI_ACCESS`. |
+| `harbor-clerk-api` | `harbor_clerk.api.app:main` | FastAPI server — REST API, MCP endpoint, and the built SPA. |
+| `harbor-clerk-seed` | `harbor_clerk.seed:main` | Database seeder. |
+| `harbor-clerk-watcher` | `harbor_clerk.watcher.main:main` | Watched-folder and IMAP observer; enqueues ingest jobs. One per deployment. |
+| `harbor-clerk-worker` | `harbor_clerk.worker.entry:main` | Ingestion worker. Subscribes to one or more queues via `--queues`. |
+<!-- END GENERATED: entry-points -->
+
 ### CLI subcommands
 
 <!-- BEGIN GENERATED: cli-commands -->

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md — `frontend`
+
+React 19 · React Router 7 · Tailwind 4 · Vite 7 · ESLint 10. Built to static
+files and served by FastAPI at `/`.
+
+## Tailwind v4 is CSS-first — do not create a config file
+
+There is **no `tailwind.config.js` and no `postcss.config.js`**, and adding one
+is wrong. Configuration lives in `src/index.css`:
+
+- `@import 'tailwindcss'` plus a `@theme {}` block for design tokens
+- the `@tailwindcss/vite` plugin, **not** the PostCSS pipeline
+- dark mode via `@custom-variant dark (&:is(.dark *))`, toggled by a `.dark`
+  class on the root element
+
+An agent that "notices the missing config" and generates one will break the
+build. Design tokens are CSS custom properties (`--color-bg-primary`,
+`--color-accent`, …) declared in `index.css`.
+
+## ESLint rules that bite
+
+- **`react-hooks/set-state-in-effect`** — you cannot call `setState`
+  synchronously at the top of a `useEffect`. Wrap the work in an async function
+  declared inside the effect and call it.
+- **`react-hooks/immutability`** — you cannot reassign a `let` in the render
+  body. Use `reduce()` rather than `forEach` with mutation.
+
+## Dependency install
+
+`.npmrc` sets `legacy-peer-deps=true`, and `docker/app.Dockerfile` copies it.
+`eslint-plugin-react-hooks@7` declares a peer dependency on `eslint@^9` but
+works fine with ESLint 10; without the flag `npm ci` fails in CI and in the
+Docker build. `recharts` needs `react-is` installed explicitly or the Vite build
+fails to resolve it.
+
+## Routing state loss
+
+Navigating from `/` to `/c/:conversationId` **unmounts** the child ChatPage and
+mounts a new instance — every `useState` and `useRef` is lost. Defer the
+`navigate()` call until after streaming completes, rather than navigating first
+and trying to preserve state.
+
+Chat conversations live at `/c/:id` (not `/chat/`); old paths redirect.
+
+## No native dialogs
+
+The macOS app hosts this SPA in a WKWebView, where `window.confirm` and
+`window.alert` **silently return false** rather than prompting. Use an inline
+two-click confirmation pattern instead — a native dialog will appear to do
+nothing.
+
+## Feature detection
+
+Source download is gated server-side (`allow_source_download`, off by default).
+Feature-detect via `useSystemConfig().allowSourceDownload` before showing
+download UI; on macOS the user-facing path is `window.harborclerk.revealInFinder`,
+which never touches the API.
+
+## Checks
+
+`npm run lint` · `npm run format:check` · `npm run type-check` — all three run
+in CI.

--- a/macos/CLAUDE.md
+++ b/macos/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md — `macos`
+
+Two Swift apps: **Harbor Clerk Server** (menubar agent managing every backend
+service) and **Harbor Clerk** (WKWebView shell around the SPA). Build scripts in
+`scripts/`, orchestrated by `Makefile`.
+
+## Process management — the rules that cost real outages
+
+- **Never call `proc.waitUntilExit()` on the MainActor.** It blocks, and every
+  other service stalls in `startupPending` behind it. Use
+  `await withCheckedContinuation` instead — the pattern `MigrationRunner`
+  already uses.
+- **Nil the `readabilityHandler` on EOF.** `Log.createPipe()` installs a
+  readability handler; if it is never cleared, `waitUntilExit()` deadlocks
+  because the pipe's read end never closes. Set
+  `handle.readabilityHandler = nil` inside the `guard !data.isEmpty` else
+  branch. This presented as Alembic finishing while the runner hung forever;
+  `sample <pid>` showed the thread parked in `mach_msg2_trap`.
+- **`@MainActor` async functions still interleave.** They can suspend at any
+  `await`, so state read before an await may be stale after it. Guard every
+  state transition against concurrent mutation — `startService()` must re-check
+  `.shutdownPending` rather than trusting an earlier check.
+- **Kill process groups, not PIDs.** Tika forks JVMs and workers spawn
+  `pdftoppm`, `tesseract`, `magick`. `kill(pid, SIGKILL)` orphans the
+  grandchildren to launchd, where they survive relaunch. Use `killpg`.
+
+`ServiceState` has seven states: `stopped`, `startupPending`, `starting`,
+`running`, `shutdownPending`, `stopping`, `errored`. Pending states render with
+blue dots.
+
+Postgres and Tika may be **launchd-managed** rather than direct subprocesses, so
+they survive a menubar crash.
+
+## Environment for subprocesses
+
+`ServiceManager` builds one shared environment dict handed to every subprocess,
+which is why macOS gets variables like `LLAMA_SERVER_URL` for free. Docker
+Compose has no equivalent — each service opts in individually, and forgetting
+one there caused summarize to silently produce extractive summaries. When adding
+a variable a worker needs, check whether the Compose side needs it too.
+
+## Networking
+
+The WKWebView app loads the SPA over **plain HTTP on loopback** at `api_port`
+(default **8100**). The HTTPS gateway is a *separate* Caddy surface on **8443**
+for local MCP clients requiring TLS, with `internal` or operator-supplied
+certificates and a loopback-versus-LAN exposure check. These are different
+surfaces; do not conflate them.
+
+Port 80 is frequently occupied on macOS (AirPlay Receiver and friends) and is
+not needed for local development.
+
+## No native dialogs in the web view
+
+`window.confirm` and `window.alert` silently return false in WKWebView. Swift
+retains only two JS bridges — `pickFolder` (NSOpenPanel) and `revealInFinder`
+(NSWorkspace). Folder management UI lives at `/folders` in the web app; resist
+adding bridges for things the web app can do.
+
+## Naming
+
+Bundle IDs, keychain service IDs, access-group suffixes, and Logger subsystems
+all use **`com.harborclerk.*`** — never `com.bitblot.*`.
+
+## Worker presets (C = logical cores)
+
+| Preset | io | cpu | llm |
+|---|---|---|---|
+| Quiet | 1 | 1 | 1 |
+| Balanced | max(2, C//4) | 2 | 1 |
+| Fast | max(2, C//2) | 3 | 1 |
+
+Hard caps: io ≤ 8, cpu ≤ 4. The `llm` queue runs a single worker in every
+preset. These are defined in `ServiceManager.workerCounts`.
+
+## Builds
+
+`build-venv.sh` uses `pip install --upgrade` for the local packages
+(`harbor-clerk`, `embedder`). An older import-guard shortcut skipped reinstalls
+even when the Python source had changed, producing a stale venv inside a
+freshly-built app.

--- a/scripts/gen_docs/generators/entry_points.py
+++ b/scripts/gen_docs/generators/entry_points.py
@@ -1,0 +1,43 @@
+"""Generate the console-script table from pyproject.toml.
+
+`[project.scripts]` is the source of truth for what binaries this package
+installs. The hand-written copy in CLAUDE.md listed five entry points with
+prose descriptions that had no mechanism keeping them honest.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
+
+# What each entry point is for. Console scripts carry no description of their
+# own, so this is the one hand-written element — and
+# test_every_entry_point_is_described asserts it covers [project.scripts]
+# exactly, so a new script cannot ship undocumented.
+DESCRIPTIONS: dict[str, str] = {
+    "harbor-clerk-api": "FastAPI server — REST API, MCP endpoint, and the built SPA.",
+    "harbor-clerk-worker": "Ingestion worker. Subscribes to one or more queues via `--queues`.",
+    "harbor-clerk-watcher": "Watched-folder and IMAP observer; enqueues ingest jobs. One per deployment.",
+    "harbor-clerk-seed": "Database seeder.",
+    "harbor-clerk": "CLI for agent harnesses. Off by default, gated by `ENABLE_CLI_ACCESS`.",
+}
+
+
+def load_scripts() -> dict[str, str]:
+    data = tomllib.loads(PYPROJECT.read_text())
+    return dict(data["project"].get("scripts", {}))
+
+
+def generate() -> str:
+    scripts = load_scripts()
+    lines = [
+        f"**{len(scripts)} console scripts**, declared in `[project.scripts]`.",
+        "",
+        "| Command | Target | Purpose |",
+        "|---|---|---|",
+    ]
+    for name in sorted(scripts):
+        lines.append(f"| `{name}` | `{scripts[name]}` | {DESCRIPTIONS.get(name, '—')} |")
+    return "\n".join(lines)

--- a/scripts/gen_docs/registry.py
+++ b/scripts/gen_docs/registry.py
@@ -55,6 +55,12 @@ def _compose_services() -> str:
     return generate()
 
 
+def _entry_points() -> str:
+    from scripts.gen_docs.generators.entry_points import generate
+
+    return generate()
+
+
 def _cli_commands() -> str:
     from scripts.gen_docs.generators.cli_commands import generate
 
@@ -69,4 +75,5 @@ GENERATORS: dict[str, Callable[[], str]] = {
     "pipeline-stages": _pipeline_stages,
     "compose-services": _compose_services,
     "cli-commands": _cli_commands,
+    "entry-points": _entry_points,
 }

--- a/src/harbor_clerk/CLAUDE.md
+++ b/src/harbor_clerk/CLAUDE.md
@@ -64,3 +64,10 @@ fetched and stored, because there is no file on disk to reference.
   endpoint blocks the event loop — wrap it in `run_in_executor`.
 - SQLAlchemy enum members must be **lowercase** to match Postgres values: both
   `postgresql.ENUM` and `sa.Enum` send `.name`, not `.value`.
+
+## Legacy upload storage
+
+The legacy upload path stores originals in the `originals` bucket under
+`originals/<doc_id>/<original_filename>`. Watched-folder and IMAP documents do
+**not** use it — watched files are read in place from `source_path`, and mail
+content is stored via the normal document path.

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -266,3 +266,20 @@ def test_rest_access_gates_are_derived_for_every_operation() -> None:
     ):
         assert by_path.get((path, "POST")) == "admin", f"{path} must be marked admin-gated"
     assert any(a == "human only" for a in by_path.values()), "human-only gate should appear"
+
+
+def test_every_entry_point_is_described() -> None:
+    """The one hand-written element of entry_points cannot go stale.
+
+    Console scripts carry no description of their own, so DESCRIPTIONS is
+    hand-maintained — but it must cover [project.scripts] exactly in both
+    directions, so a new script cannot ship undocumented and a removed one
+    cannot linger.
+    """
+    from scripts.gen_docs.generators.entry_points import DESCRIPTIONS, load_scripts
+
+    scripts = set(load_scripts())
+    undescribed = sorted(scripts - set(DESCRIPTIONS))
+    stale = sorted(set(DESCRIPTIONS) - scripts)
+    assert not undescribed, f"console scripts with no description: {undescribed}"
+    assert not stale, f"DESCRIPTIONS references scripts that no longer exist: {stale}"


### PR DESCRIPTION
Batches 3–5. The root file is now **116 lines of rules** with no reference left in it, and the gotchas that lived only in personal memory are in the repo where a fresh clone can find them.

## Batch 3 — the four pending sections

| Section | Resolution |
|---|---|
| **Entry points** | **Generated** from `[project.scripts]` — a seventh generator. Block lives in `architecture.md`, not here, because this file is rules-only. |
| **Key API surface** | Deleted — it had become a pointer duplicating the Map. |
| **Database** | Deleted — "no `tenant_id`" is a non-negotiable, the `chunks` detail is in the backend scoped file, the table list is generated. MinIO key pattern moved to the backend file. |
| **Worker presets** | Moved to `macos/CLAUDE.md` — they're defined in Swift (`ServiceManager.workerCounts`), so the Python generator can't derive them. Honest placement beats forced generation. |

`DESCRIPTIONS` is the one hand-written part of the entry-points generator, and a test asserts it covers `[project.scripts]` exactly **in both directions** — verified it fires when a description is removed.

## Batch 4 — three scoped files

- **`frontend/`** — Tailwind v4 is CSS-first and *an agent that "fixes" the missing `tailwind.config.js` breaks the build*; the two react-hooks rules that bite; `legacy-peer-deps`; routing-unmount state loss; no `window.confirm` in WKWebView.
- **`macos/`** — never `waitUntilExit()` on MainActor; nil the `readabilityHandler` or the pipe deadlocks; `@MainActor` async still interleaves; `killpg` not `kill`; **the shared-environment asymmetry with Compose that caused the summarize outage**; the 8100-vs-8443 surface split; `com.harborclerk.*`.
- **`alembic/`** — enum members must be lowercase or SQLAlchemy sends the wrong label; the `schema_metadata` embedding sentinel; log-table conventions; generated FTS columns must never be written from app code.

## Batch 5 — assembly

The Map lists every scoped file and states that console scripts, tools, routes, tables, stages, and services are generated — with the regenerate command inline.

## Still needs you

**Verifying that scoped `CLAUDE.md` files actually load in a real session.** This was the risk I flagged at the outset: a rule in a file that doesn't load is *worse* than a diluted rule in the root, because you'd believe it was in force. I can't confirm loading behavior from here — it needs you to watch it in a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
