### PR TITLE
chore(frontend): npm audit fix — brace-expansion DoS advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,9 @@
         "typescript-eslint": "^8.65.0",
         "vite": "^8.0.16",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2367,16 +2370,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
GHSA-mh99-v99m-4gvg published today and turned `dependency-audit` red on every open PR, none of which touch the frontend — the unrelated-failure mode `AGENTS.md` documents.

Lockfile-only and non-breaking: 7 insertions, 4 deletions, `found 0 vulnerabilities` after. `tsc` clean, 81/81 vitest.

Landed on its own branch because the other PRs are blocked by this check and cannot carry their own remedy.