### PR TITLE
docs: add call-site-sweep and mutation-verification to the review policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,20 @@ if someone else wrote it" is not a substitute — it is the failure mode.
 
 Review output leads with bugs, regressions, missing tests, and contract risk.
 
+Before requesting review, the author runs two mechanical checks:
+
+- **Sweep for sibling call sites.** A change that fixes a pattern, migrates a
+  contract, or adds a cleanup path is not done until the old idiom has been
+  grepped for and every hit accounted for in the PR. Three migrations each
+  shipped N−1 of N sites; the missed site was always the one outside the
+  module being edited — exactly the site self-review never visits.
+- **Mutation-verify tests guarding error handling, resource cleanup, or a
+  `finally`.** Commit first, then revert the guarded line and confirm a test
+  fails; restore, and state the result in the PR. A green suite on a change
+  you just made is not evidence — five consecutive review rounds found vacuous
+  tests, concentrated in exactly these three places, and revert-the-line
+  caught every one.
+
 ## Where knowledge goes
 
 - Project-wide rule or constraint → this file

--- a/docker/download_hf_model.py
+++ b/docker/download_hf_model.py
@@ -36,6 +36,9 @@ def download(args: argparse.Namespace) -> None:
                 raise
 
             delay = args.base_delay * (2 ** (attempt - 1)) + random.uniform(0, args.base_delay)
+            # Renders the {type}: {message} shape inline on purpose: this is a
+            # standalone build script that runs before the harbor_clerk package
+            # exists in the image, so it cannot import error_text.describe_error.
             print(
                 f"Hugging Face download failed on attempt {attempt}/{args.attempts}: {exc.__class__.__name__}: {exc}",
                 file=sys.stderr,

--- a/scripts/gen_docs/__main__.py
+++ b/scripts/gen_docs/__main__.py
@@ -14,6 +14,7 @@ import difflib
 import sys
 from pathlib import Path
 
+from harbor_clerk.error_text import describe_error
 from scripts.gen_docs.blocks import BlockError, find_blocks, replace_block
 from scripts.gen_docs.registry import GENERATORS, REPO_ROOT, TARGETS
 
@@ -41,7 +42,7 @@ def _render(path: Path) -> tuple[str, str, list[str]]:
         try:
             content = generator()
         except Exception as exc:  # noqa: BLE001 - surface which generator failed
-            raise RuntimeError(f"generator {name!r} failed: {type(exc).__name__}: {exc}") from exc
+            raise RuntimeError(f"generator {name!r} failed: {describe_error(exc)}") from exc
         updated = replace_block(updated, name, content)
 
     return original, updated, names


### PR DESCRIPTION
Process changes from the #574/#576 convergence data (see the handoff in `docs/superpowers/plans/2026-07-27-pr574-576-handoff.md`, §3a/§3b):

- **Review policy gains two author-side mechanical checks**: grep-sweep for sibling call sites before declaring a migration done (three incidents shipped N−1 of N sites), and mutation-verification for tests guarding error handling / cleanup / `finally` (five rounds, five confirmations that revert-the-line is the only technique that caught vacuous tests).
- **`scripts/gen_docs/__main__.py`** migrates the last in-env straggler of the old `{type}: {exc}` error idiom to `describe_error` (#570/#575 sweep completion).
- **`docker/download_hf_model.py`** documents why it keeps the inline idiom (standalone build script; cannot import `harbor_clerk`), so future sweeps don't flag it as an omission.

`gen_docs --check` passes; ruff clean. Three files, docs + two mechanical one-liners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)