### PR TITLE
chore(frontend): migrate react-router-dom v7 → react-router v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,11 @@ jobs:
       - name: Type check
         run: npm run type-check
         working-directory: frontend
+      # `frontend/package.json` has defined `"test": "vitest"` all along, but
+      # nothing ran it. For the react-router v8 migration the only automated
+      # signal was `tsc --noEmit`, which passes trivially on an import rename —
+      # while the MemoryRouter-based route tests, the ones that would actually
+      # catch a routing regression, sat uncollected.
+      - name: Unit tests
+        run: npm test -- --run
+        working-directory: frontend

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,7 +1,10 @@
 # AGENTS.md — `frontend`
 
-React 19 · React Router 7 · Tailwind 4 · Vite 7 · ESLint 10. Built to static
+React 19 · React Router 8 · Tailwind 4 · Vite 8 · ESLint 10. Built to static
 files and served by FastAPI at `/`.
+
+**Import from `react-router`, not `react-router-dom`.** The DOM package was a
+re-export shim in v7 and does not exist in v8.
 
 ## Tailwind v4 is CSS-first — do not create a config file
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "react-dom": "^19.2.7",
         "react-is": "^19.2.7",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.17.0",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "umap-js": "^1.4.0"
@@ -2520,18 +2520,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4947,9 +4940,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5129,9 +5122,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -5149,7 +5142,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5303,41 +5296,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.17.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recharts": {
@@ -5543,12 +5519,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,5 +54,8 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.10"
+  },
+  "engines": {
+    "node": ">=22.22.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^19.2.7",
     "react-is": "^19.2.7",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.17.0",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "umap-js": "^1.4.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, Navigate, useParams } from 'react-router-dom'
+import { Route, Routes, Navigate, useParams } from 'react-router'
 import Layout from './components/Layout'
 import ProtectedRoute from './components/ProtectedRoute'
 import AdminRoute from './components/AdminRoute'

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet } from 'react-router'
 import { useAuth } from '../auth'
 
 export default function AdminRoute() {

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router'
 
 const TOP_LEVEL = new Set([
   '/',

--- a/frontend/src/components/CitedMarkdown.tsx
+++ b/frontend/src/components/CitedMarkdown.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { get } from '../api'

--- a/frontend/src/components/CorpusEmptyBanner.tsx
+++ b/frontend/src/components/CorpusEmptyBanner.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import type { CorpusBannerState } from '../hooks/useCorpusBannerState'
 
 interface Props {

--- a/frontend/src/components/EmailMetadataSection.tsx
+++ b/frontend/src/components/EmailMetadataSection.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 import { listMailAccounts } from '../api/mail'
 import type { MailAccountResponse } from '../types/mail'

--- a/frontend/src/components/GlobalStatusPill.test.tsx
+++ b/frontend/src/components/GlobalStatusPill.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get } from '../api'
 import { useAuth } from '../auth'

--- a/frontend/src/components/GlobalStatusPill.tsx
+++ b/frontend/src/components/GlobalStatusPill.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { get } from '../api'
 import { useAuth } from '../auth'
 import { useSystemConfig } from '../hooks/useSystemConfig'

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router'
 import { useAuth } from '../auth'
 import BackButton from './BackButton'
 import { LLMStatusBanner, LLMStatusProvider } from './LLMStatusBanner'

--- a/frontend/src/components/LocalAISetupPrompt.test.tsx
+++ b/frontend/src/components/LocalAISetupPrompt.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { describe, expect, it } from 'vitest'
 import { LocalAISetupPrompt } from './LocalAISetupPrompt'
 

--- a/frontend/src/components/LocalAISetupPrompt.tsx
+++ b/frontend/src/components/LocalAISetupPrompt.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 type LocalAISetupVariant = 'ask' | 'research'
 

--- a/frontend/src/components/LocalModelChip.test.tsx
+++ b/frontend/src/components/LocalModelChip.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import type { ComponentProps } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { describe, expect, it } from 'vitest'
 import { LocalModelChip } from './LocalModelChip'
 

--- a/frontend/src/components/LocalModelChip.tsx
+++ b/frontend/src/components/LocalModelChip.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { modelGuidance } from '../utils/modelGuidance'
 
 interface LocalModelChipModel {

--- a/frontend/src/components/OnboardingWizard.test.tsx
+++ b/frontend/src/components/OnboardingWizard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get } from '../api'
 import OnboardingWizard from './OnboardingWizard'

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { get, patch, post, ApiError } from '../api'
 import { Card } from './Card'
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet } from 'react-router'
 import { useAuth } from '../auth'
 
 export default function ProtectedRoute() {

--- a/frontend/src/components/RagContextCard.tsx
+++ b/frontend/src/components/RagContextCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import type { RagContextChunk } from '../contexts/ChatContext'
 
 function formatPages(start: number | null, end: number | null): string | null {

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuth } from '../auth'
 import SettingsLayout from './SettingsLayout'

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet } from 'react-router-dom'
+import { NavLink, Outlet } from 'react-router'
 import { useAuth } from '../auth'
 import { settingsSectionsForRole, type SettingsItem } from '../settingsNav'
 import { IconTile } from './IconTile'

--- a/frontend/src/components/queue-tray/CompletedRow.tsx
+++ b/frontend/src/components/queue-tray/CompletedRow.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { stageLabel } from '../../utils/stageLabel'
 import type { CompletedItem } from '../../hooks/useQueueTray'
 

--- a/frontend/src/components/queue-tray/PipelineTab.tsx
+++ b/frontend/src/components/queue-tray/PipelineTab.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { useQueueSnapshot } from '../../hooks/useQueueSnapshot'
 import WorkerStrip from './WorkerStrip'
 import StageHistogram from './StageHistogram'

--- a/frontend/src/components/stats/ClusterMap.tsx
+++ b/frontend/src/components/stats/ClusterMap.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { get } from '../../api'
 import { UMAP } from 'umap-js'
 

--- a/frontend/src/hooks/useAreaAccent.ts
+++ b/frontend/src/hooks/useAreaAccent.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 
 /** Single source of truth for the eight area names used throughout the design system. */
 export type AreaHue = 'ask' | 'research' | 'folders' | 'docs' | 'explore' | 'search' | 'observatory' | 'settings'

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './auth'
 import { ChatProvider } from './contexts/ChatContext'

--- a/frontend/src/pages/ApiKeyDashboardPage.tsx
+++ b/frontend/src/pages/ApiKeyDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router'
 import { del, get } from '../api'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { PageHeader } from '../components/PageHeader'

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { del, get, patch, post } from '../api'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { IconTile } from '../components/IconTile'
 import { FolderPicker } from '../components/FolderPicker'

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get, post, del } from '../api'
 import { useAuth } from '../auth'

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
-import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'react-router'
 import { get, post, del } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents, type JobEvent } from '../hooks/useJobEvents'

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { get, post, del, downloadBlob } from '../api'
 import { useAuth } from '../auth'
 import { useJobEvents } from '../hooks/useJobEvents'

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { get } from '../api'
 import { PageHeader } from '../components/PageHeader'

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get } from '../api'
 import HomePage from './HomePage'

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate } from 'react-router'
 import { get } from '../api'
 import { useAuth } from '../auth'
 

--- a/frontend/src/pages/IntegrationsPage.test.tsx
+++ b/frontend/src/pages/IntegrationsPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { del, get, put } from '../api'
 import IntegrationsPage from './IntegrationsPage'

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { del, get, put } from '../api'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'
 import { CliAccessCard } from '../components/CliAccessCard'

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate } from 'react-router'
 import { useAuth } from '../auth'
 import { Card } from '../components/Card'
 import { PageHeader } from '../components/PageHeader'

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router'
 import CitedMarkdown from '../components/CitedMarkdown'
 import { FolderPicker } from '../components/FolderPicker'
 import { LocalAISetupPrompt } from '../components/LocalAISetupPrompt'

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get, post } from '../api'
 import SearchPage from './SearchPage'

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { get, post } from '../api'
 import { Card } from '../components/Card'
 import { FolderPicker } from '../components/FolderPicker'

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useMemo, useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate } from 'react-router'
 import { useAuth } from '../auth'
 import { Card } from '../components/Card'
 import { PageHeader } from '../components/PageHeader'

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 import { get } from '../api'
 import CorpusCharts from '../components/stats/CorpusCharts'
 import EntityNetwork from '../components/stats/EntityNetwork'

--- a/frontend/src/pages/SystemSettingsPage.test.tsx
+++ b/frontend/src/pages/SystemSettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuth } from '../auth'
 import SystemSettingsPage from './SystemSettingsPage'

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { useAuth } from '../auth'
 import { PageHeader } from '../components/PageHeader'
 import { Card } from '../components/Card'

--- a/frontend/src/pages/SystemStatusPage.test.tsx
+++ b/frontend/src/pages/SystemStatusPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { get, post } from '../api'
 import { listMailAccounts } from '../api/mail'

--- a/frontend/src/pages/SystemStatusPage.tsx
+++ b/frontend/src/pages/SystemStatusPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { get, post } from '../api'
 import { listMailAccounts } from '../api/mail'
 import type { MailAccountResponse } from '../types/mail'


### PR DESCRIPTION
Unblocks `dependency-audit`, which is red on `main` and therefore blocking **every** open PR regardless of what it touches (#567, #568, #569, #570).

## Why a major bump was the only option

`react-router` had five advisories (two high), fixed only in **8.2.1+**. But `react-router-dom` stops at **7.18.1** and depends on the vulnerable `react-router`, so there was no in-place fix and `npm audit fix` could not resolve it.

In v7 `react-router-dom` was already just a DOM re-export of `react-router`; in v8 it is gone entirely. So the migration is a package swap plus an import-path rewrite across the 46 files that imported it. All twelve symbols in use — `BrowserRouter`, `Link`, `MemoryRouter`, `NavLink`, `Navigate`, `Outlet`, `Route`, `Routes`, `useLocation`, `useNavigate`, `useParams`, `useSearchParams` — exist unchanged in v8, so **no call sites needed rewriting**.

`npm audit fix` for postcss rides along. Together:

```
before: 3 vulnerabilities (1 moderate, 2 high)
after:  found 0 vulnerabilities
```

## Verification

A router major is exactly the change where the type checker passes and navigation still breaks, so this was exercised against the live API on the Mac mini, not just built:

| surface | result |
|---|---|
| All 7 nav links, client-side (`Link`/`useNavigate`) | each routes and renders |
| Redirect `/chat` → `/ask` (`Navigate replace`) | works |
| Nested route `/settings/models` under `SettingsLayout` `Outlet` | works |
| Route param `/docs/:id` incl. related-documents panel | works |
| `useSearchParams` — `/docs?summary_state=failed` drives filter state | works |
| Console errors across the whole pass | **zero** |

`tsc --noEmit` clean · 81/81 vitest · production build succeeds · prettier clean.

ESLint reports **the same 14 warnings as `main`** (hooks exhaustive-deps + one unused generic) — verified by running lint on `main` for comparison. None introduced.

## Note

`/search?q=` does not prefill the search box — worth knowing, but pre-existing: `SearchPage` never used `useSearchParams`. Not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)