### PR TITLE
feat(api): add POST /api/docs/reprocess-failed for bulk recovery (#554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,13 +356,13 @@ harbor-clerk <command> --help        # man-page-class help with JSON return shap
 <!-- BEGIN GENERATED: rest-summary -->
 <!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
 
-**141 operations across 16 groups.** Full reference: [docs/architecture.md](docs/architecture.md#rest-api).
+**142 operations across 16 groups.** Full reference: [docs/architecture.md](docs/architecture.md#rest-api).
 
 | Group | Operations | Admin-only | Base path |
 |---|---|---|---|
 | `system` | 22 | 19 | `/api/system` |
 | `chat` | 19 | 7 | `/api/chat` |
-| `documents` | 15 | 4 | `/api/docs` |
+| `documents` | 16 | 5 | `/api/docs` |
 | `watch` | 12 | — | `/api/watch` |
 | `oauth` | 11 | 4 | `(various)` |
 | `api-keys` | 10 | 10 | `/api/api-keys` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -470,7 +470,7 @@ Queue subscriptions:
 <!-- BEGIN GENERATED: rest-endpoints -->
 <!-- Do not edit by hand. Regenerate: uv run python -m scripts.gen_docs -->
 
-**141 operations**, 84 of them access-gated. Generated from the FastAPI OpenAPI schema; the Access column is derived from each route's dependency tree.
+**142 operations**, 85 of them access-gated. Generated from the FastAPI OpenAPI schema; the Access column is derived from each route's dependency tree.
 
 ### `api-keys`
 
@@ -531,6 +531,7 @@ Queue subscriptions:
 | `GET` | `/api/docs/entities/top` | — | Top Entities |
 | `GET` | `/api/docs/filters` | — | Document Filters |
 | `GET` | `/api/docs/overview` | — | Corpus Overview |
+| `POST` | `/api/docs/reprocess-failed` | **admin** | Reprocess Failed Documents |
 | `DELETE` | `/api/docs/{doc_id}` | **admin** | Delete Document |
 | `GET` | `/api/docs/{doc_id}` | — | Get Document |
 | `POST` | `/api/docs/{doc_id}/cancel` | **admin** | Cancel Processing |

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -860,6 +860,13 @@ async def delete_document(
     await session.commit()
 
 
+# Error text written by the two paths that park a document in `error` on
+# purpose. Kept in step with their call sites by
+# tests/api/test_reprocess_failed.py, because a reworded string here fails open
+# — it would silently start requeuing cancelled work again.
+DELIBERATELY_STOPPED_ERRORS = ("Cancelled by user", "Queue cleared before pipeline completed")
+
+
 @router.post("/docs/reprocess-failed", status_code=status.HTTP_202_ACCEPTED)
 async def reprocess_failed_documents(
     limit: int = Query(default=1000, ge=1, le=10000),
@@ -884,10 +891,25 @@ async def reprocess_failed_documents(
     """
     failed = (
         select(Document.doc_id)
-        .where(Document.status == "active", Document.pipeline_status == PipelineStatus.error)
-        .order_by(Document.created_at)
+        .where(
+            Document.status == "active",
+            Document.pipeline_status == PipelineStatus.error,
+            # `error` is not only "the pipeline broke". Cancelling a document
+            # (worker/pipeline.py cancel_doc_jobs) and the /system/clear-queue
+            # emergency stop both park documents here too, distinguished only by
+            # this text. Requeuing those would restart work an admin deliberately
+            # stopped and silently undo the emergency stop — and since they tend
+            # to be older, an ordering by age would have requeued them *first*
+            # and spent the whole limit on them.
+            Document.error.not_in(DELIBERATELY_STOPPED_ERRORS),
+        )
+        # Most recently failed first, matching the failed-docs query in
+        # routes/system.py. The motivating case is an outage that just failed a
+        # batch; oldest-first would put permanently-broken documents at the head
+        # of every call, so a caller looping on `remaining` would keep retrying
+        # the same corrupt files and might never reach the ones it wants.
+        .order_by(Document.updated_at.desc())
     )
-    total = await session.scalar(select(func.count()).select_from(failed.subquery()))
     doc_ids = list((await session.execute(failed.limit(limit))).scalars().all())
 
     from harbor_clerk.worker.pipeline import reset_and_queue_extract_for_doc
@@ -906,13 +928,20 @@ async def reprocess_failed_documents(
         action="reprocess_failed_documents",
         target_type="document",
         target_id=None,
-        detail={"requeued": requeued, "matched": total},
+        detail={"requeued": requeued},
     )
+    # Counted *after* the loop, so "remaining" is literally what still matches
+    # rather than an inference. Counting first meant a row that stopped matching
+    # mid-loop stayed in the total while being correctly excluded from
+    # `requeued`, inflating `remaining` and telling the caller to keep retrying
+    # work that no longer exists; and because the count and the select ran as
+    # separate statements under READ COMMITTED, a batch that was still failing
+    # could return more rows than the count, reporting "requeued 7 of 5".
+    remaining = await session.scalar(select(func.count()).select_from(failed.subquery())) or 0
     await session.commit()
 
-    remaining = max(0, (total or 0) - requeued)
     logger.info("Requeued %d failed documents (%d still matching)", requeued, remaining)
-    return {"requeued": requeued, "matched": total or 0, "remaining": remaining}
+    return {"requeued": requeued, "remaining": remaining}
 
 
 @router.post("/docs/{doc_id}/reprocess", status_code=status.HTTP_202_ACCEPTED)

--- a/src/harbor_clerk/api/routes/documents.py
+++ b/src/harbor_clerk/api/routes/documents.py
@@ -860,6 +860,61 @@ async def delete_document(
     await session.commit()
 
 
+@router.post("/docs/reprocess-failed", status_code=status.HTTP_202_ACCEPTED)
+async def reprocess_failed_documents(
+    limit: int = Query(default=1000, ge=1, le=10000),
+    admin: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+):
+    """Requeue every document whose pipeline ended in `error`.
+
+    Recovering from a transient outage previously meant clicking through the
+    Documents list 100 at a time, because selection is per-page and the only
+    bulk action was `/system/reprocess-all` — which re-runs the entire corpus,
+    including the documents that succeeded (#554).
+
+    Deliberately reuses the per-document helper rather than doing one set-based
+    UPDATE. It bumps `pipeline_seq`, clears `error`, deletes the stale non-extract
+    jobs and inserts the extract job atomically; a second implementation of that
+    is a second thing to keep in step with the pipeline, and the failure mode of
+    getting it subtly wrong is a document that looks requeued and never runs.
+
+    No hidden truncation: `limit` bounds the work, and the response reports what
+    was left behind so a caller can tell "done" from "there is more".
+    """
+    failed = (
+        select(Document.doc_id)
+        .where(Document.status == "active", Document.pipeline_status == PipelineStatus.error)
+        .order_by(Document.created_at)
+    )
+    total = await session.scalar(select(func.count()).select_from(failed.subquery()))
+    doc_ids = list((await session.execute(failed.limit(limit))).scalars().all())
+
+    from harbor_clerk.worker.pipeline import reset_and_queue_extract_for_doc
+
+    requeued = 0
+    for doc_id in doc_ids:
+        # Returns None when the row stopped matching between the select and here
+        # — deleted, or already requeued by the watcher. Not an error; it just
+        # must not be counted, or the number reported back is a lie.
+        if await reset_and_queue_extract_for_doc(session, doc_id) is not None:
+            requeued += 1
+
+    await log_audit(
+        session,
+        user_id=admin.id,
+        action="reprocess_failed_documents",
+        target_type="document",
+        target_id=None,
+        detail={"requeued": requeued, "matched": total},
+    )
+    await session.commit()
+
+    remaining = max(0, (total or 0) - requeued)
+    logger.info("Requeued %d failed documents (%d still matching)", requeued, remaining)
+    return {"requeued": requeued, "matched": total or 0, "remaining": remaining}
+
+
 @router.post("/docs/{doc_id}/reprocess", status_code=status.HTTP_202_ACCEPTED)
 async def reprocess_document(
     doc_id: uuid.UUID,

--- a/tests/api/test_reprocess_failed.py
+++ b/tests/api/test_reprocess_failed.py
@@ -1,0 +1,154 @@
+"""`POST /api/docs/reprocess-failed` — bulk recovery for a failed batch (#554).
+
+Recovering from a transient outage previously meant clicking through the
+Documents list 100 at a time, because selection is per-page and the only bulk
+action was `/system/reprocess-all`, which re-runs the whole corpus including
+everything that succeeded.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from harbor_clerk.models import Document, IngestionJob
+from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
+from tests.conftest import auth_header
+
+pytestmark = pytest.mark.anyio
+
+
+def _doc(title: str, *, sha: bytes, status: str = "active", pipeline_status=PipelineStatus.error) -> Document:
+    return Document(
+        title=title,
+        status=status,
+        sha256=sha,
+        pipeline_status=pipeline_status,
+        pipeline_seq=3,
+        error="embedder unreachable",
+    )
+
+
+async def test_requeues_only_the_failed_active_documents(client, admin_user, admin_token, db_session):
+    """The whole point: the ones that worked must not be touched.
+
+    `/system/reprocess-all` already existed and re-runs everything — if this
+    endpoint did the same it would be a slower spelling of that, and it would
+    throw away good extractions to recover a handful of bad ones.
+    """
+    failed = _doc("Failed", sha=b"f" * 32)
+    ready = _doc("Ready", sha=b"r" * 32, pipeline_status=PipelineStatus.ready)
+    # "deleted" is what the live corpus actually uses for non-active rows.
+    inactive = _doc("Deleted failed", sha=b"i" * 32, status="deleted")
+    db_session.add_all([failed, ready, inactive])
+    await db_session.flush()
+    await db_session.commit()
+
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"requeued": 1, "matched": 1, "remaining": 0}
+
+    for doc, expected_seq, expected_status in (
+        (failed, 4, PipelineStatus.extracting),
+        (ready, 3, PipelineStatus.ready),
+        (inactive, 3, PipelineStatus.error),
+    ):
+        await db_session.refresh(doc)
+        assert doc.pipeline_seq == expected_seq, f"{doc.title} pipeline_seq"
+        assert doc.pipeline_status == expected_status, f"{doc.title} pipeline_status"
+
+    await db_session.refresh(failed)
+    assert failed.error is None, "the stale error must be cleared, or the UI still shows it as failed"
+
+
+async def test_queues_an_extract_job_for_the_new_generation(client, admin_user, admin_token, db_session):
+    """A requeued document that never runs is the failure this must not have.
+
+    The row is picked up by pipeline_seq, so an extract job carrying the *old*
+    seq is invisible to the worker — the document would sit in `extracting`
+    forever, looking busy.
+    """
+    failed = _doc("Failed", sha=b"f" * 32)
+    db_session.add(failed)
+    await db_session.flush()
+    db_session.add(
+        IngestionJob(
+            doc_id=failed.doc_id,
+            stage=JobStage.chunk,
+            status=JobStatus.error,
+            pipeline_seq=3,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+
+    jobs = (await db_session.execute(select(IngestionJob).where(IngestionJob.doc_id == failed.doc_id))).scalars().all()
+    stages = {(j.stage, j.status, j.pipeline_seq) for j in jobs}
+    assert (JobStage.extract, JobStatus.queued, 4) in stages, f"no queued extract at the new seq: {stages}"
+    assert not [j for j in jobs if j.stage == JobStage.chunk], "the stale chunk job should have been cleared"
+
+
+async def test_limit_reports_what_it_left_behind(client, admin_user, admin_token, db_session):
+    """A silent cap reads as 'everything is recovered' when it isn't."""
+    db_session.add_all([_doc(f"Failed {i}", sha=bytes([i]) * 32) for i in range(5)])
+    await db_session.commit()
+
+    resp = await client.post("/api/docs/reprocess-failed?limit=2", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"requeued": 2, "matched": 5, "remaining": 3}
+
+
+async def test_no_failed_documents_is_not_an_error(client, admin_user, admin_token, db_session):
+    db_session.add(_doc("Ready", sha=b"r" * 32, pipeline_status=PipelineStatus.ready))
+    await db_session.commit()
+
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"requeued": 0, "matched": 0, "remaining": 0}
+
+
+async def test_the_literal_path_is_not_swallowed_by_the_doc_id_route(client, admin_user, admin_token, db_session):
+    """`/docs/{doc_id}/reprocess` sits beside this; a UUID parse of the literal
+    segment is the classic way a route like this 422s in production and passes
+    in a unit test that calls the function directly."""
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, f"literal route matched the wrong handler: {resp.status_code} {resp.text}"
+
+
+async def test_requires_admin(client, regular_user, user_token, db_session):
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(user_token))
+    assert resp.status_code in (401, 403), f"a non-admin requeued the corpus: {resp.status_code}"
+
+
+async def test_a_row_that_stopped_matching_is_not_counted(client, admin_user, admin_token, db_session, monkeypatch):
+    """The count has to mean something, or "requeued: 126" is just len(selected).
+
+    `reset_and_queue_extract_for_doc` returns None when the row no longer
+    matches by the time the UPDATE lands — deleted, deactivated, or already
+    requeued by the watcher between the SELECT and the write. Counting the
+    attempt instead of the result reports work that did not happen, and
+    `remaining` is derived from it, so the caller is told to stop retrying.
+    """
+    import harbor_clerk.worker.pipeline as pipeline
+
+    db_session.add_all([_doc("A", sha=b"a" * 32), _doc("B", sha=b"b" * 32)])
+    await db_session.commit()
+
+    real = pipeline.reset_and_queue_extract_for_doc
+    seen: list[object] = []
+
+    async def _one_vanishes(session, doc_id, **kw):
+        seen.append(doc_id)
+        if len(seen) == 1:
+            return None  # as if the row had just been deleted
+        return await real(session, doc_id, **kw)
+
+    monkeypatch.setattr(pipeline, "reset_and_queue_extract_for_doc", _one_vanishes)
+
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"requeued": 1, "matched": 2, "remaining": 1}, (
+        "a row that stopped matching was counted as requeued"
+    )

--- a/tests/api/test_reprocess_failed.py
+++ b/tests/api/test_reprocess_failed.py
@@ -8,14 +8,17 @@ everything that succeeded.
 
 from __future__ import annotations
 
-import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from harbor_clerk.models import Document, IngestionJob
 from harbor_clerk.models.enums import JobStage, JobStatus, PipelineStatus
 from tests.conftest import auth_header
 
-pytestmark = pytest.mark.anyio
+# No pytest.mark.anyio: pyproject sets asyncio_mode = "auto", so pytest-asyncio
+# already runs these. Adding the anyio marker routes them through a second
+# plugin and a second event loop, while the `_engine` fixture is session-scoped
+# and bound to the first — "attached to a different loop". It passed locally
+# and failed every test in CI.
 
 
 def _doc(title: str, *, sha: bytes, status: str = "active", pipeline_status=PipelineStatus.error) -> Document:
@@ -46,7 +49,7 @@ async def test_requeues_only_the_failed_active_documents(client, admin_user, adm
 
     resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
     assert resp.status_code == 202, resp.text
-    assert resp.json() == {"requeued": 1, "matched": 1, "remaining": 0}
+    assert resp.json() == {"requeued": 1, "remaining": 0}
 
     for doc, expected_seq, expected_status in (
         (failed, 4, PipelineStatus.extracting),
@@ -97,7 +100,7 @@ async def test_limit_reports_what_it_left_behind(client, admin_user, admin_token
 
     resp = await client.post("/api/docs/reprocess-failed?limit=2", headers=auth_header(admin_token))
     assert resp.status_code == 202, resp.text
-    assert resp.json() == {"requeued": 2, "matched": 5, "remaining": 3}
+    assert resp.json() == {"requeued": 2, "remaining": 3}
 
 
 async def test_no_failed_documents_is_not_an_error(client, admin_user, admin_token, db_session):
@@ -106,15 +109,7 @@ async def test_no_failed_documents_is_not_an_error(client, admin_user, admin_tok
 
     resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
     assert resp.status_code == 202, resp.text
-    assert resp.json() == {"requeued": 0, "matched": 0, "remaining": 0}
-
-
-async def test_the_literal_path_is_not_swallowed_by_the_doc_id_route(client, admin_user, admin_token, db_session):
-    """`/docs/{doc_id}/reprocess` sits beside this; a UUID parse of the literal
-    segment is the classic way a route like this 422s in production and passes
-    in a unit test that calls the function directly."""
-    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
-    assert resp.status_code == 202, f"literal route matched the wrong handler: {resp.status_code} {resp.text}"
+    assert resp.json() == {"requeued": 0, "remaining": 0}
 
 
 async def test_requires_admin(client, regular_user, user_token, db_session):
@@ -142,13 +137,82 @@ async def test_a_row_that_stopped_matching_is_not_counted(client, admin_user, ad
     async def _one_vanishes(session, doc_id, **kw):
         seen.append(doc_id)
         if len(seen) == 1:
-            return None  # as if the row had just been deleted
+            # Actually stop the row matching, rather than only returning None.
+            # A mock that returns None while leaving the row in `error` is
+            # testing its own stub: the row really does still match, so
+            # remaining=1 is the right answer and the assertion proves nothing
+            # about the counting.
+            await session.execute(update(Document).where(Document.doc_id == doc_id).values(status="deleted"))
+            return None
         return await real(session, doc_id, **kw)
 
     monkeypatch.setattr(pipeline, "reset_and_queue_extract_for_doc", _one_vanishes)
 
     resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
     assert resp.status_code == 202, resp.text
-    assert resp.json() == {"requeued": 1, "matched": 2, "remaining": 1}, (
-        "a row that stopped matching was counted as requeued"
+    # remaining is 0: the vanished row no longer matches, and the other was
+    # requeued. Counting before the loop reported 1 here — telling the caller to
+    # keep retrying work that no longer existed.
+    assert resp.json() == {"requeued": 1, "remaining": 0}, (
+        "a row that stopped matching was counted as requeued, or inflated remaining"
     )
+
+
+async def test_deliberately_stopped_documents_are_left_alone(client, admin_user, admin_token, db_session):
+    """Cancelling and /system/clear-queue both park a document in `error`.
+
+    So a naive "requeue everything in error" restarts work an admin explicitly
+    stopped — and silently undoes the emergency stop. The distinguishing signal
+    is only the error text.
+    """
+    cancelled = _doc("Cancelled", sha=b"c" * 32)
+    cancelled.error = "Cancelled by user"
+    cleared = _doc("Cleared", sha=b"q" * 32)
+    cleared.error = "Queue cleared before pipeline completed"
+    genuine = _doc("Genuine", sha=b"g" * 32)
+    db_session.add_all([cancelled, cleared, genuine])
+    await db_session.commit()
+
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"requeued": 1, "remaining": 0}, "a deliberately-stopped document was restarted"
+
+    for doc in (cancelled, cleared):
+        await db_session.refresh(doc)
+        assert doc.pipeline_status == PipelineStatus.error, f"{doc.title} was restarted"
+        assert doc.pipeline_seq == 3, f"{doc.title} generation was bumped"
+
+
+def test_the_stop_sentinels_still_match_their_call_sites():
+    """The exclusion is by string match, so a reword elsewhere fails open —
+    silently restarting cancelled work with every test still green."""
+    from pathlib import Path
+
+    from harbor_clerk.api.routes.documents import DELIBERATELY_STOPPED_ERRORS
+
+    src = Path(__file__).resolve().parents[2] / "src" / "harbor_clerk"
+    corpus = (src / "worker" / "pipeline.py").read_text() + (src / "api" / "routes" / "system.py").read_text()
+    missing = [text for text in DELIBERATELY_STOPPED_ERRORS if f'"{text}"' not in corpus]
+    assert not missing, (
+        f"these sentinels no longer appear in pipeline.py or system.py: {missing}. "
+        "The writer was reworded, so reprocess-failed will restart that population again."
+    )
+
+
+async def test_the_bulk_requeue_is_audited(client, admin_user, admin_token, db_session):
+    """An admin action that mutates the corpus in bulk has to leave a record."""
+    from harbor_clerk.models import AuditLog
+
+    db_session.add(_doc("Failed", sha=b"f" * 32))
+    await db_session.commit()
+
+    resp = await client.post("/api/docs/reprocess-failed", headers=auth_header(admin_token))
+    assert resp.status_code == 202, resp.text
+
+    entries = (
+        (await db_session.execute(select(AuditLog).where(AuditLog.action == "reprocess_failed_documents")))
+        .scalars()
+        .all()
+    )
+    assert len(entries) == 1, f"expected one audit entry, got {len(entries)}"
+    assert entries[0].detail == {"requeued": 1}, entries[0].detail


### PR DESCRIPTION
Addresses the higher-value half of #554.

## The problem, measured on the live instance

Recovering a failed batch meant clicking through the Documents list 100 at a time, because selection is per-page. The only bulk action was `/system/reprocess-all`, which re-runs **everything**:

```
 pipeline_status | status  | docs
-----------------+---------+-------
 ready           | active  | 11436
 error           | active  |   126     <- what actually needs requeuing
 ready           | deleted |    40
```

So the existing escape hatch re-extracts 11,436 healthy documents to recover 126. I ran this against the live corpus to confirm the filter matches what's actually stranded rather than assuming.

## `error` is not only "the pipeline broke" — the important correction

Review caught that three distinct populations land in `pipeline_status = error`:

| written by | error text |
|---|---|
| genuine stage failure (`worker/entry.py`) | the exception |
| `cancel_doc_jobs` — an admin cancelling a document | `Cancelled by user` |
| `/system/clear-queue` — the emergency stop | `Queue cleared before pipeline completed` |

A naive "requeue everything failed" restarts a cancelled 900-page OCR and **silently undoes the emergency stop**. My original ordering (`created_at` ascending) made it worse: cancelled documents skew older, so they'd be requeued *first* and could consume the entire `limit` before a genuinely-failed document was reached.

Now excluded by sentinel text — with a test pinning those strings against the two files that write them, because the match **fails open**: a reword elsewhere would quietly start requeuing cancelled work again with the whole suite still green.

Ordering is now `updated_at DESC`, matching the failed-docs query in `routes/system.py`. The motivating case is an outage that just failed a batch; oldest-first parks permanently-broken files at the head of every call, so a caller looping on `remaining` could keep retrying the same corrupt documents.

## `remaining` now means what it says

It was `matched - requeued` with the COUNT taken *before* the loop. Two ways that lied:

- a row that stopped matching mid-loop stayed in the total while being correctly excluded from `requeued` — inflating `remaining` and telling the caller to retry work that no longer existed;
- the COUNT and the SELECT are separate statements under READ COMMITTED, so a batch still failing could return more rows than the count: `requeued: 7, matched: 5`.

Counted after the loop instead, so it's literally what still matches. `matched` is gone rather than left to mislead.

## Design notes

**Reuses the per-document helper** rather than a second set-based `UPDATE`. It bumps `pipeline_seq`, clears `error`, deletes stale non-extract jobs and inserts the extract job atomically; the failure mode of a subtly-different second copy is a document that *looks* requeued and never runs. Review confirmed the bulk path does exactly what `reprocess_document` does — no missing enqueue or status change — and that the `AGENTS.md` sync-session/event-loop trap is correctly avoided.

## Mutation testing

| mutation | result |
|---|---|
| drop the failed-only filter | **fails** ✓ |
| drop the active-only filter | **fails** ✓ |
| ignore `limit` | **fails** ✓ |
| count attempts, not successes | **fails** ✓ |
| stop excluding cancelled/cleared | **fails** ✓ |
| restore count-before-loop | **fails** ✓ |
| rename the audit action | **fails** ✓ |
| shorten the sentinel list | **fails** ✓ |

## Tests that could not fail, now fixed

- **Route ordering** — verified pointless by moving the handler below `/docs/{doc_id}/reprocess`: everything still passed, because Starlette prefers a FULL match over a PARTIAL one regardless of declaration order. Deleted rather than reworded.
- **Vanished row** — the mock returned `None` while leaving the row in `error`, so the row genuinely still matched and the assertion tested its own stub. It now actually stops the row matching.
- **Audit entry** — had no coverage at all; deleting the whole `log_audit` block left the suite green.

Also worth recording: the first revision **passed locally and failed all seven tests in CI**. Cause was `pytestmark = pytest.mark.anyio` in a project with `asyncio_mode = "auto"` — a second plugin and a second event loop, while the `_engine` fixture is session-scoped and bound to the first. Now verified under CI's Python 3.12 as well as local 3.14.

## Known trade-offs, not fixed here

- Single transaction, all-or-nothing: ~0.5 ms/doc measured, so ~5 s at the `limit=10000` ceiling. No partial progress on a mid-loop failure.
- A lock-order inversion exists against `/system/reprocess-all` if both run concurrently (that one locks in scan order, this in `updated_at` order).
- No partial index on `(status, pipeline_status)`, so the filter seq-scans `documents`.

## Scope

The UI half of #554 (Gmail-style "select all N matching") is **not** here, and no button is wired yet — so the endpoint exists but the click-through problem isn't solved end-to-end until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)