### PR TITLE
fix(config): read every persisted key back from config.json (#592)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -14,7 +14,13 @@ from harbor_clerk.models import Base
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers defaults to True, which switches off every logger
+    # not named in alembic.ini — including all of harbor_clerk.*. Production is
+    # unaffected because migrations run as a subprocess (the /system/run-migrations
+    # route and MigrationRunner.swift both shell out), but tests/test_migrations.py
+    # calls alembic in-process, so it silently disabled harbor_clerk logging for
+    # every test that ran after it and made any later log assertion vacuous.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tempfile
 
-from pydantic import Field, field_validator
+from pydantic import Field, TypeAdapter, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -176,7 +176,93 @@ def get_settings() -> Settings:
     global _settings
     if _settings is None:
         _settings = Settings()
+        # After construction, not inside it: apply_native_config calls
+        # get_settings() and would recurse on a half-built singleton.
+        apply_native_config()
     return _settings
+
+
+# Keys in config.json that deliberately do not map onto a Settings field.
+# Listed so an unmatched key is a decision rather than a silent no-op, and
+# pinned by tests/test_settings_persist_across_restart.py so a key added on the
+# Swift side has to be classified as one or the other.
+_NATIVE_ONLY_KEYS = frozenset(
+    {
+        # Menubar state and process orchestration — Python never reads these.
+        "llm_restart",  # a signal flag the menubar clears, not configuration
+        "worker_preset",  # consumed by ServiceManager to size pools
+        "postgres_port",  # folded into database_url before the worker starts
+        # Service ports the menubar assigns and then passes to each subprocess
+        # as a resolved URL (EMBEDDER_URL, TIKA_URL, ...), so the port itself
+        # never needs to reach Settings.
+        "embedder_port",
+        "reranker_port",
+        "tika_port",
+        "llama_port",
+        # Persisted here for the Preferences UI, then handed to the embedder and
+        # reranker as GPU_CACHE_HIGH_WATER_MB (see their extraEnvironment). The
+        # app process never reads it — only those two subprocesses do.
+        "gpu_cache_high_water_mb",
+        # Caddy's configuration. The gateway is a separate process that the
+        # menubar configures directly; none of it routes through Python.
+        "gateway_bind_addresses",
+        "gateway_hostname",
+        "gateway_certificate_mode",
+        "gateway_certificate_path",
+        "gateway_private_key_path",
+        "allow_remote_web",
+        "allow_remote_mcp",
+    }
+)
+
+
+def _native_config_data() -> dict:
+    """config.json as a dict, or empty if there isn't one / it's unreadable."""
+    path = get_settings().native_config_file
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as f:
+            return json.loads(f.read())
+    except Exception:
+        logger.debug("Failed to read native config %s", path, exc_info=True)
+        return {}
+
+
+def apply_native_config(only: set[str] | None = None) -> None:
+    """Overlay config.json onto the Settings singleton.
+
+    Writes to config.json were already generic — `sync_native_config` takes any
+    key — while reads were two hand-maintained lists. So eleven fields that
+    admin routes persist had no reader at all, and every change to them silently
+    reverted to the default on the next restart (#592). This is the missing
+    half: any config.json key naming a real Settings field is applied.
+
+    Values are validated against the field's own type rather than assigned raw,
+    so a hand-edited config.json cannot put a string where an int belongs and
+    have it surface later as a confusing failure somewhere else. A key that
+    fails validation is skipped and logged; it never stops startup.
+
+    `only` restricts the overlay to named fields, for the hot-path refreshers
+    that run per-request and shouldn't touch unrelated state.
+    """
+    settings = get_settings()
+    data = _native_config_data()
+    if not data:
+        return
+
+    for key, value in data.items():
+        if only is not None and key not in only:
+            continue
+        field = type(settings).model_fields.get(key)
+        if field is None:
+            if key not in _NATIVE_ONLY_KEYS and only is None:
+                logger.debug("native config key %r matches no Settings field; ignoring", key)
+            continue
+        try:
+            setattr(settings, key, TypeAdapter(field.annotation).validate_python(value))
+        except Exception:
+            logger.warning("native config key %r has an invalid value; keeping the current one", key, exc_info=True)
 
 
 def refresh_cli_access_setting() -> None:
@@ -186,17 +272,7 @@ def refresh_cli_access_setting() -> None:
     window. The change takes effect for new requests within seconds because
     MCPAuthMiddleware calls this before checking the gate.  No restart needed.
     """
-    settings = get_settings()
-    path = settings.native_config_file
-    if not path or not os.path.exists(path):
-        return
-    try:
-        with open(path) as f:
-            data = json.loads(f.read())
-        if "enable_cli_access" in data:
-            settings.enable_cli_access = bool(data["enable_cli_access"])
-    except Exception:
-        logger.debug("Failed to refresh enable_cli_access from %s", path, exc_info=True)
+    apply_native_config(only={"enable_cli_access"})
 
 
 def refresh_llm_settings() -> None:
@@ -206,25 +282,15 @@ def refresh_llm_settings() -> None:
     changes the active model via the API, the worker's cached Settings
     object is stale.  Call this before any LLM-dependent stage.
     """
-    settings = get_settings()
-    path = settings.native_config_file
-    if not path or not os.path.exists(path):
-        return
-    try:
-        with open(path) as f:
-            data = json.loads(f.read())
-        if "llm_model_id" in data:
-            settings.llm_model_id = data["llm_model_id"]
-        if "llm_yarn_enabled" in data:
-            settings.llm_yarn_enabled = bool(data["llm_yarn_enabled"])
-        if "summary_force_apple_intelligence" in data:
-            settings.summary_force_apple_intelligence = bool(data["summary_force_apple_intelligence"])
-        if "research_verifier_enabled" in data:
-            settings.research_verifier_enabled = bool(data["research_verifier_enabled"])
-        if "research_verifier_revision_enabled" in data:
-            settings.research_verifier_revision_enabled = bool(data["research_verifier_revision_enabled"])
-    except Exception:
-        logger.debug("Failed to refresh LLM settings from %s", path, exc_info=True)
+    apply_native_config(
+        only={
+            "llm_model_id",
+            "llm_yarn_enabled",
+            "summary_force_apple_intelligence",
+            "research_verifier_enabled",
+            "research_verifier_revision_enabled",
+        }
+    )
 
 
 def sync_native_config(key: str, value: str | bool | int) -> None:

--- a/src/harbor_clerk/config.py
+++ b/src/harbor_clerk/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tempfile
 
-from pydantic import Field, TypeAdapter, field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -149,10 +149,14 @@ class Settings(BaseSettings):
     # because the download endpoint exposes the raw bytes of any document the
     # caller can already see in search — that's a meaningful escalation over
     # the chunk-excerpt access read-only API keys are designed for. On macOS
-    # native, the menu app does NOT expose a way to flip this on, so the only
-    # way to access source files there is Reveal in Finder (which doesn't go
-    # through the HTTP server). On Docker, an admin can opt in by setting
-    # ALLOW_SOURCE_DOWNLOAD=true in the compose file.
+    # native, the menu app offers no UI for it, so the intended way to reach
+    # source files there is Reveal in Finder (which doesn't go through the HTTP
+    # server). Since #592 that is a statement about the UI and not a guarantee:
+    # config.json is applied generically, so anyone who can write
+    # ~/Library/Application Support/Harbor Clerk/config.json can turn this on.
+    # That is not an escalation — the same access reads the documents directly,
+    # and secret_key is in that file — but the old comment claimed more than it
+    # should. On Docker, an admin opts in with ALLOW_SOURCE_DOWNLOAD=true.
     allow_source_download: bool = Field(default=False)
 
     enable_cli_access: bool = Field(
@@ -175,10 +179,16 @@ _settings: Settings | None = None
 def get_settings() -> Settings:
     global _settings
     if _settings is None:
-        _settings = Settings()
-        # After construction, not inside it: apply_native_config calls
-        # get_settings() and would recurse on a half-built singleton.
-        apply_native_config()
+        # Build and overlay a local, then publish. Assigning `_settings` first
+        # and overlaying after would let a concurrent caller see a non-None
+        # singleton that config.json had not been applied to yet — and the
+        # window is not small, since reading the file releases the GIL. The
+        # watcher alone starts several threads that all call this at once
+        # (watcher/main.py: discovery, listener, per-folder scans, mail
+        # observer), so one of them would silently get env-only values.
+        settings = Settings()
+        _apply_to(settings)
+        _settings = settings
     return _settings
 
 
@@ -216,21 +226,41 @@ _NATIVE_ONLY_KEYS = frozenset(
 )
 
 
-def _native_config_data() -> dict:
-    """config.json as a dict, or empty if there isn't one / it's unreadable."""
-    path = get_settings().native_config_file
+def _native_config_data(path: str) -> dict:
+    """config.json as a dict, or empty if there isn't one / it's unusable.
+
+    Takes the path rather than reading it off the singleton: this runs during
+    `get_settings()` before the singleton is published, so it cannot call it.
+
+    The `isinstance` check is not defensive padding. `json.loads` happily
+    returns a list or a string for a hand-mangled file, and the caller's
+    `.items()` would then raise from inside `get_settings()` — leaving the
+    singleton unpublished on the first call and, worse, quietly un-overlaid on
+    every call after it.
+    """
     if not path or not os.path.exists(path):
         return {}
     try:
         with open(path) as f:
-            return json.loads(f.read())
+            data = json.loads(f.read())
     except Exception:
         logger.debug("Failed to read native config %s", path, exc_info=True)
         return {}
+    if not isinstance(data, dict):
+        logger.warning("native config %s is a %s, not an object; ignoring it", path, type(data).__name__)
+        return {}
+    return data
 
 
-def apply_native_config(only: set[str] | None = None) -> None:
-    """Overlay config.json onto the Settings singleton.
+# Keys already reported as invalid, so the per-request refreshers do not log the
+# same complaint on every call. `refresh_llm_settings` runs before every LLM
+# stage and `refresh_cli_access_setting` on every MCP request; a bad value in
+# config.json would otherwise emit a warning and a full traceback each time.
+_reported_invalid: set[tuple[str, str]] = set()
+
+
+def _apply_to(settings: Settings, only: set[str] | None = None) -> None:
+    """Overlay config.json onto `settings` in place.
 
     Writes to config.json were already generic — `sync_native_config` takes any
     key — while reads were two hand-maintained lists. So eleven fields that
@@ -238,31 +268,53 @@ def apply_native_config(only: set[str] | None = None) -> None:
     reverted to the default on the next restart (#592). This is the missing
     half: any config.json key naming a real Settings field is applied.
 
-    Values are validated against the field's own type rather than assigned raw,
-    so a hand-edited config.json cannot put a string where an int belongs and
-    have it surface later as a confusing failure somewhere else. A key that
-    fails validation is skipped and logged; it never stops startup.
+    Assignment goes through the model's own validator rather than `setattr`.
+    `model_config` does not set `validate_assignment`, so a plain `setattr`
+    validates nothing, and validating against the bare annotation is not enough
+    either — it drops the `Field(ge=...)` constraints and the field validators,
+    which would let config.json hold a `reranker_pool_size` of 0 that the same
+    value in an env var rejects at startup. A key that fails is skipped and
+    logged; it never stops the process starting.
 
-    `only` restricts the overlay to named fields, for the hot-path refreshers
-    that run per-request and shouldn't touch unrelated state.
+    Takes the object explicitly so `get_settings()` can overlay before it
+    publishes the singleton — see the note there.
     """
-    settings = get_settings()
-    data = _native_config_data()
+    if only is not None:
+        unknown = only - set(type(settings).model_fields)
+        if unknown:
+            # The caller named fields that do not exist, so those refreshes are
+            # silently doing nothing — the exact shape of #592, one level up.
+            logger.warning("refresh requested for unknown Settings fields: %s", sorted(unknown))
+
+    data = _native_config_data(settings.native_config_file)
     if not data:
         return
 
     for key, value in data.items():
         if only is not None and key not in only:
             continue
-        field = type(settings).model_fields.get(key)
-        if field is None:
-            if key not in _NATIVE_ONLY_KEYS and only is None:
+        if key not in type(settings).model_fields:
+            if key not in _NATIVE_ONLY_KEYS:
                 logger.debug("native config key %r matches no Settings field; ignoring", key)
             continue
         try:
-            setattr(settings, key, TypeAdapter(field.annotation).validate_python(value))
+            type(settings).__pydantic_validator__.validate_assignment(settings, key, value)
         except Exception:
-            logger.warning("native config key %r has an invalid value; keeping the current one", key, exc_info=True)
+            seen = (key, repr(value))
+            if seen not in _reported_invalid:
+                # Bounded: the refreshers re-read the file on every call, so a
+                # config.json being edited in a loop would otherwise grow this
+                # forever. Dropping the memo just re-warns, which is the safe
+                # direction.
+                if len(_reported_invalid) >= 100:
+                    _reported_invalid.clear()
+                _reported_invalid.add(seen)
+                logger.warning("native config key %r has an invalid value; keeping the current one", key, exc_info=True)
+
+
+def apply_native_config(only: set[str] | None = None) -> None:
+    """Overlay config.json onto the Settings singleton. See `_apply_to`."""
+    _apply_to(get_settings(), only)
 
 
 def refresh_cli_access_setting() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,12 +113,11 @@ def test_refresh_cli_access_setting_no_native_config(monkeypatch):
     monkeypatch.delenv("ENABLE_CLI_ACCESS", raising=False)
     from harbor_clerk import config as _config
 
-    _config._settings = None
+    monkeypatch.setattr(_config, "_settings", None)
     monkeypatch.setenv("NATIVE_CONFIG_FILE", "")
 
     from harbor_clerk.config import refresh_cli_access_setting
 
-    _config._settings = None
     # Should not raise, and enable_cli_access keeps its default False
     refresh_cli_access_setting()
     assert _config.get_settings().enable_cli_access is False
@@ -163,7 +162,7 @@ def test_refresh_cli_access_setting_disable_after_enable(monkeypatch, tmp_path):
 
     from harbor_clerk import config as _config
 
-    _config._settings = None
+    monkeypatch.setattr(_config, "_settings", None)
 
     from harbor_clerk.config import refresh_cli_access_setting
 
@@ -193,7 +192,7 @@ def test_refresh_cli_access_setting_key_absent_leaves_unchanged(monkeypatch, tmp
 
     from harbor_clerk import config as _config
 
-    _config._settings = None
+    monkeypatch.setattr(_config, "_settings", None)
 
     from harbor_clerk.config import refresh_cli_access_setting
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,8 +124,18 @@ def test_refresh_cli_access_setting_no_native_config(monkeypatch):
     assert _config.get_settings().enable_cli_access is False
 
 
-def test_refresh_cli_access_setting_reads_from_file(monkeypatch, tmp_path):
-    """refresh_cli_access_setting picks up enable_cli_access=true from config.json."""
+def test_cli_access_is_read_from_file_at_startup(monkeypatch, tmp_path):
+    """config.json is applied when Settings is built, not only on refresh.
+
+    This assertion used to run the other way round: it required
+    `get_settings()` to return False *despite* config.json saying true, until
+    something called `refresh_cli_access_setting()` by hand. That was the #592
+    bug written down as a requirement — config.json was persisted generically
+    and read back only by two hand-maintained lists, so anything not on a list
+    reverted on restart. Startup now applies the file, so the setting is live
+    without a refresher, and CLI access no longer depends on whether some
+    request path happened to call one first.
+    """
     config_file = tmp_path / "config.json"
     config_file.write_text('{"enable_cli_access": true}\n')
 
@@ -134,14 +144,12 @@ def test_refresh_cli_access_setting_reads_from_file(monkeypatch, tmp_path):
 
     from harbor_clerk import config as _config
 
-    _config._settings = None
+    monkeypatch.setattr(_config, "_settings", None)
 
-    from harbor_clerk.config import refresh_cli_access_setting
+    assert _config.get_settings().enable_cli_access is True
 
-    # Before refresh: default is False (env var absent)
-    assert _config.get_settings().enable_cli_access is False
-
-    refresh_cli_access_setting()
+    # And the refresher remains idempotent on an already-applied value.
+    _config.refresh_cli_access_setting()
     assert _config.get_settings().enable_cli_access is True
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -52,3 +52,25 @@ def test_upgrade_to_head(alembic_cfg, sync_engine):
     ):
         assert expected in tables, f"Table {expected} missing after upgrade"
     assert "document_versions" not in tables, "document_versions should be absent after 0017"
+
+
+def test_migrating_does_not_disable_application_loggers(alembic_cfg, sync_engine):
+    """`fileConfig` must not switch off every logger it doesn't name.
+
+    alembic/env.py calls `logging.config.fileConfig`, whose `disable_existing_loggers`
+    defaults to True — so running a migration in-process disabled all of
+    harbor_clerk.* for the rest of the session. Production never noticed
+    (migrations run as a subprocess both from /system/run-migrations and from
+    MigrationRunner.swift), but in this suite it silenced every later log
+    assertion, which is the worst kind of failure: tests that pass by capturing
+    nothing.
+    """
+    import logging
+
+    logger = logging.getLogger("harbor_clerk.config")
+    command.upgrade(alembic_cfg, "head")
+
+    assert not logger.disabled, (
+        "running a migration disabled harbor_clerk logging — any later test asserting "
+        "on log output will silently capture nothing"
+    )

--- a/tests/test_settings_persist_across_restart.py
+++ b/tests/test_settings_persist_across_restart.py
@@ -1,0 +1,182 @@
+"""`Settings` fields persisted on macOS must survive a restart.
+
+The companion to `test_env_vars_are_reachable.py`, which covers the ~17 raw
+`os.environ` reads. This covers the 59 pydantic fields — the larger and more
+consequential half, and the ones that guard structurally cannot see.
+
+The bug (#592) was an asymmetry. Writes were generic: `sync_native_config(key,
+value)` accepted any key and put it in config.json. Reads were two
+hand-maintained lists naming eleven keys between them. So eleven fields an admin
+could change through the UI were written to disk, never read back, and silently
+reverted to their defaults on the next restart — no error, no log, nothing to
+notice except a setting that would not stick.
+
+The fix makes reads as generic as writes. That also means "which fields are
+reachable on macOS?" stops being an interesting question: config.json now
+applies *any* key naming a real field, so the answer is all of them.
+
+An earlier draft of this file asserted the opposite — a list of fields with "no
+macOS route", exempting the ones judged fine. It failed with 18 names, and every
+one of them was a false positive created by the fix it was meant to guard. A
+guard whose premise its own change invalidates is worse than no guard: it
+teaches the next person to add names to an exemption dict. So the list is gone
+and what remains is behavioural — write the keys, rebuild Settings the way a
+restart does, and check the values came back.
+
+The one thing this cannot see is Swift: `_swift_env_keys` matched text, and #588
+shipped a reference to a property that did not exist. The macOS build job added
+alongside this closes that; compilability is not a question a regex can answer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from harbor_clerk.config import Settings
+
+REPO = Path(__file__).resolve().parents[1]
+SWIFT_DIR = REPO / "macos" / "HarborClerkServer" / "HarborClerkServer"
+SRC = REPO / "src" / "harbor_clerk"
+
+
+def _keys_persisted_by_admin_routes() -> set[str]:
+    """Keys reaching `sync_native_config`, from literals and from the generic
+    loop in `update_retrieval_settings` (which forwards a request model's
+    fields, so the model's own fields are the key set)."""
+    keys: set[str] = set()
+    for path in SRC.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        keys |= set(re.findall(r'sync_native_config\(\s*["\']([a-z][a-z0-9_]*)["\']', text))
+
+    # api/routes/system.py::update_retrieval_settings forwards every set field
+    # of RetrievalSettingsUpdate; those names are the keys it writes.
+    try:
+        from harbor_clerk.api.schemas.system import RetrievalSettingsUpdate
+
+        keys |= set(RetrievalSettingsUpdate.model_fields)
+    except Exception:  # schema moved or renamed — the literal scan still applies
+        pass
+    return keys
+
+
+def _restart_with(config_json: dict, tmp_path, monkeypatch):
+    """Rebuild Settings the way a process restart does, with this config.json.
+
+    Deliberately does *not* call `apply_native_config` — the whole claim of #592
+    is that startup reads the file on its own. An earlier draft of these tests
+    called it explicitly, and so removing the call from `get_settings()`
+    entirely left all of them green: they proved the overlay worked when
+    invoked, never that anything invoked it.
+
+    The path arrives by env var because `native_config_file` is itself a
+    Settings field, so it has to be resolvable before the overlay can run.
+    """
+    import json
+
+    from harbor_clerk import config as cfg
+
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps(config_json))
+    monkeypatch.setenv("NATIVE_CONFIG_FILE", str(cfg_file))
+    monkeypatch.setattr(cfg, "_settings", None)
+    return cfg.get_settings()
+
+
+def test_config_json_is_a_universal_route(tmp_path, monkeypatch):
+    """Any config.json key naming a real field must be applied — no allowlist.
+
+    Before the fix, reads were two hand-maintained lists while writes were
+    generic, so adding a field to a PUT route was silently only half the work.
+    An allowlist here would recreate exactly that: the next field added would be
+    persisted and unread, and nothing would say so. Both keys below were on
+    neither list.
+    """
+    settings = _restart_with({"reranker_timeout_seconds": 5.0, "mcp_max_k": 7}, tmp_path, monkeypatch)
+    assert settings.reranker_timeout_seconds == 5.0, "config.json key naming a real field was not applied at startup"
+    assert settings.mcp_max_k == 7
+
+
+def test_an_invalid_value_is_skipped_not_fatal(tmp_path, monkeypatch):
+    """A hand-edited config.json must not stop the process starting, and must not
+    put a string where an int belongs to fail confusingly somewhere later."""
+    from harbor_clerk.config import Settings
+
+    default = Settings.model_fields["mcp_max_k"].default
+    settings = _restart_with({"mcp_max_k": "not-a-number"}, tmp_path, monkeypatch)  # must not raise
+    assert settings.mcp_max_k == default, "an invalid value was applied instead of being skipped"
+
+
+def test_persisted_keys_survive_a_restart(tmp_path, monkeypatch):
+    """The #592 bug itself, driven rather than inspected.
+
+    Every key an admin route persists must still be there after a restart.
+    Asserting only that the key *names* a real field would be vacuous — the
+    eleven broken ones always did; what was missing was anything reading them.
+    """
+    from harbor_clerk import config as cfg
+
+    persisted = _keys_persisted_by_admin_routes() & set(Settings.model_fields)
+    assert persisted, "found no persisted keys — the scan is broken, not the code"
+
+    # A value distinguishable from the default, per field type.
+    current = cfg.get_settings()
+    probe: dict[str, object] = {}
+    for key in sorted(persisted):
+        value = getattr(current, key, None)
+        if isinstance(value, bool):
+            probe[key] = not value
+        elif isinstance(value, int):
+            probe[key] = value + 7
+        elif isinstance(value, float):
+            probe[key] = value + 7.0
+        elif isinstance(value, str):
+            probe[key] = f"{value}-probe"
+
+    settings = _restart_with(probe, tmp_path, monkeypatch)
+    reverted = [k for k, v in probe.items() if getattr(settings, k) != v]
+    assert not reverted, (
+        f"these keys are persisted by admin routes but do not survive a restart: {reverted}. "
+        "They are written to config.json and never read back, so every change an admin "
+        "makes to them silently reverts to the default."
+    )
+
+
+def test_every_key_swift_writes_is_classified():
+    """A key the menubar writes must be a Settings field or explicitly native-only.
+
+    This is #592 generalised. That bug was writes being generic while reads were
+    a list, so a new key was persisted and silently never read. The same shape
+    exists one level up: Swift can add a `data["new_key"]` write, and if Python
+    neither has a field for it nor names it native-only, it lands in config.json
+    and quietly does nothing — which looks identical to working.
+
+    Being wrong here is cheap and loud (add a name), whereas the failure it
+    replaces is silent and only shows up as "we changed it and nothing
+    happened".
+    """
+    from harbor_clerk.config import _NATIVE_ONLY_KEYS
+
+    settings_swift = SWIFT_DIR / "Settings.swift"
+    assert settings_swift.exists(), f"expected {settings_swift} — the guard cannot run"
+
+    written = set(re.findall(r'data\["([a-z][a-z0-9_]*)"\]', settings_swift.read_text()))
+    assert written, "found no data[...] writes — the pattern is broken, not the Swift"
+
+    unclassified = sorted(written - set(Settings.model_fields) - _NATIVE_ONLY_KEYS)
+    assert not unclassified, (
+        f"the menubar writes these config.json keys but Python neither has a Settings "
+        f"field for them nor lists them as native-only: {unclassified}. They are "
+        "persisted and then ignored. Add the field, or add the key to "
+        "_NATIVE_ONLY_KEYS with a comment saying what consumes it."
+    )
+
+
+def test_native_only_keys_are_not_settings_fields():
+    """A name in both places reads as native-only while actually being applied."""
+    from harbor_clerk.config import _NATIVE_ONLY_KEYS
+
+    both = sorted(_NATIVE_ONLY_KEYS & set(Settings.model_fields))
+    assert not both, f"listed as native-only but really are Settings fields, so they are applied: {both}"

--- a/tests/test_settings_persist_across_restart.py
+++ b/tests/test_settings_persist_across_restart.py
@@ -23,9 +23,11 @@ teaches the next person to add names to an exemption dict. So the list is gone
 and what remains is behavioural — write the keys, rebuild Settings the way a
 restart does, and check the values came back.
 
-The one thing this cannot see is Swift: `_swift_env_keys` matched text, and #588
-shipped a reference to a property that did not exist. The macOS build job added
-alongside this closes that; compilability is not a question a regex can answer.
+The one thing this cannot see is Swift. `test_every_key_swift_writes_is_classified`
+below matches `data["..."]` textually, so it answers "is this key classified?"
+and nothing about whether the Swift compiles — #588 shipped a reference to a
+property that did not exist and no check caught it, because nothing in CI builds
+Swift. That is a separate gap and still open.
 """
 
 from __future__ import annotations
@@ -104,9 +106,11 @@ def test_an_invalid_value_is_skipped_not_fatal(tmp_path, monkeypatch):
     put a string where an int belongs to fail confusingly somewhere later."""
     from harbor_clerk.config import Settings
 
-    default = Settings.model_fields["mcp_max_k"].default
+    # What the field resolves to without any config.json — not the declared
+    # default, which a repo .env or an exported MCP_MAX_K would diverge from.
+    baseline = Settings().mcp_max_k
     settings = _restart_with({"mcp_max_k": "not-a-number"}, tmp_path, monkeypatch)  # must not raise
-    assert settings.mcp_max_k == default, "an invalid value was applied instead of being skipped"
+    assert settings.mcp_max_k == baseline, "an invalid value was applied instead of being skipped"
 
 
 def test_persisted_keys_survive_a_restart(tmp_path, monkeypatch):
@@ -180,3 +184,102 @@ def test_native_only_keys_are_not_settings_fields():
 
     both = sorted(_NATIVE_ONLY_KEYS & set(Settings.model_fields))
     assert not both, f"listed as native-only but really are Settings fields, so they are applied: {both}"
+
+
+def test_the_singleton_is_never_visible_before_the_overlay(tmp_path, monkeypatch):
+    """`get_settings()` must publish a fully-overlaid object, or not at all.
+
+    A first version of this fix assigned the singleton and *then* applied
+    config.json, because the overlay called `get_settings()` and would otherwise
+    recurse. That opens a window — spanning open/read/json.loads, all of which
+    release the GIL — where a concurrent caller gets a non-None singleton with
+    env-only values. The watcher alone starts discovery, listener, mail-observer
+    and per-folder scan threads that all call this at once, so a thread landing
+    in the window would silently see `enable_cli_access=False` and reject a CLI
+    request that config.json had enabled.
+
+    Asserted as the invariant rather than by racing threads: at the moment the
+    overlay runs, the module global must still be unset. A timing test would
+    pass on a fast machine whether or not the bug was present.
+    """
+    import json
+
+    from harbor_clerk import config as cfg
+
+    (tmp_path / "config.json").write_text(json.dumps({"mcp_max_k": 11}))
+    monkeypatch.setenv("NATIVE_CONFIG_FILE", str(tmp_path / "config.json"))
+    monkeypatch.setattr(cfg, "_settings", None)
+
+    seen: list[object] = []
+    real = cfg._apply_to
+    monkeypatch.setattr(cfg, "_apply_to", lambda s, only=None: (seen.append(cfg._settings), real(s, only))[1])
+
+    assert cfg.get_settings().mcp_max_k == 11
+    assert seen and seen[0] is None, (
+        "the singleton was already published while config.json was still being applied — "
+        "a concurrent caller would see un-overlaid settings"
+    )
+
+
+def test_field_constraints_and_validators_are_enforced(tmp_path, monkeypatch):
+    """config.json must not be able to hold a value an env var would reject.
+
+    `model_config` does not set `validate_assignment`, so a plain `setattr`
+    validates nothing; and validating against the bare annotation drops both the
+    `Field(ge=...)` constraints and the field validators. Either way
+    `reranker_pool_size: 0` lands in a Settings object the model declares
+    impossible, while `RERANKER_POOL_SIZE=0` is rejected at startup.
+    """
+    from harbor_clerk.config import Settings
+
+    baseline = Settings()
+    settings = _restart_with(
+        {"reranker_pool_size": 0, "reranker_top_k_pad": -99, "public_url": "https://x.example.com/"},
+        tmp_path,
+        monkeypatch,
+    )
+
+    assert settings.reranker_pool_size == baseline.reranker_pool_size, "ge=1 was not enforced on the overlay"
+    assert settings.reranker_top_k_pad == baseline.reranker_top_k_pad, "ge=0 was not enforced on the overlay"
+    assert settings.public_url == "https://x.example.com", (
+        "the _strip_trailing_slash field validator was bypassed, so public_url now "
+        "violates the invariant its own validator declares"
+    )
+
+
+def test_a_non_dict_config_json_does_not_break_startup(tmp_path, monkeypatch):
+    """A hand-mangled file must not take the process down — nor, worse, half-start it.
+
+    `json.loads` returns a list for `[1, 2]`, and iterating it raised from
+    inside `get_settings()` *after* the singleton was published: the first call
+    blew up and every call after it silently returned un-overlaid settings.
+    """
+    from harbor_clerk import config as cfg
+
+    (tmp_path / "config.json").write_text("[1, 2]")
+    monkeypatch.setenv("NATIVE_CONFIG_FILE", str(tmp_path / "config.json"))
+    monkeypatch.setattr(cfg, "_settings", None)
+
+    settings = cfg.get_settings()  # must not raise
+    assert settings.mcp_max_k == type(settings)().mcp_max_k
+
+
+def test_a_refresh_for_an_unknown_field_is_reported(tmp_path, monkeypatch, caplog):
+    """A typo in a refresher's `only` set silently stops refreshing that field.
+
+    That is #592's own shape one level up, so it must not be quiet — and the
+    branch that logs unmatched keys deliberately skips the `only` path, since
+    every key not in `only` has already been passed over.
+    """
+    import logging
+
+    from harbor_clerk import config as cfg
+
+    _restart_with({"mcp_max_k": 3}, tmp_path, monkeypatch)
+    with caplog.at_level(logging.WARNING, logger=cfg.__name__):
+        cfg.apply_native_config(only={"llm_model_idd"})
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("unknown Settings fields" in m and "llm_model_idd" in m for m in messages), (
+        f"a refresh for a non-existent field logged nothing: {messages}"
+    )


### PR DESCRIPTION
Closes #592.

## The bug

Writes to `config.json` were generic — `sync_native_config(key, value)` accepted any key. Reads were **two hand-maintained lists** naming eleven keys between them.

So eleven fields an admin could change through the UI were written to disk, never read back, and silently reverted to their defaults on the next restart. No error, no log, nothing to notice except a setting that would not stick.

## The fix

Make reads as generic as writes. `apply_native_config()` applies any `config.json` key naming a real `Settings` field, validating each against the field's own type — so a hand-edited file cannot put a string where an int belongs and surface it as a confusing failure somewhere else. An invalid value is skipped and logged, never fatal. The two existing refreshers become `only=` calls into the same code path.

## Precedence change, and why it is inert

The overlay runs after construction, so `config.json` now wins over the environment. I checked this against a live install rather than assuming:

| key | also an env var? | can they disagree? |
|---|---|---|
| `api_port`, `gateway_port`, `log_level`, `secret_key`, `llm_model_id`, `reranker_enabled` | yes | **no** — Swift passes each from the same `data["<key>"]` it is written from |
| `enable_cli_access`, `summary_force_apple_intelligence` | no | n/a |

Under Docker `NATIVE_CONFIG_FILE` is unset, so the overlay never runs there at all.

## Tests are behavioural

Two dead ends worth recording, because both looked fine:

- A first draft asserted persisted keys *named* real fields. The eleven broken ones always did — what was missing was anything **reading** them. Vacuous.
- A second draft called `apply_native_config` directly. Deleting the call from `get_settings()` entirely left every test green — they proved the overlay worked when invoked, never that anything invoked it.

These set `NATIVE_CONFIG_FILE` and rebuild the singleton the way a restart does, touching nothing by hand.

I also dropped a planned "every field has a macOS route" guard. It failed with 18 names — and every one was a false positive created by this very fix, since `config.json` is now a universal route. A guard whose premise its own change invalidates is worse than none: it teaches the next person to grow an exemption dict.

## Generalising it one level up

New guard: every key the menubar writes must be either a `Settings` field or explicitly native-only. Swift can otherwise add a `data["new_key"]` write that lands in `config.json` and quietly does nothing — the same asymmetry, one level higher.

It caught `gpu_cache_high_water_mb` on its first run. That one is correctly native-only (it reaches the embedder and reranker as `GPU_CACHE_HIGH_WATER_MB`), but `_NATIVE_ONLY_KEYS` went from 3 entries to 14, which is what it always should have been.

## Verification

Eight mutations, all killed:

| mutation | killed by |
|---|---|
| overlay is a no-op | universal-route + restart |
| pre-fix allowlist restored | universal-route + restart |
| `get_settings` stops applying it | universal-route + restart |
| values assigned raw, unvalidated | invalid-value |
| validation errors propagate | invalid-value |
| Swift adds an unclassified key | classification |
| a native-only entry dropped | classification |
| a real field mislabelled native-only | native-only-are-not-fields |

`1655 passed` (root, 2 pre-existing failures from stale local `.worktrees/` dirs, absent on a fresh checkout), `33 passed` (embedder), ruff clean.

## Note

One existing test changed meaning rather than breaking: it required `get_settings()` to return `False` while `config.json` said `true`, until something called a refresher by hand. That was #592 written down as a requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)