### PR TITLE
ci(eval-harness): run the 421 uncollected tests, and fix what they caught (#587)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,37 @@ jobs:
             || { echo "::error::xcodebuild reported success but ran no tests"; exit 1; }
         working-directory: macos/HarborClerk
 
+  eval-harness:
+    # scripts/test_corpora is its own uv project, so `testpaths = ["tests"]` in
+    # the root pyproject never saw it: 421 tests that had not run once. AGENTS.md
+    # names this harness as how you prove a retrieval or pipeline change did not
+    # regress, so the tool relied on for that had no protection of its own.
+    #
+    # Wiring it up immediately found a live break — see the mcp pin in
+    # scripts/test_corpora/pyproject.toml.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      # test_entity_overlap_english really does load en_core_web_sm. It could be
+      # marked requires_models and skipped, like the root job does — but that is
+      # how a suite ends up green without running, which is the whole subject of
+      # this job. The model is ~12MB.
+      - name: Install the spaCy model the metrics tests use
+        # Same --extra as the test step: a differing extra set makes uv re-sync
+        # between the two, which can prune the just-installed model.
+        run: uv run --extra test python -m spacy download en_core_web_sm
+        working-directory: scripts/test_corpora
+      - name: Run tests
+        # No --locked here, unlike the embedder job: this project's uv.lock is
+        # deliberately untracked (#326, "the harness doesn't need lockstep
+        # version pinning across machines"), so there is nothing to check
+        # against. CI therefore resolves fresh, exactly as a developer running
+        # `uv sync` does — which is precisely how mcp 2.0.0 got in, and why the
+        # `<2` bound in pyproject.toml is load-bearing rather than belt-and-braces.
+        run: uv run --extra test pytest tests/ -v --tb=short
+        working-directory: scripts/test_corpora
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/test_corpora/pyproject.toml
+++ b/scripts/test_corpora/pyproject.toml
@@ -7,7 +7,14 @@ dependencies = [
     "httpx>=0.28",
     "anthropic>=0.43",
     "openai>=1.50",
-    "mcp>=1.9",
+    # Same major as the app (root pyproject pins mcp>=1.9.0, locked at 1.28.1).
+# This lock had floated to 2.0.0, where streamablehttp_client is renamed
+# streamable_http_client and no longer takes headers= or timeout= — so
+# runner/client.py raised ImportError on the first MCP call. Nothing caught
+# it because nothing ran these tests (#587). Migrating the harness to the
+# 2.x client API is worth doing, but not while it is a major ahead of the
+# server it exercises.
+    "mcp>=1.9,<2",
     "pyyaml>=6",
     "tenacity>=9",
     "pypdfium2>=4",

--- a/scripts/test_corpora/tests/test_metrics.py
+++ b/scripts/test_corpora/tests/test_metrics.py
@@ -28,8 +28,14 @@ def test_citation_extra_counts_model_only():
     assert citation_extra(["a", "b"], ["a", "b", "c", "d"]) == 2
 
 
-def test_entity_overlap_english(monkeypatch):
-    """Use a stub spaCy doc so we don't depend on the model loading."""
+def test_entity_overlap_english():
+    """Exercises the real en_core_web_sm pipeline.
+
+    The docstring used to say it stubbed the model, and it took a `monkeypatch`
+    it never used — the stub was intended and never written. Nothing noticed,
+    because nothing ran this suite (#587). It genuinely needs the model, so CI
+    installs it rather than the assertion being weakened to match the comment.
+    """
     baseline = "California and Delaware appear in the contract from Acme."
     model = "The contract from Acme references California."
     score = entity_overlap(baseline, model, lang="en")

--- a/tests/test_ci_collects_every_test_suite.py
+++ b/tests/test_ci_collects_every_test_suite.py
@@ -10,9 +10,9 @@ asserts the link between "tests exist here" and "CI runs them":
   - `frontend` vitest — `"test": "vitest"` was defined in package.json and run
     by no workflow, so a react-router major upgrade had `tsc --noEmit` as its
     only automated signal.
-  - `scripts/test_corpora/tests` — 35 files, ~191 tests, still uncollected. It
-    is its own uv project with its own dependencies, so a root-venv run cannot
-    even import 19 of them; that is a wiring gap, not rotted code.
+  - `scripts/test_corpora/tests` — its own uv project, so the root
+    `testpaths = ["tests"]` never saw it. 421 tests that had never run; wiring
+    them up found runner/client.py broken against its own lockfile (#587).
   - `macos/**/*Tests` — 152 XCTest cases across the two Swift apps. This guard
     only scanned `test_*.py`, so the entire Swift half of the product was
     invisible to the very check meant to catch uncollected suites. Worse, the
@@ -42,12 +42,7 @@ WORKFLOWS = REPO / ".github" / "workflows"
 # Directories that legitimately hold no CI-run tests. Each needs a reason and,
 # where it is a gap rather than a decision, an issue number.
 UNCOLLECTED_WITH_REASON: dict[str, str] = {
-    # Its own uv project (scripts/test_corpora/pyproject.toml) with its own
-    # dependencies, so it needs a job of its own the way `embedder` does — a
-    # root-venv run cannot import 19 of the 35 files. The harness is also
-    # destructive by design (it wipes and re-ingests corpora), so the CI shape
-    # needs a decision, not just a `run:` line.
-    "scripts/test_corpora/tests": "separate uv project, needs its own CI job like embedder — see issue #587",
+    # Empty: every suite in the repo is now run by some job.
 }
 
 _SKIP_PARTS = {".venv", "node_modules", "site-packages", "build", ".git", ".claude", ".worktrees", "dist"}


### PR DESCRIPTION
Closes #587.

`scripts/test_corpora` is its own uv project, so the root `testpaths = ["tests"]` never saw it — **421 tests that had never run once**. AGENTS.md names this harness as how you prove a retrieval or pipeline change didn't regress, so the tool relied on for that had no protection of its own.

## The decision the issue asked for

The issue held off because the harness is destructive by design. That doesn't apply to the unit tests:

- both files touching a live endpoint (`test_client.py`, `test_sweep_ingest.py`) use `httpx.MockTransport`
- every `_ingest_corpus` call in the tests is patched

Verified by running with `DATABASE_URL` and `HARBOR_CLERK_URL` pointed at dead addresses: **421 passed, no network, 10s.**

## What wiring it up found

`runner/client.py:189,205` imports `streamablehttp_client`. In **mcp 2.0.0** that's renamed `streamable_http_client` and takes neither `headers=` nor `timeout=` — it wants a prebuilt `http_client`. So the harness raises `ImportError` on its first MCP call, which is exactly what the test's own docstring predicts:

> Without it, Phase 1 baselines crash on the very first MCP `list_tools()` call after Phase 0 completes.

The test has been correct and failing all along. Nothing ran it.

**This is not hypothetical.** This project's `uv.lock` is deliberately untracked (#326), so `mcp>=1.9` resolves to the newest release on every fresh `uv sync` — the harness is broken for anyone on a clean checkout today. It passes only where an older venv is lying around, which is how mine passed at first (mcp 1.27.1).

Pinned `mcp>=1.9,<2`. The app is on 1.28.1 from the same `mcp>=1.9` declaration, and putting the client a major ahead of the server it exercises isn't something to do blind. **The 2.x migration is worth doing deliberately, behind a live sweep — I'd rather that be its own change than a side effect of a CI PR.**

## Two judgement calls worth flagging

**No `--locked`**, unlike the `embedder` job — there's no committed lock to check against. CI resolves fresh exactly as a developer does, which is what makes the `<2` bound load-bearing rather than decorative. (The alternative, committing the lock, would reverse the deliberate decision in #326.)

**`test_entity_overlap_english`** said it stubbed spaCy "so we don't depend on the model loading", and took a `monkeypatch` it never used — the stub was intended and never written, so it really loads `en_core_web_sm`. CI installs the model (~12MB) rather than weakening the assertion to match the comment. Marking it `requires_models` and skipping would be the same silent-coverage failure this job exists to end.

## Verification

- clean venv (`rm -rf .venv uv.lock`), both CI steps in order: **421 passed**
- mutation: removing the `eval-harness` job fails `test_ci_collects_every_test_suite.py` ✓
- `UNCOLLECTED_WITH_REASON` is now **empty** — every suite in the repo is run by some job

🤖 Generated with [Claude Code](https://claude.com/claude-code)