### PR TITLE
ci(macos): build and test both Swift apps, and unblock the 148 dead tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,44 @@ jobs:
         run: uv run --locked --extra test pytest tests/ -v --tb=short -m "not requires_models"
         working-directory: embedder
 
+  macos:
+    # Nothing compiled Swift on a PR, so half the product had no CI at all.
+    # #588 merged green with `AppSettings.shared.embedNeedsPrefix` referenced but
+    # never declared — the app simply did not build, and it took a manual build
+    # on the Mac mini to notice. A textual guard cannot catch that; only a
+    # compiler can.
+    #
+    # This runs the tests rather than just building, because the 148 tests in
+    # HarborClerkServerTests had never executed either (see the XCTest guard in
+    # AppDelegate for why) and a build-only job would have left them dead.
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # BundleResourceTests asserts frontend-dist/index.html lands in the app
+      # bundle, and the Copy Frontend Dist phase warns rather than fails when the
+      # source is absent — so without this the app would package an empty web UI
+      # and exactly one test would tell us. Verified by holding dist back: 148
+      # tests, 1 failure, that one.
+      - name: Build frontend
+        run: npm ci && npm run build
+        working-directory: frontend
+      # CODE_SIGNING_ALLOWED=NO: the runner has no signing identity, and this job
+      # is about compilation and behaviour, not distribution. `make sign` covers
+      # the signed path at release time.
+      - name: Menubar app — build and test
+        run: |
+          xcodebuild -project HarborClerkServer.xcodeproj -scheme HarborClerkServer \
+            -configuration Debug CODE_SIGNING_ALLOWED=NO -quiet test
+        working-directory: macos/HarborClerkServer
+      - name: Client app — build and test
+        run: |
+          xcodebuild -project HarborClerk.xcodeproj -scheme HarborClerk \
+            -configuration Debug CODE_SIGNING_ALLOWED=NO -quiet test
+        working-directory: macos/HarborClerk
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
     # HarborClerkServerTests had never executed either (see the XCTest guard in
     # AppDelegate for why) and a build-only job would have left them dead.
     runs-on: macos-15
+    # A hung xcodebuild would otherwise run to GitHub's 360-minute default on a
+    # runner billed at 10x — ~60 core-hours for one wedged run, on a PR that can
+    # never go green without a manual re-run. The suite takes ~90s; 20 leaves
+    # room for a cold runner without leaving room for a hang.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -83,6 +88,14 @@ jobs:
       # source is absent — so without this the app would package an empty web UI
       # and exactly one test would tell us. Verified by holding dist back: 148
       # tests, 1 failure, that one.
+      # macos/AGENTS.md: the linked SDK is behaviour-changing (linked-on-or-after
+      # gating for ATS, TCC, hardened runtime), so which one CI used is part of
+      # reading a result. Not pinned here — choosing the version to standardise
+      # on is a real decision, and the shipped binary is built by `make sign` on
+      # a maintainer's machine, not by this job. Printing it at least makes an
+      # image rotation visible instead of silent.
+      - name: Record the toolchain
+        run: xcodebuild -version && xcrun --show-sdk-version
       - name: Build frontend
         run: npm ci && npm run build
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,33 @@ jobs:
       # CODE_SIGNING_ALLOWED=NO: the runner has no signing identity, and this job
       # is about compilation and behaviour, not distribution. `make sign` covers
       # the signed path at release time.
+      # Why the wrapper rather than a bare xcodebuild: it exits 0 when a scheme
+      # runs *zero* tests. Drop a target from the scheme and the job stays green
+      # while testing nothing — the exact failure this job exists to end. So the
+      # count is asserted, not assumed.
+      #
+      # `set -o pipefail` keeps xcodebuild's exit status authoritative through
+      # the tee, so an actual test failure still fails the step on its own; the
+      # grep afterwards only adds the zero-tests case. Deliberately not filtering
+      # the output through a grep in the pipeline — that swallows the exit code,
+      # and matching "with 0 failures" would happily match a passing sibling
+      # suite while the run as a whole failed. `-quiet` is dropped because it
+      # suppresses the very line being checked.
       - name: Menubar app — build and test
         run: |
+          set -o pipefail
           xcodebuild -project HarborClerkServer.xcodeproj -scheme HarborClerkServer \
-            -configuration Debug CODE_SIGNING_ALLOWED=NO -quiet test
+            -configuration Debug CODE_SIGNING_ALLOWED=NO test 2>&1 | tee "$RUNNER_TEMP/xcodebuild.log"
+          grep -qE "Executed [1-9][0-9]* tests?" "$RUNNER_TEMP/xcodebuild.log" \
+            || { echo "::error::xcodebuild reported success but ran no tests"; exit 1; }
         working-directory: macos/HarborClerkServer
       - name: Client app — build and test
         run: |
+          set -o pipefail
           xcodebuild -project HarborClerk.xcodeproj -scheme HarborClerk \
-            -configuration Debug CODE_SIGNING_ALLOWED=NO -quiet test
+            -configuration Debug CODE_SIGNING_ALLOWED=NO test 2>&1 | tee "$RUNNER_TEMP/xcodebuild.log"
+          grep -qE "Executed [1-9][0-9]* tests?" "$RUNNER_TEMP/xcodebuild.log" \
+            || { echo "::error::xcodebuild reported success but ran no tests"; exit 1; }
         working-directory: macos/HarborClerk
 
   frontend:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,12 +125,16 @@ Read those rather than any transcription, and regenerate with
 
 ## CI
 
-Six required checks on PRs to `main`: `python`, `embedder`, `frontend`,
+Required checks on PRs to `main`: `python`, `embedder`, `macos`, `frontend`,
 `codeql`, `dependency-audit`, `container-scan`. The `python` job also verifies
-generated docs are current.
+generated docs are current. Counted in prose once — "six required checks" — and
+it was wrong by the next PR, so it isn't counted here.
 
-`embedder` is new — **branch protection must be updated to require it**, or the
-guard it exists to provide stays advisory.
+**A new job is not enforced until branch protection requires it.** Adding one to
+`ci.yml` makes it run and go green; it does not make it able to block a merge.
+Every job added this week (`embedder`, `macos`) needed a separate
+`gh api -X PATCH repos/:owner/:repo/branches/main/protection/required_status_checks`
+call, and until that lands the guard is advisory.
 
 ## Instruction files and your harness
 

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -20,7 +20,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // That is why none of these tests have ever run. Checked via the
         // environment rather than NSClassFromString("XCTestCase") because the
         // runner exports it before launch, so it is already set here.
-        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil { return }
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            // Logged rather than returning silently: if this ever fires outside
+            // a test run (an inherited environment, `launchctl setenv`), the
+            // symptom is a menubar app that starts no services and shows no
+            // status item, and this line is the only thing that would explain it.
+            Log.logger("lifecycle").notice("XCTest host launch — skipping service startup")
+            return
+        }
 
         // First-launch master key bootstrap. Idempotent — generates the key in
         // Keychain only on the very first launch; subsequent launches just read.
@@ -60,7 +67,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard !isQuitting else { return .terminateNow }
         isQuitting = true
-        healthChecker.stopPolling()
+        // Optional: under an XCTest host launch this was never created, and
+        // anything terminating the host via NSApp.terminate would crash here.
+        healthChecker?.stopPolling()
 
         // 30-second hard deadline. The audit memo
         // (project_menubar_process_management_audit.md) traced multiple

--- a/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/AppDelegate.swift
@@ -13,6 +13,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var isQuitting = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Under XCTest the app is only a host for the test bundle. Booting the
+        // real stack here reaches the Keychain and launches PostgreSQL, Tika and
+        // the Python services, and the runner times out before the test bundle
+        // ever connects ("The test runner hung before establishing connection").
+        // That is why none of these tests have ever run. Checked via the
+        // environment rather than NSClassFromString("XCTestCase") because the
+        // runner exports it before launch, so it is already set here.
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil { return }
+
         // First-launch master key bootstrap. Idempotent — generates the key in
         // Keychain only on the very first launch; subsequent launches just read.
         // Must run before ServiceManager.startAll() because the Python subprocesses

--- a/macos/HarborClerkServer/HarborClerkServer/ProcessExtensions.swift
+++ b/macos/HarborClerkServer/HarborClerkServer/ProcessExtensions.swift
@@ -126,7 +126,27 @@ extension Process {
 
         await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
             DispatchQueue.global().async {
-                proc.waitUntilExit()
+                // Poll rather than `waitUntilExit()`. That call runs its own
+                // runloop waiting for a termination notification, and if the
+                // child exits between the `isRunning` guard above and the call
+                // itself, the notification is already gone and it blocks
+                // forever. Reproduced at 3 of 8 full test-suite runs on
+                // /usr/bin/true, which exits faster than we can get here.
+                //
+                // Nothing rescues it once wedged: the SIGKILL escalation above
+                // opens with `guard proc.isRunning`, sees a process that has
+                // already exited, and returns without resuming anything. So the
+                // continuation is never resumed and shutdown waits forever —
+                // the deadlock #341 bounded for the Pipe case, reached by a
+                // different route.
+                //
+                // `terminationHandler` would be the tidier fix but is not ours
+                // to take: PythonService sets one for its restart logic and
+                // also calls this helper, so assigning here would silently
+                // clobber it.
+                while proc.isRunning {
+                    usleep(20_000)  // 20ms — bounded by the SIGKILL escalation
+                }
                 c.resume()
             }
         }

--- a/tests/test_ci_collects_every_test_suite.py
+++ b/tests/test_ci_collects_every_test_suite.py
@@ -100,24 +100,49 @@ def _swift_test_dirs() -> set[str]:
         rel = path.relative_to(REPO)
         if _SKIP_PARTS & set(rel.parts):
             continue
-        if "XCTestCase" in path.read_text(encoding="utf-8", errors="replace"):
+        # A subclass declaration, not the bare word: this PR's own AppDelegate
+        # comment mentions NSClassFromString("XCTestCase"), which made the app
+        # source itself register as a test directory.
+        if re.search(r"class\s+\w+\s*:[^{\n]*\bXCTestCase\b", path.read_text(encoding="utf-8", errors="replace")):
             found.add(str(rel.parent))
     return found
 
 
 def _xcodebuild_tested_dirs() -> set[str]:
-    """Project directories some workflow step runs `xcodebuild ... test` in."""
+    """Xcode project directories some PR-triggered job runs `xcodebuild ... test` in.
+
+    Three ways an earlier version of this said yes while nothing ran:
+
+      - the word `test` appearing in a *comment* ("tests are flaky on CI, build
+        only for now") satisfied it, which is the most likely wording of exactly
+        the change it exists to catch;
+      - it keyed on `working-directory`, so hoisting one step to `macos/` made
+        the prefix match cover every project underneath it;
+      - it never looked at triggers, so moving the job to a manual workflow, or
+        adding `if: false`, left it green.
+    """
     tested: set[str] = set()
     for wf in WORKFLOWS.glob("*.yml"):
         doc = yaml.safe_load(wf.read_text()) or {}
+        # PyYAML reads a bare `on:` key as the boolean True.
+        triggers = doc.get("on", doc.get(True)) or {}
+        names = set(triggers) if isinstance(triggers, (dict, list)) else {triggers}
+        if "pull_request" not in names:
+            continue  # a workflow that does not run on PRs guards nothing here
+
         for job in (doc.get("jobs") or {}).values():
+            if str(job.get("if", "")).strip().lower() in {"false", "${{ false }}", "${{false}}"}:
+                continue
             for step in job.get("steps") or []:
-                run = step.get("run") or ""
-                if "xcodebuild" not in run or not re.search(r"\btest\b", run):
+                code = "\n".join(re.sub(r"#.*$", "", line) for line in (step.get("run") or "").splitlines())
+                if "xcodebuild" not in code or not re.search(r"(?<![-\w])test\b", code):
                     continue
                 cwd = step.get("working-directory") or job.get("defaults", {}).get("run", {}).get("working-directory")
-                if cwd:
-                    tested.add(cwd.rstrip("/"))
+                # Anchor on -project, not the working directory: the project path
+                # is what actually says which target gets tested.
+                for proj in re.findall(r"-project\s+(\S+\.xcodeproj)", code):
+                    full = f"{cwd.rstrip('/')}/{proj}" if cwd else proj
+                    tested.add(str(Path(full).parent))
     return tested
 
 

--- a/tests/test_ci_collects_every_test_suite.py
+++ b/tests/test_ci_collects_every_test_suite.py
@@ -13,6 +13,11 @@ asserts the link between "tests exist here" and "CI runs them":
   - `scripts/test_corpora/tests` — 35 files, ~191 tests, still uncollected. It
     is its own uv project with its own dependencies, so a root-venv run cannot
     even import 19 of them; that is a wiring gap, not rotted code.
+  - `macos/**/*Tests` — 152 XCTest cases across the two Swift apps. This guard
+    only scanned `test_*.py`, so the entire Swift half of the product was
+    invisible to the very check meant to catch uncollected suites. Worse, the
+    148 in HarborClerkServerTests could not even run: the test host booted the
+    real service stack on launch and the runner timed out before connecting.
 
 The failure mode is silent by construction: a test that never runs cannot fail,
 so the suite looks green precisely because the coverage is missing. Same shape
@@ -86,6 +91,54 @@ def _collected_dirs() -> set[str]:
 def _is_collected(test_dir: str, collected: set[str]) -> bool:
     """A parent target collects its children: `tests/` covers `tests/mail`."""
     return any(test_dir == c or test_dir.startswith(f"{c}/") for c in collected)
+
+
+def _swift_test_dirs() -> set[str]:
+    """Directories holding XCTest cases, keyed by the Xcode project above them."""
+    found: set[str] = set()
+    for path in REPO.rglob("*.swift"):
+        rel = path.relative_to(REPO)
+        if _SKIP_PARTS & set(rel.parts):
+            continue
+        if "XCTestCase" in path.read_text(encoding="utf-8", errors="replace"):
+            found.add(str(rel.parent))
+    return found
+
+
+def _xcodebuild_tested_dirs() -> set[str]:
+    """Project directories some workflow step runs `xcodebuild ... test` in."""
+    tested: set[str] = set()
+    for wf in WORKFLOWS.glob("*.yml"):
+        doc = yaml.safe_load(wf.read_text()) or {}
+        for job in (doc.get("jobs") or {}).values():
+            for step in job.get("steps") or []:
+                run = step.get("run") or ""
+                if "xcodebuild" not in run or not re.search(r"\btest\b", run):
+                    continue
+                cwd = step.get("working-directory") or job.get("defaults", {}).get("run", {}).get("working-directory")
+                if cwd:
+                    tested.add(cwd.rstrip("/"))
+    return tested
+
+
+def test_every_swift_test_target_is_run_by_ci():
+    """The Python-only scan above cannot see these, which is how they were missed.
+
+    A build-only job would not be enough: these tests existed and passed
+    locally, but nothing ran them, so `AppSettings.shared.embedNeedsPrefix`
+    shipped referencing a property that did not exist (#588).
+    """
+    swift_dirs = _swift_test_dirs()
+    assert swift_dirs, "found no XCTestCase files — the scan is broken, not the repo"
+
+    tested = _xcodebuild_tested_dirs()
+    missing = sorted(d for d in swift_dirs if not any(d.startswith(f"{t}/") or d == t for t in tested))
+
+    assert not missing, (
+        "these Swift test targets are not run by any CI job, so their coverage is "
+        f"imaginary: {missing}. Add an `xcodebuild ... test` step whose "
+        "working-directory contains the project."
+    )
 
 
 def test_every_test_directory_is_collected_by_ci():


### PR DESCRIPTION
## Why

Nothing compiled Swift on a PR. #588 merged green with `AppSettings.shared.embedNeedsPrefix` referenced but never declared — the app didn't build at all, and it took a manual build on the Mac mini to notice. No textual guard catches that; only a compiler does.

## Three things were broken, not one

**1. The tests couldn't run.** `applicationDidFinishLaunching` reaches the Keychain (`MasterKeyManager.loadOrGenerate()`) and starts PostgreSQL, Tika and the Python services. Under XCTest the app is only a host for the test bundle, so the runner timed out before connecting: *"The test runner hung before establishing connection."* That's why **148 tests in `HarborClerkServerTests` had never executed once**.

Guarded on `XCTestConfigurationFilePath` — the runner exports it before launch, so it's already set there, unlike `NSClassFromString("XCTestCase")` which depends on bundle-injection timing. It now logs before returning: if it ever fires outside a test run, the symptom is a menubar app that starts nothing, and that line is the only thing that would explain it.

**2. Unblocking them exposed a production hang.** `Process.waitUntilExit()` runs its own runloop waiting for a termination notification, so when the child exits between the `isRunning` guard and the call, the notification is already gone and it blocks **forever**.

Nothing rescues it: the SIGKILL escalation opens with `guard proc.isRunning`, sees an already-exited process, and returns without resuming anything — so the continuation is never resumed and shutdown waits forever. That's the deadlock #341 bounded for the Pipe case, reached by a different route, and it's live on every stop path (`PythonService`, `GatewayService`, `LlamaService`, `ServiceManager`).

| | full-suite runs | hung |
|---|---|---|
| before | 8 | **3** |
| after | 10 | 0 |

Fixed by polling `isRunning`. `terminationHandler` would be tidier but isn't ours to take — `PythonService.swift:51` sets one for its restart logic *and* calls this helper, so assigning here would silently clobber it.

**3. The frontend step is load-bearing.** `BundleResourceTests` asserts `frontend-dist/index.html` lands in the app bundle, and the Copy Frontend Dist phase *warns* rather than fails when the source is missing. Verified by holding `frontend/dist` back: 148 tests, 1 failure, that one. It passed locally at first only because an earlier build had left `frontend/dist` behind.

## Corrections to an earlier version of this PR

An earlier body claimed **"148 tests, 0 failures, 3.7s"** as evidence the suite was healthy. That was one observation of a suite that hung 37% of the time — accurate for a run that completes, and misleading as a claim. The table above replaces it.

The mutation evidence was also weaker than claimed. `build` → `test` only failed the guard if the mutation removed *every* occurrence of the word; `# tests are flaky on CI, build only for now` — the most likely wording of exactly that change — sailed through. Four bypasses are now verified failing:

| bypass | before | now |
|---|---|---|
| `test` only in a comment | passed | **fails** ✓ |
| one project, `working-directory: macos` covering both via prefix | passed | **fails** ✓ |
| job moved to a `workflow_dispatch`-only workflow | passed | **fails** ✓ |
| job left in place with `if: false` | passed | **fails** ✓ |

`"XCTestCase" in text` also matched this PR's own AppDelegate comment, so app source registered as a test directory; it now matches a subclass declaration.

## Other fixes from review

- **`timeout-minutes: 20`** — without it a hang runs to GitHub's 360-minute default on a runner billed at 10x, ~60 core-hours per wedged run.
- **`-quiet` dropped** — it hid the failure diagnosis (no file, no line, no expected-vs-actual) and, during a hang, every test line.
- **Zero-test assertion** — `xcodebuild` exits 0 when a scheme runs no tests, so the count is checked rather than assumed.
- `applicationShouldTerminate` force-unwrapped a `healthChecker` the early return leaves nil.
- `AGENTS.md` said "six required checks"; rewritten so it can't rot the same way, with the branch-protection step spelled out — **adding a job makes it run, not enforce**.

## Open question for you

**Xcode is not pinned.** The `macos-15` image ships an older SDK than the machine that builds releases (Xcode 26.6 / SDK 26.5 here), and `macos/AGENTS.md` is explicit that the linked SDK is behaviour-changing. I've made the toolchain print so an image rotation is visible rather than silent, but choosing the version to standardise on is your call, not something to slip into a CI PR.

This also needs adding to branch protection to actually block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)