### PR TITLE
fix(mail): close the IMAP socket, and stop the respawn loop lying about itself

### DIFF
--- a/src/harbor_clerk/api/routes/mail.py
+++ b/src/harbor_clerk/api/routes/mail.py
@@ -7,6 +7,7 @@ via auth) and by Stage 4's UI.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from datetime import UTC, datetime
 from uuid import UUID
@@ -160,6 +161,14 @@ async def test_mail_account(
         folders = await discover_folders(conn)
         await conn.logout()
     except AuthError as exc:
+        # AuthError comes from login(), after connect() completed the TLS
+        # handshake — so a live socket exists here, exactly as in the watcher's
+        # label task. This path is if anything more reachable: an admin fixing a
+        # mistyped app password retries this endpoint, and each attempt would
+        # pin a connection for ~30 min against the provider's per-account cap.
+        # The sibling branch below already closes; this one simply did not.
+        with contextlib.suppress(Exception):
+            await conn.logout()
         account.status = "auth_error"
         detail = message_or_type(exc)
         account.last_error = detail

--- a/src/harbor_clerk/api/routes/mail.py
+++ b/src/harbor_clerk/api/routes/mail.py
@@ -159,16 +159,7 @@ async def test_mail_account(
         await conn.connect()
         await conn.login()
         folders = await discover_folders(conn)
-        await conn.logout()
     except AuthError as exc:
-        # AuthError comes from login(), after connect() completed the TLS
-        # handshake — so a live socket exists here, exactly as in the watcher's
-        # label task. This path is if anything more reachable: an admin fixing a
-        # mistyped app password retries this endpoint, and each attempt would
-        # pin a connection for ~30 min against the provider's per-account cap.
-        # The sibling branch below already closes; this one simply did not.
-        with contextlib.suppress(Exception):
-            await conn.logout()
         account.status = "auth_error"
         detail = message_or_type(exc)
         account.last_error = detail
@@ -177,11 +168,18 @@ async def test_mail_account(
     except Exception as exc:
         # Network errors, timeouts, etc. — don't change account status
         # (the account isn't broken, just unreachable right now).
-        try:
-            await conn.logout()
-        except Exception:
-            pass
         return TestConnectionResponse(success=False, error=f"connection failed: {describe_error(exc)}")
+    finally:
+        # One close for every exit — success, auth failure, network error, and
+        # cancellation. AuthError comes from login(), after connect() completed
+        # the TLS handshake, so a live socket exists on all of these paths; an
+        # admin fixing a mistyped app password retries this endpoint, and each
+        # attempt would pin a connection for ~30 min against the provider's
+        # per-account cap. CancelledError in particular is not an Exception and
+        # bypasses both branches above. logout() is idempotent and swallows its
+        # own errors; best-effort here is enough.
+        with contextlib.suppress(Exception):
+            await conn.logout()
 
     account.status = "active"
     account.last_error = None

--- a/src/harbor_clerk/mail/imap_client.py
+++ b/src/harbor_clerk/mail/imap_client.py
@@ -13,6 +13,8 @@ login attempt — making accidental logging of the connection object safe.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import time
 from typing import Any
@@ -132,17 +134,53 @@ class IMAPConnection:
         await self._audit("LOGIN", _args, (result, lines), duration_ms, None)
 
     async def logout(self) -> None:
-        """Close the connection. Idempotent — safe to call when not logged in."""
-        if self._client is None:
+        """Close the connection. Idempotent — safe to call when not logged in.
+
+        Dropping `self._client` is not enough to release the socket. aioimaplib
+        schedules `loop.create_connection(...)` in `IMAP4.__init__`, so the
+        transport is owned by the event loop; losing the Python reference leaves
+        it open until the server reaps it — roughly 30 minutes on Gmail. That
+        was survivable while a failed label task was never retried, because it
+        leaked one socket per watcher lifetime. With respawn-on-failure it
+        repeats: at the backoff cap, about twelve attempts an hour with roughly
+        six alive at once, against Gmail's limit of fifteen simultaneous IMAP
+        connections per account — enough for one sick label to lock out the
+        healthy ones.
+
+        The LOGOUT itself is still conditional (there is nothing to log out of
+        if login never succeeded), but the transport close is not.
+        """
+        client, self._client = self._client, None
+        logged_in, self._logged_in = self._logged_in, False
+        if client is None:
             return
         try:
-            if self._logged_in:
-                await self._client.logout()
+            if logged_in:
+                await client.logout()
         except Exception as exc:
             logger.debug("logout() raised: %s — ignoring", exc)
-        finally:
-            self._logged_in = False
-            self._client = None
+
+        # Reach past the wrapper for the socket. These are aioimaplib internals,
+        # like the EXAMINE state fix in readonly_imap — pinned by tests so an
+        # upstream rename fails loudly rather than silently leaking again.
+        protocol = getattr(client, "protocol", None)
+        transport = getattr(protocol, "transport", None)
+        if transport is not None:
+            try:
+                transport.close()
+            except Exception as exc:
+                logger.debug("transport.close() raised: %s — ignoring", exc)
+
+        # `create_connection` runs as a task nobody awaits. If it failed — the
+        # common case when we are here after a connect error — its exception is
+        # never retrieved and asyncio logs "Task exception was never retrieved"
+        # at shutdown, which is how this class of bug stayed invisible.
+        task = getattr(client, "_client_task", None)
+        if task is not None:
+            if not task.done():
+                task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await task
 
     async def examine(self, mailbox: str) -> tuple[str, list[bytes]]:
         """Open `mailbox` in read-only mode (IMAP EXAMINE command).

--- a/src/harbor_clerk/mail/imap_client.py
+++ b/src/harbor_clerk/mail/imap_client.py
@@ -14,7 +14,6 @@ login attempt — making accidental logging of the connection object safe.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import time
 from typing import Any
@@ -159,17 +158,17 @@ class IMAPConnection:
                 await client.logout()
         except Exception as exc:
             logger.debug("logout() raised: %s — ignoring", exc)
+        except BaseException:
+            # CancelledError is not an Exception, so it used to leave before the
+            # close below — reintroducing the leak on the one path where the
+            # docstring promises it cannot happen. Close, then re-raise.
+            self._close_transport(client)
+            raise
 
         # Reach past the wrapper for the socket. These are aioimaplib internals,
         # like the EXAMINE state fix in readonly_imap — pinned by tests so an
         # upstream rename fails loudly rather than silently leaking again.
-        protocol = getattr(client, "protocol", None)
-        transport = getattr(protocol, "transport", None)
-        if transport is not None:
-            try:
-                transport.close()
-            except Exception as exc:
-                logger.debug("transport.close() raised: %s — ignoring", exc)
+        self._close_transport(client)
 
         # `create_connection` runs as a task nobody awaits. If it failed — the
         # common case when we are here after a connect error — its exception is
@@ -179,8 +178,21 @@ class IMAPConnection:
         if task is not None:
             if not task.done():
                 task.cancel()
-            with contextlib.suppress(Exception, asyncio.CancelledError):
-                await task
+            # gather(return_exceptions=True) retrieves it without swallowing a
+            # cancellation aimed at *us* — `suppress(CancelledError)` around a
+            # bare await would absorb the caller's own cancel.
+            await asyncio.gather(task, return_exceptions=True)
+
+    @staticmethod
+    def _close_transport(client: Any) -> None:
+        protocol = getattr(client, "protocol", None)
+        transport = getattr(protocol, "transport", None)
+        if transport is None:
+            return
+        try:
+            transport.close()
+        except Exception as exc:
+            logger.debug("transport.close() raised: %s — ignoring", exc)
 
     async def examine(self, mailbox: str) -> tuple[str, list[bytes]]:
         """Open `mailbox` in read-only mode (IMAP EXAMINE command).

--- a/src/harbor_clerk/mail/imap_client.py
+++ b/src/harbor_clerk/mail/imap_client.py
@@ -158,30 +158,34 @@ class IMAPConnection:
                 await client.logout()
         except Exception as exc:
             logger.debug("logout() raised: %s — ignoring", exc)
-        except BaseException:
-            # CancelledError is not an Exception, so it used to leave before the
-            # close below — reintroducing the leak on the one path where the
-            # docstring promises it cannot happen. Close, then re-raise.
+        finally:
+            # The close and the drain run on *every* exit. CancelledError is not
+            # an Exception, so without the finally a cancellation delivered
+            # during the LOGOUT — the normal way a watcher label task exits —
+            # would leave before the close, reintroducing the leak on the one
+            # path where the docstring promises it cannot happen.
+            #
+            # Reach past the wrapper for the socket. These are aioimaplib
+            # internals, like the EXAMINE state fix in readonly_imap — pinned by
+            # tests so an upstream rename fails loudly rather than silently
+            # leaking again.
             self._close_transport(client)
-            raise
 
-        # Reach past the wrapper for the socket. These are aioimaplib internals,
-        # like the EXAMINE state fix in readonly_imap — pinned by tests so an
-        # upstream rename fails loudly rather than silently leaking again.
-        self._close_transport(client)
-
-        # `create_connection` runs as a task nobody awaits. If it failed — the
-        # common case when we are here after a connect error — its exception is
-        # never retrieved and asyncio logs "Task exception was never retrieved"
-        # at shutdown, which is how this class of bug stayed invisible.
-        task = getattr(client, "_client_task", None)
-        if task is not None:
-            if not task.done():
-                task.cancel()
-            # gather(return_exceptions=True) retrieves it without swallowing a
-            # cancellation aimed at *us* — `suppress(CancelledError)` around a
-            # bare await would absorb the caller's own cancel.
-            await asyncio.gather(task, return_exceptions=True)
+            # `create_connection` runs as a task nobody awaits. If it failed —
+            # the common case when we are here after a connect error — its
+            # exception is never retrieved and asyncio logs "Task exception was
+            # never retrieved" at shutdown, which is how this class of bug
+            # stayed invisible. On the cancellation path the task is already
+            # done (a completed login implies the connection task finished), so
+            # the gather returns without suspending.
+            task = getattr(client, "_client_task", None)
+            if task is not None:
+                if not task.done():
+                    task.cancel()
+                # gather(return_exceptions=True) retrieves it without swallowing
+                # a cancellation aimed at *us* — `suppress(CancelledError)`
+                # around a bare await would absorb the caller's own cancel.
+                await asyncio.gather(task, return_exceptions=True)
 
     @staticmethod
     def _close_transport(client: Any) -> None:

--- a/src/harbor_clerk/watcher/mail_observer.py
+++ b/src/harbor_clerk/watcher/mail_observer.py
@@ -401,7 +401,15 @@ class MailObserver:
             # login(), or the bookkeeping writes above were still in flight. A
             # label cancelled mid-handshake (watcher shutdown, or the label
             # going inactive) used to leak both its socket and the audit
-            # session. logout() is idempotent and swallows its own errors.
-            with contextlib.suppress(Exception):
-                await conn.logout()
-            await audit_ctx.__aexit__(None, None, None)
+            # session.
+            #
+            # logout() swallows its own errors but deliberately *re-raises a
+            # cancellation delivered during the LOGOUT round-trip* — and
+            # suppress(Exception) does not cover CancelledError — so the audit
+            # exit needs its own finally, or that one path strands the audit
+            # session and its pooled connection until GC.
+            try:
+                with contextlib.suppress(Exception):
+                    await conn.logout()
+            finally:
+                await audit_ctx.__aexit__(None, None, None)

--- a/src/harbor_clerk/watcher/mail_observer.py
+++ b/src/harbor_clerk/watcher/mail_observer.py
@@ -118,12 +118,21 @@ class MailObserver:
         finally:
             await self.stop()
 
+    @property
+    def _per_label_state(self) -> tuple[dict, ...]:
+        """Every per-label dict except `_tasks`, which has its own lifecycle
+        (cancel-then-drop) and cannot simply be discarded.
+
+        Derived rather than hand-listed so `_forget` and the `known` union below
+        cannot drift — a new dict added here is covered by both. Forgetting to
+        update one of them is exactly the omission this change fixes.
+        """
+        return (self._consecutive_failures, self._retry_not_before, self._spawned_at)
+
     def _forget(self, label_id: UUID) -> None:
-        """Drop every scrap of per-label state. One place, so a new dict cannot
-        be added to __init__ and quietly outlive the label it describes."""
-        self._consecutive_failures.pop(label_id, None)
-        self._retry_not_before.pop(label_id, None)
-        self._spawned_at.pop(label_id, None)
+        """Drop this label's backoff bookkeeping. Does not touch `_tasks`."""
+        for d in self._per_label_state:
+            d.pop(label_id, None)
 
     async def _reconcile(self, session_factory: async_sessionmaker) -> None:
         """Spawn / cancel per-label tasks to match the desired-state DB query."""
@@ -173,11 +182,23 @@ class MailObserver:
             # something that will never happen.
             if lid not in desired_ids:
                 self._forget(lid)
-                logger.info(
-                    "label %s sync task stopped after %.0fs; label or account no longer active",
-                    lid,
-                    ran_for,
-                )
+                if exc is not None:
+                    # A sibling label can crash *while* the account is being
+                    # marked auth_error by another — same account, both leave
+                    # desired_ids. Suppressing the cause here loses the only
+                    # record of a genuine failure.
+                    logger.warning(
+                        "label %s sync task died after %.0fs while going inactive: %s",
+                        lid,
+                        ran_for,
+                        describe_error(exc),
+                    )
+                else:
+                    logger.info(
+                        "label %s sync task stopped after %.0fs; label or account no longer active",
+                        lid,
+                        ran_for,
+                    )
                 continue
             # A task that ran a good while got as far as working; treat its
             # death as a fresh incident rather than escalating an old streak.
@@ -235,7 +256,7 @@ class MailObserver:
         # reactivation it sits behind a stale gate for up to the cap, silently,
         # and its next failure escalates from the old streak instead of
         # restarting at the base delay.
-        known = set(self._tasks) | set(self._consecutive_failures) | set(self._retry_not_before) | set(self._spawned_at)
+        known = set(self._tasks).union(*self._per_label_state)
         for lid in known - desired_ids:
             task = self._tasks.pop(lid, None)
             self._forget(lid)
@@ -283,14 +304,26 @@ class MailObserver:
             await conn.connect()
             await conn.login()
         except AuthError as exc:
-            async with session_factory() as session:
-                acc = (
-                    await session.execute(select(MailAccount).where(MailAccount.account_id == account.account_id))
-                ).scalar_one()
-                acc.status = "auth_error"
-                acc.last_error = message_or_type(exc)
-                await session.commit()
-            await audit_ctx.__aexit__(None, None, None)
+            # AuthError comes from login(), i.e. *after* connect() completed the
+            # TLS handshake — so there is a live socket here, and this is the
+            # path that leaks most: a wrong app password fails every label on
+            # the account at once, and again on every re-activation. Fixing
+            # logout() is no use if the branch that needs it does not call it.
+            try:
+                async with session_factory() as session:
+                    acc = (
+                        await session.execute(select(MailAccount).where(MailAccount.account_id == account.account_id))
+                    ).scalar_one_or_none()
+                    if acc is not None:
+                        acc.status = "auth_error"
+                        acc.last_error = message_or_type(exc)
+                        await session.commit()
+            except Exception:
+                logger.exception("could not record auth failure for label %s", label_id)
+            finally:
+                with contextlib.suppress(Exception):
+                    await conn.logout()
+                await audit_ctx.__aexit__(None, None, None)
             return
         except Exception as exc:
             # Latch it. Without this the account stays `active` with no

--- a/src/harbor_clerk/watcher/mail_observer.py
+++ b/src/harbor_clerk/watcher/mail_observer.py
@@ -301,101 +301,107 @@ class MailObserver:
             )
 
         try:
-            await conn.connect()
-            await conn.login()
-        except AuthError as exc:
-            # AuthError comes from login(), i.e. *after* connect() completed the
-            # TLS handshake — so there is a live socket here, and this is the
-            # path that leaks most: a wrong app password fails every label on
-            # the account at once, and again on every re-activation. Fixing
-            # logout() is no use if the branch that needs it does not call it.
             try:
-                async with session_factory() as session:
-                    acc = (
-                        await session.execute(select(MailAccount).where(MailAccount.account_id == account.account_id))
-                    ).scalar_one_or_none()
-                    if acc is not None:
-                        acc.status = "auth_error"
-                        acc.last_error = message_or_type(exc)
-                        await session.commit()
-            except Exception:
-                logger.exception("could not record auth failure for label %s", label_id)
-            finally:
-                with contextlib.suppress(Exception):
-                    await conn.logout()
-                await audit_ctx.__aexit__(None, None, None)
-            return
-        except Exception as exc:
-            # Latch it. Without this the account stays `active` with no
-            # last_error, so the UI shows a healthy account that never syncs —
-            # and the supervisor retries forever with nothing explaining why.
-            logger.warning("connect/login failed for label %s: %s", label_id, describe_error(exc))
-            try:
-                async with session_factory() as session:
-                    acc = (
-                        await session.execute(select(MailAccount).where(MailAccount.account_id == account.account_id))
-                    ).scalar_one_or_none()
-                    if acc is not None:
-                        acc.last_error = describe_error(exc)
-                        await session.commit()
-            except Exception:
-                # "connect failed" and "DB down" co-occur constantly. Letting
-                # this escape would skip the audit exit below and strand its
-                # session + pooled connection — once per retry, now that we
-                # retry.
-                logger.exception("could not record connect failure for label %s", label_id)
-            finally:
-                with contextlib.suppress(Exception):
-                    await conn.logout()
-                await audit_ctx.__aexit__(None, None, None)
-            return
-
-        # Login worked: clear any latched failure, or the UI shows a broken
-        # account that is in fact syncing — the inverse of the bug this fixes.
-        try:
-            async with session_factory() as session:
-                acc = (
-                    await session.execute(select(MailAccount).where(MailAccount.account_id == account.account_id))
-                ).scalar_one_or_none()
-                if acc is not None and acc.last_error is not None:
-                    acc.last_error = None
-                    acc.last_connected_at = datetime.now(UTC)
-                    await session.commit()
-        except Exception:
-            logger.exception("could not clear last_error for label %s", label_id)
-
-        async def on_tick(c: IMAPConnection) -> None:
-            async with session_factory() as session:
-                lbl = (
-                    await session.execute(select(WatchedLabel).where(WatchedLabel.label_id == label_id))
-                ).scalar_one()
+                await conn.connect()
+                await conn.login()
+            except AuthError as exc:
+                # AuthError comes from login(), i.e. *after* connect() completed
+                # the TLS handshake — so there is a live socket here, and this
+                # is the path that leaks most: a wrong app password fails every
+                # label on the account at once, and again on every
+                # re-activation. The outer finally is what closes it.
                 try:
-                    if lbl.uidvalidity is None:
-                        await sync_label_initial(session, c, lbl)
-                    else:
-                        try:
-                            await sync_label_incremental(session, c, lbl)
-                        except UidValidityChanged:
-                            await handle_uidvalidity_change(session, c, lbl)
-                    await detect_unlabeled_messages(session, c, lbl)
-                    # Stage 3: turn newly-discovered watched_messages into Documents
-                    await ingest_pending_messages(session, c, lbl)
-                    # Stage 3: lifecycle — soft-delete Documents whose watched_messages went unlabeled
-                    await soft_delete_documents_for_unlabeled(session, lbl)
-                    # Stage 3: lifecycle — restore Documents that came back via re-label
-                    await restore_documents_for_relabeled(session, lbl)
-                    lbl.last_synced_at = datetime.now(UTC)
-                    await session.commit()
-                except Exception as exc:
-                    logger.exception("sync failed for label %s: %s", label_id, exc)
-                    await session.rollback()
+                    async with session_factory() as session:
+                        acc = (
+                            await session.execute(
+                                select(MailAccount).where(MailAccount.account_id == account.account_id)
+                            )
+                        ).scalar_one_or_none()
+                        if acc is not None:
+                            acc.status = "auth_error"
+                            acc.last_error = message_or_type(exc)
+                            await session.commit()
+                except Exception:
+                    logger.exception("could not record auth failure for label %s", label_id)
+                return
+            except Exception as exc:
+                # Latch it. Without this the account stays `active` with no
+                # last_error, so the UI shows a healthy account that never syncs
+                # — and the supervisor retries forever with nothing explaining
+                # why.
+                logger.warning("connect/login failed for label %s: %s", label_id, describe_error(exc))
+                try:
+                    async with session_factory() as session:
+                        acc = (
+                            await session.execute(
+                                select(MailAccount).where(MailAccount.account_id == account.account_id)
+                            )
+                        ).scalar_one_or_none()
+                        if acc is not None:
+                            acc.last_error = describe_error(exc)
+                            await session.commit()
+                except Exception:
+                    # "connect failed" and "DB down" co-occur constantly. The
+                    # cleanup in the outer finally runs either way; catching
+                    # here keeps the reap loop attributing this death to the
+                    # connect failure logged above, not the bookkeeping write.
+                    logger.exception("could not record connect failure for label %s", label_id)
+                return
 
-        try:
-            # Initial tick (in case label has no cursor yet)
-            await on_tick(conn)
-            await poll_or_idle_loop(conn, on_tick=on_tick, poll_interval=self.poll_interval)
-        except asyncio.CancelledError:
-            pass
+            # Login worked: clear any latched failure, or the UI shows a broken
+            # account that is in fact syncing — the inverse of the bug this fixes.
+            try:
+                async with session_factory() as session:
+                    acc = (
+                        await session.execute(select(MailAccount).where(MailAccount.account_id == account.account_id))
+                    ).scalar_one_or_none()
+                    if acc is not None and acc.last_error is not None:
+                        acc.last_error = None
+                        acc.last_connected_at = datetime.now(UTC)
+                        await session.commit()
+            except Exception:
+                logger.exception("could not clear last_error for label %s", label_id)
+
+            async def on_tick(c: IMAPConnection) -> None:
+                async with session_factory() as session:
+                    lbl = (
+                        await session.execute(select(WatchedLabel).where(WatchedLabel.label_id == label_id))
+                    ).scalar_one()
+                    try:
+                        if lbl.uidvalidity is None:
+                            await sync_label_initial(session, c, lbl)
+                        else:
+                            try:
+                                await sync_label_incremental(session, c, lbl)
+                            except UidValidityChanged:
+                                await handle_uidvalidity_change(session, c, lbl)
+                        await detect_unlabeled_messages(session, c, lbl)
+                        # Stage 3: turn newly-discovered watched_messages into Documents
+                        await ingest_pending_messages(session, c, lbl)
+                        # Stage 3: lifecycle — soft-delete Documents whose watched_messages went unlabeled
+                        await soft_delete_documents_for_unlabeled(session, lbl)
+                        # Stage 3: lifecycle — restore Documents that came back via re-label
+                        await restore_documents_for_relabeled(session, lbl)
+                        lbl.last_synced_at = datetime.now(UTC)
+                        await session.commit()
+                    except Exception as exc:
+                        logger.exception("sync failed for label %s: %s", label_id, exc)
+                        await session.rollback()
+
+            try:
+                # Initial tick (in case label has no cursor yet)
+                await on_tick(conn)
+                await poll_or_idle_loop(conn, on_tick=on_tick, poll_interval=self.poll_interval)
+            except asyncio.CancelledError:
+                pass
         finally:
-            await conn.logout()
+            # One cleanup for every exit: the sync loop ending, auth failure,
+            # connect failure — and the case the three per-branch cleanups this
+            # replaces all missed: cancellation delivered while connect(),
+            # login(), or the bookkeeping writes above were still in flight. A
+            # label cancelled mid-handshake (watcher shutdown, or the label
+            # going inactive) used to leak both its socket and the audit
+            # session. logout() is idempotent and swallows its own errors.
+            with contextlib.suppress(Exception):
+                await conn.logout()
             await audit_ctx.__aexit__(None, None, None)

--- a/src/harbor_clerk/watcher/mail_observer.py
+++ b/src/harbor_clerk/watcher/mail_observer.py
@@ -118,6 +118,13 @@ class MailObserver:
         finally:
             await self.stop()
 
+    def _forget(self, label_id: UUID) -> None:
+        """Drop every scrap of per-label state. One place, so a new dict cannot
+        be added to __init__ and quietly outlive the label it describes."""
+        self._consecutive_failures.pop(label_id, None)
+        self._retry_not_before.pop(label_id, None)
+        self._spawned_at.pop(label_id, None)
+
     async def _reconcile(self, session_factory: async_sessionmaker) -> None:
         """Spawn / cancel per-label tasks to match the desired-state DB query."""
         async with session_factory() as session:
@@ -154,10 +161,24 @@ class MailObserver:
             # with a result rather than as cancelled — `task.cancelled()` alone
             # would classify every shutdown as a clean exit and respawn it.
             if task.cancelled() or self._stop_event.is_set():
-                self._consecutive_failures.pop(lid, None)
+                self._forget(lid)
                 continue
 
             exc = task.exception()
+
+            # `_run_label` also *returns* on purpose when the account has gone
+            # auth_error or its key no longer matches. Those are not failures
+            # and no respawn is coming, because the label has left desired_ids
+            # — so arming a backoff and logging "respawning in Ns" promises
+            # something that will never happen.
+            if lid not in desired_ids:
+                self._forget(lid)
+                logger.info(
+                    "label %s sync task stopped after %.0fs; label or account no longer active",
+                    lid,
+                    ran_for,
+                )
+                continue
             # A task that ran a good while got as far as working; treat its
             # death as a fresh incident rather than escalating an old streak.
             failures = 1 if ran_for >= _HEALTHY_RUN_SECONDS else self._consecutive_failures.get(lid, 0) + 1
@@ -175,8 +196,12 @@ class MailObserver:
                     describe_error(exc),
                 )
             else:
+                # Still desired, but the coroutine returned rather than raised:
+                # the connect/login failure path does exactly this, having
+                # already logged and latched the reason. "without error" would
+                # be wrong — it failed, it just did not propagate.
                 logger.warning(
-                    "label %s sync task exited after %.0fs without error (failure %d); respawning in %.0fs",
+                    "label %s sync task returned early after %.0fs (failure %d); respawning in %.0fs",
                     lid,
                     ran_for,
                     failures,
@@ -202,14 +227,18 @@ class MailObserver:
             self._spawned_at[lbl.label_id] = now
             self._tasks[lbl.label_id] = asyncio.create_task(self._run_label(lbl.label_id, session_factory))
 
-        # Cancel tasks for labels that are no longer active
-        for lid in actual_ids - desired_ids:
-            # Drop the backoff bookkeeping too: otherwise a reactivated account
-            # sits behind a stale gate for up to the cap, silently, right after
-            # the operator fixed it.
-            self._consecutive_failures.pop(lid, None)
-            self._retry_not_before.pop(lid, None)
+        # Cancel tasks for labels that are no longer active, and forget the
+        # bookkeeping for anything undesired — keyed off every id we hold state
+        # for, not just running tasks. `actual_ids` is computed *after* the reap
+        # loop popped dead tasks, so a label that died and then went inactive
+        # would never appear here and would keep its backoff forever: on
+        # reactivation it sits behind a stale gate for up to the cap, silently,
+        # and its next failure escalates from the old streak instead of
+        # restarting at the base delay.
+        known = set(self._tasks) | set(self._consecutive_failures) | set(self._retry_not_before) | set(self._spawned_at)
+        for lid in known - desired_ids:
             task = self._tasks.pop(lid, None)
+            self._forget(lid)
             if task is not None:
                 task.cancel()
 

--- a/tests/api/test_mail_routes.py
+++ b/tests/api/test_mail_routes.py
@@ -122,7 +122,6 @@ async def test_test_connection_endpoint(client, admin_user, admin_token, monkeyp
     """Test connection endpoint: opens IMAP conn, runs LIST, returns folders."""
     from tests.mail.conftest import FakeIMAP
 
-    FakeIMAP.reset()
     FakeIMAP.set_login_response("OK", b"OK")
     FakeIMAP.set_list_response(
         "OK",
@@ -160,7 +159,6 @@ async def test_test_connection_endpoint(client, admin_user, admin_token, monkeyp
 async def test_test_connection_auth_error(client, admin_user, admin_token, monkeypatch):
     from tests.mail.conftest import FakeIMAP
 
-    FakeIMAP.reset()
     FakeIMAP.set_login_response("NO", b"AUTHENTICATIONFAILED Invalid credentials")
     monkeypatch.setattr("harbor_clerk.mail.imap_client.ReadOnlyIMAP4_SSL", FakeIMAP)
 
@@ -351,10 +349,15 @@ async def test_test_connection_closes_the_socket_on_auth_failure(client, admin_u
     from harbor_clerk.mail.imap_client import IMAPConnection
     from tests.mail.conftest import FakeIMAP
 
-    FakeIMAP.reset()
     FakeIMAP.set_login_response("NO", b"AUTHENTICATIONFAILED Invalid credentials")
     monkeypatch.setattr("harbor_clerk.mail.imap_client.ReadOnlyIMAP4_SSL", FakeIMAP)
 
+    # This proves the route *calls* logout() on the auth-failure path — it
+    # cannot prove the socket closes, because FakeIMAP has no protocol/transport
+    # for the real logout() to reach. The close half of the contract is proven
+    # by tests/mail/test_imap_client.py::
+    # test_logout_closes_the_transport_even_when_login_never_succeeded; the two
+    # compose.
     logouts = []
     real_logout = IMAPConnection.logout
 

--- a/tests/api/test_mail_routes.py
+++ b/tests/api/test_mail_routes.py
@@ -336,3 +336,48 @@ async def test_rescan_label_resets_cursor(client, admin_user, admin_token, db_se
     await db_session.refresh(label)
     assert label.last_uid_seen == 0
     assert label.uidvalidity is None
+
+
+async def test_test_connection_closes_the_socket_on_auth_failure(client, admin_user, admin_token, monkeypatch):
+    """The same leak as the watcher's label task, at a more reachable site.
+
+    `AuthError` comes from `login()`, after `connect()` completed the TLS
+    handshake — so a live socket exists. An admin fixing a mistyped app password
+    retries this endpoint, and each attempt would pin a connection for ~30 min
+    against the provider's per-account cap, on the very account whose label
+    tasks need those connections. The sibling `except Exception` branch already
+    closed; this one did not.
+    """
+    from harbor_clerk.mail.imap_client import IMAPConnection
+    from tests.mail.conftest import FakeIMAP
+
+    FakeIMAP.reset()
+    FakeIMAP.set_login_response("NO", b"AUTHENTICATIONFAILED Invalid credentials")
+    monkeypatch.setattr("harbor_clerk.mail.imap_client.ReadOnlyIMAP4_SSL", FakeIMAP)
+
+    logouts = []
+    real_logout = IMAPConnection.logout
+
+    async def _tracked_logout(self):
+        logouts.append(1)
+        return await real_logout(self)
+
+    monkeypatch.setattr(IMAPConnection, "logout", _tracked_logout)
+
+    body = {
+        "display_name": "leak-check",
+        "provider": "gmail",
+        "imap_host": "imap.gmail.com",
+        "imap_port": 993,
+        "imap_username": "leak@example.com",
+        "app_password": "wrong",
+    }
+    account_id = (await client.post("/api/mail/accounts", json=body, headers=auth_header(admin_token))).json()[
+        "account_id"
+    ]
+
+    resp = await client.post(f"/api/mail/accounts/{account_id}/test", headers=auth_header(admin_token))
+    assert resp.status_code == 200
+    assert resp.json()["success"] is False
+
+    assert logouts, "auth failure returned without closing the connection it opened"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,25 @@ def _reset_global_settings_singleton():
     _config._settings = None
 
 
+@pytest.fixture(autouse=True)
+def _reset_fake_imap_class_state():
+    """Reset FakeIMAP's class-level response staging before AND after every
+    test, suite-wide.
+
+    FakeIMAP stages responses as *class* attributes, so a test that sets one
+    and never resets poisons every later FakeIMAP consumer in the run. This
+    fixture used to live in tests/mail/conftest.py, which left tests/api/ — a
+    FakeIMAP consumer via test_mail_routes.py — with no reset at all: the last
+    staged response (a NO login) survived for the rest of an api-only run,
+    an order-dependency lying in wait for the next test that adopts the fake.
+    """
+    from tests.mail.conftest import FakeIMAP
+
+    FakeIMAP.reset()
+    yield
+    FakeIMAP.reset()
+
+
 @pytest.fixture(scope="session")
 def _engine():
     """Create engine and run Alembic migrations once per test session."""

--- a/tests/mail/conftest.py
+++ b/tests/mail/conftest.py
@@ -187,22 +187,14 @@ class FakeIMAP:
         raise TimeoutError("no idle events queued")
 
 
-import pytest  # noqa: E402
-
-
-@pytest.fixture(autouse=True)
-def _reset_fake_imap_state():
-    """Reset FakeIMAP's class-level response staging between every mail test.
-
-    Without this, leftover responses from a previous test leak into the
-    next — rendering tests order-dependent.
-    """
-    FakeIMAP.reset()
-    yield
-    FakeIMAP.reset()
-
+# FakeIMAP's class-level staging is reset around every test by the suite-wide
+# autouse fixture in tests/conftest.py — it lives there, not here, because
+# tests/api/ consumes the fake too and a fixture in this conftest cannot
+# reach it.
 
 from uuid import uuid4  # noqa: E402
+
+import pytest  # noqa: E402
 
 from harbor_clerk.models import MailAccount, WatchedLabel  # noqa: E402
 

--- a/tests/mail/test_imap_client.py
+++ b/tests/mail/test_imap_client.py
@@ -252,6 +252,106 @@ async def test_logout_cancels_a_still_pending_connection_task():
     assert task.cancelled()
 
 
+class _RecordingTransport:
+    def __init__(self, closed: list):
+        self._closed = closed
+
+    def close(self):
+        self._closed.append(1)
+
+
+def _connected_client(closed: list, logouts: list, logout_raises: BaseException | None = None):
+    """Shaped like a real post-handshake aioimaplib client: a protocol holding
+    the transport, and a *completed* connection task — which is what a
+    successful login implies."""
+    import asyncio
+
+    class _Client:
+        def __init__(self):
+            self.protocol = type("P", (), {"transport": _RecordingTransport(closed)})()
+            self._client_task = asyncio.get_event_loop().create_future()
+            self._client_task.set_result(None)
+
+        async def logout(self):
+            logouts.append(1)
+            if logout_raises is not None:
+                raise logout_raises
+            return "OK", [b"BYE"]
+
+    return _Client()
+
+
+async def test_logout_closes_the_transport_after_a_successful_login():
+    """The production-common path: every watcher shutdown and every label
+    cancel goes through logged_in=True → LOGOUT → close. Every other socket
+    test here drives the login-failed path, so a regression that closes the
+    socket only when login failed would ship green without this one.
+    """
+    from harbor_clerk.mail.imap_client import IMAPConnection
+
+    closed: list = []
+    logouts: list = []
+    conn = IMAPConnection(host="h", port=993, username="u", password="p")
+    conn._client = _connected_client(closed, logouts)
+    conn._logged_in = True
+
+    await conn.logout()
+
+    assert logouts == [1], "LOGOUT was never sent on a logged-in connection"
+    assert closed, "transport was never closed on the logged-in path"
+    assert conn._client is None
+    assert conn._logged_in is False
+
+
+async def test_logout_closes_the_transport_even_when_the_logout_command_fails():
+    """A server that errors or drops the connection mid-LOGOUT must not leak
+    the socket — the LOGOUT is best-effort, the close is not."""
+    from harbor_clerk.mail.imap_client import IMAPConnection
+
+    closed: list = []
+    logouts: list = []
+    conn = IMAPConnection(host="h", port=993, username="u", password="p")
+    conn._client = _connected_client(closed, logouts, logout_raises=RuntimeError("connection reset"))
+    conn._logged_in = True
+
+    await conn.logout()  # must not raise: LOGOUT errors are swallowed
+
+    assert logouts == [1]
+    assert closed, "transport leaked because the LOGOUT command failed"
+
+
+async def test_logout_closes_the_transport_when_cancelled_mid_logout():
+    """CancelledError is not an Exception: without the finally, a cancellation
+    delivered during the LOGOUT — the normal way a watcher label task exits —
+    would skip the close and the drain, on exactly the path the docstring
+    promises cannot leak. The cancellation itself must still propagate.
+    """
+    import asyncio
+
+    from harbor_clerk.mail.imap_client import IMAPConnection
+
+    closed: list = []
+    logouts: list = []
+    conn = IMAPConnection(host="h", port=993, username="u", password="p")
+    client = _connected_client(closed, logouts, logout_raises=asyncio.CancelledError())
+    # A pending connection task cannot coexist with logged_in=True against the
+    # real library — a completed login implies it finished. Staged here anyway,
+    # because it is the only way to observe that the drain half of the cleanup
+    # runs on the cancellation path and not just the fall-through one.
+    pending = asyncio.get_event_loop().create_future()
+    client._client_task = pending
+
+    conn._client = client
+    conn._logged_in = True
+
+    with pytest.raises(asyncio.CancelledError):
+        await conn.logout()
+
+    assert closed, "cancellation mid-LOGOUT leaked the socket"
+    assert pending.cancelled(), "the connection-task drain was skipped on the cancellation path"
+    assert conn._client is None
+
+
 def test_aioimaplib_still_exposes_the_attributes_logout_reaches_for():
     """`logout()` reaches past the wrapper for the socket, so it depends on two
     aioimaplib internals. The other tests here use stubs with those names
@@ -264,8 +364,12 @@ def test_aioimaplib_still_exposes_the_attributes_logout_reaches_for():
         "aioimaplib.IMAP4._client_task is gone — logout() no longer drains the connection task"
     )
 
-    protocol = aioimaplib.IMAP4ClientProtocol.__new__(aioimaplib.IMAP4ClientProtocol)
-    assert hasattr(protocol, "transport") or "transport" in aioimaplib.IMAP4ClientProtocol.__init__.__code__.co_names, (
+    # Constructed for real, not via __new__: on a bare __new__ instance the
+    # attribute does not exist yet (it is assigned in __init__), so a hasattr
+    # check there is always False and the pin degrades to a string search that
+    # any textual survival of the word "transport" keeps green.
+    protocol = aioimaplib.IMAP4ClientProtocol(None)
+    assert hasattr(protocol, "transport"), (
         "IMAP4ClientProtocol.transport is gone — logout() no longer closes the socket"
     )
 

--- a/tests/mail/test_imap_client.py
+++ b/tests/mail/test_imap_client.py
@@ -191,6 +191,8 @@ async def test_logout_closes_the_transport_even_when_login_never_succeeded():
         def close(self):
             closed.append(True)
 
+    logouts = []
+
     class _Client:
         def __init__(self):
             self.protocol = type("P", (), {"transport": _Transport()})()
@@ -198,7 +200,10 @@ async def test_logout_closes_the_transport_even_when_login_never_succeeded():
             self._client_task.set_result(None)
 
         async def logout(self):
-            raise AssertionError("must not LOGOUT when login never succeeded")
+            # Recorded, not raised: `logout()` wraps this call in
+            # `except Exception`, which swallows AssertionError — so raising
+            # here would make the guard inert.
+            logouts.append(1)
 
     conn = IMAPConnection(host="h", port=993, username="u", password="p")
     conn._client = _Client()
@@ -207,6 +212,7 @@ async def test_logout_closes_the_transport_even_when_login_never_succeeded():
     await conn.logout()
 
     assert closed, "transport was never closed — the socket leaks until the server reaps it"
+    assert logouts == [], "sent LOGOUT when login never succeeded"
     assert conn._client is None
 
 
@@ -262,3 +268,10 @@ def test_aioimaplib_still_exposes_the_attributes_logout_reaches_for():
     assert hasattr(protocol, "transport") or "transport" in aioimaplib.IMAP4ClientProtocol.__init__.__code__.co_names, (
         "IMAP4ClientProtocol.transport is gone — logout() no longer closes the socket"
     )
+
+    # The third internal, and the one whose loss is most silent: without
+    # `protocol`, both getattrs return None and the close no-ops while every
+    # stub-based test stays green.
+    created = aioimaplib.IMAP4.create_client.__code__.co_names
+    assert "protocol" in created, "IMAP4.protocol is gone — logout() can no longer reach the transport"
+    assert "_client_task" in created, "IMAP4._client_task is no longer assigned — logout() drains nothing"

--- a/tests/mail/test_imap_client.py
+++ b/tests/mail/test_imap_client.py
@@ -210,21 +210,25 @@ async def test_logout_closes_the_transport_even_when_login_never_succeeded():
     assert conn._client is None
 
 
-async def test_logout_retrieves_the_connection_task_exception():
-    """`create_connection` runs as a task nobody awaits. When it fails — the
-    common case after a connect error — its exception is never retrieved, and
-    asyncio only surfaces it as "Task exception was never retrieved" at
-    shutdown. That is how this leak stayed invisible.
+async def test_logout_cancels_a_still_pending_connection_task():
+    """`create_connection` runs as a task nobody awaits.
+
+    The earlier version of this test used an already-failed task, so
+    `task.done()` held unconditionally and `task.exception()` — the assertion
+    itself — was what retrieved the exception. It passed against the unfixed
+    code. This uses a *pending* task, which only reaches a terminal state if
+    `logout()` actually cancels it.
     """
     import asyncio
 
     from harbor_clerk.mail.imap_client import IMAPConnection
 
-    async def _failed_connect():
-        raise OSError("connection refused")
+    async def _never_connects():
+        await asyncio.sleep(3600)
 
-    task = asyncio.ensure_future(_failed_connect())
+    task = asyncio.ensure_future(_never_connects())
     await asyncio.sleep(0)
+    assert not task.done()
 
     class _Client:
         protocol = None
@@ -238,5 +242,23 @@ async def test_logout_retrieves_the_connection_task_exception():
 
     await conn.logout()
 
-    assert task.done()
-    assert task.exception() is not None  # retrieved, so asyncio won't complain
+    assert task.done(), "pending connection task was left running"
+    assert task.cancelled()
+
+
+def test_aioimaplib_still_exposes_the_attributes_logout_reaches_for():
+    """`logout()` reaches past the wrapper for the socket, so it depends on two
+    aioimaplib internals. The other tests here use stubs with those names
+    hard-coded, which would keep passing through an upstream rename while the
+    leak silently returned. Pin them against the real library.
+    """
+    import aioimaplib
+
+    assert "_client_task" in aioimaplib.IMAP4.__annotations__ or hasattr(aioimaplib.IMAP4, "_client_task"), (
+        "aioimaplib.IMAP4._client_task is gone — logout() no longer drains the connection task"
+    )
+
+    protocol = aioimaplib.IMAP4ClientProtocol.__new__(aioimaplib.IMAP4ClientProtocol)
+    assert hasattr(protocol, "transport") or "transport" in aioimaplib.IMAP4ClientProtocol.__init__.__code__.co_names, (
+        "IMAP4ClientProtocol.transport is gone — logout() no longer closes the socket"
+    )

--- a/tests/mail/test_imap_client.py
+++ b/tests/mail/test_imap_client.py
@@ -166,3 +166,77 @@ async def test_uid_allows_read_subcommands(_patch_aioimaplib, verb, monkeypatch)
     result, _lines = await conn.uid(verb, "1:*")
     assert result == "OK"
     assert captured == [(verb, ("1:*",))]
+
+
+async def test_logout_closes_the_transport_even_when_login_never_succeeded():
+    """Dropping the client reference does not release the socket.
+
+    aioimaplib schedules `loop.create_connection(...)` in `IMAP4.__init__`, so
+    the transport is owned by the event loop; losing the Python reference leaves
+    it open until the server reaps it (~30 min on Gmail). LOGOUT is skipped when
+    `_logged_in` is false — the connect-ok/login-failed path — so before this
+    fix that path closed nothing at all.
+
+    Harmless when a dead task was never retried: one socket per watcher
+    lifetime. With respawn-on-failure it repeats, against Gmail's limit of 15
+    simultaneous IMAP connections per account.
+    """
+    import asyncio
+
+    from harbor_clerk.mail.imap_client import IMAPConnection
+
+    closed = []
+
+    class _Transport:
+        def close(self):
+            closed.append(True)
+
+    class _Client:
+        def __init__(self):
+            self.protocol = type("P", (), {"transport": _Transport()})()
+            self._client_task = asyncio.get_event_loop().create_future()
+            self._client_task.set_result(None)
+
+        async def logout(self):
+            raise AssertionError("must not LOGOUT when login never succeeded")
+
+    conn = IMAPConnection(host="h", port=993, username="u", password="p")
+    conn._client = _Client()
+    conn._logged_in = False  # connected, but login raised
+
+    await conn.logout()
+
+    assert closed, "transport was never closed — the socket leaks until the server reaps it"
+    assert conn._client is None
+
+
+async def test_logout_retrieves_the_connection_task_exception():
+    """`create_connection` runs as a task nobody awaits. When it fails — the
+    common case after a connect error — its exception is never retrieved, and
+    asyncio only surfaces it as "Task exception was never retrieved" at
+    shutdown. That is how this leak stayed invisible.
+    """
+    import asyncio
+
+    from harbor_clerk.mail.imap_client import IMAPConnection
+
+    async def _failed_connect():
+        raise OSError("connection refused")
+
+    task = asyncio.ensure_future(_failed_connect())
+    await asyncio.sleep(0)
+
+    class _Client:
+        protocol = None
+
+        def __init__(self, t):
+            self._client_task = t
+
+    conn = IMAPConnection(host="h", port=993, username="u", password="p")
+    conn._client = _Client(task)
+    conn._logged_in = False
+
+    await conn.logout()
+
+    assert task.done()
+    assert task.exception() is not None  # retrieved, so asyncio won't complain

--- a/tests/mail/test_mail_observer.py
+++ b/tests/mail/test_mail_observer.py
@@ -474,3 +474,90 @@ async def test_reactivating_a_label_clears_its_backoff(db_session, mock_aioimap,
     assert label_id not in observer._retry_not_before
 
     await observer.stop()
+
+
+async def test_backoff_is_forgotten_for_a_label_that_died_then_went_inactive(
+    db_session, mock_aioimap, observer_session_factory
+):
+    """The cleanup keyed off `actual_ids`, computed *after* the reap loop popped
+    dead tasks — so a label that died and *then* went inactive could never
+    appear in it, and kept its backoff forever. On reactivation it sat behind a
+    stale gate for up to the cap with nothing logged, and its next failure
+    escalated from the old streak instead of restarting at the base delay.
+    """
+    import asyncio
+
+    from sqlalchemy import select as _select
+
+    from harbor_clerk.models import WatchedLabel as _WL
+    from harbor_clerk.watcher.mail_observer import MailObserver
+
+    label_id = await _one_active_label(db_session, "forget")
+    observer = MailObserver(session_factory=observer_session_factory)
+
+    async def _boom():
+        raise RuntimeError("died")
+
+    dead = asyncio.create_task(_boom())
+    await asyncio.sleep(0)
+    observer._tasks[label_id] = dead
+    observer._spawned_at[label_id] = __import__("time").monotonic()
+
+    # Reap while still desired: backoff is armed and the task is gone.
+    await observer._reconcile(observer_session_factory)
+    assert observer._consecutive_failures.get(label_id) == 1
+    assert label_id not in observer._tasks
+
+    # Now the label goes inactive — the state must not survive it.
+    lbl = (await db_session.execute(_select(_WL).where(_WL.label_id == label_id))).scalar_one()
+    lbl.status = "paused"
+    await db_session.commit()
+
+    await observer._reconcile(observer_session_factory)
+
+    assert label_id not in observer._consecutive_failures, "stale backoff survived deactivation"
+    assert label_id not in observer._retry_not_before
+    assert label_id not in observer._spawned_at
+
+    await observer.stop()
+
+
+async def test_deliberate_exit_is_not_logged_as_a_failure(db_session, mock_aioimap, observer_session_factory, caplog):
+    """`_run_label` returns on purpose when the account goes auth_error or its
+    key stops matching. No respawn follows, because the label has left
+    desired_ids — so logging "respawning in Ns" promises something that never
+    happens, and arming a backoff for it is meaningless.
+    """
+    import asyncio
+    import logging
+
+    from sqlalchemy import select as _select
+
+    from harbor_clerk.models import WatchedLabel as _WL
+    from harbor_clerk.watcher.mail_observer import MailObserver
+
+    label_id = await _one_active_label(db_session, "deliberate")
+    observer = MailObserver(session_factory=observer_session_factory)
+
+    # Label is already inactive when its task finishes cleanly.
+    lbl = (await db_session.execute(_select(_WL).where(_WL.label_id == label_id))).scalar_one()
+    lbl.status = "paused"
+    await db_session.commit()
+
+    async def _clean_exit():
+        return None
+
+    done = asyncio.create_task(_clean_exit())
+    await asyncio.sleep(0)
+    observer._tasks[label_id] = done
+    observer._spawned_at[label_id] = __import__("time").monotonic()
+
+    with caplog.at_level(logging.INFO):
+        await observer._reconcile(observer_session_factory)
+
+    text = caplog.text
+    assert "respawning" not in text, f"promised a respawn that cannot happen: {text}"
+    assert "no longer active" in text
+    assert label_id not in observer._consecutive_failures
+
+    await observer.stop()

--- a/tests/mail/test_mail_observer.py
+++ b/tests/mail/test_mail_observer.py
@@ -561,3 +561,52 @@ async def test_deliberate_exit_is_not_logged_as_a_failure(db_session, mock_aioim
     assert label_id not in observer._consecutive_failures
 
     await observer.stop()
+
+
+async def test_auth_failure_closes_the_connection_it_opened(
+    db_session, mock_aioimap, observer_session_factory, monkeypatch
+):
+    """The path that leaks most, and the one the logout() fix exists for.
+
+    `AuthError` is raised by `login()` — after `connect()` completed the TLS
+    handshake — so there is a live socket. A wrong app password fails every
+    label on the account at once, and again on every re-activation, each time
+    holding a socket for ~30 min against Gmail's 15-connection limit. Fixing
+    `logout()` achieves nothing if this branch does not call it.
+    """
+    from harbor_clerk.mail.exceptions import AuthError
+    from harbor_clerk.mail.imap_client import IMAPConnection
+    from harbor_clerk.watcher.mail_observer import MailObserver
+
+    label_id = await _one_active_label(db_session, "authleak")
+
+    logouts = []
+    real_logout = IMAPConnection.logout
+
+    async def _tracked_logout(self):
+        logouts.append(1)
+        return await real_logout(self)
+
+    async def _connect_ok(self):
+        self._client = object()  # handshake completed; a socket exists
+
+    async def _login_fails(self):
+        raise AuthError("AUTHENTICATIONFAILED Invalid credentials")
+
+    monkeypatch.setattr(IMAPConnection, "connect", _connect_ok)
+    monkeypatch.setattr(IMAPConnection, "login", _login_fails)
+    monkeypatch.setattr(IMAPConnection, "logout", _tracked_logout)
+
+    observer = MailObserver(session_factory=observer_session_factory)
+    await observer._run_label(label_id, observer_session_factory)
+
+    assert logouts, "auth failure returned without closing the connection it opened"
+
+    # And the account is still marked, so the behaviour that mattered is intact.
+    from sqlalchemy import select as _select
+
+    from harbor_clerk.models import MailAccount as _MA
+
+    acc = (await db_session.execute(_select(_MA))).scalars().first()
+    await db_session.refresh(acc)
+    assert acc.status == "auth_error"

--- a/tests/mail/test_mail_observer.py
+++ b/tests/mail/test_mail_observer.py
@@ -472,6 +472,7 @@ async def test_reactivating_a_label_clears_its_backoff(db_session, mock_aioimap,
 
     assert label_id not in observer._consecutive_failures
     assert label_id not in observer._retry_not_before
+    assert label_id not in observer._spawned_at
 
     await observer.stop()
 
@@ -629,3 +630,55 @@ async def test_auth_failure_closes_the_connection_it_opened(
     acc = (await db_session.execute(_select(_MA))).scalars().first()
     await db_session.refresh(acc)
     assert acc.status == "auth_error"
+
+
+async def test_cancelling_a_label_mid_connect_still_closes_the_socket(
+    db_session, mock_aioimap, observer_session_factory, monkeypatch
+):
+    """The window the per-branch cleanups missed. `_reconcile` cancels a task
+    the moment its label goes inactive, and `stop()` cancels them all — and a
+    hung TLS handshake to an unreachable host is exactly where such a task
+    spends its time. CancelledError is not an Exception, so before the outer
+    finally none of the cleanup branches ran on this path: the half-open socket
+    (aioimaplib schedules `create_connection` in `__init__`, so one exists the
+    moment the client object does) leaked until the server reaped it.
+    """
+    import asyncio
+
+    from harbor_clerk.mail.imap_client import IMAPConnection
+    from harbor_clerk.watcher.mail_observer import MailObserver
+
+    closed = []
+
+    class _Transport:
+        def close(self):
+            closed.append(1)
+
+    class _HalfOpenClient:
+        """A client whose handshake never completes: the connection task has
+        produced a socket, but the server greeting never arrives."""
+
+        def __init__(self):
+            self.protocol = type("P", (), {"transport": _Transport()})()
+            self._client_task = asyncio.get_event_loop().create_future()
+            self._client_task.set_result(None)
+
+    in_connect = asyncio.Event()
+
+    async def _connect_hangs(self):
+        self._client = _HalfOpenClient()
+        in_connect.set()
+        await asyncio.sleep(3600)  # greeting never arrives; only a cancel ends this
+
+    monkeypatch.setattr(IMAPConnection, "connect", _connect_hangs)
+
+    label_id = await _one_active_label(db_session, "cancelmid")
+    observer = MailObserver(session_factory=observer_session_factory)
+    task = asyncio.create_task(observer._run_label(label_id, observer_session_factory))
+    await asyncio.wait_for(in_connect.wait(), timeout=5)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert closed, "cancellation mid-connect leaked the socket"

--- a/tests/mail/test_mail_observer.py
+++ b/tests/mail/test_mail_observer.py
@@ -574,6 +574,8 @@ async def test_auth_failure_closes_the_connection_it_opened(
     holding a socket for ~30 min against Gmail's 15-connection limit. Fixing
     `logout()` achieves nothing if this branch does not call it.
     """
+    import asyncio
+
     from harbor_clerk.mail.exceptions import AuthError
     from harbor_clerk.mail.imap_client import IMAPConnection
     from harbor_clerk.watcher.mail_observer import MailObserver
@@ -587,8 +589,24 @@ async def test_auth_failure_closes_the_connection_it_opened(
         logouts.append(1)
         return await real_logout(self)
 
+    closed = []
+
+    class _Transport:
+        def close(self):
+            closed.append(1)
+
+    class _ConnectedClient:
+        """Shaped like a real post-handshake client, so `logout()` actually
+        reaches the transport — a bare object() misses every getattr and the
+        test would prove only that logout() was *called*."""
+
+        def __init__(self):
+            self.protocol = type("P", (), {"transport": _Transport()})()
+            self._client_task = asyncio.get_event_loop().create_future()
+            self._client_task.set_result(None)
+
     async def _connect_ok(self):
-        self._client = object()  # handshake completed; a socket exists
+        self._client = _ConnectedClient()  # handshake completed; a socket exists
 
     async def _login_fails(self):
         raise AuthError("AUTHENTICATIONFAILED Invalid credentials")
@@ -601,6 +619,7 @@ async def test_auth_failure_closes_the_connection_it_opened(
     await observer._run_label(label_id, observer_session_factory)
 
     assert logouts, "auth failure returned without closing the connection it opened"
+    assert closed, "logout() was called but the socket was never actually closed"
 
     # And the account is still marked, so the behaviour that mattered is intact.
     from sqlalchemy import select as _select

--- a/tests/mail/test_mail_observer.py
+++ b/tests/mail/test_mail_observer.py
@@ -682,3 +682,102 @@ async def test_cancelling_a_label_mid_connect_still_closes_the_socket(
         await task
 
     assert closed, "cancellation mid-connect leaked the socket"
+
+
+async def test_network_failure_during_login_still_closes_the_socket(
+    db_session, mock_aioimap, observer_session_factory, monkeypatch
+):
+    """The third of the three paths the cleanup covers: connect() completed —
+    a socket exists — and then login died with a *non-auth* error: a timeout,
+    a dropped connection. The auth and cancel-mid-connect variants are pinned
+    above; this path shares the same finally and now shares a test.
+    """
+    import asyncio
+
+    from harbor_clerk.mail.imap_client import IMAPConnection
+    from harbor_clerk.watcher.mail_observer import MailObserver
+
+    closed = []
+
+    class _Transport:
+        def close(self):
+            closed.append(1)
+
+    class _ConnectedClient:
+        def __init__(self):
+            self.protocol = type("P", (), {"transport": _Transport()})()
+            self._client_task = asyncio.get_event_loop().create_future()
+            self._client_task.set_result(None)
+
+    async def _connect_ok(self):
+        self._client = _ConnectedClient()
+
+    async def _login_drops(self):
+        raise RuntimeError("connection reset by peer")
+
+    monkeypatch.setattr(IMAPConnection, "connect", _connect_ok)
+    monkeypatch.setattr(IMAPConnection, "login", _login_drops)
+
+    label_id = await _one_active_label(db_session, "netfail")
+    observer = MailObserver(session_factory=observer_session_factory)
+    await observer._run_label(label_id, observer_session_factory)
+
+    assert closed, "a non-auth login failure leaked the socket it opened"
+
+    # And the failure is latched, so the UI has something to show.
+    from sqlalchemy import select as _select
+
+    from harbor_clerk.models import MailAccount as _MA
+
+    acc = (await db_session.execute(_select(_MA))).scalars().first()
+    await db_session.refresh(acc)
+    assert acc.last_error is not None
+    assert "connection reset by peer" in acc.last_error
+
+
+async def test_cancellation_during_logout_still_exits_the_audit_session(
+    db_session, mock_aioimap, observer_session_factory, monkeypatch
+):
+    """logout() deliberately re-raises a cancellation delivered mid-LOGOUT, and
+    suppress(Exception) does not cover CancelledError — so without its own
+    finally around the audit exit, this one path strands the audit session and
+    its pooled connection until GC. Found by unprimed review; the socket half
+    was covered, the audit half was not.
+    """
+    import asyncio
+
+    from harbor_clerk.mail.exceptions import AuthError
+    from harbor_clerk.mail.imap_client import IMAPConnection
+    from harbor_clerk.watcher import mail_observer as mo
+
+    exits = []
+
+    class _RecordingAuditScope:
+        async def __aenter__(self):
+            return None  # no audit session: IMAPConnection._audit no-ops
+
+        async def __aexit__(self, *exc):
+            exits.append(1)
+            return False
+
+    async def _connect_ok(self):
+        self._client = object()
+
+    async def _login_fails(self):
+        raise AuthError("AUTHENTICATIONFAILED")
+
+    async def _logout_cancelled(self):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(mo, "audit_session_scope", lambda: _RecordingAuditScope())
+    monkeypatch.setattr(IMAPConnection, "connect", _connect_ok)
+    monkeypatch.setattr(IMAPConnection, "login", _login_fails)
+    monkeypatch.setattr(IMAPConnection, "logout", _logout_cancelled)
+
+    label_id = await _one_active_label(db_session, "auditcancel")
+    observer = MailObserver(session_factory=observer_session_factory)
+
+    with pytest.raises(asyncio.CancelledError):
+        await observer._run_label(label_id, observer_session_factory)
+
+    assert exits == [1], "cancellation during logout skipped the audit-session exit"


### PR DESCRIPTION
Three findings from the cross-change audit of merged `main`. All three are in code that only became reachable once #569 made label tasks retry — so the respawn fix turned two latent problems into recurring ones.

## 1. The socket leak, now repeating — the one with live consequence

`IMAPConnection.logout()` sent LOGOUT only when `_logged_in`, then dropped `self._client`. That releases nothing: aioimaplib schedules `loop.create_connection(...)` in `IMAP4.__init__`, so the transport is owned by the event loop and stays open until the server reaps it — **~30 minutes on Gmail**.

Harmless while a dead task was never retried: one socket per watcher lifetime. With respawn it repeats — at the backoff cap, **~12 attempts/hour with ~6 alive at once, against Gmail's limit of 15 simultaneous IMAP connections per account**. One sick label can lock out the healthy ones.

`logout()` now closes the transport unconditionally (LOGOUT stays conditional — nothing to log out of if login never succeeded) and retrieves the `create_connection` task's exception. Nobody awaits that task, so on a failed connect its exception only ever appeared as asyncio's *"Task exception was never retrieved"* at shutdown. That is exactly how this stayed invisible.

## 2. Backoff state outlived the label

The cleanup iterated `actual_ids - desired_ids`, and `actual_ids` is computed **after** the reap loop pops dead tasks — so a label that died and *then* went inactive could never appear in it. Its bookkeeping survived forever: on reactivation it sat behind a stale gate for up to the 300s cap with nothing logged, and its next failure escalated from the old streak instead of restarting at the base delay. Precisely what the cleanup comment claimed to prevent.

Now keyed off every id we hold state for, through a single `_forget` so a future dict cannot quietly outlive its label. `_spawned_at` was also never popped on the cancel path.

## 3. Deliberate exits logged as failures

`_run_label` returns *on purpose* when the account goes auth_error or its key stops matching. Those give `exc is None`, so the reaper logged `"exited without error (failure N); respawning in Ds"` — arming a backoff and promising a respawn that cannot happen, since the label has left `desired_ids`.

It now recognises that case. The remaining `exc is None` case is the connect/login failure path, which returns rather than raises after logging and latching its reason — so "returned early", not "without error". It did fail.

## Verification

Each fix mutation-tested: removing the transport close, reverting the cleanup to `actual_ids`, and dropping the deliberate-exit branch each fail their own test and nothing else.

`uv run pytest tests/` — 1592 passed, 9 skipped. ruff clean.