### PR TITLE
fix(embedder): return the GPU allocator cache after inference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,5 @@ HARBOR_CLERK_MASTER_KEY=
 
 # Concurrent encodes in the embedder. 1 serialises the single shared model.
 EMBED_MAX_CONCURRENCY=1
+# Release the GPU allocator cache once it exceeds this many MB. 0 disables.
+GPU_CACHE_HIGH_WATER_MB=4096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,8 @@ services:
       # Concurrent encodes. 1 keeps the single shared model serialised, which is
       # what the service is tuned for; raise only with measurements.
       EMBED_MAX_CONCURRENCY: ${EMBED_MAX_CONCURRENCY:-1}
+      # Release the device allocator cache past this many MB. 0 disables.
+      GPU_CACHE_HIGH_WATER_MB: ${GPU_CACHE_HIGH_WATER_MB:-4096}
     healthcheck:
       test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/health').raise_for_status()"]
       interval: 10s
@@ -143,6 +145,9 @@ services:
       - harbor-clerk
 
   reranker:
+    environment:
+      # Same exposure as the embedder — variable-length passages.
+      GPU_CACHE_HIGH_WATER_MB: ${GPU_CACHE_HIGH_WATER_MB:-4096}
     build:
       context: .
       dockerfile: docker/reranker.Dockerfile

--- a/embedder/src/embedder/app.py
+++ b/embedder/src/embedder/app.py
@@ -127,9 +127,13 @@ async def embed(request: EmbedRequest):
     def _encode_and_release():
         # Both on the worker thread: `empty_cache` blocks, and doing it on the
         # event loop would re-create the /health starvation #553 was about.
-        out = model.encode(texts, normalize_embeddings=True)
-        release_gpu_cache()
-        return out
+        # In a finally because an MPS OOM is the likeliest failure here, and it
+        # surfaces as a 5xx that embedder_client retries — six more encodes
+        # against an allocator we never drained.
+        try:
+            return model.encode(texts, normalize_embeddings=True)
+        finally:
+            release_gpu_cache()
 
     async with slots:
         embeddings = await asyncio.to_thread(_encode_and_release)

--- a/embedder/src/embedder/app.py
+++ b/embedder/src/embedder/app.py
@@ -16,6 +16,8 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 from sentence_transformers import SentenceTransformer
 
+from embedder.gpu_cache import release_gpu_cache
+
 logger = logging.getLogger(__name__)
 
 MODEL_NAME = os.environ.get("EMBED_MODEL", "ibm-granite/granite-embedding-311m-multilingual-r2")
@@ -122,8 +124,15 @@ async def embed(request: EmbedRequest):
     # Note: the slot is released on exit, but a cancelled request cannot cancel
     # the worker thread — the encode runs to completion regardless. Reachable
     # today only at shutdown; worth knowing before wrapping /embed in a timeout.
+    def _encode_and_release():
+        # Both on the worker thread: `empty_cache` blocks, and doing it on the
+        # event loop would re-create the /health starvation #553 was about.
+        out = model.encode(texts, normalize_embeddings=True)
+        release_gpu_cache()
+        return out
+
     async with slots:
-        embeddings = await asyncio.to_thread(model.encode, texts, normalize_embeddings=True)
+        embeddings = await asyncio.to_thread(_encode_and_release)
 
     return EmbedResponse(
         embeddings=embeddings.tolist(),

--- a/embedder/src/embedder/gpu_cache.py
+++ b/embedder/src/embedder/gpu_cache.py
@@ -1,4 +1,4 @@
-"""Return GPU allocator cache to the OS after inference.
+"""Return GPU allocator cache to the OS when it grows past a high-water mark.
 
 PyTorch's caching allocator keeps freed device blocks for reuse and never
 returns them. That is normally self-limiting — a steady workload reaches a
@@ -7,7 +7,7 @@ the inputs are documents and email bodies whose lengths vary by orders of
 magnitude: nearly every batch asks for a shape the cache has not seen, so it
 allocates a fresh block and the cache ratchets upward forever.
 
-Measured on the Mac mini (M4, 32 GB), embedding a real corpus:
+Measured on the Mac mini (M4, 32 GB) during a 7,449-message email ingest:
 
     fresh embedder process          1.5 GB
     after ~1.5 hours of ingest       40 GB   (phys_footprint, peak 44 GB)
@@ -15,17 +15,18 @@ Measured on the Mac mini (M4, 32 GB), embedding a real corpus:
 At that point the machine had 347 MB free, 15 GB in the compressor and 13 GB of
 swap in use. Restarting the embedder returned free memory to 11 GB.
 
-Ten batches of 64 variable-length texts, with and without releasing:
+It is not a leak: `current_allocated_memory` never moved off 594 MB and
+`gc.collect()` changed nothing. Only `empty_cache()` returns it.
 
-    unmanaged (GB)  6.7 12.8  6.5  8.6  8.6  9.6 11.9 16.3 11.5 12.4
-    managed   (GB)  4.1  8.6  2.4  2.9  2.9  2.3  3.0  7.4  2.6  3.5
-
-Managed still spikes while a large batch is in flight — that is live
-allocation, not cache — but it returns to baseline instead of ratcheting.
-
-Releasing costs nothing measurable (97.2s vs 96.8s over five batches) and on a
-machine this tight it is slightly *faster*, because holding gigabytes of dead
-cache costs more in compression and swap than re-allocating does.
+**Why a high-water mark rather than releasing after every call.** The same
+endpoints serve two very different workloads. Ingest sends batches of 64
+variable-length chunks, which is what ratchets. Search sends a *single* query
+string on every request, and `/rerank` sits on that same request path. Draining
+unconditionally would throw away the cache the next query is about to reuse, on
+an interactive path whose latency budget is already tight — and the reranker has
+no concurrency gate, so one thread's drain would pull the cache out from under
+the others mid-flight. Gating on the gap means small requests never pay, and the
+ratchet is still bounded.
 
 Call this on the worker thread, never the event loop: `empty_cache` blocks, and
 starving `/health` is exactly what #553 was about.
@@ -35,33 +36,70 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 
 logger = logging.getLogger(__name__)
 
-# Escape hatch. Set to 0/false to keep PyTorch's default caching behaviour, e.g.
-# on a machine with headroom to spare where the reuse is worth more than the RAM.
-RELEASE_GPU_CACHE = os.environ.get("RELEASE_GPU_CACHE", "true").lower() not in ("0", "false", "no")
 
-_warned = False
+def _int_env(name: str, default: int) -> int:
+    """Total parse — this runs at import, so a bad value must not stop startup."""
+    raw = os.environ.get(name, "")
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        if raw:
+            logger.warning("%s=%r is not an integer; using %d", name, raw, default)
+        return default
+
+
+# Release once the cached-but-unused pool exceeds this. Measured on the Mac
+# mini, the two workloads separate by more than an order of magnitude:
+#
+#     search steady state (single-query encodes)   0.44 GB   flat
+#     after three ingest batches of 64             8.22 GB
+#
+# 4 GB sits well clear of both: search never triggers a drain, and the ratchet
+# is caught long before it costs swap. A first attempt at 2 GB was too low —
+# searches issued right after an ingest still sat above the mark and drained on
+# every request, which is the interactive path this gate exists to protect.
+CACHE_HIGH_WATER_MB = _int_env("GPU_CACHE_HIGH_WATER_MB", 4096)
+
+# 0 disables entirely, restoring PyTorch's default behaviour.
+ENABLED = CACHE_HIGH_WATER_MB > 0
+
+_last_warned_at = 0.0
+_WARN_INTERVAL_SECONDS = 300.0
+
+
+def _warn(msg: str) -> None:
+    """Rate-limited rather than once-per-process: this guards an OOM-class
+    outage, and a single log line hours ago is not a signal anyone will see."""
+    global _last_warned_at
+    now = time.monotonic()
+    if now - _last_warned_at >= _WARN_INTERVAL_SECONDS:
+        _last_warned_at = now
+        logger.warning(msg, exc_info=True)
 
 
 def release_gpu_cache() -> None:
-    """Hand cached device memory back, on whichever backend is active.
+    """Drain the device allocator's free pool if it has grown past the mark.
 
     Silent no-op on CPU-only deployments (Docker), where there is no device
-    allocator to drain.
+    allocator. Never raises — cache hygiene must not fail an inference call.
     """
-    global _warned
-    if not RELEASE_GPU_CACHE:
+    if not ENABLED:
         return
     try:
         import torch
 
+        threshold = CACHE_HIGH_WATER_MB * 1024 * 1024
         if torch.backends.mps.is_available():
-            torch.mps.empty_cache()
+            gap = torch.mps.driver_allocated_memory() - torch.mps.current_allocated_memory()
+            if gap > threshold:
+                torch.mps.empty_cache()
         elif torch.cuda.is_available():
-            torch.cuda.empty_cache()
-    except Exception:  # noqa: BLE001 — never fail an encode over cache hygiene
-        if not _warned:
-            logger.warning("could not release GPU cache; continuing", exc_info=True)
-            _warned = True
+            gap = torch.cuda.memory_reserved() - torch.cuda.memory_allocated()
+            if gap > threshold:
+                torch.cuda.empty_cache()
+    except Exception:  # never fail an encode over cache hygiene
+        _warn("could not release GPU cache; continuing")

--- a/embedder/src/embedder/gpu_cache.py
+++ b/embedder/src/embedder/gpu_cache.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 
 logger = logging.getLogger(__name__)
@@ -102,18 +103,33 @@ _WARN_INTERVAL_SECONDS = 300.0
 # mark and every subsequent request trying again.
 #
 # Gated on ineffectiveness rather than on time alone, because a blanket
-# interval defeats the `finally` at both call sites. embedder_client retries a
-# 5xx up to 7 times with cumulative minimum elapsed of 0.25/0.75/1.75/3.75s
-# before attempts 2-5 — all inside a flat 5s window — so an OOM would drain
-# once and then skip every retry, which is precisely the case the `finally`
-# was added for. And the first drain is the one least likely to work: it runs
-# while the failed encode's intermediates are still reachable through the
-# in-flight traceback.
+# interval defeats the `finally` at the /embed call site: embedder_client
+# retries a 5xx up to 7 times with cumulative minimum elapsed of
+# 0.25/0.75/1.75/3.75s before attempts 2-5 — all inside a flat 5s window — so
+# an OOM would drain once and then skip every retry, which is precisely the
+# case that `finally` was added for. (/rerank is different: rerank_hits
+# catches once and degrades to the hybrid order, no retry — there the finally
+# protects the next request.)
+#
+# Residual risk, stated plainly: if the *first* OOM-path drain is itself
+# ineffective — plausible, since it runs while the failed encode's
+# intermediates are still reachable through the in-flight traceback — it
+# starts this cooldown and suppresses the retries' drains after all. That
+# worst case is the pre-#574 status quo (no drain at all), never worse than
+# it, and it ends within the 5s window; a drain that *works* records no
+# cooldown, so the recovering case is never throttled.
 _MIN_DRAIN_INTERVAL_SECONDS = 5.0
 # A drain that recovers less than this did not work — the heaps were pinned by
 # something live. Only *those* start a cooldown.
 _MIN_USEFUL_RECLAIM_BYTES = 64 * 1024 * 1024
 _last_drain_at = float("-inf")
+# check-gap → check-cooldown → drain → record is not atomic, and /rerank runs
+# release on the default executor with no concurrency gate — so without the
+# lock, N simultaneous requests all clear the cooldown check before any
+# records a timestamp: N blocking drains, which is the storm the cooldown
+# exists to stop, plus cross-thread `after` measurements crediting one
+# thread's reclaim to another and recording the wrong cooldown state.
+_drain_lock = threading.Lock()
 
 
 def _warn(msg: str) -> None:
@@ -145,36 +161,43 @@ def release_gpu_cache() -> None:
         else:
             return  # CPU-only: no device allocator to drain
 
-        gap = measure(torch)
-        if gap <= CACHE_HIGH_WATER_MB * 1024 * 1024:
+        # Non-blocking: a thread that finds the lock held would only repeat the
+        # holder's drain microseconds later against the same heaps, so skipping
+        # is the correct outcome — and an inference thread never stalls here.
+        if not _drain_lock.acquire(blocking=False):
             return
+        try:
+            gap = measure(torch)
+            if gap <= CACHE_HIGH_WATER_MB * 1024 * 1024:
+                return
 
-        now = time.monotonic()
-        if now - _last_drain_at < _MIN_DRAIN_INTERVAL_SECONDS:
-            return
+            now = time.monotonic()
+            if now - _last_drain_at < _MIN_DRAIN_INTERVAL_SECONDS:
+                return
 
-        drain()
-        after = measure(torch)
-        reclaimed = gap - after
+            drain()
+            after = measure(torch)
+            reclaimed = gap - after
 
-        # Cool down only if that achieved nothing. A drain that worked is
-        # evidence the heaps are releasable, so blocking the next one would
-        # defeat the `finally` at both call sites: embedder_client retries a 5xx
-        # up to 7 times, with cumulative minimum elapsed of 0.25/0.75/1.75/3.75s
-        # before attempts 2-5 — all inside a flat 5s window.
-        _last_drain_at = now if reclaimed < _MIN_USEFUL_RECLAIM_BYTES else float("-inf")
+            # Cool down only if that achieved nothing. A drain that worked is
+            # evidence the heaps are releasable, so blocking the next one would
+            # defeat the /embed `finally` under embedder_client's retries — see
+            # the note on _MIN_DRAIN_INTERVAL_SECONDS.
+            _last_drain_at = now if reclaimed < _MIN_USEFUL_RECLAIM_BYTES else float("-inf")
 
-        # INFO, not DEBUG: both services hard-code basicConfig(level=INFO) with
-        # no override, so a debug line is unreachable in every shipped
-        # deployment — and this is the only signal distinguishing "working" from
-        # "firing constantly and recovering nothing".
-        logger.info(
-            "%s cache drained: %.0f MB -> %.0f MB (reclaimed %.0f MB)",
-            label,
-            gap / 1024 / 1024,
-            after / 1024 / 1024,
-            reclaimed / 1024 / 1024,
-        )
+            # INFO, not DEBUG: both services hard-code basicConfig(level=INFO)
+            # with no override, so a debug line is unreachable in every shipped
+            # deployment — and this is the only signal distinguishing "working"
+            # from "firing constantly and recovering nothing".
+            logger.info(
+                "%s cache drained: %.0f MB -> %.0f MB (reclaimed %.0f MB)",
+                label,
+                gap / 1024 / 1024,
+                after / 1024 / 1024,
+                reclaimed / 1024 / 1024,
+            )
+        finally:
+            _drain_lock.release()
     except Exception:  # never fail an encode over cache hygiene
         _warn("could not release GPU cache; continuing")
 

--- a/embedder/src/embedder/gpu_cache.py
+++ b/embedder/src/embedder/gpu_cache.py
@@ -69,7 +69,7 @@ def _int_env(name: str, default: int) -> int:
         # with no log line. Fail loudly toward the safe value instead.
         logger.warning("%s=%d is negative; using %d", name, value, default)
         return default
-    if 0 < value > _MAX_SANE_HIGH_WATER_MB:
+    if value > _MAX_SANE_HIGH_WATER_MB:
         # A value larger than any plausible machine is "off" in effect, which is
         # the same failure the negative branch exists to prevent — just spelled
         # differently. 0 stays a deliberate, documented disable.
@@ -96,12 +96,23 @@ ENABLED = CACHE_HIGH_WATER_MB > 0
 _last_warned_at = float("-inf")
 _WARN_INTERVAL_SECONDS = 300.0
 
-# Minimum gap between drain *attempts*. A drain costs 3-17ms for ~1 GB, so the
-# point is not the cost of one — it is that under concurrency a drain can
+# Minimum gap after an *ineffective* drain. A drain costs 3-17ms for ~1 GB, so
+# the point is not the cost of one — it is that under concurrency a drain can
 # reclaim nothing while activations pin the heaps, leaving the gap above the
-# mark and every subsequent request trying again. One attempt per interval
-# bounds that to a rounding error.
+# mark and every subsequent request trying again.
+#
+# Gated on ineffectiveness rather than on time alone, because a blanket
+# interval defeats the `finally` at both call sites. embedder_client retries a
+# 5xx up to 7 times with cumulative minimum elapsed of 0.25/0.75/1.75/3.75s
+# before attempts 2-5 — all inside a flat 5s window — so an OOM would drain
+# once and then skip every retry, which is precisely the case the `finally`
+# was added for. And the first drain is the one least likely to work: it runs
+# while the failed encode's intermediates are still reachable through the
+# in-flight traceback.
 _MIN_DRAIN_INTERVAL_SECONDS = 5.0
+# A drain that recovers less than this did not work — the heaps were pinned by
+# something live. Only *those* start a cooldown.
+_MIN_USEFUL_RECLAIM_BYTES = 64 * 1024 * 1024
 _last_drain_at = float("-inf")
 
 
@@ -141,14 +152,29 @@ def release_gpu_cache() -> None:
         now = time.monotonic()
         if now - _last_drain_at < _MIN_DRAIN_INTERVAL_SECONDS:
             return
-        _last_drain_at = now
 
         drain()
-        # Logged because nothing else shows whether the guard ever fired or how
-        # much it recovered — which is what distinguishes "working" from
-        # "firing constantly and reclaiming nothing".
         after = measure(torch)
-        logger.debug("%s cache drained: gap %.0f MB -> %.0f MB", label, gap / 1024 / 1024, after / 1024 / 1024)
+        reclaimed = gap - after
+
+        # Cool down only if that achieved nothing. A drain that worked is
+        # evidence the heaps are releasable, so blocking the next one would
+        # defeat the `finally` at both call sites: embedder_client retries a 5xx
+        # up to 7 times, with cumulative minimum elapsed of 0.25/0.75/1.75/3.75s
+        # before attempts 2-5 — all inside a flat 5s window.
+        _last_drain_at = now if reclaimed < _MIN_USEFUL_RECLAIM_BYTES else float("-inf")
+
+        # INFO, not DEBUG: both services hard-code basicConfig(level=INFO) with
+        # no override, so a debug line is unreachable in every shipped
+        # deployment — and this is the only signal distinguishing "working" from
+        # "firing constantly and recovering nothing".
+        logger.info(
+            "%s cache drained: %.0f MB -> %.0f MB (reclaimed %.0f MB)",
+            label,
+            gap / 1024 / 1024,
+            after / 1024 / 1024,
+            reclaimed / 1024 / 1024,
+        )
     except Exception:  # never fail an encode over cache hygiene
         _warn("could not release GPU cache; continuing")
 

--- a/embedder/src/embedder/gpu_cache.py
+++ b/embedder/src/embedder/gpu_cache.py
@@ -45,11 +45,18 @@ def _int_env(name: str, default: int) -> int:
     """Total parse — this runs at import, so a bad value must not stop startup."""
     raw = os.environ.get(name, "")
     try:
-        return max(0, int(raw))
+        value = int(raw)
     except ValueError:
         if raw:
             logger.warning("%s=%r is not an integer; using %d", name, raw, default)
         return default
+    if value < 0:
+        # Clamping to 0 would land on the "off" sentinel, so an operator typing
+        # -1 to mean "no limit" would silently get the unbounded growth back
+        # with no log line. Fail loudly toward the safe value instead.
+        logger.warning("%s=%d is negative; using %d", name, value, default)
+        return default
+    return value
 
 
 # Release once the cached-but-unused pool exceeds this. Measured on the Mac
@@ -67,7 +74,7 @@ CACHE_HIGH_WATER_MB = _int_env("GPU_CACHE_HIGH_WATER_MB", 4096)
 # 0 disables entirely, restoring PyTorch's default behaviour.
 ENABLED = CACHE_HIGH_WATER_MB > 0
 
-_last_warned_at = 0.0
+_last_warned_at = float("-inf")
 _WARN_INTERVAL_SECONDS = 300.0
 
 

--- a/embedder/src/embedder/gpu_cache.py
+++ b/embedder/src/embedder/gpu_cache.py
@@ -1,0 +1,67 @@
+"""Return GPU allocator cache to the OS after inference.
+
+PyTorch's caching allocator keeps freed device blocks for reuse and never
+returns them. That is normally self-limiting — a steady workload reaches a
+steady state and the cache is pure win. It is not self-limiting here, because
+the inputs are documents and email bodies whose lengths vary by orders of
+magnitude: nearly every batch asks for a shape the cache has not seen, so it
+allocates a fresh block and the cache ratchets upward forever.
+
+Measured on the Mac mini (M4, 32 GB), embedding a real corpus:
+
+    fresh embedder process          1.5 GB
+    after ~1.5 hours of ingest       40 GB   (phys_footprint, peak 44 GB)
+
+At that point the machine had 347 MB free, 15 GB in the compressor and 13 GB of
+swap in use. Restarting the embedder returned free memory to 11 GB.
+
+Ten batches of 64 variable-length texts, with and without releasing:
+
+    unmanaged (GB)  6.7 12.8  6.5  8.6  8.6  9.6 11.9 16.3 11.5 12.4
+    managed   (GB)  4.1  8.6  2.4  2.9  2.9  2.3  3.0  7.4  2.6  3.5
+
+Managed still spikes while a large batch is in flight — that is live
+allocation, not cache — but it returns to baseline instead of ratcheting.
+
+Releasing costs nothing measurable (97.2s vs 96.8s over five batches) and on a
+machine this tight it is slightly *faster*, because holding gigabytes of dead
+cache costs more in compression and swap than re-allocating does.
+
+Call this on the worker thread, never the event loop: `empty_cache` blocks, and
+starving `/health` is exactly what #553 was about.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Escape hatch. Set to 0/false to keep PyTorch's default caching behaviour, e.g.
+# on a machine with headroom to spare where the reuse is worth more than the RAM.
+RELEASE_GPU_CACHE = os.environ.get("RELEASE_GPU_CACHE", "true").lower() not in ("0", "false", "no")
+
+_warned = False
+
+
+def release_gpu_cache() -> None:
+    """Hand cached device memory back, on whichever backend is active.
+
+    Silent no-op on CPU-only deployments (Docker), where there is no device
+    allocator to drain.
+    """
+    global _warned
+    if not RELEASE_GPU_CACHE:
+        return
+    try:
+        import torch
+
+        if torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+        elif torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001 — never fail an encode over cache hygiene
+        if not _warned:
+            logger.warning("could not release GPU cache; continuing", exc_info=True)
+            _warned = True

--- a/embedder/src/embedder/gpu_cache.py
+++ b/embedder/src/embedder/gpu_cache.py
@@ -22,11 +22,19 @@ It is not a leak: `current_allocated_memory` never moved off 594 MB and
 endpoints serve two very different workloads. Ingest sends batches of 64
 variable-length chunks, which is what ratchets. Search sends a *single* query
 string on every request, and `/rerank` sits on that same request path. Draining
-unconditionally would throw away the cache the next query is about to reuse, on
-an interactive path whose latency budget is already tight — and the reranker has
-no concurrency gate, so one thread's drain would pull the cache out from under
-the others mid-flight. Gating on the gap means small requests never pay, and the
-ratchet is still bounded.
+unconditionally throws away the cache the next query is about to reuse, on an
+interactive path whose latency budget is already tight. Gating on the gap means
+small requests never pay, and the ratchet is still bounded.
+
+**Why a cooldown as well.** `empty_cache()` can only release heaps with no live
+buffers, so a drain issued while another request holds activations reclaims
+almost nothing — measured at 8 MB of 1024. Without a cooldown the gap stays
+above the mark, so the *next* request drains too, and every one after it: the
+gate degrades into firing constantly and reclaiming nothing, under exactly the
+concurrent load that triggers it. (An earlier draft of this comment claimed the
+hazard was one thread pulling the cache out from under another. That is not
+possible — live tensors are never freed by `empty_cache` — and the real
+pathology is the opposite one.)
 
 Call this on the worker thread, never the event loop: `empty_cache` blocks, and
 starving `/health` is exactly what #553 was about.
@@ -39,6 +47,11 @@ import os
 import time
 
 logger = logging.getLogger(__name__)
+
+
+# Larger than the unified memory of any Mac this ships on, so a value above it
+# is a typo or a misunderstanding rather than a configuration.
+_MAX_SANE_HIGH_WATER_MB = 512 * 1024
 
 
 def _int_env(name: str, default: int) -> int:
@@ -55,6 +68,12 @@ def _int_env(name: str, default: int) -> int:
         # -1 to mean "no limit" would silently get the unbounded growth back
         # with no log line. Fail loudly toward the safe value instead.
         logger.warning("%s=%d is negative; using %d", name, value, default)
+        return default
+    if 0 < value > _MAX_SANE_HIGH_WATER_MB:
+        # A value larger than any plausible machine is "off" in effect, which is
+        # the same failure the negative branch exists to prevent — just spelled
+        # differently. 0 stays a deliberate, documented disable.
+        logger.warning("%s=%d exceeds any plausible device memory; using %d", name, value, default)
         return default
     return value
 
@@ -77,6 +96,14 @@ ENABLED = CACHE_HIGH_WATER_MB > 0
 _last_warned_at = float("-inf")
 _WARN_INTERVAL_SECONDS = 300.0
 
+# Minimum gap between drain *attempts*. A drain costs 3-17ms for ~1 GB, so the
+# point is not the cost of one — it is that under concurrency a drain can
+# reclaim nothing while activations pin the heaps, leaving the gap above the
+# mark and every subsequent request trying again. One attempt per interval
+# bounds that to a rounding error.
+_MIN_DRAIN_INTERVAL_SECONDS = 5.0
+_last_drain_at = float("-inf")
+
 
 def _warn(msg: str) -> None:
     """Rate-limited rather than once-per-process: this guards an OOM-class
@@ -94,19 +121,41 @@ def release_gpu_cache() -> None:
     Silent no-op on CPU-only deployments (Docker), where there is no device
     allocator. Never raises — cache hygiene must not fail an inference call.
     """
+    global _last_drain_at
     if not ENABLED:
         return
     try:
         import torch
 
-        threshold = CACHE_HIGH_WATER_MB * 1024 * 1024
         if torch.backends.mps.is_available():
-            gap = torch.mps.driver_allocated_memory() - torch.mps.current_allocated_memory()
-            if gap > threshold:
-                torch.mps.empty_cache()
+            measure, drain, label = _mps_gap, torch.mps.empty_cache, "mps"
         elif torch.cuda.is_available():
-            gap = torch.cuda.memory_reserved() - torch.cuda.memory_allocated()
-            if gap > threshold:
-                torch.cuda.empty_cache()
+            measure, drain, label = _cuda_gap, torch.cuda.empty_cache, "cuda"
+        else:
+            return  # CPU-only: no device allocator to drain
+
+        gap = measure(torch)
+        if gap <= CACHE_HIGH_WATER_MB * 1024 * 1024:
+            return
+
+        now = time.monotonic()
+        if now - _last_drain_at < _MIN_DRAIN_INTERVAL_SECONDS:
+            return
+        _last_drain_at = now
+
+        drain()
+        # Logged because nothing else shows whether the guard ever fired or how
+        # much it recovered — which is what distinguishes "working" from
+        # "firing constantly and reclaiming nothing".
+        after = measure(torch)
+        logger.debug("%s cache drained: gap %.0f MB -> %.0f MB", label, gap / 1024 / 1024, after / 1024 / 1024)
     except Exception:  # never fail an encode over cache hygiene
         _warn("could not release GPU cache; continuing")
+
+
+def _mps_gap(torch) -> int:
+    return torch.mps.driver_allocated_memory() - torch.mps.current_allocated_memory()
+
+
+def _cuda_gap(torch) -> int:
+    return torch.cuda.memory_reserved() - torch.cuda.memory_allocated()

--- a/embedder/src/embedder/reranker.py
+++ b/embedder/src/embedder/reranker.py
@@ -74,15 +74,25 @@ async def rerank(req: RerankRequest):
     if not req.passages:
         return RerankResponse(scores=[], model=MODEL_NAME)
 
+    # Bind before handing work to the executor. The previous form,
+    # `run_in_executor(None, _model.predict, pairs)`, evaluated `_model.predict`
+    # eagerly on the event loop; a closure reading the global instead resolves
+    # it on the worker thread — after an await — so lifespan shutdown can null
+    # it in between and turn the intended 503 into an AttributeError 500. Same
+    # hazard app.py guards against.
+    model = _model
     pairs = [[req.query, p] for p in req.passages]
 
     def _predict_and_release():
         # Same exposure as the embedder: variable-length passages mean the
         # allocator cache never reaches a steady state. Released on the worker
-        # thread so the event loop stays free.
-        out = _model.predict(pairs)
-        release_gpu_cache()
-        return out
+        # thread so the event loop stays free, and in a finally so an OOM —
+        # the likeliest failure on a tight machine — still drains rather than
+        # leaving the pool full for the retry that follows.
+        try:
+            return model.predict(pairs)
+        finally:
+            release_gpu_cache()
 
     raw_scores = await asyncio.get_event_loop().run_in_executor(None, _predict_and_release)
     indexed = sorted(

--- a/embedder/src/embedder/reranker.py
+++ b/embedder/src/embedder/reranker.py
@@ -15,6 +15,8 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 from sentence_transformers import CrossEncoder
 
+from embedder.gpu_cache import release_gpu_cache
+
 logger = logging.getLogger(__name__)
 
 MODEL_NAME = os.environ.get("RERANKER_MODEL", "BAAI/bge-reranker-v2-m3")
@@ -73,7 +75,16 @@ async def rerank(req: RerankRequest):
         return RerankResponse(scores=[], model=MODEL_NAME)
 
     pairs = [[req.query, p] for p in req.passages]
-    raw_scores = await asyncio.get_event_loop().run_in_executor(None, _model.predict, pairs)
+
+    def _predict_and_release():
+        # Same exposure as the embedder: variable-length passages mean the
+        # allocator cache never reaches a steady state. Released on the worker
+        # thread so the event loop stays free.
+        out = _model.predict(pairs)
+        release_gpu_cache()
+        return out
+
+    raw_scores = await asyncio.get_event_loop().run_in_executor(None, _predict_and_release)
     indexed = sorted(
         ((i, float(s)) for i, s in enumerate(raw_scores)),
         key=lambda x: x[1],

--- a/embedder/src/embedder/reranker.py
+++ b/embedder/src/embedder/reranker.py
@@ -87,8 +87,10 @@ async def rerank(req: RerankRequest):
         # Same exposure as the embedder: variable-length passages mean the
         # allocator cache never reaches a steady state. Released on the worker
         # thread so the event loop stays free, and in a finally so an OOM —
-        # the likeliest failure on a tight machine — still drains rather than
-        # leaving the pool full for the retry that follows.
+        # the likeliest failure on a tight machine — still drains. Unlike
+        # /embed there is no retry behind this: search_rerank.rerank_hits
+        # catches once and degrades to the hybrid order, so the drain here is
+        # for the *next* search, not a retry of this one.
         try:
             return model.predict(pairs)
         finally:

--- a/embedder/tests/test_embedder_app.py
+++ b/embedder/tests/test_embedder_app.py
@@ -244,37 +244,3 @@ def test_encode_releases_the_gpu_cache(stub_model):
             assert c.post("/embed", json={"texts": ["b", "c"]}).status_code == 200
 
     assert len(calls) == 2, f"expected a release per encode, got {len(calls)}"
-
-
-def test_release_is_a_noop_without_a_device(monkeypatch):
-    """CPU-only deployments (Docker) have no device allocator to drain, and a
-    failure here must never fail an encode."""
-    import builtins
-
-    from embedder.gpu_cache import release_gpu_cache
-
-    real_import = builtins.__import__
-
-    def _no_torch(name, *a, **kw):
-        if name == "torch":
-            raise ImportError("no torch here")
-        return real_import(name, *a, **kw)
-
-    monkeypatch.setattr(builtins, "__import__", _no_torch)
-    release_gpu_cache()  # must not raise
-
-
-def test_release_can_be_disabled(monkeypatch):
-    """Escape hatch for machines with headroom, where cache reuse wins."""
-    import importlib
-
-    monkeypatch.setenv("RELEASE_GPU_CACHE", "false")
-    import embedder.gpu_cache as gc
-
-    importlib.reload(gc)
-    try:
-        assert gc.RELEASE_GPU_CACHE is False
-        gc.release_gpu_cache()  # no-op, must not raise
-    finally:
-        monkeypatch.delenv("RELEASE_GPU_CACHE", raising=False)
-        importlib.reload(gc)

--- a/embedder/tests/test_embedder_app.py
+++ b/embedder/tests/test_embedder_app.py
@@ -218,3 +218,63 @@ def test_embed_returns_503_before_the_semaphore_exists(stub_model):
         # Outside the TestClient context lifespan never ran, so both globals are None.
         assert app_module._encode_slots is None
         assert app_module._model is None
+
+
+def test_encode_releases_the_gpu_cache(stub_model):
+    """The allocator cache must be handed back after each encode.
+
+    PyTorch's caching allocator never returns device memory on its own. That is
+    fine for a steady workload, but the inputs here are documents and email
+    bodies of wildly varying length, so nearly every batch asks for an unseen
+    shape and the cache ratchets. Measured on the Mac mini: 1.5 GB fresh, 40 GB
+    after ~1.5 hours of ingest, with the machine down to 347 MB free.
+    """
+    from unittest.mock import patch
+
+    calls = []
+
+    with (
+        patch("embedder.app.SentenceTransformer", return_value=stub_model),
+        patch("embedder.app.release_gpu_cache", side_effect=lambda: calls.append(1)),
+    ):
+        from embedder.app import app
+
+        with TestClient(app) as c:
+            assert c.post("/embed", json={"texts": ["a"]}).status_code == 200
+            assert c.post("/embed", json={"texts": ["b", "c"]}).status_code == 200
+
+    assert len(calls) == 2, f"expected a release per encode, got {len(calls)}"
+
+
+def test_release_is_a_noop_without_a_device(monkeypatch):
+    """CPU-only deployments (Docker) have no device allocator to drain, and a
+    failure here must never fail an encode."""
+    import builtins
+
+    from embedder.gpu_cache import release_gpu_cache
+
+    real_import = builtins.__import__
+
+    def _no_torch(name, *a, **kw):
+        if name == "torch":
+            raise ImportError("no torch here")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _no_torch)
+    release_gpu_cache()  # must not raise
+
+
+def test_release_can_be_disabled(monkeypatch):
+    """Escape hatch for machines with headroom, where cache reuse wins."""
+    import importlib
+
+    monkeypatch.setenv("RELEASE_GPU_CACHE", "false")
+    import embedder.gpu_cache as gc
+
+    importlib.reload(gc)
+    try:
+        assert gc.RELEASE_GPU_CACHE is False
+        gc.release_gpu_cache()  # no-op, must not raise
+    finally:
+        monkeypatch.delenv("RELEASE_GPU_CACHE", raising=False)
+        importlib.reload(gc)

--- a/embedder/tests/test_embedder_app.py
+++ b/embedder/tests/test_embedder_app.py
@@ -271,3 +271,41 @@ def test_cache_is_released_even_when_encode_raises(stub_model):
             assert r.status_code >= 500
 
     assert calls == [1], "cache was not released when the encode raised"
+
+
+def test_release_runs_on_the_worker_thread_not_the_event_loop(stub_model):
+    """The #553 invariant, asserted in three comments and guarded by none.
+
+    `empty_cache()` blocks. Doing it on the event loop re-creates exactly the
+    /health starvation the service was fixed for. Mutating the call site to
+    release outside `to_thread` left all 25 tests green.
+    """
+    import threading
+    from unittest.mock import patch
+
+    loop_thread = []
+    release_thread = []
+
+    def _note_encode(texts, normalize_embeddings=True):
+        loop_thread.append(threading.current_thread().name)
+        return np.stack([np.full(768, 0.1, dtype=np.float32) for _ in texts])
+
+    stub_model.encode.side_effect = _note_encode
+
+    with (
+        patch("embedder.app.SentenceTransformer", return_value=stub_model),
+        patch(
+            "embedder.app.release_gpu_cache",
+            side_effect=lambda: release_thread.append(threading.current_thread().name),
+        ),
+    ):
+        from embedder.app import app
+
+        with TestClient(app) as c:
+            assert c.post("/embed", json={"texts": ["a"]}).status_code == 200
+
+    assert release_thread, "release never ran"
+    assert release_thread[0] == loop_thread[0], (
+        f"release ran on {release_thread[0]} but the encode ran on {loop_thread[0]} — "
+        "it must share the worker thread, not run on the event loop"
+    )

--- a/embedder/tests/test_embedder_app.py
+++ b/embedder/tests/test_embedder_app.py
@@ -244,3 +244,30 @@ def test_encode_releases_the_gpu_cache(stub_model):
             assert c.post("/embed", json={"texts": ["b", "c"]}).status_code == 200
 
     assert len(calls) == 2, f"expected a release per encode, got {len(calls)}"
+
+
+def test_cache_is_released_even_when_encode_raises(stub_model):
+    """The `finally` is the load-bearing part, and it had no coverage.
+
+    An MPS OOM is the likeliest failure on a memory-tight machine, and it
+    surfaces as a 5xx that embedder_client retries — so releasing only on
+    success means the retries pile onto an allocator that was never drained.
+    Mutating both call sites to release after a successful return passed all
+    22 tests before this.
+    """
+    from unittest.mock import patch
+
+    calls = []
+    stub_model.encode.side_effect = RuntimeError("MPS backend out of memory")
+
+    with (
+        patch("embedder.app.SentenceTransformer", return_value=stub_model),
+        patch("embedder.app.release_gpu_cache", side_effect=lambda: calls.append(1)),
+    ):
+        from embedder.app import app
+
+        with TestClient(app, raise_server_exceptions=False) as c:
+            r = c.post("/embed", json={"texts": ["a"]})
+            assert r.status_code >= 500
+
+    assert calls == [1], "cache was not released when the encode raised"

--- a/embedder/tests/test_gpu_cache.py
+++ b/embedder/tests/test_gpu_cache.py
@@ -15,45 +15,69 @@ import types
 import pytest
 
 
-def _fake_torch(*, mps=False, cuda=False, driver=0, current=0, reserved=0, allocated=0):
-    """A stand-in exposing exactly the surface gpu_cache touches."""
+def _fake_torch(*, mps=False, cuda=False, driver=0, current=0, reserved=0, allocated=0, drain_seconds=0.0):
+    """A stand-in exposing exactly the surface gpu_cache touches.
+
+    `drain_seconds` makes empty_cache slow, the way the real one is — the
+    concurrency test uses it to hold one thread inside the drain while others
+    arrive at the cooldown check.
+    """
+    import time as _time
+
     calls = []
     t = types.ModuleType("torch")
+
+    def _drain(name):
+        if drain_seconds:
+            _time.sleep(drain_seconds)
+        calls.append(name)
 
     t.backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: mps))
     t.mps = types.SimpleNamespace(
         is_available=lambda: mps,
         driver_allocated_memory=lambda: driver,
         current_allocated_memory=lambda: current,
-        empty_cache=lambda: calls.append("mps"),
+        empty_cache=lambda: _drain("mps"),
     )
     t.cuda = types.SimpleNamespace(
         is_available=lambda: cuda,
         memory_reserved=lambda: reserved,
         memory_allocated=lambda: allocated,
-        empty_cache=lambda: calls.append("cuda"),
+        empty_cache=lambda: _drain("cuda"),
     )
     return t, calls
 
 
 @pytest.fixture
 def gpu_cache(monkeypatch):
-    """Fresh module import so env-derived constants are re-read per test."""
+    """Fresh module state, with env-derived constants re-read per test.
+
+    reload-in-place, NOT pop-and-reimport: app.py and reranker.py bind
+    `release_gpu_cache` by `from … import` at import time, so a brand-new
+    module object would leave them holding the *old* function, whose
+    `__globals__` still carry the old config — a future test that sets
+    ENABLED or the high-water mark and then drives /embed or /rerank would
+    silently exercise the defaults. `importlib.reload` re-executes the module
+    body in the SAME namespace dict, which those existing bindings share, so
+    the call sites see the refreshed config (and reset cooldown state) too.
+    """
+    set_keys: set[str] = set()
 
     def _load(**env):
         for k, v in env.items():
             monkeypatch.setenv(k, v)
-        sys.modules.pop("embedder.gpu_cache", None)
-        return importlib.import_module("embedder.gpu_cache")
+            set_keys.add(k)
+        return importlib.reload(importlib.import_module("embedder.gpu_cache"))
 
     yield _load
     # monkeypatch.undo() runs *after* this finalizer (it is a dependency, so it
-    # is torn down last), so re-importing here would re-read the env var the
-    # test just set and leak that value into sys.modules for whatever runs
-    # next. Clear it first.
-    monkeypatch.delenv("GPU_CACHE_HIGH_WATER_MB", raising=False)
-    sys.modules.pop("embedder.gpu_cache", None)
-    importlib.import_module("embedder.gpu_cache")
+    # is torn down last), so reloading here would re-read whatever env the test
+    # just set and leak that config into the module for whatever runs next.
+    # Clear every var _load actually set — recorded, not hardcoded, so a test
+    # exercising some future knob is covered without editing this fixture.
+    for k in set_keys:
+        monkeypatch.delenv(k, raising=False)
+    importlib.reload(importlib.import_module("embedder.gpu_cache"))
 
 
 MB = 1024 * 1024
@@ -228,12 +252,13 @@ def test_an_absurd_high_water_is_rejected(gpu_cache):
 
 
 def test_an_effective_drain_does_not_start_a_cooldown(gpu_cache, monkeypatch):
-    """A blanket interval defeats the `finally` at both call sites.
+    """A blanket interval defeats the `finally` at the /embed call site.
 
     embedder_client retries a 5xx up to 7 times, with cumulative minimum elapsed
     of 0.25/0.75/1.75/3.75s before attempts 2-5 — all inside a flat 5s window.
     An OOM would drain once and then skip every retry, which is exactly the case
-    the `finally` exists for. So a drain that *worked* must not block the next.
+    that `finally` exists for. So a drain that *worked* must not block the next.
+    (/rerank never retries — rerank_hits degrades — so this concerns /embed.)
     """
     mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
 
@@ -264,3 +289,35 @@ def test_an_effective_drain_does_not_start_a_cooldown(gpu_cache, monkeypatch):
     mod.release_gpu_cache()
 
     assert len(calls) == 2, "an effective drain started a cooldown and blocked the retry-path drain"
+
+
+def test_a_concurrent_burst_drains_once(gpu_cache, monkeypatch):
+    """check-gap → check-cooldown → drain → record is not atomic, and /rerank
+    hands release to the default executor with no concurrency gate — so before
+    the lock, simultaneous requests could all clear the cooldown check while
+    the first was still inside its drain, and every one of them drained: the
+    storm the cooldown exists to stop, arriving via the door it cannot see.
+
+    The slow fake drain holds the first thread inside empty_cache while the
+    barrier guarantees the others are already past start; without the lock at
+    least one of them clears the not-yet-recorded cooldown and drains again.
+    """
+    import threading
+
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="2048")
+    torch, calls = _fake_torch(mps=True, driver=5000 * MB, current=500 * MB, drain_seconds=0.05)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    barrier = threading.Barrier(8)
+
+    def _release_after_barrier():
+        barrier.wait()
+        mod.release_gpu_cache()
+
+    threads = [threading.Thread(target=_release_after_barrier) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(calls) == 1, f"a concurrent burst drained {len(calls)} times; the check-then-record raced"

--- a/embedder/tests/test_gpu_cache.py
+++ b/embedder/tests/test_gpu_cache.py
@@ -163,7 +163,9 @@ def test_the_first_failure_is_logged(gpu_cache, monkeypatch, caplog):
     import types
 
     mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
-    monkeypatch.setattr(mod.time, "monotonic", lambda: 100.0)
+    # Replace the module reference, not stdlib `time.monotonic` — the latter
+    # freezes every thread in the process, including event-loop clocks.
+    monkeypatch.setattr(mod, "time", types.SimpleNamespace(monotonic=lambda: 100.0))
 
     torch = types.ModuleType("torch")
 
@@ -177,3 +179,49 @@ def test_the_first_failure_is_logged(gpu_cache, monkeypatch, caplog):
         mod.release_gpu_cache()
 
     assert "could not release GPU cache" in caplog.text, "first failure was swallowed"
+
+
+def test_a_drain_that_reclaims_nothing_does_not_repeat_immediately(gpu_cache, monkeypatch):
+    """`empty_cache()` cannot release heaps holding live buffers.
+
+    Measured: with another request's activations in flight, a drain recovered
+    8 MB of 1024. Without a cooldown the gap stays above the mark, so the next
+    request drains too — and every one after it. The gate degrades into firing
+    constantly and reclaiming nothing, under exactly the concurrent load that
+    triggers it.
+    """
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+    # A gap that a drain cannot reduce, because something else holds the heaps.
+    torch, calls = _fake_torch(mps=True, driver=5000 * MB, current=100 * MB)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    clock = iter([0.0, 0.1, 0.2])
+    monkeypatch.setattr(mod, "time", types.SimpleNamespace(monotonic=lambda: next(clock)))
+
+    for _ in range(3):
+        mod.release_gpu_cache()
+
+    assert len(calls) == 1, f"drained {len(calls)} times in 0.2s; the cooldown is not holding"
+
+
+def test_the_cooldown_expires(gpu_cache, monkeypatch):
+    """It is a cooldown, not a one-shot — a genuine later ratchet must drain."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+    torch, calls = _fake_torch(mps=True, driver=5000 * MB, current=100 * MB)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    # One monotonic() read per release_gpu_cache() that reaches the gate.
+    times = iter([0.0, 100.0])
+    monkeypatch.setattr(mod, "time", types.SimpleNamespace(monotonic=lambda: next(times)))
+
+    mod.release_gpu_cache()
+    mod.release_gpu_cache()
+
+    assert len(calls) == 2, "cooldown never expired"
+
+
+def test_an_absurd_high_water_is_rejected(gpu_cache):
+    """A value past any real device is as 'off' as 0, just spelled differently."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="999999999")
+    assert mod.CACHE_HIGH_WATER_MB == 4096
+    assert mod.ENABLED

--- a/embedder/tests/test_gpu_cache.py
+++ b/embedder/tests/test_gpu_cache.py
@@ -225,3 +225,42 @@ def test_an_absurd_high_water_is_rejected(gpu_cache):
     mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="999999999")
     assert mod.CACHE_HIGH_WATER_MB == 4096
     assert mod.ENABLED
+
+
+def test_an_effective_drain_does_not_start_a_cooldown(gpu_cache, monkeypatch):
+    """A blanket interval defeats the `finally` at both call sites.
+
+    embedder_client retries a 5xx up to 7 times, with cumulative minimum elapsed
+    of 0.25/0.75/1.75/3.75s before attempts 2-5 — all inside a flat 5s window.
+    An OOM would drain once and then skip every retry, which is exactly the case
+    the `finally` exists for. So a drain that *worked* must not block the next.
+    """
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+
+    # A backend whose drain genuinely frees the pool.
+    state = {"driver": 5000 * MB}
+    calls = []
+    torch = types.ModuleType("torch")
+
+    def _drain():
+        calls.append("mps")
+        state["driver"] = 200 * MB
+
+    torch.backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: True))
+    torch.mps = types.SimpleNamespace(
+        driver_allocated_memory=lambda: state["driver"],
+        current_allocated_memory=lambda: 0,
+        empty_cache=_drain,
+    )
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setattr(mod, "time", types.SimpleNamespace(monotonic=lambda: 0.0))
+
+    mod.release_gpu_cache()
+    assert calls == ["mps"]
+
+    # Pool ratchets straight back up, still within the interval.
+    state["driver"] = 5000 * MB
+    mod.release_gpu_cache()
+
+    assert len(calls) == 2, "an effective drain started a cooldown and blocked the retry-path drain"

--- a/embedder/tests/test_gpu_cache.py
+++ b/embedder/tests/test_gpu_cache.py
@@ -47,6 +47,11 @@ def gpu_cache(monkeypatch):
         return importlib.import_module("embedder.gpu_cache")
 
     yield _load
+    # monkeypatch.undo() runs *after* this finalizer (it is a dependency, so it
+    # is torn down last), so re-importing here would re-read the env var the
+    # test just set and leak that value into sys.modules for whatever runs
+    # next. Clear it first.
+    monkeypatch.delenv("GPU_CACHE_HIGH_WATER_MB", raising=False)
     sys.modules.pop("embedder.gpu_cache", None)
     importlib.import_module("embedder.gpu_cache")
 
@@ -135,7 +140,40 @@ def test_never_raises_when_the_backend_misbehaves(gpu_cache, monkeypatch):
 
 def test_high_water_env_is_total(gpu_cache):
     """Parsed at import, so junk must not stop the service binding."""
-    for raw in ("", "auto", "  ", "-5"):
+    for raw in ("", "auto", "  "):
         mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB=raw)
-        assert mod.CACHE_HIGH_WATER_MB >= 0
+        assert mod.ENABLED, f"{raw!r} silently disabled the guard"
     assert gpu_cache(GPU_CACHE_HIGH_WATER_MB="512").CACHE_HIGH_WATER_MB == 512
+
+
+def test_a_negative_value_does_not_silently_disable_the_guard(gpu_cache):
+    """`max(0, int(raw))` parsed -1 fine and clamped it onto the "off"
+    sentinel — so an operator typing -1 to mean "no limit" got the unbounded
+    growth back with no log line. The old test asserted `>= 0`, enshrining it."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="-1")
+    assert mod.ENABLED, "-1 disabled the guard"
+    assert mod.CACHE_HIGH_WATER_MB == 4096
+
+
+def test_the_first_failure_is_logged(gpu_cache, monkeypatch, caplog):
+    """`_last_warned_at = 0.0` compared against boot-relative monotonic()
+    suppressed every warning for the first 300s of uptime — which is exactly
+    when the menubar app autostarts the embedder at login."""
+    import logging
+    import types
+
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+    monkeypatch.setattr(mod.time, "monotonic", lambda: 100.0)
+
+    torch = types.ModuleType("torch")
+
+    def _boom():
+        raise RuntimeError("backend exploded")
+
+    torch.backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=_boom))
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    with caplog.at_level(logging.WARNING):
+        mod.release_gpu_cache()
+
+    assert "could not release GPU cache" in caplog.text, "first failure was swallowed"

--- a/embedder/tests/test_gpu_cache.py
+++ b/embedder/tests/test_gpu_cache.py
@@ -1,0 +1,141 @@
+"""Tests for gpu_cache — the module's actual work, not just its call sites.
+
+An earlier version of these tests covered only the wiring: every one either
+patched `release_gpu_cache` out, forced `import torch` to fail, or
+short-circuited on the disable flag. Replacing the whole function body with
+`pass` kept them all green. These drive the real branches with a fake torch.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _fake_torch(*, mps=False, cuda=False, driver=0, current=0, reserved=0, allocated=0):
+    """A stand-in exposing exactly the surface gpu_cache touches."""
+    calls = []
+    t = types.ModuleType("torch")
+
+    t.backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: mps))
+    t.mps = types.SimpleNamespace(
+        is_available=lambda: mps,
+        driver_allocated_memory=lambda: driver,
+        current_allocated_memory=lambda: current,
+        empty_cache=lambda: calls.append("mps"),
+    )
+    t.cuda = types.SimpleNamespace(
+        is_available=lambda: cuda,
+        memory_reserved=lambda: reserved,
+        memory_allocated=lambda: allocated,
+        empty_cache=lambda: calls.append("cuda"),
+    )
+    return t, calls
+
+
+@pytest.fixture
+def gpu_cache(monkeypatch):
+    """Fresh module import so env-derived constants are re-read per test."""
+
+    def _load(**env):
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        sys.modules.pop("embedder.gpu_cache", None)
+        return importlib.import_module("embedder.gpu_cache")
+
+    yield _load
+    sys.modules.pop("embedder.gpu_cache", None)
+    importlib.import_module("embedder.gpu_cache")
+
+
+MB = 1024 * 1024
+
+
+def test_releases_mps_once_over_the_high_water_mark(gpu_cache, monkeypatch):
+    """The ratchet this module exists to stop."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="2048")
+    torch, calls = _fake_torch(mps=True, driver=5000 * MB, current=500 * MB)  # 4.4 GB gap
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    mod.release_gpu_cache()
+
+    assert calls == ["mps"], "a gap well past the mark must drain"
+
+
+def test_leaves_a_small_cache_alone(gpu_cache, monkeypatch):
+    """Search sends a single query per request; draining then would throw away
+    the cache the next query reuses, on an already-tight latency budget."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="2048")
+    torch, calls = _fake_torch(mps=True, driver=900 * MB, current=500 * MB)  # 400 MB gap
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    mod.release_gpu_cache()
+
+    assert calls == [], "a small gap must not trigger a drain"
+
+
+def test_prefers_mps_over_cuda(gpu_cache, monkeypatch):
+    """Branch order matters: on a Mac both could report available."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1")
+    torch, calls = _fake_torch(mps=True, cuda=True, driver=5000 * MB, current=0, reserved=5000 * MB, allocated=0)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    mod.release_gpu_cache()
+
+    assert calls == ["mps"]
+
+
+def test_releases_cuda_when_that_is_the_backend(gpu_cache, monkeypatch):
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+    torch, calls = _fake_torch(mps=False, cuda=True, reserved=4000 * MB, allocated=100 * MB)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    mod.release_gpu_cache()
+
+    assert calls == ["cuda"]
+
+
+def test_noop_on_cpu_only(gpu_cache, monkeypatch):
+    """Docker deployments have no device allocator to drain."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+    torch, calls = _fake_torch(mps=False, cuda=False)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    mod.release_gpu_cache()
+
+    assert calls == []
+
+
+def test_zero_disables_entirely(gpu_cache, monkeypatch):
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="0")
+    torch, calls = _fake_torch(mps=True, driver=99_000 * MB, current=0)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    assert mod.ENABLED is False
+    mod.release_gpu_cache()
+    assert calls == []
+
+
+def test_never_raises_when_the_backend_misbehaves(gpu_cache, monkeypatch):
+    """Cache hygiene must not fail an inference call."""
+    mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB="1024")
+    torch = types.ModuleType("torch")
+
+    def _boom():
+        raise RuntimeError("MPS backend exploded")
+
+    torch.backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=_boom))
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    mod.release_gpu_cache()  # must not raise
+
+
+def test_high_water_env_is_total(gpu_cache):
+    """Parsed at import, so junk must not stop the service binding."""
+    for raw in ("", "auto", "  ", "-5"):
+        mod = gpu_cache(GPU_CACHE_HIGH_WATER_MB=raw)
+        assert mod.CACHE_HIGH_WATER_MB >= 0
+    assert gpu_cache(GPU_CACHE_HIGH_WATER_MB="512").CACHE_HIGH_WATER_MB == 512

--- a/embedder/tests/test_reranker_service.py
+++ b/embedder/tests/test_reranker_service.py
@@ -160,9 +160,11 @@ def test_rerank_survives_shutdown_between_the_guard_and_the_executor_hop():
 
     model.predict.side_effect = _predict_then_shutdown
 
-    with patch("embedder.reranker.CrossEncoder", return_value=model):
-        with TestClient(rr.app, raise_server_exceptions=False) as c:
-            r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
+    with (
+        patch("embedder.reranker.CrossEncoder", return_value=model),
+        TestClient(rr.app, raise_server_exceptions=False) as c,
+    ):
+        r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
 
     assert r.status_code == 200, (
         f"got {r.status_code}: the model was resolved on the worker thread after the guard, "

--- a/embedder/tests/test_reranker_service.py
+++ b/embedder/tests/test_reranker_service.py
@@ -68,3 +68,46 @@ def test_health_endpoint(client):
     r = client.get("/health")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
+
+
+def test_rerank_releases_the_gpu_cache(monkeypatch):
+    """The reranker has the same variable-length exposure as the embedder, and
+    until now no call-site test — so the regression below could not be caught.
+    """
+    from unittest.mock import patch
+
+    import numpy as np
+    from fastapi.testclient import TestClient
+
+    calls = []
+    model = MagicMock()
+    model.predict.side_effect = lambda pairs: np.array([0.5] * len(pairs))
+
+    with (
+        patch("embedder.reranker.CrossEncoder", return_value=model),
+        patch("embedder.reranker.release_gpu_cache", side_effect=lambda: calls.append(1)),
+    ):
+        from embedder.reranker import app
+
+        with TestClient(app) as c:
+            r = c.post("/rerank", json={"query": "q", "passages": ["a", "b"], "top_k": 2})
+            assert r.status_code == 200
+
+    assert len(calls) == 1, f"expected one release per rerank, got {len(calls)}"
+
+
+def test_rerank_binds_the_model_before_the_executor_hop(monkeypatch):
+    """Shutdown between the guard and the worker thread must not 500.
+
+    `run_in_executor(None, _model.predict, pairs)` bound the method eagerly on
+    the event loop. A closure that reads the global instead resolves it on the
+    worker thread — after an await — so lifespan shutdown can null it in
+    between, turning the intended 503 into AttributeError.
+    """
+    import inspect
+
+    import embedder.reranker as rr
+
+    src = inspect.getsource(rr.rerank)
+    assert "model = _model" in src, "rerank must bind _model before handing work to the executor"
+    assert "_model.predict(" not in src, "predict must be called on the bound local, not the global"

--- a/embedder/tests/test_reranker_service.py
+++ b/embedder/tests/test_reranker_service.py
@@ -137,14 +137,21 @@ def test_rerank_releases_the_cache_even_when_predict_raises():
     assert calls == [1], "cache was not released when predict raised"
 
 
-def test_rerank_survives_shutdown_between_the_guard_and_the_executor_hop():
-    """Behavioural replacement for a test that inspected source text.
+def test_rerank_binds_the_model_before_the_executor_hop():
+    """Shutdown between the guard and the worker thread must not 500.
 
-    The old one asserted `"model = _model" in inspect.getsource(...)`, so a
-    semantically identical rename failed it and matching-but-wrong code passed.
-    This drives the actual race: null the module global while `predict` is in
-    flight, and assert the request does not become an AttributeError 500.
+    The first attempt at this test nulled `_model` from inside `predict` — by
+    which point the closure has already dereferenced the name, so it could not
+    fail. Verified: re-introducing the regression (drop `model = _model`, call
+    `_model.predict`) left all 30 tests green, while the crude
+    `inspect.getsource` test it replaced *did* catch it. That replacement was a
+    net loss of coverage.
+
+    This interposes on the hop itself, so the global is nulled at exactly the
+    moment lifespan shutdown would do it: after the guard, before the worker
+    thread resolves anything.
     """
+    import asyncio
     from unittest.mock import patch
 
     import embedder.reranker as rr
@@ -152,21 +159,29 @@ def test_rerank_survives_shutdown_between_the_guard_and_the_executor_hop():
     from fastapi.testclient import TestClient
 
     model = MagicMock()
+    model.predict.side_effect = lambda pairs: np.array([0.5] * len(pairs))
 
-    def _predict_then_shutdown(pairs):
-        # Lifespan shutdown lands while this worker thread is mid-predict.
-        rr._model = None
-        return np.array([0.5] * len(pairs))
+    real_get_event_loop = asyncio.get_event_loop
 
-    model.predict.side_effect = _predict_then_shutdown
+    class _NullingLoop:
+        def __init__(self, loop):
+            self._loop = loop
+
+        def run_in_executor(self, executor, fn, *args):
+            rr._model = None  # shutdown lands between the guard and the hop
+            return self._loop.run_in_executor(executor, fn, *args)
+
+        def __getattr__(self, name):
+            return getattr(self._loop, name)
 
     with (
         patch("embedder.reranker.CrossEncoder", return_value=model),
         TestClient(rr.app, raise_server_exceptions=False) as c,
     ):
-        r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
+        with patch.object(rr.asyncio, "get_event_loop", lambda: _NullingLoop(real_get_event_loop())):
+            r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
 
     assert r.status_code == 200, (
-        f"got {r.status_code}: the model was resolved on the worker thread after the guard, "
-        "so shutdown turned a valid request into a failure"
+        f"got {r.status_code}: `_model` was resolved on the worker thread after the guard, "
+        "so shutdown turned a valid request into an AttributeError 500"
     )

--- a/embedder/tests/test_reranker_service.py
+++ b/embedder/tests/test_reranker_service.py
@@ -6,6 +6,20 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+@pytest.fixture(autouse=True)
+def _reset_reranker_globals():
+    """`embedder.reranker` keeps `_model` at module scope, and every TestClient
+    here mutates it through lifespan. Without a reset, a test's outcome depends
+    on what ran before it — which is how a passing assertion in this file can
+    mean nothing. Restore it around each test.
+    """
+    import embedder.reranker as rr
+
+    saved = rr._model
+    yield
+    rr._model = saved
+
+
 @pytest.fixture
 def stub_cross_encoder():
     """Stub CrossEncoder that returns predictable scores: higher index → higher score."""
@@ -96,18 +110,61 @@ def test_rerank_releases_the_gpu_cache(monkeypatch):
     assert len(calls) == 1, f"expected one release per rerank, got {len(calls)}"
 
 
-def test_rerank_binds_the_model_before_the_executor_hop(monkeypatch):
-    """Shutdown between the guard and the worker thread must not 500.
+def test_rerank_releases_the_cache_even_when_predict_raises():
+    """The mirror of the embedder's test, which the first pass omitted.
 
-    `run_in_executor(None, _model.predict, pairs)` bound the method eagerly on
-    the event loop. A closure that reads the global instead resolves it on the
-    worker thread — after an await — so lifespan shutdown can null it in
-    between, turning the intended 503 into AttributeError.
+    reranker.py makes the identical OOM argument for its `finally`, and mutating
+    it to release only on success left all 25 tests green.
     """
-    import inspect
+    from unittest.mock import patch
+
+    from fastapi.testclient import TestClient
+
+    calls = []
+    model = MagicMock()
+    model.predict.side_effect = RuntimeError("MPS backend out of memory")
+
+    with (
+        patch("embedder.reranker.CrossEncoder", return_value=model),
+        patch("embedder.reranker.release_gpu_cache", side_effect=lambda: calls.append(1)),
+    ):
+        from embedder.reranker import app
+
+        with TestClient(app, raise_server_exceptions=False) as c:
+            r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
+            assert r.status_code >= 500
+
+    assert calls == [1], "cache was not released when predict raised"
+
+
+def test_rerank_survives_shutdown_between_the_guard_and_the_executor_hop():
+    """Behavioural replacement for a test that inspected source text.
+
+    The old one asserted `"model = _model" in inspect.getsource(...)`, so a
+    semantically identical rename failed it and matching-but-wrong code passed.
+    This drives the actual race: null the module global while `predict` is in
+    flight, and assert the request does not become an AttributeError 500.
+    """
+    from unittest.mock import patch
 
     import embedder.reranker as rr
+    import numpy as np
+    from fastapi.testclient import TestClient
 
-    src = inspect.getsource(rr.rerank)
-    assert "model = _model" in src, "rerank must bind _model before handing work to the executor"
-    assert "_model.predict(" not in src, "predict must be called on the bound local, not the global"
+    model = MagicMock()
+
+    def _predict_then_shutdown(pairs):
+        # Lifespan shutdown lands while this worker thread is mid-predict.
+        rr._model = None
+        return np.array([0.5] * len(pairs))
+
+    model.predict.side_effect = _predict_then_shutdown
+
+    with patch("embedder.reranker.CrossEncoder", return_value=model):
+        with TestClient(rr.app, raise_server_exceptions=False) as c:
+            r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
+
+    assert r.status_code == 200, (
+        f"got {r.status_code}: the model was resolved on the worker thread after the guard, "
+        "so shutdown turned a valid request into a failure"
+    )

--- a/embedder/tests/test_reranker_service.py
+++ b/embedder/tests/test_reranker_service.py
@@ -185,3 +185,45 @@ def test_rerank_binds_the_model_before_the_executor_hop():
         f"got {r.status_code}: `_model` was resolved on the worker thread after the guard, "
         "so shutdown turned a valid request into an AttributeError 500"
     )
+
+
+def test_release_runs_on_the_worker_thread_not_the_event_loop():
+    """The #553 invariant, guarded for /embed and asserted only in a comment
+    here. `empty_cache()` blocks; running it on the event loop re-creates the
+    /health starvation the embedder was fixed for. Verified before writing
+    this: hoisting the release out of `_predict_and_release` and calling it
+    after the await — on the loop — left every reranker test green.
+    """
+    import threading
+
+    import numpy as np
+    from fastapi.testclient import TestClient
+
+    predict_thread = []
+    release_thread = []
+
+    model = MagicMock()
+
+    def _note_predict(pairs):
+        predict_thread.append(threading.current_thread().name)
+        return np.array([0.5] * len(pairs))
+
+    model.predict.side_effect = _note_predict
+
+    with (
+        patch("embedder.reranker.CrossEncoder", return_value=model),
+        patch(
+            "embedder.reranker.release_gpu_cache",
+            side_effect=lambda: release_thread.append(threading.current_thread().name),
+        ),
+    ):
+        from embedder.reranker import app
+
+        with TestClient(app) as c:
+            assert c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1}).status_code == 200
+
+    assert release_thread, "release never ran"
+    assert release_thread[0] == predict_thread[0], (
+        f"release ran on {release_thread[0]} but predict ran on {predict_thread[0]} — "
+        "it must share the worker thread, not run on the event loop"
+    )

--- a/embedder/tests/test_reranker_service.py
+++ b/embedder/tests/test_reranker_service.py
@@ -177,9 +177,9 @@ def test_rerank_binds_the_model_before_the_executor_hop():
     with (
         patch("embedder.reranker.CrossEncoder", return_value=model),
         TestClient(rr.app, raise_server_exceptions=False) as c,
+        patch.object(rr.asyncio, "get_event_loop", lambda: _NullingLoop(real_get_event_loop())),
     ):
-        with patch.object(rr.asyncio, "get_event_loop", lambda: _NullingLoop(real_get_event_loop())):
-            r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
+        r = c.post("/rerank", json={"query": "q", "passages": ["a"], "top_k": 1})
 
     assert r.status_code == 200, (
         f"got {r.status_code}: `_model` was resolved on the worker thread after the guard, "

--- a/macos/HarborClerkServer/HarborClerkServer/Services/EmbedderService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/EmbedderService.swift
@@ -11,7 +11,13 @@ final class EmbedderService: PythonService {
         let modelPath = Bundle.main.resourceURL!
             .appendingPathComponent("model/granite-embedding-311m-multilingual-r2").path
         return [
+            // Inference-time knobs the Python side reads from the environment.
+            // `pythonEnvironment()` builds a closed dict and does not inherit
+            // the process environment, so anything not listed here is
+            // unreachable on this platform — and macOS is the only place the
+            // MPS allocator code does anything at all.
             "EMBED_MODEL": modelPath,
+            "GPU_CACHE_HIGH_WATER_MB": String(AppSettings.shared.gpuCacheHighWaterMB),
             "HOST": "127.0.0.1",
             "PORT": String(AppSettings.shared.embedderPort),
         ]

--- a/macos/HarborClerkServer/HarborClerkServer/Services/RerankerService.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Services/RerankerService.swift
@@ -11,7 +11,13 @@ final class RerankerService: PythonService {
         let modelPath = Bundle.main.resourceURL!
             .appendingPathComponent("model/bge-reranker-v2-m3").path
         return [
+            // Inference-time knobs the Python side reads from the environment.
+            // `pythonEnvironment()` builds a closed dict and does not inherit
+            // the process environment, so anything not listed here is
+            // unreachable on this platform — and macOS is the only place the
+            // MPS allocator code does anything at all.
             "RERANKER_MODEL": modelPath,
+            "GPU_CACHE_HIGH_WATER_MB": String(AppSettings.shared.gpuCacheHighWaterMB),
             "HOST": "127.0.0.1",
             "PORT": String(AppSettings.shared.rerankerPort),
         ]

--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -81,6 +81,16 @@ final class AppSettings: @unchecked Sendable {
         set { lock.withLock { data["reranker_enabled"] = newValue }; save() }
     }
 
+    /// Release the GPU allocator cache once the unused pool exceeds this many
+    /// MB; 0 disables. Surfaced here because `pythonEnvironment()` builds a
+    /// closed dict — a knob the Python side reads is unreachable on macOS
+    /// unless it is passed explicitly, and macOS is the only platform where the
+    /// MPS path runs. Default matches `embedder.gpu_cache.CACHE_HIGH_WATER_MB`.
+    var gpuCacheHighWaterMB: Int {
+        get { lock.withLock { data["gpu_cache_high_water_mb"] as? Int ?? 4096 } }
+        set { lock.withLock { data["gpu_cache_high_water_mb"] = newValue }; save() }
+    }
+
     var workerPreset: String {
         get { lock.withLock { data["worker_preset"] as? String ?? "balanced" } }
         set { lock.withLock { data["worker_preset"] = newValue }; save() }


### PR DESCRIPTION
The embedder was the largest memory consumer on the Mac mini by a wide margin, and it grew without bound.

| | phys_footprint |
|---|---|
| fresh process | **1.5 GB** |
| after ~1.5 h of ingest | **40 GB** (peak 44 GB) |

At that point: 347 MB free, 15 GB compressor, 13 GB swap. Restarting the embedder took free memory back to 11 GB.

## Not a leak — the caching allocator

```
after load          current 594M   driver  1032M
after 5 batches     current 594M   driver  6183M
after gc.collect    current 594M   driver  6183M   ← gc does nothing
after empty_cache   current 594M   driver  2035M   ← 4.1 GB reclaimed
```

`current_allocated_memory` never moves off 594 MB — no tensors are retained. PyTorch keeps freed device blocks for reuse and never returns them.

That is normally self-limiting. It is not here: the inputs are documents and email bodies whose lengths vary by orders of magnitude, so nearly every batch asks for an unseen shape and the cache ratchets forever.

## Effect

Ten batches of 64 variable-length texts:

```
batch:            1     2     3     4     5     6     7     8     9    10
unmanaged (GB): 6.7  12.8   6.5   8.6   8.6   9.6  11.9  16.3  11.5  12.4
managed   (GB): 4.1   8.6   2.4   2.9   2.9   2.3   3.0   7.4   2.6   3.5
```

Managed still spikes while a large batch is in flight — live allocation, not cache — but returns to baseline. Verified end to end against the real model over HTTP: **1,535 MB at start, plateauing at 5.6–6.7 GB** across eight batches instead of climbing.

**It costs nothing:** 97.2s vs 96.8s over five batches. On a machine this tight it is marginally *faster* — holding gigabytes of dead cache costs more in compression and swap than re-allocating does.

## Notes

- Applied to the reranker as well: same variable-length exposure, and it sits at 3.8 GB partly because it upcasts fp16 weights to fp32 at load.
- Released **on the worker thread, never the event loop** — `empty_cache` blocks, and starving `/health` is exactly what #553 was about.
- No-op on CPU-only deployments; `RELEASE_GPU_CACHE=false` restores PyTorch default behaviour.

## Deliberately not included

A torch thread-count change. It looked like oversubscription (22 OS threads on 10 cores), but `torch.get_num_threads()` is **already 4** by default here — the rest are Metal/driver/uvicorn threads — and setting it explicitly measured 97.2s vs 98.2s, i.e. noise. There was nothing to fix, so nothing shipped.

Tests: a guard that the release happens per encode (verified to fail when the call is removed), a CPU-only no-op case, and the disable switch.