### PR TITLE
fix(macos): add the AppSettings accessor #588 forgot, unbreaking the build

### DIFF
--- a/macos/HarborClerkServer/HarborClerkServer/Settings.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/Settings.swift
@@ -71,6 +71,12 @@ final class AppSettings: @unchecked Sendable {
         set { lock.withLock { data["embedder_port"] = newValue }; save() }
     }
 
+    /// e5 rollback switch; default must match EMBED_NEEDS_PREFIX in embedder/src/embedder/app.py.
+    var embedNeedsPrefix: Bool {
+        get { lock.withLock { data["embed_needs_prefix"] as? Bool ?? false } }
+        set { lock.withLock { data["embed_needs_prefix"] = newValue }; save() }
+    }
+
     var rerankerPort: Int {
         get { lock.withLock { data["reranker_port"] as? Int ?? 8201 } }
         set { lock.withLock { data["reranker_port"] = newValue }; save() }


### PR DESCRIPTION
## What broke

[#588](https://github.com/r0shi/harborclerk/pull/588) plumbed `EMBED_NEEDS_PREFIX` through `EmbedderService.extraEnvironment` as `AppSettings.shared.embedNeedsPrefix ? "true" : "false"` — but never added the accessor. `git grep embedNeedsPrefix` on main returns only that one use, so **HarborClerkServer does not compile on main**.

It merged green because none of the six required CI checks builds Swift, and `tests/test_env_vars_are_reachable.py` matches the Swift dict key textually rather than compiling anything.

## The fix

One accessor on `AppSettings`, following the existing dict-with-default pattern:

- config.json key: `embed_needs_prefix`
- default: `false` — matching the Python default in `embedder/src/embedder/app.py` (`EMBED_NEEDS_PREFIX`, the e5 rollback switch)

Kept to the one accessor so the known `EmbedderService.swift` conflict with #574 (`fix/mps-cache-growth`) stays trivial to resolve.

## Verification

Both apps built via `xcodebuild -configuration Release -arch arm64` (same invocation as `scripts/package.sh`, signing disabled):

- HarborClerkServer: `** BUILD SUCCEEDED **`
- HarborClerk: `** BUILD SUCCEEDED **`

No test changes needed — the reachability guard is satisfied by the existing dict key, and the accessor makes it true rather than merely textual.

## Follow-up worth considering (not in this PR)

A CI job that compiles the Swift apps (or at least type-checks `HarborClerkServer`) would have caught this class of break; today no required check builds Swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)