### PR TITLE
fix(errors): migrate the call sites #570 missed

### DIFF
--- a/docs/superpowers/reports/2026-07-24-mac-mini-field-report.md
+++ b/docs/superpowers/reports/2026-07-24-mac-mini-field-report.md
@@ -176,11 +176,13 @@ Two of those — the 22 GB and 17 GB models — **cannot run on this machine at 
 
 Resident during ingest: llama ~12 GB wired + 2 workers 2.8 GB + embedder 1.1 GB + reranker 1.1 GB + Tika JVM 0.7 GB + Postgres + API ≈ **18–19 GB before any headroom**.
 
-> **Superseded — read this with the figures below.** Those are `ps` RSS, which
+> **Superseded — the figures above are `ps` RSS**, which
 > excludes compressed and swapped pages. Measured later with `footprint` during
 > the much larger 7,449-message email ingest, the embedder reached **40 GB**
 > phys_footprint (peak 44 GB) — it was the single largest consumer, not the LLM,
-> and it grows without bound. See the GPU-allocator-cache fix. The statement in
+> and it grows without bound — PyTorch's caching allocator never returns freed
+> device blocks, and the inputs vary enough in length that it never reaches a
+> steady state (PR #574). The statement in
 > §1 that "there was no memory bug to find" remains correct about #553
 > specifically: the restarts were health-probe starvation, not memory. The
 > unbounded growth is a separate defect that this report's RSS figures were too

--- a/docs/superpowers/reports/2026-07-24-mac-mini-field-report.md
+++ b/docs/superpowers/reports/2026-07-24-mac-mini-field-report.md
@@ -94,7 +94,7 @@ whole post-patch run, against four restarts and ~27 failures/minute before it.
 
 Then the residual **plateaus**: total errors sat at 126 across the final four samples. Nothing re-drives failed documents in bulk, so pre-patch damage is permanent until someone reprocesses each one by hand. That is the concrete case for #554.
 
-**The field test also caught a flaw in my own fix.** The retry's real window was 1.75–3.50s (N attempts sleep after only the first N−1, and half-to-full jitter halves each ceiling — my original "~7.5s" was bad arithmetic), while an embedder restart takes ~7.2s. So the retry could not survive the exact failure it was written for. Corrected to 6 attempts → 7.75–15.50s, with a test that derives the window from the constants and asserts it exceeds a measured restart.
+**The field test also caught a flaw in my own fix.** The retry's real window was 1.75–3.50s (N attempts sleep after only the first N−1, and half-to-full jitter halves each ceiling — my original "~7.5s" was bad arithmetic), while an embedder restart takes ~7.2s. So the retry could not survive the exact failure it was written for. Corrected to 7 attempts → 11.75–23.50s (6 cleared the measurement by only 7%, which is luck rather than margin), with a test that derives the window from the constants and asserts it exceeds a measured restart.
 
 > **The installed bundle on this machine is still hand-patched.** I left it that way because reverting would knowingly re-break the box. Originals are at `~/Library/Application Support/Harbor Clerk/bundle-backup-2026-07-24/`, and any rebuild from `macos/` overwrites the patch anyway.
 
@@ -175,6 +175,16 @@ Qwen3-8B-Q4_K_M.gguf                5.0 GB
 Two of those — the 22 GB and 17 GB models — **cannot run on this machine at all** alongside the rest of the stack, and nothing stopped them being downloaded. That is #556, and the field evidence says it should be a **hard gate**, not a hint: 55.8 GB of models is also what put the volume at 99 % full earlier in the session.
 
 Resident during ingest: llama ~12 GB wired + 2 workers 2.8 GB + embedder 1.1 GB + reranker 1.1 GB + Tika JVM 0.7 GB + Postgres + API ≈ **18–19 GB before any headroom**.
+
+> **Superseded — read this with the figures below.** Those are `ps` RSS, which
+> excludes compressed and swapped pages. Measured later with `footprint` during
+> the much larger 7,449-message email ingest, the embedder reached **40 GB**
+> phys_footprint (peak 44 GB) — it was the single largest consumer, not the LLM,
+> and it grows without bound. See the GPU-allocator-cache fix. The statement in
+> §1 that "there was no memory bug to find" remains correct about #553
+> specifically: the restarts were health-probe starvation, not memory. The
+> unbounded growth is a separate defect that this report's RSS figures were too
+> coarse to see.
 
 ### Postgres is running stock defaults
 

--- a/src/harbor_clerk/embedder_client.py
+++ b/src/harbor_clerk/embedder_client.py
@@ -34,6 +34,7 @@ import time
 import httpx
 
 from harbor_clerk.config import get_settings
+from harbor_clerk.error_text import describe_error
 
 logger = logging.getLogger(__name__)
 
@@ -191,13 +192,13 @@ def embed_texts(
             resp = httpx.post(url, json=_payload(texts, task), timeout=timeout)
         except httpx.TransportError as exc:
             if not _is_retryable_transport(exc):
-                raise EmbedderError(f"embedder call failed: {type(exc).__name__}: {exc}") from exc
-            last_detail = f"{type(exc).__name__}: {exc}"
+                raise EmbedderError(f"embedder call failed: {describe_error(exc)}") from exc
+            last_detail = describe_error(exc)
         except httpx.RequestError as exc:
             # DecodingError / TooManyRedirects are RequestError but NOT
             # TransportError. Retrying will not help, but the caller is still
             # owed an EmbedderError rather than a raw httpx type.
-            raise EmbedderError(f"embedder request failed: {type(exc).__name__}: {exc}") from exc
+            raise EmbedderError(f"embedder request failed: {describe_error(exc)}") from exc
         else:
             if not _is_retryable_status(resp.status_code):
                 # Every 2xx and every non-429 4xx: succeed or fail, never retry.
@@ -244,10 +245,10 @@ async def embed_texts_async(
                 resp = await client.post(url, json=_payload(texts, task))
             except httpx.TransportError as exc:
                 if not _is_retryable_transport(exc):
-                    raise EmbedderError(f"embedder call failed: {type(exc).__name__}: {exc}") from exc
-                last_detail = f"{type(exc).__name__}: {exc}"
+                    raise EmbedderError(f"embedder call failed: {describe_error(exc)}") from exc
+                last_detail = describe_error(exc)
             except httpx.RequestError as exc:
-                raise EmbedderError(f"embedder request failed: {type(exc).__name__}: {exc}") from exc
+                raise EmbedderError(f"embedder request failed: {describe_error(exc)}") from exc
             else:
                 if not _is_retryable_status(resp.status_code):
                     return _parse(resp, len(texts))

--- a/src/harbor_clerk/llm/tools.py
+++ b/src/harbor_clerk/llm/tools.py
@@ -22,7 +22,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from harbor_clerk.api.scope import UserScope
-from harbor_clerk.error_text import describe_error
+from harbor_clerk.error_text import describe_error, message_or_type
 
 if TYPE_CHECKING:
     from harbor_clerk.llm.models import ModelInfo
@@ -791,7 +791,12 @@ async def execute_tool(
         return await func(**mapped_args)
     except PermissionError as e:
         logger.warning("Tool permission error: %s - %s", name, e)
-        return json.dumps({"error": describe_error(e)})
+        # Authored, user-facing strings ("Not authenticated", "Admin access
+        # required"), so the class name is noise — the same distinction
+        # error_text draws for AuthError and the validation ValueErrors. The
+        # dedicated branch exists precisely because these differ from the
+        # unexpected exceptions below.
+        return json.dumps({"error": message_or_type(e)})
     except Exception as e:
         logger.exception("Tool execution error: %s", name)
         return json.dumps({"error": describe_error(e)})

--- a/tests/test_embedder_client.py
+++ b/tests/test_embedder_client.py
@@ -302,3 +302,32 @@ def test_null_embeddings_becomes_an_embedder_error(httpx_mock: HTTPXMock):
 
     with pytest.raises(EmbedderError, match="expected a list"):
         embed_texts(["a"], task="passage")
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_errors_never_render_a_dangling_colon(httpx_mock: HTTPXMock):
+    """Every retryable transport exception stringifies empty when raised bare.
+
+    `f"{type(exc).__name__}: {exc}"` then yields "ConnectTimeout: ", and that
+    string reaches `ingestion_jobs.error` and `documents.error`, which the
+    document detail page renders verbatim. This module was written in the same
+    window as error_text and was the one file its migration missed.
+    """
+    for exc in (
+        httpx.ConnectTimeout(""),
+        httpx.ConnectError(""),
+        httpx.PoolTimeout(""),
+        httpx.ReadError(""),
+        httpx.RemoteProtocolError(""),
+    ):
+        httpx_mock.reset()
+        for _ in range(8):
+            httpx_mock.add_exception(exc, url=EMBED_URL)
+        with pytest.raises(EmbedderError) as excinfo:
+            embed_texts(["hello"], task="passage", max_attempts=2)
+        rendered = str(excinfo.value)
+        assert type(exc).__name__ in rendered, rendered
+        assert ": " not in rendered.rstrip().removesuffix(type(exc).__name__) or not rendered.rstrip().endswith(":"), (
+            f"dangling colon in {rendered!r}"
+        )
+        assert not rendered.rstrip().endswith(":"), f"dangling colon in {rendered!r}"

--- a/tests/test_embedder_client.py
+++ b/tests/test_embedder_client.py
@@ -304,30 +304,63 @@ def test_null_embeddings_becomes_an_embedder_error(httpx_mock: HTTPXMock):
         embed_texts(["a"], task="passage")
 
 
-@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
-def test_errors_never_render_a_dangling_colon(httpx_mock: HTTPXMock):
-    """Every retryable transport exception stringifies empty when raised bare.
+# --------------------------------------------------------------------------
+# Rendering — every changed line, on both entry points
+# --------------------------------------------------------------------------
 
-    `f"{type(exc).__name__}: {exc}"` then yields "ConnectTimeout: ", and that
+# Three distinct code paths render an exception, and they are easy to conflate:
+#   retryable transport  -> retries, then _give_up
+#   non-retryable transport (ReadTimeout, the canonical case) -> immediate raise
+#   RequestError that is not a TransportError -> immediate raise
+# Each exists twice, once per entry point. Parametrised so a failure names the
+# case rather than hiding the rest behind the first one.
+_EMPTY_MESSAGE_EXCEPTIONS = [
+    pytest.param(httpx.ConnectTimeout(""), id="retryable-connect-timeout"),
+    pytest.param(httpx.ConnectError(""), id="retryable-connect-error"),
+    pytest.param(httpx.PoolTimeout(""), id="retryable-pool-timeout"),
+    pytest.param(httpx.ReadError(""), id="retryable-read-error"),
+    pytest.param(httpx.WriteError(""), id="retryable-write-error"),
+    pytest.param(httpx.RemoteProtocolError(""), id="retryable-remote-protocol"),
+    pytest.param(httpx.CloseError(""), id="retryable-close-error"),
+    pytest.param(httpx.ReadTimeout(""), id="non-retryable-read-timeout"),
+    pytest.param(httpx.WriteTimeout(""), id="non-retryable-write-timeout"),
+    pytest.param(httpx.DecodingError(""), id="request-error-decoding"),
+    pytest.param(httpx.TooManyRedirects(""), id="request-error-redirects"),
+]
+
+
+def _assert_named_without_dangling_colon(rendered: str, exc: Exception) -> None:
+    assert type(exc).__name__ in rendered, f"failure type not named: {rendered!r}"
+    assert not rendered.rstrip().endswith(":"), f"dangling colon in {rendered!r}"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+@pytest.mark.parametrize("exc", _EMPTY_MESSAGE_EXCEPTIONS)
+def test_sync_errors_never_render_a_dangling_colon(httpx_mock: HTTPXMock, exc):
+    """Every exception here stringifies empty when raised bare.
+
+    `f"{type(exc).__name__}: {exc}"` then yields "ReadTimeout: ", and that
     string reaches `ingestion_jobs.error` and `documents.error`, which the
-    document detail page renders verbatim. This module was written in the same
-    window as error_text and was the one file its migration missed.
+    document detail page renders verbatim.
     """
-    for exc in (
-        httpx.ConnectTimeout(""),
-        httpx.ConnectError(""),
-        httpx.PoolTimeout(""),
-        httpx.ReadError(""),
-        httpx.RemoteProtocolError(""),
-    ):
-        httpx_mock.reset()
-        for _ in range(8):
-            httpx_mock.add_exception(exc, url=EMBED_URL)
-        with pytest.raises(EmbedderError) as excinfo:
-            embed_texts(["hello"], task="passage", max_attempts=2)
-        rendered = str(excinfo.value)
-        assert type(exc).__name__ in rendered, rendered
-        assert ": " not in rendered.rstrip().removesuffix(type(exc).__name__) or not rendered.rstrip().endswith(":"), (
-            f"dangling colon in {rendered!r}"
-        )
-        assert not rendered.rstrip().endswith(":"), f"dangling colon in {rendered!r}"
+    for _ in range(4):
+        httpx_mock.add_exception(exc, url=EMBED_URL)
+
+    with pytest.raises(EmbedderError) as excinfo:
+        embed_texts(["hello"], task="passage", max_attempts=2)
+
+    _assert_named_without_dangling_colon(str(excinfo.value), exc)
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+@pytest.mark.parametrize("exc", _EMPTY_MESSAGE_EXCEPTIONS)
+async def test_async_errors_never_render_a_dangling_colon(httpx_mock: HTTPXMock, exc):
+    """Half the changed lines live on the async path, and nothing covered it —
+    reverting all three kept the suite green."""
+    for _ in range(4):
+        httpx_mock.add_exception(exc, url=EMBED_URL)
+
+    with pytest.raises(EmbedderError) as excinfo:
+        await embed_texts_async(["q"], task="query", max_attempts=2)
+
+    _assert_named_without_dangling_colon(str(excinfo.value), exc)


### PR DESCRIPTION
Found by a cross-change audit of merged `main` — the kind of defect no single-PR review could see.

#567 and #570 landed in the same window, and #570's migration (eleven modules) **missed the one file #567 had just created**. `embedder_client.py` still used the exact format #570 exists to remove, at six sites, and did not import `error_text` at all.

## Why it matters

It is the path `error_text`'s own docstring singles out. Every exception in the retryable set stringifies empty when raised bare:

```
ingestion_jobs.error: "EmbedderError: embedder call failed after 7/7 attempts: ConnectTimeout:"
```

`DocumentDetailPage` renders that verbatim — so the user sees precisely the dangling colon #570 removed everywhere else. **No test caught it** because every exception in the suite is constructed with a non-empty message.

## Also

- **`llm/tools.py` PermissionError** rendered with `describe_error`, but the only ones raised carry authored strings (`"Not authenticated"`, `"Admin access required"`) — so the chat LLM and the user got `PermissionError: Not authenticated`. The dedicated `except` branch exists *because* these differ from the unexpected exceptions below it. Now `message_or_type`, matching the rule applied to `AuthError` and the validation `ValueError`s.
- **The retry deadline's comment overclaimed.** It reasoned about a stage bound it does not provide: `run_embed` calls `embed_texts` once per batch with a fresh clock, so a large document can still exceed the 3600s stage alarm in aggregate and surface as "Stage embed timed out" — the masking the comment said it prevents. Corrected to state what it actually bounds.
- **Field report reconciled.** It said "6 attempts" where 7 shipped, and quoted embedder RSS of 1.1 GB while attributing pressure to the LLM. RSS excludes compressed and swapped pages; measured with `footprint` during the larger email ingest the embedder reached **40 GB** and was the largest consumer by far. Noted inline rather than rewritten — the report's #553 conclusion (restarts were probe starvation, not memory) still holds.

Test asserts no rendering ends in a dangling colon, across every empty-message transport exception in the retryable set.