### PR TITLE
docs(macos): the SDK bump already shipped — correct a stale, inverted warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,16 +125,22 @@ Read those rather than any transcription, and regenerate with
 
 ## CI
 
-Required checks on PRs to `main`: `python`, `embedder`, `macos`, `frontend`,
-`codeql`, `dependency-audit`, `container-scan`. The `python` job also verifies
-generated docs are current. Counted in prose once — "six required checks" — and
+Required checks on PRs to `main`: `python`, `embedder`, `macos`,
+`eval-harness`, `frontend`, `codeql`, `dependency-audit`, `container-scan`. The
+`python` job also verifies generated docs are current. Counted in prose once — "six required checks" — and
 it was wrong by the next PR, so it isn't counted here.
 
 **A new job is not enforced until branch protection requires it.** Adding one to
 `ci.yml` makes it run and go green; it does not make it able to block a merge.
-Every job added this week (`embedder`, `macos`) needed a separate
+Every job added this week (`embedder`, `macos`, `eval-harness`) needed a separate
 `gh api -X PATCH repos/:owner/:repo/branches/main/protection/required_status_checks`
 call, and until that lands the guard is advisory.
+
+**Add the job to `main` before requiring it.** A required context that never
+reports blocks the merge, so requiring `macos` and `eval-harness` while their own
+PRs were still open would have deadlocked all four open PRs — including the two
+that added those jobs, which then could not merge to supply them. Land the job,
+then require it, then rebase everything else.
 
 ## Instruction files and your harness
 

--- a/macos/AGENTS.md
+++ b/macos/AGENTS.md
@@ -57,14 +57,42 @@ exception. That is a known gap, not a decision — see #561.
 ## Do not bump the SDK without re-testing
 
 Many of macOS's stricter privacy and security defaults are gated
-**"linked-on-or-after"** the SDK a binary was built against. The build currently
-targets `MACOSX_DEPLOYMENT_TARGET = 15.0` and links the macOS 15.x SDK, which
-means it is **grandfathered into the older, looser behavior** even when running
-on a much newer OS.
+**"linked-on-or-after"** the SDK a binary was built against. Rebuilding against a
+newer SDK is what *flips the stricter rules on* — ATS, TCC/file access,
+hardened-runtime and JIT policy can all change behavior with no source change at
+all. So an SDK bump is a behavioral change, not housekeeping.
 
-Rebuilding against a newer SDK is what *flips the stricter rules on* — ATS,
-TCC/file access, hardened-runtime and JIT policy can all change behavior with no
-source change at all. So an SDK bump is a behavioral change, not housekeeping.
+**The bump has already happened.** This section used to say the build "links the
+macOS 15.x SDK" and is "grandfathered into the older, looser behavior". That is
+no longer true, and nothing recorded the change: the deployment target is still
+15.0, but the SDK follows whatever Xcode is on the build machine, so installing
+Xcode 26 silently moved it. Measured on the shipped bundles:
+
+```
+$ vtool -show-build /Applications/HarborClerkServer.app/Contents/MacOS/HarborClerkServer
+ platform MACOS
+    minos 15.0
+      sdk 26.5
+```
+
+So the stricter rules are **already live in every build since that Xcode
+upgrade**, and have been through a full field test — an 11,436-document corpus,
+IMAP sync, search and Research — with no observed breakage. The `#561` ATS gap
+(no ATS keys declared, loopback cleartext relying on WebKit's implicit localhost
+allowance) is therefore running *under* the stricter regime today, not waiting
+for it.
+
+Two consequences worth keeping in mind:
+
+- **The risk is inverted from how it reads.** Building on a machine with an older
+  Xcode now *loosens* the shipped binary rather than being the safe default. The
+  CI `macos` job runs on `macos-15`, whose SDK is older than the release
+  machine's, so CI validates a **more permissive** configuration than ships — it
+  cannot catch a regression that only the stricter SDK triggers.
+- **"Do not bump without re-testing" needs a way to notice a bump.** It was
+  bypassed here not by anyone deciding to bump, but by a routine Xcode upgrade.
+  `vtool -show-build` on the built binary is the check; pinning Xcode in the job
+  and at release time is the fix, and is not yet done.
 
 When bumping, re-test on the target OS: the WKWebView loopback load, watched-
 folder access from the background watcher, and every spawned helper (Postgres,


### PR DESCRIPTION
Came out of a question about whether the SDK gap I flagged in #596 was potential or actual. It's neither: **the bump already happened, silently, and shipped.**

## Measured, not inferred

```
$ vtool -show-build /Applications/HarborClerkServer.app/Contents/MacOS/HarborClerkServer
 platform MACOS
    minos 15.0
      sdk 26.5
```

Both bundles, rebuilt 22 Jul, with 7 processes from them running right now. `macos/AGENTS.md` said the build "links the macOS 15.x SDK" and is "grandfathered into the older, looser behavior" — that stopped being true at some point and nothing recorded it.

Nobody decided to bump. The deployment target is still `15.0`, but the **SDK follows whatever Xcode is on the build machine**, so upgrading to Xcode 26 moved it. The section's own rule — "do not bump the SDK without re-testing" — was bypassed without anyone bumping anything, which is the part worth writing down.

## Is anything broken?

**No observed breakage.** Those binaries carried the whole field test: 11,436-document corpus, IMAP sync of 7,444 messages, search, Research. The stricter linked-on-or-after rules have been active throughout. The #561 ATS gap (no ATS keys declared; loopback cleartext relying on WebKit's implicit localhost allowance) is running *under* the stricter regime today rather than waiting for it — which is mildly reassuring for #561, though it doesn't make the missing declaration correct.

## Two things this inverts

- **Older Xcode is now the risky one.** Building on a machine with an older Xcode *loosens* the shipped binary rather than being the conservative default.
- **CI is more permissive than production.** The `macos` job runs on `macos-15`, whose SDK is older than the release machine's, so it validates a configuration looser than what ships and cannot catch a regression only the stricter SDK triggers. That's the opposite of how I characterised the gap in #596, and the correction matters more than the original note did.

## What this doesn't do

Doesn't pin Xcode — in CI or at release. That's the actual fix and it needs a decision on which version to standardise on. This change records the check (`vtool -show-build` on the built binary) so a future silent bump is at least detectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)